### PR TITLE
[Network] DNS Fixes

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -49,8 +49,6 @@ DEPENDENCIES = [
     'applicationinsights',
     'argcomplete>=1.8.0',
     'azure-cli-nspkg',
-    'azure-mgmt-trafficmanager==0.30.0rc6',
-    'azure-mgmt-dns==1.0.0',
     'colorama',
     'jmespath',
     'msrest>=0.4.4',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -50,7 +50,7 @@ DEPENDENCIES = [
     'argcomplete>=1.8.0',
     'azure-cli-nspkg',
     'azure-mgmt-trafficmanager==0.30.0rc6',
-    'azure-mgmt-dns==0.30.0rc6',
+    'azure-mgmt-dns==1.0.0',
     'colorama',
     'jmespath',
     'msrest>=0.4.4',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -471,6 +471,9 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     helps['network dns record-set {} remove-record'.format(record)] = """
         type: command
         short-summary: Remove {} record from its record set.
+        long-summary: >
+            By default, if the last record in a set is removed, the record set is deleted. To
+            retain the empty record set, include --keep-empty-record-set.
     """.format(record.upper())
 
     helps['network dns record-set {} create'.format(record)] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -571,6 +571,7 @@ register_cli_argument('network dns record-set create', 'if_none_match', help='Cr
 for item in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     register_cli_argument('network dns record-set {} add-record'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
     register_cli_argument('network dns record-set {} remove-record'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone.')
+    register_cli_argument('network dns record-set {} remove-record'.format(item), 'keep_empty_record_set', action='store_true', help='Keep the empty record set if the last record is removed.')
 register_cli_argument('network dns record-set cname set-record', 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
 
 register_cli_argument('network dns record-set soa', 'relative_record_set_name', ignore_type, default='@')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1405,7 +1405,7 @@ def list_dns_record_set(client, resource_group_name, zone_name, record_type=None
     if record_type:
         return client.list_by_type(resource_group_name, zone_name, record_type)
     else:
-        return client.list_all_in_resource_group(resource_group_name, zone_name)
+        return client.list_by_dns_zone(resource_group_name, zone_name)
 
 def update_dns_record_set(instance, metadata=None):
     if metadata is not None:
@@ -1434,7 +1434,7 @@ def export_zone(resource_group_name, zone_name):
     from time import localtime, strftime
 
     client = get_mgmt_service_client(DnsManagementClient)
-    record_sets = client.record_sets.list_all_in_resource_group(resource_group_name, zone_name)
+    record_sets = client.record_sets.list_by_dns_zone(resource_group_name, zone_name)
 
     zone_obj = OrderedDict({
         '$origin': zone_name.rstrip('.') + '.',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1388,9 +1388,9 @@ def create_dns_zone(client, resource_group_name, zone_name, location='global', t
 def list_dns_zones(resource_group_name=None):
     ncf = get_mgmt_service_client(DnsManagementClient).zones
     if resource_group_name:
-        return ncf.list_in_resource_group(resource_group_name)
+        return ncf.list_by_resource_group(resource_group_name)
     else:
-        return ncf.list_in_subscription()
+        return ncf.list()
 
 def create_dns_record_set(resource_group_name, zone_name, record_set_name, record_set_type,
                           metadata=None, if_match=None, if_none_match=None, ttl=3600):
@@ -1588,12 +1588,12 @@ def import_zone(resource_group_name, zone_name, file_name):
             root_ns.ttl = rs.ttl
             rs = root_ns
             rs.type = rs.type.rsplit('/', 1)[1]
-        print("Importing {} records of type '{}' and name '{}'"
-              .format(record_count, rs.type, rs.name))
         try:
             client.record_sets.create_or_update(
                 resource_group_name, zone_name, rs.name, rs.type, rs)
             cum_records += record_count
+            print("({}/{}) Imported {} records of type '{}' and name '{}'"
+                  .format(cum_records, total_records, record_count, rs.type, rs.name))
         except CloudError as ex:
             logger.error(ex)
     print("\n== {}/{} RECORDS IMPORTED SUCCESSFULLY: '{}' =="
@@ -1675,55 +1675,61 @@ def add_dns_txt_record(resource_group_name, zone_name, record_set_name, value):
     assert original_len == final_len
     return _add_save_record(record, record_type, record_set_name, resource_group_name, zone_name)
 
-def remove_dns_aaaa_record(resource_group_name, zone_name, record_set_name, ipv6_address):
+def remove_dns_aaaa_record(resource_group_name, zone_name, record_set_name, ipv6_address,
+                           keep_empty_record_set=False):
     record = AaaaRecord(ipv6_address)
     record_type = 'aaaa'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_a_record(resource_group_name, zone_name, record_set_name, ipv4_address):
+def remove_dns_a_record(resource_group_name, zone_name, record_set_name, ipv4_address,
+                        keep_empty_record_set=False):
     record = ARecord(ipv4_address)
     record_type = 'a'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_cname_record(resource_group_name, zone_name, record_set_name, cname):
+def remove_dns_cname_record(resource_group_name, zone_name, record_set_name, cname,
+                            keep_empty_record_set=False):
     record = CnameRecord(cname)
     record_type = 'cname'
     return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
-                          is_list=False)
+                          is_list=False, keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_mx_record(resource_group_name, zone_name, record_set_name, preference, exchange):
+def remove_dns_mx_record(resource_group_name, zone_name, record_set_name, preference, exchange,
+                         keep_empty_record_set=False):
     record = MxRecord(int(preference), exchange)
     record_type = 'mx'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_ns_record(resource_group_name, zone_name, record_set_name, dname):
+def remove_dns_ns_record(resource_group_name, zone_name, record_set_name, dname,
+                         keep_empty_record_set=False):
     record = NsRecord(dname)
     record_type = 'ns'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_ptr_record(resource_group_name, zone_name, record_set_name, dname):
+def remove_dns_ptr_record(resource_group_name, zone_name, record_set_name, dname,
+                          keep_empty_record_set=False):
     record = PtrRecord(dname)
     record_type = 'ptr'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
-
-def remove_dns_soa_record(resource_group_name, zone_name, record_set_name, host, email,
-                          serial_number, refresh_time, retry_time, expire_time, minimum_ttl):
-    record = SoaRecord(host, email, serial_number, refresh_time, retry_time, expire_time,
-                       minimum_ttl)
-    record_type = 'soa'
     return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
-                          is_list=False)
+                          keep_empty_record_set=keep_empty_record_set)
 
 def remove_dns_srv_record(resource_group_name, zone_name, record_set_name, priority, weight,
-                          port, target):
+                          port, target, keep_empty_record_set=False):
     record = SrvRecord(priority, weight, port, target)
     record_type = 'srv'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
-def remove_dns_txt_record(resource_group_name, zone_name, record_set_name, value):
+def remove_dns_txt_record(resource_group_name, zone_name, record_set_name, value,
+                          keep_empty_record_set=False):
     record = TxtRecord(value)
     record_type = 'txt'
-    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name)
+    return _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
+                          keep_empty_record_set=keep_empty_record_set)
 
 def _add_record(record_set, record, record_type, is_list=False):
 
@@ -1752,7 +1758,7 @@ def _add_save_record(record, record_type, record_set_name, resource_group_name, 
                                 record_type, record_set)
 
 def _remove_record(record, record_type, record_set_name, resource_group_name, zone_name,
-                   is_list=True):
+                   keep_empty_record_set, is_list=True):
     ncf = get_mgmt_service_client(DnsManagementClient).record_sets
     record_set = ncf.get(resource_group_name, zone_name, record_set_name, record_type)
     record_property = _type_to_property_name(record_type)
@@ -1768,8 +1774,17 @@ def _remove_record(record, record_type, record_set_name, resource_group_name, zo
     else:
         setattr(record_set, record_property, None)
 
-    return ncf.create_or_update(resource_group_name, zone_name, record_set_name,
-                                record_type, record_set)
+    if is_list:
+        records_remaining = len(getattr(record_set, record_property))
+    else:
+        records_remaining = 1 if getattr(record_set, record_property) is not None else 0
+
+    if not records_remaining and not keep_empty_record_set:
+        logger.info('Removing empty %s record set: %s', record_type, record_set_name)
+        return ncf.delete(resource_group_name, zone_name, record_set_name, record_type)
+    else:
+        return ncf.create_or_update(resource_group_name, zone_name, record_set_name,
+                                    record_type, record_set)
 
 def dict_matches_filter(d, filter_dict):
     sentinel = object()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1529,6 +1529,7 @@ def _build_record(data):
 # pylint: disable=too-many-statements
 def import_zone(resource_group_name, zone_name, file_name):
     from azure.cli.core._util import read_file_content
+    import sys
     file_text = read_file_content(file_name)
     zone_obj = parse_zone_file(file_text, zone_name)
 
@@ -1568,7 +1569,7 @@ def import_zone(resource_group_name, zone_name, file_name):
     cum_records = 0
 
     client = get_mgmt_service_client(DnsManagementClient)
-    print('== BEGINNING ZONE IMPORT: {} ==\n'.format(zone_name))
+    print('== BEGINNING ZONE IMPORT: {} ==\n'.format(zone_name), file=sys.stderr)
     client.zones.create_or_update(resource_group_name, zone_name, Zone('global'))
     for rs in record_sets.values():
 
@@ -1593,11 +1594,12 @@ def import_zone(resource_group_name, zone_name, file_name):
                 resource_group_name, zone_name, rs.name, rs.type, rs)
             cum_records += record_count
             print("({}/{}) Imported {} records of type '{}' and name '{}'"
-                  .format(cum_records, total_records, record_count, rs.type, rs.name))
+                  .format(cum_records, total_records, record_count, rs.type, rs.name),
+                  file=sys.stderr)
         except CloudError as ex:
             logger.error(ex)
     print("\n== {}/{} RECORDS IMPORTED SUCCESSFULLY: '{}' =="
-          .format(cum_records, total_records, zone_name))
+          .format(cum_records, total_records, zone_name), file=sys.stderr)
 
 
 def add_dns_aaaa_record(resource_group_name, zone_name, record_set_name, ipv6_address):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -1,32 +1,61 @@
 interactions:
 - request:
-    body: !!python/unicode '{"location": "global"}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f7f659f6-f54c-11e6-bb32-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/dnszones?api-version=2016-04-01
+  response:
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/partners.zhachuxiang.com","name":"partners.zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a09d-2bd18a6bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/zhachuxiang.com","name":"zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000005-0000-0000-8940-7cb0896bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":5}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/tjp-dns\/providers\/Microsoft.Network\/dnszones\/tjpzone.com","name":"tjpzone.com","type":"Microsoft.Network\/dnszones","etag":"00000003-0000-0000-56a1-61a4c487d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-08.azure-dns.com.","ns2-08.azure-dns.net.","ns3-08.azure-dns.org.","ns4-08.azure-dns.info."],"numberOfRecordSets":8}}]}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:20 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['1434']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "global"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [764dfb40-f536-11e6-9d21-a0b3ccf7272a]
+      x-ms-client-request-id: [f8bdf49a-f54c-11e6-ba6e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      cache-control: [private]
-      content-length: ['463']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:14 GMT']
-      etag: [00000002-0000-0000-d8ab-30374389d201]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['463']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:23 GMT']
+      ETag: [00000002-0000-0000-e755-c1b95989d201]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -35,57 +64,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [776b0400-f536-11e6-9b44-a0b3ccf7272a]
+      x-ms-client-request-id: [fa2bd126-f54c-11e6-882a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones?api-version=2016-04-01
+  response:
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}]}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:24 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['475']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [faebc352-f54c-11e6-8929-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:26 GMT']
+      ETag: [00000002-0000-0000-e755-c1b95989d201]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['463']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:16 GMT']
-      etag: [00000002-0000-0000-d8ab-30374389d201]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"type": "a", "properties": {"TTL": 3600}, "name": "myrsa"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrsa", "type": "a"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['59']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [77e479c0-f536-11e6-8956-a0b3ccf7272a]
+      x-ms-client-request-id: [fb7b5c1a-f54c-11e6-962e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"e5635321-8323-48f5-8673-4d10caba2f7d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"29c9f5af-90f9-46a9-b765-3fa357421092","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['328']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:16 GMT']
-      etag: [e5635321-8323-48f5-8673-4d10caba2f7d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['328']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:26 GMT']
+      ETag: [29c9f5af-90f9-46a9-b765-3fa357421092]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -94,61 +152,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [78937e70-f536-11e6-8ef7-a0b3ccf7272a]
+      x-ms-client-request-id: [fc5f783e-f54c-11e6-be76-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"e5635321-8323-48f5-8673-4d10caba2f7d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"29c9f5af-90f9-46a9-b765-3fa357421092","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:28 GMT']
+      ETag: [29c9f5af-90f9-46a9-b765-3fa357421092]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['328']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:17 GMT']
-      etag: [e5635321-8323-48f5-8673-4d10caba2f7d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "e5635321-8323-48f5-8673-4d10caba2f7d", "type":
-      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
-      "10.0.0.10"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]}, "name":
+      "myrsa", "etag": "29c9f5af-90f9-46a9-b765-3fa357421092"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [78d2aa4f-f536-11e6-bac2-a0b3ccf7272a]
+      x-ms-client-request-id: [fcd0dbc6-f54c-11e6-bc20-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8581b653-1c5f-46ec-8f22-86c283ceccef","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ff5b4318-2db7-45db-ac33-4656c802e2c1","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:29 GMT']
+      ETag: [ff5b4318-2db7-45db-ac33-4656c802e2c1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['355']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:18 GMT']
-      etag: [8581b653-1c5f-46ec-8f22-86c283ceccef]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -157,87 +215,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [799cd821-f536-11e6-8092-a0b3ccf7272a]
+      x-ms-client-request-id: [fdb100da-f54c-11e6-88ca-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsaalt'' does not exist in resource group ''cli_test_dns'' of subscription
-        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['172']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['172']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:30 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "a", "properties": {"ARecords": [{"ipv4Address":
-      "10.0.0.10"}], "TTL": 3600}, "name": "myrsaalt"}'
+    body: '{"properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]},
+      "name": "myrsaalt", "type": "a"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [79de26e1-f536-11e6-83dd-a0b3ccf7272a]
+      x-ms-client-request-id: [fe04e918-f54c-11e6-8b0e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"904cf244-040b-4dfc-a732-b52b3c85d701","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"3dbddacf-47c0-4e11-b337-7feb3132f1b5","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['364']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:20 GMT']
-      etag: [904cf244-040b-4dfc-a732-b52b3c85d701]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['364']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:30 GMT']
+      ETag: [3dbddacf-47c0-4e11-b337-7feb3132f1b5]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "aaaa", "properties": {"TTL": 3600}, "name":
-      "myrsaaaa"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrsaaaa", "type": "aaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['65']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7aa76a4f-f536-11e6-926e-a0b3ccf7272a]
+      x-ms-client-request-id: [fec29da2-f54c-11e6-ad27-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"7ebf2eb6-4611-4c9e-ab3a-9a443346648d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"24c602e8-c113-4b70-886f-8a824168d113","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['346']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:21 GMT']
-      etag: [7ebf2eb6-4611-4c9e-ab3a-9a443346648d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['346']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:32 GMT']
+      ETag: [24c602e8-c113-4b70-886f-8a824168d113]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -246,61 +302,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b67ad0f-f536-11e6-b85c-a0b3ccf7272a]
+      x-ms-client-request-id: [ffa0d2a8-f54c-11e6-8537-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"7ebf2eb6-4611-4c9e-ab3a-9a443346648d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"24c602e8-c113-4b70-886f-8a824168d113","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:33 GMT']
+      ETag: [24c602e8-c113-4b70-886f-8a824168d113]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['346']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:22 GMT']
-      etag: [7ebf2eb6-4611-4c9e-ab3a-9a443346648d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "7ebf2eb6-4611-4c9e-ab3a-9a443346648d", "type":
-      "Microsoft.Network/dnszones/AAAA", "properties": {"AAAARecords": [{"ipv6Address":
-      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa"}'
+    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
+      "TTL": 3600}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "etag": "24c602e8-c113-4b70-886f-8a824168d113", "name": "myrsaaaa", "type":
+      "Microsoft.Network/dnszones/AAAA"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['355']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7ba949f0-f536-11e6-aee9-a0b3ccf7272a]
+      x-ms-client-request-id: [000e29c8-f54d-11e6-a734-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:34 GMT']
+      ETag: [051d9f4a-4c96-4d82-b84d-f4e48c32c4dd]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['384']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:23 GMT']
-      etag: [b471e023-5fc4-4c4e-a164-8629ef877d06]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -309,87 +366,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c66314f-f536-11e6-a2a0-a0b3ccf7272a]
+      x-ms-client-request-id: [00faeade-f54d-11e6-a0a2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsaaaaalt'' does not exist in resource group ''cli_test_dns'' of
-        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaaaaalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['175']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['175']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:36 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "aaaa", "properties": {"AAAARecords": [{"ipv6Address":
-      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaaalt"}'
+    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
+      "TTL": 3600}, "name": "myrsaaaaalt", "type": "aaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c8ea0de-f536-11e6-b122-a0b3ccf7272a]
+      x-ms-client-request-id: [015198e8-f54d-11e6-9be0-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"959feca8-0c94-4f4f-aff1-d502ff8746d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e845ad97-e924-4926-bca1-512f108b8e0b","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['393']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:24 GMT']
-      etag: [959feca8-0c94-4f4f-aff1-d502ff8746d6]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['393']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:37 GMT']
+      ETag: [e845ad97-e924-4926-bca1-512f108b8e0b]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "cname", "properties": {"TTL": 3600}, "name":
-      "myrscname"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrscname", "type": "cname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['67']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d501c21-f536-11e6-bd4d-a0b3ccf7272a]
+      x-ms-client-request-id: [02179406-f54d-11e6-b169-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"460642ce-85fe-4e39-abc4-39decc168585","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"07268b8c-9c31-40d0-a0f5-bf613e5e7d31","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:26 GMT']
-      etag: [460642ce-85fe-4e39-abc4-39decc168585]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['334']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:37 GMT']
+      ETag: [07268b8c-9c31-40d0-a0f5-bf613e5e7d31]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -398,61 +453,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e0eff4f-f536-11e6-b4c4-a0b3ccf7272a]
+      x-ms-client-request-id: [02e4b80c-f54d-11e6-bfa8-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"460642ce-85fe-4e39-abc4-39decc168585","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"07268b8c-9c31-40d0-a0f5-bf613e5e7d31","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:38 GMT']
+      ETag: [07268b8c-9c31-40d0-a0f5-bf613e5e7d31]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:27 GMT']
-      etag: [460642ce-85fe-4e39-abc4-39decc168585]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "460642ce-85fe-4e39-abc4-39decc168585", "type":
-      "Microsoft.Network/dnszones/CNAME", "properties": {"CNAMERecord": {"cname":
-      "mycname"}, "TTL": 3600}, "name": "myrscname", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname"}'
+    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "properties": {"TTL": 3600, "CNAMERecord": {"cname": "mycname"}}, "name": "myrscname",
+      "etag": "07268b8c-9c31-40d0-a0f5-bf613e5e7d31"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e4d19c0-f536-11e6-a7b6-a0b3ccf7272a]
+      x-ms-client-request-id: [032eb262-f54d-11e6-aab0-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:39 GMT']
+      ETag: [9800fcf9-4aad-4e33-ad89-ca8d30713082]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['368']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:27 GMT']
-      etag: [d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -461,86 +516,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7f0964de-f536-11e6-804e-a0b3ccf7272a]
+      x-ms-client-request-id: [03eaa22c-f54d-11e6-8ea4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrscnamealt'' does not exist in resource group ''cli_test_dns'' of
-        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrscnamealt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['176']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:28 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['176']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:40 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "cname", "properties": {"CNAMERecord": {"cname":
-      "mycname"}, "TTL": 3600}, "name": "myrscnamealt"}'
+    body: '{"properties": {"TTL": 3600, "CNAMERecord": {"cname": "mycname"}}, "name":
+      "myrscnamealt", "type": "cname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['107']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7f34938f-f536-11e6-b890-a0b3ccf7272a]
+      x-ms-client-request-id: [043f3066-f54d-11e6-9198-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a9382639-60ad-4904-83c7-5f244e813b67","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"48354d6b-4f3e-4bd0-8d0d-aa906eb71a19","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      cache-control: [private]
-      content-length: ['377']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:29 GMT']
-      etag: [a9382639-60ad-4904-83c7-5f244e813b67]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['377']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:41 GMT']
+      ETag: [48354d6b-4f3e-4bd0-8d0d-aa906eb71a19]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "mx", "properties": {"TTL": 3600}, "name": "myrsmx"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrsmx", "type": "mx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7fdc4540-f536-11e6-83aa-a0b3ccf7272a]
+      x-ms-client-request-id: [04f8b8cc-f54d-11e6-a8cc-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"22c86623-20d5-4453-a979-c2764b2b5ab1","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"dba3043f-b609-42a9-8053-b20e71947d7f","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:30 GMT']
-      etag: [22c86623-20d5-4453-a979-c2764b2b5ab1]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['334']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:42 GMT']
+      ETag: [dba3043f-b609-42a9-8053-b20e71947d7f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -549,61 +603,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [809cfd30-f536-11e6-955e-a0b3ccf7272a]
+      x-ms-client-request-id: [05f2bce4-f54d-11e6-bbdb-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"22c86623-20d5-4453-a979-c2764b2b5ab1","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"dba3043f-b609-42a9-8053-b20e71947d7f","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:44 GMT']
+      ETag: [dba3043f-b609-42a9-8053-b20e71947d7f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:31 GMT']
-      etag: [22c86623-20d5-4453-a979-c2764b2b5ab1]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "22c86623-20d5-4453-a979-c2764b2b5ab1", "type":
-      "Microsoft.Network/dnszones/MX", "properties": {"MXRecords": [{"preference":
-      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmx", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx"}'
+    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
+      "12"}]}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "etag": "dba3043f-b609-42a9-8053-b20e71947d7f", "name": "myrsmx", "type": "Microsoft.Network/dnszones/MX"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['342']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [80c6f361-f536-11e6-a531-a0b3ccf7272a]
+      x-ms-client-request-id: [064cd6f6-f54d-11e6-8c1a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:45 GMT']
+      ETag: [9422ccfb-638f-436d-b973-feda6490aa8c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['367']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:31 GMT']
-      etag: [2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -612,86 +666,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [81bf5d21-f536-11e6-b3f5-a0b3ccf7272a]
+      x-ms-client-request-id: [0739bb64-f54d-11e6-90b3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsmxalt'' does not exist in resource group ''cli_test_dns'' of subscription
-        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsmxalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['173']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['173']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:46 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "mx", "properties": {"MXRecords": [{"preference":
-      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmxalt"}'
+    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
+      "12"}]}, "name": "myrsmxalt", "type": "mx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8201bd4f-f536-11e6-b703-a0b3ccf7272a]
+      x-ms-client-request-id: [07a5fac6-f54d-11e6-9f66-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"cf10167d-b400-4b1f-b6b6-0b12962f0c74","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a91689da-999b-4642-ab53-155d91cc6bf7","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['376']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:34 GMT']
-      etag: [cf10167d-b400-4b1f-b6b6-0b12962f0c74]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['376']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:48 GMT']
+      ETag: [a91689da-999b-4642-ab53-155d91cc6bf7]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "ns", "properties": {"TTL": 3600}, "name": "myrsns"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrsns", "type": "ns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [82b507c0-f536-11e6-aea8-a0b3ccf7272a]
+      x-ms-client-request-id: [09263db0-f54d-11e6-8125-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"22b3d3c8-e473-4677-9999-60172bcf740a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"d11f343e-b047-45b2-99c0-ed37cac6b487","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:35 GMT']
-      etag: [22b3d3c8-e473-4677-9999-60172bcf740a]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['334']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:49 GMT']
+      ETag: [d11f343e-b047-45b2-99c0-ed37cac6b487]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -700,60 +753,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [83525930-f536-11e6-9bbf-a0b3ccf7272a]
+      x-ms-client-request-id: [09b065a8-f54d-11e6-a364-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"22b3d3c8-e473-4677-9999-60172bcf740a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"d11f343e-b047-45b2-99c0-ed37cac6b487","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:50 GMT']
+      ETag: [d11f343e-b047-45b2-99c0-ed37cac6b487]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
-      etag: [22b3d3c8-e473-4677-9999-60172bcf740a]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "22b3d3c8-e473-4677-9999-60172bcf740a", "type":
-      "Microsoft.Network/dnszones/NS", "properties": {"NSRecords": [{"nsdname": "foobar.com"}],
-      "TTL": 3600}, "name": "myrsns", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns"}'
+    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "etag": "d11f343e-b047-45b2-99c0-ed37cac6b487", "name": "myrsns", "type": "Microsoft.Network/dnszones/NS"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['331']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [837b3df0-f536-11e6-b88d-a0b3ccf7272a]
+      x-ms-client-request-id: [09d6d4c6-f54d-11e6-95c6-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:51 GMT']
+      ETag: [bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['358']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
-      etag: [a2d47e7d-262a-45a7-8d0c-70e9ac82635f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -762,85 +815,84 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [841e34b0-f536-11e6-8826-a0b3ccf7272a]
+      x-ms-client-request-id: [0a97ae0c-f54d-11e6-8c1b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsnsalt'' does not exist in resource group ''cli_test_dns'' of subscription
-        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsnsalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['173']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['173']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:51 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "ns", "properties": {"NSRecords": [{"nsdname":
-      "foobar.com"}], "TTL": 3600}, "name": "myrsnsalt"}'
+    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
+      "name": "myrsnsalt", "type": "ns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [844f08b0-f536-11e6-beb4-a0b3ccf7272a]
+      x-ms-client-request-id: [0ac08164-f54d-11e6-b4f3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"166c371a-3cfc-4bf0-b840-a079e1ae3590","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['367']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:37 GMT']
-      etag: [dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['367']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:52 GMT']
+      ETag: [166c371a-3cfc-4bf0-b840-a079e1ae3590]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "ptr", "properties": {"TTL": 3600}, "name": "myrsptr"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrsptr", "type": "ptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [84fc5fae-f536-11e6-babe-a0b3ccf7272a]
+      x-ms-client-request-id: [0b7c94f6-f54d-11e6-9b5a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"7f32354a-6cc9-438a-8b48-cafae8cc31e1","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:38 GMT']
-      etag: [86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:54 GMT']
+      ETag: [7f32354a-6cc9-438a-8b48-cafae8cc31e1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -849,61 +901,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [85c44391-f536-11e6-8a97-a0b3ccf7272a]
+      x-ms-client-request-id: [0c498928-f54d-11e6-a99a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"7f32354a-6cc9-438a-8b48-cafae8cc31e1","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:54 GMT']
+      ETag: [7f32354a-6cc9-438a-8b48-cafae8cc31e1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:39 GMT']
-      etag: [86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe", "type":
-      "Microsoft.Network/dnszones/PTR", "properties": {"PTRRecords": [{"ptrdname":
-      "foobar.com"}], "TTL": 3600}, "name": "myrsptr", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr"}'
+    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600}, "name":
+      "myrsptr", "etag": "7f32354a-6cc9-438a-8b48-cafae8cc31e1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8607670f-f536-11e6-b109-a0b3ccf7272a]
+      x-ms-client-request-id: [0c8e1852-f54d-11e6-8cd1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:55 GMT']
+      ETag: [5b342e84-c256-435a-87e1-1566413f8ab6]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['365']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:41 GMT']
-      etag: [211c88d3-2c90-46a7-852f-db08ace7647f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -912,86 +964,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [86bd97ae-f536-11e6-9a78-a0b3ccf7272a]
+      x-ms-client-request-id: [0d784ae4-f54d-11e6-a845-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsptralt'' does not exist in resource group ''cli_test_dns'' of
-        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsptralt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['174']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['174']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:56 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname":
-      "foobar.com"}], "TTL": 3600}, "name": "myrsptralt"}'
+    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
+      "name": "myrsptralt", "type": "ptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [86fdadf0-f536-11e6-8d4e-a0b3ccf7272a]
+      x-ms-client-request-id: [0dd67e0c-f54d-11e6-8116-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"538fba91-048b-4d61-87b6-f39c46a39a1e","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"3a74dd30-1694-4817-ac4d-306869ad5a3b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['374']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:42 GMT']
-      etag: [538fba91-048b-4d61-87b6-f39c46a39a1e]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['374']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:57 GMT']
+      ETag: [3a74dd30-1694-4817-ac4d-306869ad5a3b]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "srv", "properties": {"TTL": 3600}, "name": "myrssrv"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrssrv", "type": "srv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [87bcb830-f536-11e6-aef0-a0b3ccf7272a]
+      x-ms-client-request-id: [0eab21fa-f54d-11e6-a68f-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"a523796d-ca25-44f6-9847-1c708bdf72a8","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:44 GMT']
-      etag: [a523796d-ca25-44f6-9847-1c708bdf72a8]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:59 GMT']
+      ETag: [7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1000,62 +1051,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [888bef0f-f536-11e6-b7e5-a0b3ccf7272a]
+      x-ms-client-request-id: [0f6f460c-f54d-11e6-b839-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"a523796d-ca25-44f6-9847-1c708bdf72a8","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:09:59 GMT']
+      ETag: [7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:44 GMT']
-      etag: [a523796d-ca25-44f6-9847-1c708bdf72a8]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "a523796d-ca25-44f6-9847-1c708bdf72a8", "type":
-      "Microsoft.Network/dnszones/SRV", "properties": {"SRVRecords": [{"priority":
-      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
-      "myrssrv", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv"}'
+    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "properties": {"SRVRecords": [{"target": "target.com", "port": 1234, "weight":
+      50, "priority": 1}], "TTL": 3600}, "name": "myrssrv", "etag": "7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['378']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [88cb4200-f536-11e6-a1a9-a0b3ccf7272a]
+      x-ms-client-request-id: [0fad117a-f54d-11e6-8171-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:00 GMT']
+      ETag: [e2db6cb4-1fc2-4b7a-be89-f8f88335eb33]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['400']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:45 GMT']
-      etag: [32bbbc4c-f0cf-4298-896d-5f01863347a6]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1064,87 +1114,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [897d05cf-f536-11e6-9491-a0b3ccf7272a]
+      x-ms-client-request-id: [106dbbfe-f54d-11e6-8542-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrssrvalt'' does not exist in resource group ''cli_test_dns'' of
-        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrssrvalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['174']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['174']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:01 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "srv", "properties": {"SRVRecords": [{"priority":
-      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
-      "myrssrvalt"}'
+    body: '{"properties": {"SRVRecords": [{"target": "target.com", "port": 1234, "weight":
+      50, "priority": 1}], "TTL": 3600}, "name": "myrssrvalt", "type": "srv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [89bf17de-f536-11e6-830b-a0b3ccf7272a]
+      x-ms-client-request-id: [10ae506e-f54d-11e6-a799-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"00786d34-636a-485e-9448-8c02f3bf608f","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"c8f272fb-586e-472d-b310-ef98dcad9206","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['409']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:47 GMT']
-      etag: [00786d34-636a-485e-9448-8c02f3bf608f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['409']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:02 GMT']
+      ETag: [c8f272fb-586e-472d-b310-ef98dcad9206]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '{"type": "txt", "properties": {"TTL": 3600}, "name": "myrstxt"}'
+    body: '{"properties": {"TTL": 3600}, "name": "myrstxt", "type": "txt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a7d5ecf-f536-11e6-ad29-a0b3ccf7272a]
+      x-ms-client-request-id: [117385a6-f54d-11e6-b278-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"ac231f7d-90ff-418c-b61e-bba9463fae77","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3c5a8350-3bc1-4840-b97e-c8cc8049665c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:48 GMT']
-      etag: [ac231f7d-90ff-418c-b61e-bba9463fae77]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:03 GMT']
+      ETag: [3c5a8350-3bc1-4840-b97e-c8cc8049665c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1153,61 +1201,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b233bc0-f536-11e6-ad2e-a0b3ccf7272a]
+      x-ms-client-request-id: [12486bae-f54d-11e6-9a0b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"ac231f7d-90ff-418c-b61e-bba9463fae77","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3c5a8350-3bc1-4840-b97e-c8cc8049665c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:04 GMT']
+      ETag: [3c5a8350-3bc1-4840-b97e-c8cc8049665c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:49 GMT']
-      etag: [ac231f7d-90ff-418c-b61e-bba9463fae77]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "ac231f7d-90ff-418c-b61e-bba9463fae77", "type":
-      "Microsoft.Network/dnszones/TXT", "properties": {"TXTRecords": [{"value": ["some_text"]}],
-      "TTL": 3600}, "name": "myrstxt", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt"}'
+    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}, "name":
+      "myrstxt", "etag": "3c5a8350-3bc1-4840-b97e-c8cc8049665c"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['335']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b737ea1-f536-11e6-87bb-a0b3ccf7272a]
+      x-ms-client-request-id: [1296ea62-f54d-11e6-84dd-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:05 GMT']
+      ETag: [d47d8efa-d596-48e7-9e17-8131f9a6b89c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['363']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:49 GMT']
-      etag: [3bc68872-862e-4743-8bb9-442defe71796]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1216,57 +1264,56 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8c13b640-f536-11e6-a65b-a0b3ccf7272a]
+      x-ms-client-request-id: [13622722-f54d-11e6-852b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrstxtalt'' does not exist in resource group ''cli_test_dns'' of
-        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrstxtalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['174']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:50 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['174']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:06 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
-      ["some_text"]}], "TTL": 3600}, "name": "myrstxtalt"}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
+      "name": "myrstxtalt", "type": "txt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8c5727de-f536-11e6-bc6c-a0b3ccf7272a]
+      x-ms-client-request-id: [13a6b102-f54d-11e6-986a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['372']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:51 GMT']
-      etag: [57309cca-7a36-4446-beac-c797f9fbd1c2]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['372']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:08 GMT']
+      ETag: [80d9aa7b-5885-4fc6-9f60-7a419f84e299]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1275,62 +1322,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8cf27d80-f536-11e6-8f1f-a0b3ccf7272a]
+      x-ms-client-request-id: [14e024f0-f54d-11e6-89b9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8581b653-1c5f-46ec-8f22-86c283ceccef","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ff5b4318-2db7-45db-ac33-4656c802e2c1","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:09 GMT']
+      ETag: [ff5b4318-2db7-45db-ac33-4656c802e2c1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['355']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:51 GMT']
-      etag: [8581b653-1c5f-46ec-8f22-86c283ceccef]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "8581b653-1c5f-46ec-8f22-86c283ceccef", "type":
-      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
-      "10.0.0.10"}, {"ipv4Address": "10.0.0.11"}], "TTL": 3600}, "name": "myrsa",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
+      "10.0.0.11"}]}, "name": "myrsa", "etag": "ff5b4318-2db7-45db-ac33-4656c802e2c1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['359']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d2637b0-f536-11e6-85be-a0b3ccf7272a]
+      x-ms-client-request-id: [152a4b80-f54d-11e6-8a3d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:09 GMT']
+      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['383']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:52 GMT']
-      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1339,27 +1385,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8dbf4361-f536-11e6-9729-a0b3ccf7272a]
+      x-ms-client-request-id: [15ea2a6e-f54d-11e6-85ea-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e816bc67-505e-4bc7-b356-219770b7dd87","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"0724e025-6d13-4e12-9dce-b247ca1f164f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-06.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:10 GMT']
+      ETag: [0724e025-6d13-4e12-9dce-b247ca1f164f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['483']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
-      etag: [e816bc67-505e-4bc7-b356-219770b7dd87]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1368,62 +1414,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8e2e31cf-f536-11e6-9e93-a0b3ccf7272a]
+      x-ms-client-request-id: [160dab50-f54d-11e6-8671-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e816bc67-505e-4bc7-b356-219770b7dd87","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"0724e025-6d13-4e12-9dce-b247ca1f164f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-06.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:11 GMT']
+      ETag: [0724e025-6d13-4e12-9dce-b247ca1f164f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['483']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
-      etag: [e816bc67-505e-4bc7-b356-219770b7dd87]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "e816bc67-505e-4bc7-b356-219770b7dd87", "type":
-      "Microsoft.Network/dnszones/SOA", "properties": {"SOARecord": {"expireTime":
-      30, "email": "foo.com", "minimumTTL": 20, "retryTime": 90, "serialNumber": 123,
-      "host": "ns1-02.azure-dns.com.", "refreshTime": 60}, "TTL": 3600}, "name": "@",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@"}'
+    body: '{"type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
+      "properties": {"TTL": 3600, "SOARecord": {"email": "foo.com", "refreshTime":
+      60, "expireTime": 30, "minimumTTL": 20, "serialNumber": 123, "host": "ns1-06.azure-dns.com.",
+      "retryTime": 90}}, "name": "@", "etag": "0724e025-6d13-4e12-9dce-b247ca1f164f"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['442']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8e8181f0-f536-11e6-af7a-a0b3ccf7272a]
+      x-ms-client-request-id: [164c7cf4-f54d-11e6-bfd4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"85c82917-8056-4766-9905-2678090a3f4d","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"3d6eb440-f802-4e59-b99f-2fb554d28d67","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-06.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:11 GMT']
+      ETag: [3d6eb440-f802-4e59-b99f-2fb554d28d67]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['450']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
-      etag: [85c82917-8056-4766-9905-2678090a3f4d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1432,59 +1477,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f517c1e-f536-11e6-a308-a0b3ccf7272a]
+      x-ms-client-request-id: [16ef74d2-f54d-11e6-8995-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''longtxt'' does not exist in resource group ''cli_test_dns'' of subscription
-        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''longtxt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      cache-control: [private]
-      content-length: ['171']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:56 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['171']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:12 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
-      ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
-      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],
-      "TTL": 3600}, "name": "longtxt"}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]},
+      "name": "longtxt", "type": "txt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['600']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8fa62bcf-f536-11e6-897d-a0b3ccf7272a]
+      x-ms-client-request-id: [172f98f4-f54d-11e6-adc6-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['857']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:57 GMT']
-      etag: [14674cae-a373-46ca-965c-8a7fadade754]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Length: ['857']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:13 GMT']
+      ETag: [f3051cb3-9143-4e8f-aa9d-149673794dcd]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1493,28 +1536,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [90ad1480-f536-11e6-988c-a0b3ccf7272a]
+      x-ms-client-request-id: [17e8ee50-f54d-11e6-b2c3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":19}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":19}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:13 GMT']
+      ETag: [00000002-0000-0000-e755-c1b95989d201]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['464']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:58 GMT']
-      etag: [00000002-0000-0000-d8ab-30374389d201]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1523,28 +1566,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [913641b0-f536-11e6-8a2c-a0b3ccf7272a]
+      x-ms-client-request-id: [18785cfe-f54d-11e6-8d6e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:15 GMT']
+      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['383']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:28:59 GMT']
-      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1553,26 +1596,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [91dc93cf-f536-11e6-9728-a0b3ccf7272a]
+      x-ms-client-request-id: [1915adac-f54d-11e6-8d66-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"2512aab9-9b2c-462e-bc9f-b00c5b93f3cb","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."},{"nsdname":"ns4-02.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"85c82917-8056-4766-9905-2678090a3f4d","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"959feca8-0c94-4f4f-aff1-d502ff8746d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"904cf244-040b-4dfc-a732-b52b3c85d701","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a9382639-60ad-4904-83c7-5f244e813b67","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"cf10167d-b400-4b1f-b6b6-0b12962f0c74","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"538fba91-048b-4d61-87b6-f39c46a39a1e","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"00786d34-636a-485e-9448-8c02f3bf608f","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"145f36b2-fb1f-4bd6-80db-2911a216d644","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-06.azure-dns.com."},{"nsdname":"ns2-06.azure-dns.net."},{"nsdname":"ns3-06.azure-dns.org."},{"nsdname":"ns4-06.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"3d6eb440-f802-4e59-b99f-2fb554d28d67","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-06.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e845ad97-e924-4926-bca1-512f108b8e0b","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"3dbddacf-47c0-4e11-b337-7feb3132f1b5","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"48354d6b-4f3e-4bd0-8d0d-aa906eb71a19","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a91689da-999b-4642-ab53-155d91cc6bf7","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"166c371a-3cfc-4bf0-b840-a079e1ae3590","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"3a74dd30-1694-4817-ac4d-306869ad5a3b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"c8f272fb-586e-472d-b310-ef98dcad9206","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:16 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['7820']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1581,27 +1624,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [928508cf-f536-11e6-9ea4-a0b3ccf7272a]
+      x-ms-client-request-id: [19c3acbe-f54d-11e6-b730-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:17 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['1606']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:01 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1610,61 +1653,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [933b1261-f536-11e6-ab1a-a0b3ccf7272a]
+      x-ms-client-request-id: [1a45375a-f54d-11e6-b14d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:17 GMT']
+      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['383']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:02 GMT']
-      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"etag": "3781bd0f-f812-46fa-8247-cf4ed6d6f394", "type":
-      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
-      "10.0.0.11"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.11"}]}, "name":
+      "myrsa", "etag": "c4878879-71cf-4470-91bc-a234d3704b70"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [938fe921-f536-11e6-bab6-a0b3ccf7272a]
+      x-ms-client-request-id: [1a6c011c-f54d-11e6-acb3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:18 GMT']
+      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['355']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:03 GMT']
-      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1673,561 +1716,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9498315e-f536-11e6-a23b-a0b3ccf7272a]
+      x-ms-client-request-id: [1b279f14-f54d-11e6-adf5-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:20 GMT']
+      ETag: [051d9f4a-4c96-4d82-b84d-f4e48c32c4dd]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['384']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:05 GMT']
-      etag: [b471e023-5fc4-4c4e-a164-8629ef877d06]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "b471e023-5fc4-4c4e-a164-8629ef877d06", "type":
-      "Microsoft.Network/dnszones/AAAA", "properties": {"AAAARecords": [], "TTL":
-      3600}, "name": "myrsaaaa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['316']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [94f349b0-f536-11e6-8e04-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"c608fbeb-bc3d-40ee-8450-fcf6daeddd26","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['346']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:06 GMT']
-      etag: [c608fbeb-bc3d-40ee-8450-fcf6daeddd26]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [95d56c4f-f536-11e6-9877-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['368']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:07 GMT']
-      etag: [d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1", "type":
-      "Microsoft.Network/dnszones/CNAME", "properties": {"TTL": 3600}, "name": "myrscname",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['301']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [96384ccf-f536-11e6-b657-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"4d6dce7d-3f42-4c03-9895-dd859268aa75","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:07 GMT']
-      etag: [4d6dce7d-3f42-4c03-9895-dd859268aa75]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [96f02b1e-f536-11e6-ad42-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['367']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:09 GMT']
-      etag: [2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3", "type":
-      "Microsoft.Network/dnszones/MX", "properties": {"MXRecords": [], "TTL": 3600},
-      "name": "myrsmx", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [97312bc0-f536-11e6-b607-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9d79fec4-8859-4476-9d9d-5b7da83cb12d","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:09 GMT']
-      etag: [9d79fec4-8859-4476-9d9d-5b7da83cb12d]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [97e2534f-f536-11e6-a2af-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['358']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:10 GMT']
-      etag: [a2d47e7d-262a-45a7-8d0c-70e9ac82635f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "a2d47e7d-262a-45a7-8d0c-70e9ac82635f", "type":
-      "Microsoft.Network/dnszones/NS", "properties": {"NSRecords": [], "TTL": 3600},
-      "name": "myrsns", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9829475e-f536-11e6-baa1-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"50a9e4aa-b877-46a2-872a-8c79830dfd0c","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['334']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:11 GMT']
-      etag: [50a9e4aa-b877-46a2-872a-8c79830dfd0c]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [98d7afcf-f536-11e6-9094-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['365']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:12 GMT']
-      etag: [211c88d3-2c90-46a7-852f-db08ace7647f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "211c88d3-2c90-46a7-852f-db08ace7647f", "type":
-      "Microsoft.Network/dnszones/PTR", "properties": {"PTRRecords": [], "TTL": 3600},
-      "name": "myrsptr", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['311']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9902694f-f536-11e6-b3c4-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"233b47bb-eb87-4892-b06c-e1674f6705d4","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:12 GMT']
-      etag: [233b47bb-eb87-4892-b06c-e1674f6705d4]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [99cda88f-f536-11e6-89a4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['400']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:14 GMT']
-      etag: [32bbbc4c-f0cf-4298-896d-5f01863347a6]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "32bbbc4c-f0cf-4298-896d-5f01863347a6", "type":
-      "Microsoft.Network/dnszones/SRV", "properties": {"SRVRecords": [], "TTL": 3600},
-      "name": "myrssrv", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['311']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9a0d70b0-f536-11e6-b185-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"76ee8192-4ce9-43a3-a179-35c540c096b4","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:14 GMT']
-      etag: [76ee8192-4ce9-43a3-a179-35c540c096b4]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9acc05c0-f536-11e6-8f33-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['363']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:15 GMT']
-      etag: [3bc68872-862e-4743-8bb9-442defe71796]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "3bc68872-862e-4743-8bb9-442defe71796", "type":
-      "Microsoft.Network/dnszones/TXT", "properties": {"TXTRecords": [], "TTL": 3600},
-      "name": "myrstxt", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['311']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9b0fc580-f536-11e6-974e-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"da1357d3-6a9a-42e8-a9c4-be3e331f3eb2","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['340']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:15 GMT']
-      etag: [da1357d3-6a9a-42e8-a9c4-be3e331f3eb2]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9bccace1-f536-11e6-98a4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['355']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:17 GMT']
-      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9c59aaa1-f536-11e6-a30b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['355']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:17 GMT']
-      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"etag": "fece3fa7-dc70-4a1b-bc8e-1d0ff535030e", "type":
-      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [], "TTL": 3600},
-      "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['301']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9c9e069e-f536-11e6-beb8-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"771e1271-2dbb-4c07-8d9a-3da00948647f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['328']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:19 GMT']
-      etag: [771e1271-2dbb-4c07-8d9a-3da00948647f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9d5b8a40-f536-11e6-9b4c-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"771e1271-2dbb-4c07-8d9a-3da00948647f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
-    headers:
-      cache-control: [private]
-      content-length: ['328']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:19 GMT']
-      etag: [771e1271-2dbb-4c07-8d9a-3da00948647f]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2237,24 +1747,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9df6dfde-f536-11e6-83cb-a0b3ccf7272a]
+      x-ms-client-request-id: [1b6af1ae-f54d-11e6-b0d2-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      cache-control: [private]
-      content-length: ['0']
-      date: ['Fri, 17 Feb 2017 17:29:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:20 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2263,26 +1773,566 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9ec94b0f-f536-11e6-9880-a0b3ccf7272a]
+      x-ms-client-request-id: [1c2f540a-f54d-11e6-9f97-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:21 GMT']
+      ETag: [9800fcf9-4aad-4e33-ad89-ca8d30713082]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['368']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1c6f27d8-f54d-11e6-91f7-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:22 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1d344282-f54d-11e6-a6b2-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:23 GMT']
+      ETag: [9422ccfb-638f-436d-b973-feda6490aa8c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['367']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1d72b5e8-f54d-11e6-b971-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:23 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1e304a9c-f54d-11e6-89a3-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:24 GMT']
+      ETag: [bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['358']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1e593164-f54d-11e6-a29b-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:25 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1ef5aab8-f54d-11e6-bde5-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:25 GMT']
+      ETag: [5b342e84-c256-435a-87e1-1566413f8ab6]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['365']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1f3b058c-f54d-11e6-9783-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:26 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1ff047be-f54d-11e6-bc84-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:27 GMT']
+      ETag: [e2db6cb4-1fc2-4b7a-be89-f8f88335eb33]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['400']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [20317a24-f54d-11e6-b265-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2117e8e6-f54d-11e6-8e83-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
+      ETag: [d47d8efa-d596-48e7-9e17-8131f9a6b89c]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['363']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [213f2036-f54d-11e6-bbee-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [21dd8ff6-f54d-11e6-8c82-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
-        ''myrsa'' does not exist in resource group ''cli_test_dns'' of subscription
-        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['169']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 17 Feb 2017 17:29:22 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:30 GMT']
+      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [227f7c42-f54d-11e6-ac33-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:31 GMT']
+      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [22a72f8a-f54d-11e6-a920-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:32 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [237817c6-f54d-11e6-8297-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
+        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['169']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:33 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [240f907e-f54d-11e6-9035-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:34 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2496d9b4-f54d-11e6-af92-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
+        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['169']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:10:35 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2512881e-f54d-11e6-af45-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com:443/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone6362295903867614190464448e?api-version=2016-04-01']
+      Cache-Control: [private]
+      Content-Length: ['0']
+      Date: ['Fri, 17 Feb 2017 20:10:36 GMT']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationResults/delzone6362295903867614190464448e?api-version=2016-04-01']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2512881e-f54d-11e6-af45-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone6362295903867614190464448e?api-version=2016-04-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 20:11:06 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['22']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -6,56 +6,56 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f7f659f6-f54c-11e6-bb32-a0b3ccf7272a]
+      x-ms-client-request-id: [54369b40-f55c-11e6-b3cd-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/dnszones?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/partners.zhachuxiang.com","name":"partners.zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a09d-2bd18a6bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/zhachuxiang.com","name":"zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000005-0000-0000-8940-7cb0896bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":5}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/tjp-dns\/providers\/Microsoft.Network\/dnszones\/tjpzone.com","name":"tjpzone.com","type":"Microsoft.Network\/dnszones","etag":"00000003-0000-0000-56a1-61a4c487d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-08.azure-dns.com.","ns2-08.azure-dns.net.","ns3-08.azure-dns.org.","ns4-08.azure-dns.info."],"numberOfRecordSets":8}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/partners.zhachuxiang.com","name":"partners.zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a09d-2bd18a6bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/rgnemv_f442667004ba\/providers\/Microsoft.Network\/dnszones\/zhachuxiang.com","name":"zhachuxiang.com","type":"Microsoft.Network\/dnszones","etag":"00000005-0000-0000-8940-7cb0896bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":5}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/tjp-dns\/providers\/Microsoft.Network\/dnszones\/tjpzone.com","name":"tjpzone.com","type":"Microsoft.Network\/dnszones","etag":"00000003-0000-0000-56a1-61a4c487d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-08.azure-dns.com.","ns2-08.azure-dns.net.","ns3-08.azure-dns.org.","ns4-08.azure-dns.info."],"numberOfRecordSets":8}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:20 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['1434']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:17 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "global"}'
+    body: !!python/unicode '{"location": "global"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f8bdf49a-f54c-11e6-ba6e-a0b3ccf7272a]
+      x-ms-client-request-id: [550005c0-f55c-11e6-8ead-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-3d64-1b166989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['463']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:23 GMT']
-      ETag: [00000002-0000-0000-e755-c1b95989d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['463']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:20 GMT']
+      etag: [00000002-0000-0000-3d64-1b166989d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -64,27 +64,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa2bd126-f54c-11e6-882a-a0b3ccf7272a]
+      x-ms-client-request-id: [566c6700-f55c-11e6-9bea-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-3d64-1b166989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:24 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['475']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -93,57 +93,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [faebc352-f54c-11e6-8929-a0b3ccf7272a]
+      x-ms-client-request-id: [56f7b70f-f55c-11e6-8a40-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-3d64-1b166989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:26 GMT']
-      ETag: [00000002-0000-0000-e755-c1b95989d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['463']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:22 GMT']
+      etag: [00000002-0000-0000-3d64-1b166989d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrsa", "type": "a"}'
+    body: !!python/unicode '{"type": "a", "properties": {"TTL": 3600}, "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['59']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb7b5c1a-f54c-11e6-962e-a0b3ccf7272a]
+      x-ms-client-request-id: [57813261-f55c-11e6-83b5-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"29c9f5af-90f9-46a9-b765-3fa357421092","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ae8cc1e0-ee5e-4bf8-aa57-9ebcdd532738","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['328']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:26 GMT']
-      ETag: [29c9f5af-90f9-46a9-b765-3fa357421092]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:23 GMT']
+      etag: [ae8cc1e0-ee5e-4bf8-aa57-9ebcdd532738]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -152,61 +152,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fc5f783e-f54c-11e6-be76-a0b3ccf7272a]
+      x-ms-client-request-id: [5845bade-f55c-11e6-988d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"29c9f5af-90f9-46a9-b765-3fa357421092","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ae8cc1e0-ee5e-4bf8-aa57-9ebcdd532738","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:28 GMT']
-      ETag: [29c9f5af-90f9-46a9-b765-3fa357421092]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:24 GMT']
+      etag: [ae8cc1e0-ee5e-4bf8-aa57-9ebcdd532738]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]}, "name":
-      "myrsa", "etag": "29c9f5af-90f9-46a9-b765-3fa357421092"}'
+    body: !!python/unicode '{"etag": "ae8cc1e0-ee5e-4bf8-aa57-9ebcdd532738", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fcd0dbc6-f54c-11e6-bc20-a0b3ccf7272a]
+      x-ms-client-request-id: [58ad564f-f55c-11e6-a895-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ff5b4318-2db7-45db-ac33-4656c802e2c1","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"2e687612-ea9b-48ce-bd08-b3bd4abe447e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:29 GMT']
-      ETag: [ff5b4318-2db7-45db-ac33-4656c802e2c1]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:25 GMT']
+      etag: [2e687612-ea9b-48ce-bd08-b3bd4abe447e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -215,85 +215,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fdb100da-f54c-11e6-88ca-a0b3ccf7272a]
+      x-ms-client-request-id: [59aee7cf-f55c-11e6-8ff2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsaalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['172']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:30 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['172']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]},
-      "name": "myrsaalt", "type": "a"}'
+    body: !!python/unicode '{"type": "a", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}], "TTL": 3600}, "name": "myrsaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fe04e918-f54c-11e6-8b0e-a0b3ccf7272a]
+      x-ms-client-request-id: [5a1300cf-f55c-11e6-9618-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"3dbddacf-47c0-4e11-b337-7feb3132f1b5","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"f3f19226-1d0c-4ee5-805c-2a098cc95026","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['364']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:30 GMT']
-      ETag: [3dbddacf-47c0-4e11-b337-7feb3132f1b5]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['364']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:28 GMT']
+      etag: [f3f19226-1d0c-4ee5-805c-2a098cc95026]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrsaaaa", "type": "aaaa"}'
+    body: !!python/unicode '{"type": "aaaa", "properties": {"TTL": 3600}, "name":
+      "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['65']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fec29da2-f54c-11e6-ad27-a0b3ccf7272a]
+      x-ms-client-request-id: [5b1aaccf-f55c-11e6-a278-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"24c602e8-c113-4b70-886f-8a824168d113","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"8a3a895a-224f-4e95-9b4d-c514b9419f53","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:32 GMT']
-      ETag: [24c602e8-c113-4b70-886f-8a824168d113]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:29 GMT']
+      etag: [8a3a895a-224f-4e95-9b4d-c514b9419f53]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -302,62 +304,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ffa0d2a8-f54c-11e6-8537-a0b3ccf7272a]
+      x-ms-client-request-id: [5c0cd500-f55c-11e6-b10a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"24c602e8-c113-4b70-886f-8a824168d113","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"8a3a895a-224f-4e95-9b4d-c514b9419f53","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:33 GMT']
-      ETag: [24c602e8-c113-4b70-886f-8a824168d113]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:30 GMT']
+      etag: [8a3a895a-224f-4e95-9b4d-c514b9419f53]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
-      "TTL": 3600}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "etag": "24c602e8-c113-4b70-886f-8a824168d113", "name": "myrsaaaa", "type":
-      "Microsoft.Network/dnszones/AAAA"}'
+    body: !!python/unicode '{"etag": "8a3a895a-224f-4e95-9b4d-c514b9419f53", "type":
+      "Microsoft.Network/dnszones/AAAA", "properties": {"AAAARecords": [{"ipv6Address":
+      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['355']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [000e29c8-f54d-11e6-a734-a0b3ccf7272a]
+      x-ms-client-request-id: [5c68d7b0-f55c-11e6-ae99-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"a2a7bd8e-87d5-42dd-b551-cfec7afe3f64","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:34 GMT']
-      ETag: [051d9f4a-4c96-4d82-b84d-f4e48c32c4dd]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:31 GMT']
+      etag: [a2a7bd8e-87d5-42dd-b551-cfec7afe3f64]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -366,85 +367,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [00faeade-f54d-11e6-a0a2-a0b3ccf7272a]
+      x-ms-client-request-id: [5d43a74f-f55c-11e6-9abf-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaaaaalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsaaaaalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['175']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:36 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['175']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
-      "TTL": 3600}, "name": "myrsaaaaalt", "type": "aaaa"}'
+    body: !!python/unicode '{"type": "aaaa", "properties": {"AAAARecords": [{"ipv6Address":
+      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [015198e8-f54d-11e6-9be0-a0b3ccf7272a]
+      x-ms-client-request-id: [5d9ceade-f55c-11e6-8672-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e845ad97-e924-4926-bca1-512f108b8e0b","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"0ef88d78-8745-4c28-a5ce-2fd71335f0d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['393']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:37 GMT']
-      ETag: [e845ad97-e924-4926-bca1-512f108b8e0b]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:33 GMT']
+      etag: [0ef88d78-8745-4c28-a5ce-2fd71335f0d6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrscname", "type": "cname"}'
+    body: !!python/unicode '{"type": "cname", "properties": {"TTL": 3600}, "name":
+      "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['67']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [02179406-f54d-11e6-b169-a0b3ccf7272a]
+      x-ms-client-request-id: [5e67dc00-f55c-11e6-9bae-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"07268b8c-9c31-40d0-a0f5-bf613e5e7d31","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"dee26b5c-0a86-4a14-af8b-a95b8b382586","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:37 GMT']
-      ETag: [07268b8c-9c31-40d0-a0f5-bf613e5e7d31]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:35 GMT']
+      etag: [dee26b5c-0a86-4a14-af8b-a95b8b382586]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -453,61 +456,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [02e4b80c-f54d-11e6-bfa8-a0b3ccf7272a]
+      x-ms-client-request-id: [5f574511-f55c-11e6-9015-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"07268b8c-9c31-40d0-a0f5-bf613e5e7d31","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"dee26b5c-0a86-4a14-af8b-a95b8b382586","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:38 GMT']
-      ETag: [07268b8c-9c31-40d0-a0f5-bf613e5e7d31]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:36 GMT']
+      etag: [dee26b5c-0a86-4a14-af8b-a95b8b382586]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "properties": {"TTL": 3600, "CNAMERecord": {"cname": "mycname"}}, "name": "myrscname",
-      "etag": "07268b8c-9c31-40d0-a0f5-bf613e5e7d31"}'
+    body: !!python/unicode '{"etag": "dee26b5c-0a86-4a14-af8b-a95b8b382586", "type":
+      "Microsoft.Network/dnszones/CNAME", "properties": {"CNAMERecord": {"cname":
+      "mycname"}, "TTL": 3600}, "name": "myrscname", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [032eb262-f54d-11e6-aab0-a0b3ccf7272a]
+      x-ms-client-request-id: [5fb96240-f55c-11e6-9b72-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"e57114ba-7d9a-4b9f-bc78-e8e38a58eccd","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:39 GMT']
-      ETag: [9800fcf9-4aad-4e33-ad89-ca8d30713082]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:37 GMT']
+      etag: [e57114ba-7d9a-4b9f-bc78-e8e38a58eccd]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -516,85 +519,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [03eaa22c-f54d-11e6-8ea4-a0b3ccf7272a]
+      x-ms-client-request-id: [60805bc0-f55c-11e6-a680-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrscnamealt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrscnamealt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['176']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:40 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['176']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:39 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "CNAMERecord": {"cname": "mycname"}}, "name":
-      "myrscnamealt", "type": "cname"}'
+    body: !!python/unicode '{"type": "cname", "properties": {"CNAMERecord": {"cname":
+      "mycname"}, "TTL": 3600}, "name": "myrscnamealt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['107']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [043f3066-f54d-11e6-9198-a0b3ccf7272a]
+      x-ms-client-request-id: [60d5809e-f55c-11e6-8352-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"48354d6b-4f3e-4bd0-8d0d-aa906eb71a19","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a8708c2a-1e5b-4419-ad00-b6dac0615cc4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['377']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:41 GMT']
-      ETag: [48354d6b-4f3e-4bd0-8d0d-aa906eb71a19]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['377']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:39 GMT']
+      etag: [a8708c2a-1e5b-4419-ad00-b6dac0615cc4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrsmx", "type": "mx"}'
+    body: !!python/unicode '{"type": "mx", "properties": {"TTL": 3600}, "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [04f8b8cc-f54d-11e6-a8cc-a0b3ccf7272a]
+      x-ms-client-request-id: [61b72e11-f55c-11e6-b9e4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"dba3043f-b609-42a9-8053-b20e71947d7f","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"e4d2499d-6424-4398-ad3a-d4477b3e89fe","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:42 GMT']
-      ETag: [dba3043f-b609-42a9-8053-b20e71947d7f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:40 GMT']
+      etag: [e4d2499d-6424-4398-ad3a-d4477b3e89fe]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -603,61 +607,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [05f2bce4-f54d-11e6-bbdb-a0b3ccf7272a]
+      x-ms-client-request-id: [62a92f30-f55c-11e6-8305-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"dba3043f-b609-42a9-8053-b20e71947d7f","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"e4d2499d-6424-4398-ad3a-d4477b3e89fe","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:44 GMT']
-      ETag: [dba3043f-b609-42a9-8053-b20e71947d7f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:41 GMT']
+      etag: [e4d2499d-6424-4398-ad3a-d4477b3e89fe]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
-      "12"}]}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "etag": "dba3043f-b609-42a9-8053-b20e71947d7f", "name": "myrsmx", "type": "Microsoft.Network/dnszones/MX"}'
+    body: !!python/unicode '{"etag": "e4d2499d-6424-4398-ad3a-d4477b3e89fe", "type":
+      "Microsoft.Network/dnszones/MX", "properties": {"MXRecords": [{"preference":
+      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmx", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['342']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [064cd6f6-f54d-11e6-8c1a-a0b3ccf7272a]
+      x-ms-client-request-id: [63013a40-f55c-11e6-97a9-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"311ce09b-69aa-4e31-9a3a-e5e38e199531","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:45 GMT']
-      ETag: [9422ccfb-638f-436d-b973-feda6490aa8c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:43 GMT']
+      etag: [311ce09b-69aa-4e31-9a3a-e5e38e199531]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -666,85 +670,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0739bb64-f54d-11e6-90b3-a0b3ccf7272a]
+      x-ms-client-request-id: [6409f7b0-f55c-11e6-8093-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsmxalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsmxalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['173']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:46 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['173']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:44 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
-      "12"}]}, "name": "myrsmxalt", "type": "mx"}'
+    body: !!python/unicode '{"type": "mx", "properties": {"MXRecords": [{"preference":
+      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmxalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [07a5fac6-f54d-11e6-9f66-a0b3ccf7272a]
+      x-ms-client-request-id: [645ad6cf-f55c-11e6-af9b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a91689da-999b-4642-ab53-155d91cc6bf7","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a9e0c1bb-2ee7-4f5c-8624-67fd0e80c3b3","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['376']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:48 GMT']
-      ETag: [a91689da-999b-4642-ab53-155d91cc6bf7]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['376']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:46 GMT']
+      etag: [a9e0c1bb-2ee7-4f5c-8624-67fd0e80c3b3]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrsns", "type": "ns"}'
+    body: !!python/unicode '{"type": "ns", "properties": {"TTL": 3600}, "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09263db0-f54d-11e6-8125-a0b3ccf7272a]
+      x-ms-client-request-id: [6540ca00-f55c-11e6-9b67-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"d11f343e-b047-45b2-99c0-ed37cac6b487","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"97f49581-76d9-41cf-a13c-ef59b08e5505","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:49 GMT']
-      ETag: [d11f343e-b047-45b2-99c0-ed37cac6b487]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:46 GMT']
+      etag: [97f49581-76d9-41cf-a13c-ef59b08e5505]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -753,60 +758,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09b065a8-f54d-11e6-a364-a0b3ccf7272a]
+      x-ms-client-request-id: [65ef808f-f55c-11e6-97ca-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"d11f343e-b047-45b2-99c0-ed37cac6b487","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"97f49581-76d9-41cf-a13c-ef59b08e5505","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:50 GMT']
-      ETag: [d11f343e-b047-45b2-99c0-ed37cac6b487]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:47 GMT']
+      etag: [97f49581-76d9-41cf-a13c-ef59b08e5505]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "etag": "d11f343e-b047-45b2-99c0-ed37cac6b487", "name": "myrsns", "type": "Microsoft.Network/dnszones/NS"}'
+    body: !!python/unicode '{"etag": "97f49581-76d9-41cf-a13c-ef59b08e5505", "type":
+      "Microsoft.Network/dnszones/NS", "properties": {"NSRecords": [{"nsdname": "foobar.com"}],
+      "TTL": 3600}, "name": "myrsns", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['331']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09d6d4c6-f54d-11e6-95c6-a0b3ccf7272a]
+      x-ms-client-request-id: [66560a8f-f55c-11e6-aa78-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"cd8f057e-6465-4643-898f-131dbbc4173a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:51 GMT']
-      ETag: [bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['358']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:47 GMT']
+      etag: [cd8f057e-6465-4643-898f-131dbbc4173a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -815,84 +820,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0a97ae0c-f54d-11e6-8c1b-a0b3ccf7272a]
+      x-ms-client-request-id: [6700a270-f55c-11e6-902b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsnsalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsnsalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['173']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:51 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['173']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:49 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
-      "name": "myrsnsalt", "type": "ns"}'
+    body: !!python/unicode '{"type": "ns", "properties": {"NSRecords": [{"nsdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsnsalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ac08164-f54d-11e6-b4f3-a0b3ccf7272a]
+      x-ms-client-request-id: [673c72ee-f55c-11e6-ac0a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"166c371a-3cfc-4bf0-b840-a079e1ae3590","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"e4a49c32-398d-4610-a1ed-a8e4324a9193","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['367']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:52 GMT']
-      ETag: [166c371a-3cfc-4bf0-b840-a079e1ae3590]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      cache-control: [private]
+      content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:50 GMT']
+      etag: [e4a49c32-398d-4610-a1ed-a8e4324a9193]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrsptr", "type": "ptr"}'
+    body: !!python/unicode '{"type": "ptr", "properties": {"TTL": 3600}, "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0b7c94f6-f54d-11e6-9b5a-a0b3ccf7272a]
+      x-ms-client-request-id: [680d7e8f-f55c-11e6-8ca4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"7f32354a-6cc9-438a-8b48-cafae8cc31e1","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"f638d738-e6e7-4f09-a791-91cae56ca54a","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:54 GMT']
-      ETag: [7f32354a-6cc9-438a-8b48-cafae8cc31e1]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:51 GMT']
+      etag: [f638d738-e6e7-4f09-a791-91cae56ca54a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -901,61 +907,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0c498928-f54d-11e6-a99a-a0b3ccf7272a]
+      x-ms-client-request-id: [68d143c0-f55c-11e6-907d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"7f32354a-6cc9-438a-8b48-cafae8cc31e1","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"f638d738-e6e7-4f09-a791-91cae56ca54a","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:54 GMT']
-      ETag: [7f32354a-6cc9-438a-8b48-cafae8cc31e1]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:52 GMT']
+      etag: [f638d738-e6e7-4f09-a791-91cae56ca54a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600}, "name":
-      "myrsptr", "etag": "7f32354a-6cc9-438a-8b48-cafae8cc31e1"}'
+    body: !!python/unicode '{"etag": "f638d738-e6e7-4f09-a791-91cae56ca54a", "type":
+      "Microsoft.Network/dnszones/PTR", "properties": {"PTRRecords": [{"ptrdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsptr", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0c8e1852-f54d-11e6-8cd1-a0b3ccf7272a]
+      x-ms-client-request-id: [69200000-f55c-11e6-bff3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"3f7a8b31-7f53-4dba-adca-a00cd6418c8c","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:55 GMT']
-      ETag: [5b342e84-c256-435a-87e1-1566413f8ab6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['365']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:53 GMT']
+      etag: [3f7a8b31-7f53-4dba-adca-a00cd6418c8c]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -964,85 +970,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d784ae4-f54d-11e6-a845-a0b3ccf7272a]
+      x-ms-client-request-id: [69e83200-f55c-11e6-a96a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsptralt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsptralt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:56 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:54 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
-      "name": "myrsptralt", "type": "ptr"}'
+    body: !!python/unicode '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsptralt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0dd67e0c-f54d-11e6-8116-a0b3ccf7272a]
+      x-ms-client-request-id: [6a41eac0-f55c-11e6-880b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"3a74dd30-1694-4817-ac4d-306869ad5a3b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"2a38f6a4-7288-4966-8d7d-44ba59055fa6","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['374']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:57 GMT']
-      ETag: [3a74dd30-1694-4817-ac4d-306869ad5a3b]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['374']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:55 GMT']
+      etag: [2a38f6a4-7288-4966-8d7d-44ba59055fa6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrssrv", "type": "srv"}'
+    body: !!python/unicode '{"type": "srv", "properties": {"TTL": 3600}, "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0eab21fa-f54d-11e6-a68f-a0b3ccf7272a]
+      x-ms-client-request-id: [6b16c6ee-f55c-11e6-ad35-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"ab722bbc-31e3-43e5-b6b6-6ce739edf95f","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:59 GMT']
-      ETag: [7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:56 GMT']
+      etag: [ab722bbc-31e3-43e5-b6b6-6ce739edf95f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1051,61 +1058,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f6f460c-f54d-11e6-b839-a0b3ccf7272a]
+      x-ms-client-request-id: [6be33eb0-f55c-11e6-86cb-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"ab722bbc-31e3-43e5-b6b6-6ce739edf95f","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:09:59 GMT']
-      ETag: [7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:57 GMT']
+      etag: [ab722bbc-31e3-43e5-b6b6-6ce739edf95f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "properties": {"SRVRecords": [{"target": "target.com", "port": 1234, "weight":
-      50, "priority": 1}], "TTL": 3600}, "name": "myrssrv", "etag": "7dfd06a5-56f2-44c4-aba2-42cd9c4d16ab"}'
+    body: !!python/unicode '{"etag": "ab722bbc-31e3-43e5-b6b6-6ce739edf95f", "type":
+      "Microsoft.Network/dnszones/SRV", "properties": {"SRVRecords": [{"priority":
+      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
+      "myrssrv", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['378']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0fad117a-f54d-11e6-8171-a0b3ccf7272a]
+      x-ms-client-request-id: [6c34e11e-f55c-11e6-b621-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"b155e57c-fa39-4272-b4e5-d2b71ecc3741","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:00 GMT']
-      ETag: [e2db6cb4-1fc2-4b7a-be89-f8f88335eb33]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['400']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:58 GMT']
+      etag: [b155e57c-fa39-4272-b4e5-d2b71ecc3741]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1114,85 +1122,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [106dbbfe-f54d-11e6-8542-a0b3ccf7272a]
+      x-ms-client-request-id: [6d00bca1-f55c-11e6-8b39-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrssrvalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrssrvalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:01 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:59 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"SRVRecords": [{"target": "target.com", "port": 1234, "weight":
-      50, "priority": 1}], "TTL": 3600}, "name": "myrssrvalt", "type": "srv"}'
+    body: !!python/unicode '{"type": "srv", "properties": {"SRVRecords": [{"priority":
+      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
+      "myrssrvalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [10ae506e-f54d-11e6-a799-a0b3ccf7272a]
+      x-ms-client-request-id: [6d537080-f55c-11e6-a814-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"c8f272fb-586e-472d-b310-ef98dcad9206","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"af516e8f-e36f-4279-a644-8853aa0483ec","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['409']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:02 GMT']
-      ETag: [c8f272fb-586e-472d-b310-ef98dcad9206]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['409']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 21:59:59 GMT']
+      etag: [af516e8f-e36f-4279-a644-8853aa0483ec]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "name": "myrstxt", "type": "txt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TTL": 3600}, "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [117385a6-f54d-11e6-b278-a0b3ccf7272a]
+      x-ms-client-request-id: [6e271430-f55c-11e6-81d9-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3c5a8350-3bc1-4840-b97e-c8cc8049665c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e8468515-761d-4d31-beac-bc57aba3699d","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:03 GMT']
-      ETag: [3c5a8350-3bc1-4840-b97e-c8cc8049665c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:01 GMT']
+      etag: [e8468515-761d-4d31-beac-bc57aba3699d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1201,61 +1211,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [12486bae-f54d-11e6-9a0b-a0b3ccf7272a]
+      x-ms-client-request-id: [6f1348f0-f55c-11e6-905c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3c5a8350-3bc1-4840-b97e-c8cc8049665c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e8468515-761d-4d31-beac-bc57aba3699d","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:04 GMT']
-      ETag: [3c5a8350-3bc1-4840-b97e-c8cc8049665c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:02 GMT']
+      etag: [e8468515-761d-4d31-beac-bc57aba3699d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}, "name":
-      "myrstxt", "etag": "3c5a8350-3bc1-4840-b97e-c8cc8049665c"}'
+    body: !!python/unicode '{"etag": "e8468515-761d-4d31-beac-bc57aba3699d", "type":
+      "Microsoft.Network/dnszones/TXT", "properties": {"TXTRecords": [{"value": ["some_text"]}],
+      "TTL": 3600}, "name": "myrstxt", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['335']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1296ea62-f54d-11e6-84dd-a0b3ccf7272a]
+      x-ms-client-request-id: [6f7e8dde-f55c-11e6-983e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:05 GMT']
-      ETag: [d47d8efa-d596-48e7-9e17-8131f9a6b89c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['363']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:03 GMT']
+      etag: [aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1264,56 +1274,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [13622722-f54d-11e6-852b-a0b3ccf7272a]
+      x-ms-client-request-id: [704930de-f55c-11e6-98d4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrstxtalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrstxtalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:06 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:05 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
-      "name": "myrstxtalt", "type": "txt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
+      ["some_text"]}], "TTL": 3600}, "name": "myrstxtalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [13a6b102-f54d-11e6-986a-a0b3ccf7272a]
+      x-ms-client-request-id: [709d4451-f55c-11e6-99d6-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b3b86023-245f-4caa-8077-ea089f74542f","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['372']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:08 GMT']
-      ETag: [80d9aa7b-5885-4fc6-9f60-7a419f84e299]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['372']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:05 GMT']
+      etag: [b3b86023-245f-4caa-8077-ea089f74542f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1322,61 +1333,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [14e024f0-f54d-11e6-89b9-a0b3ccf7272a]
+      x-ms-client-request-id: [717ecab0-f55c-11e6-9297-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ff5b4318-2db7-45db-ac33-4656c802e2c1","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"2e687612-ea9b-48ce-bd08-b3bd4abe447e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:09 GMT']
-      ETag: [ff5b4318-2db7-45db-ac33-4656c802e2c1]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:06 GMT']
+      etag: [2e687612-ea9b-48ce-bd08-b3bd4abe447e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
-      "10.0.0.11"}]}, "name": "myrsa", "etag": "ff5b4318-2db7-45db-ac33-4656c802e2c1"}'
+    body: !!python/unicode '{"etag": "2e687612-ea9b-48ce-bd08-b3bd4abe447e", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}, {"ipv4Address": "10.0.0.11"}], "TTL": 3600}, "name": "myrsa",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['359']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [152a4b80-f54d-11e6-8a3d-a0b3ccf7272a]
+      x-ms-client-request-id: [71d3c880-f55c-11e6-be30-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48d87cd6-c864-44e4-96d7-2a1a88892ead","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:09 GMT']
-      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:07 GMT']
+      etag: [48d87cd6-c864-44e4-96d7-2a1a88892ead]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1385,27 +1397,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [15ea2a6e-f54d-11e6-85ea-a0b3ccf7272a]
+      x-ms-client-request-id: [7281bbc0-f55c-11e6-a49e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"0724e025-6d13-4e12-9dce-b247ca1f164f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-06.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb9c4d40-99d4-4b97-8d26-050c6391f472","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:10 GMT']
-      ETag: [0724e025-6d13-4e12-9dce-b247ca1f164f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['483']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:08 GMT']
+      etag: [fb9c4d40-99d4-4b97-8d26-050c6391f472]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1414,61 +1426,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [160dab50-f54d-11e6-8671-a0b3ccf7272a]
+      x-ms-client-request-id: [72ba7f00-f55c-11e6-bd8d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"0724e025-6d13-4e12-9dce-b247ca1f164f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-06.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb9c4d40-99d4-4b97-8d26-050c6391f472","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:11 GMT']
-      ETag: [0724e025-6d13-4e12-9dce-b247ca1f164f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['483']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:09 GMT']
+      etag: [fb9c4d40-99d4-4b97-8d26-050c6391f472]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
-      "properties": {"TTL": 3600, "SOARecord": {"email": "foo.com", "refreshTime":
-      60, "expireTime": 30, "minimumTTL": 20, "serialNumber": 123, "host": "ns1-06.azure-dns.com.",
-      "retryTime": 90}}, "name": "@", "etag": "0724e025-6d13-4e12-9dce-b247ca1f164f"}'
+    body: !!python/unicode '{"etag": "fb9c4d40-99d4-4b97-8d26-050c6391f472", "type":
+      "Microsoft.Network/dnszones/SOA", "properties": {"SOARecord": {"expireTime":
+      30, "email": "foo.com", "minimumTTL": 20, "retryTime": 90, "serialNumber": 123,
+      "host": "ns1-01.azure-dns.com.", "refreshTime": 60}, "TTL": 3600}, "name": "@",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['442']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [164c7cf4-f54d-11e6-bfd4-a0b3ccf7272a]
+      x-ms-client-request-id: [72f58c2e-f55c-11e6-9d69-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"3d6eb440-f802-4e59-b99f-2fb554d28d67","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-06.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"907dabe5-ee41-4010-a12b-7bfb4bcf9d70","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:11 GMT']
-      ETag: [3d6eb440-f802-4e59-b99f-2fb554d28d67]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['450']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:09 GMT']
+      etag: [907dabe5-ee41-4010-a12b-7bfb4bcf9d70]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1477,57 +1490,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [16ef74d2-f54d-11e6-8995-a0b3ccf7272a]
+      x-ms-client-request-id: [73b61d0f-f55c-11e6-866b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''longtxt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''longtxt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['171']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:12 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['171']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:10 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
-      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]},
-      "name": "longtxt", "type": "txt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
+      ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],
+      "TTL": 3600}, "name": "longtxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['600']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [172f98f4-f54d-11e6-adc6-a0b3ccf7272a]
+      x-ms-client-request-id: [73ec4840-f55c-11e6-a184-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"5e8b4d4a-6a27-42cd-bdc8-7a7216cbb753","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['857']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:13 GMT']
-      ETag: [f3051cb3-9143-4e8f-aa9d-149673794dcd]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['857']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:11 GMT']
+      etag: [5e8b4d4a-6a27-42cd-bdc8-7a7216cbb753]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1536,28 +1551,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [17e8ee50-f54d-11e6-b2c3-a0b3ccf7272a]
+      x-ms-client-request-id: [748aab21-f55c-11e6-b842-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-e755-c1b95989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-06.azure-dns.com.","ns2-06.azure-dns.net.","ns3-06.azure-dns.org.","ns4-06.azure-dns.info."],"numberOfRecordSets":19}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-3d64-1b166989d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":19}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:13 GMT']
-      ETag: [00000002-0000-0000-e755-c1b95989d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['464']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:12 GMT']
+      etag: [00000002-0000-0000-3d64-1b166989d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1566,28 +1581,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [18785cfe-f54d-11e6-8d6e-a0b3ccf7272a]
+      x-ms-client-request-id: [751510cf-f55c-11e6-986c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48d87cd6-c864-44e4-96d7-2a1a88892ead","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:15 GMT']
-      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:12 GMT']
+      etag: [48d87cd6-c864-44e4-96d7-2a1a88892ead]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1596,26 +1611,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1915adac-f54d-11e6-8d66-a0b3ccf7272a]
+      x-ms-client-request-id: [75bbb10f-f55c-11e6-86a3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"145f36b2-fb1f-4bd6-80db-2911a216d644","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-06.azure-dns.com."},{"nsdname":"ns2-06.azure-dns.net."},{"nsdname":"ns3-06.azure-dns.org."},{"nsdname":"ns4-06.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"3d6eb440-f802-4e59-b99f-2fb554d28d67","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-06.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e845ad97-e924-4926-bca1-512f108b8e0b","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"3dbddacf-47c0-4e11-b337-7feb3132f1b5","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"48354d6b-4f3e-4bd0-8d0d-aa906eb71a19","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a91689da-999b-4642-ab53-155d91cc6bf7","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"166c371a-3cfc-4bf0-b840-a079e1ae3590","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"3a74dd30-1694-4817-ac4d-306869ad5a3b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"c8f272fb-586e-472d-b310-ef98dcad9206","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"124e8921-4179-4459-bc69-4a8937f35a46","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"907dabe5-ee41-4010-a12b-7bfb4bcf9d70","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"5e8b4d4a-6a27-42cd-bdc8-7a7216cbb753","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48d87cd6-c864-44e4-96d7-2a1a88892ead","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"a2a7bd8e-87d5-42dd-b551-cfec7afe3f64","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"0ef88d78-8745-4c28-a5ce-2fd71335f0d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"f3f19226-1d0c-4ee5-805c-2a098cc95026","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"e57114ba-7d9a-4b9f-bc78-e8e38a58eccd","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a8708c2a-1e5b-4419-ad00-b6dac0615cc4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"311ce09b-69aa-4e31-9a3a-e5e38e199531","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a9e0c1bb-2ee7-4f5c-8624-67fd0e80c3b3","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"cd8f057e-6465-4643-898f-131dbbc4173a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"e4a49c32-398d-4610-a1ed-a8e4324a9193","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"3f7a8b31-7f53-4dba-adca-a00cd6418c8c","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"2a38f6a4-7288-4966-8d7d-44ba59055fa6","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"b155e57c-fa39-4272-b4e5-d2b71ecc3741","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"af516e8f-e36f-4279-a644-8853aa0483ec","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b3b86023-245f-4caa-8077-ea089f74542f","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:16 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['7820']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:13 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1624,27 +1639,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [19c3acbe-f54d-11e6-b730-a0b3ccf7272a]
+      x-ms-client-request-id: [7651af80-f55c-11e6-9eb0-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"f3051cb3-9143-4e8f-aa9d-149673794dcd","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"80d9aa7b-5885-4fc6-9f60-7a419f84e299","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"5e8b4d4a-6a27-42cd-bdc8-7a7216cbb753","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b3b86023-245f-4caa-8077-ea089f74542f","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:17 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['1606']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1653,61 +1668,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1a45375a-f54d-11e6-b14d-a0b3ccf7272a]
+      x-ms-client-request-id: [77079200-f55c-11e6-81e3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"c4878879-71cf-4470-91bc-a234d3704b70","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48d87cd6-c864-44e4-96d7-2a1a88892ead","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:17 GMT']
-      ETag: [c4878879-71cf-4470-91bc-a234d3704b70]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:15 GMT']
+      etag: [48d87cd6-c864-44e4-96d7-2a1a88892ead]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.11"}]}, "name":
-      "myrsa", "etag": "c4878879-71cf-4470-91bc-a234d3704b70"}'
+    body: !!python/unicode '{"etag": "48d87cd6-c864-44e4-96d7-2a1a88892ead", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.11"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1a6c011c-f54d-11e6-acb3-a0b3ccf7272a]
+      x-ms-client-request-id: [773dbd2e-f55c-11e6-9edd-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ec4e4435-5b8d-45d8-b136-66ca8f3a98c4","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:18 GMT']
-      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:17 GMT']
+      etag: [ec4e4435-5b8d-45d8-b136-66ca8f3a98c4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1716,28 +1731,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b279f14-f54d-11e6-adf5-a0b3ccf7272a]
+      x-ms-client-request-id: [7805a111-f55c-11e6-b6fe-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"051d9f4a-4c96-4d82-b84d-f4e48c32c4dd","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"a2a7bd8e-87d5-42dd-b551-cfec7afe3f64","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:20 GMT']
-      ETag: [051d9f4a-4c96-4d82-b84d-f4e48c32c4dd]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['384']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:18 GMT']
+      etag: [a2a7bd8e-87d5-42dd-b551-cfec7afe3f64]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1747,24 +1762,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b6af1ae-f54d-11e6-b0d2-a0b3ccf7272a]
+      x-ms-client-request-id: [783f279e-f55c-11e6-bdf4-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:20 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:18 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1773,28 +1788,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c2f540a-f54d-11e6-9f97-a0b3ccf7272a]
+      x-ms-client-request-id: [791a4561-f55c-11e6-b742-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9800fcf9-4aad-4e33-ad89-ca8d30713082","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"e57114ba-7d9a-4b9f-bc78-e8e38a58eccd","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:21 GMT']
-      ETag: [9800fcf9-4aad-4e33-ad89-ca8d30713082]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:20 GMT']
+      etag: [e57114ba-7d9a-4b9f-bc78-e8e38a58eccd]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1804,24 +1819,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c6f27d8-f54d-11e6-91f7-a0b3ccf7272a]
+      x-ms-client-request-id: [796e0ab0-f55c-11e6-ab3f-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:22 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1830,28 +1845,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1d344282-f54d-11e6-a6b2-a0b3ccf7272a]
+      x-ms-client-request-id: [7a0fc8f0-f55c-11e6-a970-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9422ccfb-638f-436d-b973-feda6490aa8c","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"311ce09b-69aa-4e31-9a3a-e5e38e199531","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:23 GMT']
-      ETag: [9422ccfb-638f-436d-b973-feda6490aa8c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:21 GMT']
+      etag: [311ce09b-69aa-4e31-9a3a-e5e38e199531]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1861,24 +1876,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1d72b5e8-f54d-11e6-b971-a0b3ccf7272a]
+      x-ms-client-request-id: [7a63b54f-f55c-11e6-b14e-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:23 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1887,27 +1902,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1e304a9c-f54d-11e6-89a3-a0b3ccf7272a]
+      x-ms-client-request-id: [7b300600-f55c-11e6-94d1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"cd8f057e-6465-4643-898f-131dbbc4173a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:24 GMT']
-      ETag: [bf8d72bb-5ceb-4fb5-ae9f-6bd5afe7eaad]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['358']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:23 GMT']
+      etag: [cd8f057e-6465-4643-898f-131dbbc4173a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1917,24 +1932,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1e593164-f54d-11e6-a29b-a0b3ccf7272a]
+      x-ms-client-request-id: [7b88fb6e-f55c-11e6-b006-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:25 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:24 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1943,28 +1958,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1ef5aab8-f54d-11e6-bde5-a0b3ccf7272a]
+      x-ms-client-request-id: [7c68d41e-f55c-11e6-8fa4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"5b342e84-c256-435a-87e1-1566413f8ab6","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"3f7a8b31-7f53-4dba-adca-a00cd6418c8c","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:25 GMT']
-      ETag: [5b342e84-c256-435a-87e1-1566413f8ab6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['365']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:24 GMT']
+      etag: [3f7a8b31-7f53-4dba-adca-a00cd6418c8c]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1974,24 +1989,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1f3b058c-f54d-11e6-9783-a0b3ccf7272a]
+      x-ms-client-request-id: [7ca5dd21-f55c-11e6-960b-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:26 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:25 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2000,28 +2015,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1ff047be-f54d-11e6-bc84-a0b3ccf7272a]
+      x-ms-client-request-id: [7d70ce40-f55c-11e6-afc9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2db6cb4-1fc2-4b7a-be89-f8f88335eb33","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"b155e57c-fa39-4272-b4e5-d2b71ecc3741","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:27 GMT']
-      ETag: [e2db6cb4-1fc2-4b7a-be89-f8f88335eb33]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['400']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:27 GMT']
+      etag: [b155e57c-fa39-4272-b4e5-d2b71ecc3741]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2031,24 +2046,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [20317a24-f54d-11e6-b265-a0b3ccf7272a]
+      x-ms-client-request-id: [7dbb92de-f55c-11e6-9206-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2057,28 +2072,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2117e8e6-f54d-11e6-8e83-a0b3ccf7272a]
+      x-ms-client-request-id: [7eb18b9e-f55c-11e6-8ab2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"d47d8efa-d596-48e7-9e17-8131f9a6b89c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
-      ETag: [d47d8efa-d596-48e7-9e17-8131f9a6b89c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['363']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:29 GMT']
+      etag: [aa43ce9e-fdb6-4a30-b5b5-3ffe5af3f0e0]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2088,54 +2103,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [213f2036-f54d-11e6-bbee-a0b3ccf7272a]
+      x-ms-client-request-id: [7ef60eb0-f55c-11e6-8f7f-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:29 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [21dd8ff6-f54d-11e6-8c82-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:30 GMT']
-      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['355']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:29 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2144,28 +2129,58 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [227f7c42-f54d-11e6-ac33-a0b3ccf7272a]
+      x-ms-client-request-id: [7fedb51e-f55c-11e6-86b6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ea8a8b21-09d6-41f0-ab9b-3ddf87382396","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ec4e4435-5b8d-45d8-b136-66ca8f3a98c4","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:31 GMT']
-      ETag: [ea8a8b21-09d6-41f0-ab9b-3ddf87382396]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:31 GMT']
+      etag: [ec4e4435-5b8d-45d8-b136-66ca8f3a98c4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8083174f-f55c-11e6-b2fb-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ec4e4435-5b8d-45d8-b136-66ca8f3a98c4","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['355']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:31 GMT']
+      etag: [ec4e4435-5b8d-45d8-b136-66ca8f3a98c4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2175,24 +2190,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [22a72f8a-f54d-11e6-a920-a0b3ccf7272a]
+      x-ms-client-request-id: [80cc0730-f55c-11e6-8c31-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:32 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2201,26 +2216,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [237817c6-f54d-11e6-8297-a0b3ccf7272a]
+      x-ms-client-request-id: [81c7300f-f55c-11e6-a918-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
-        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsa'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['169']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:33 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['169']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:34 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -2230,24 +2246,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [240f907e-f54d-11e6-9035-a0b3ccf7272a]
+      x-ms-client-request-id: [8247d1c0-f55c-11e6-b3a7-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:34 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:34 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -2256,26 +2272,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2496d9b4-f54d-11e6-af92-a0b3ccf7272a]
+      x-ms-client-request-id: [82e3eab0-f55c-11e6-bafc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
-        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsa'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['169']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:10:35 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      cache-control: [private]
+      content-length: ['169']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:00:36 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -2285,26 +2302,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2512881e-f54d-11e6-af45-a0b3ccf7272a]
+      x-ms-client-request-id: [838e0d61-f55c-11e6-a9e0-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com:443/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone6362295903867614190464448e?api-version=2016-04-01']
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Fri, 17 Feb 2017 20:10:36 GMT']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationResults/delzone6362295903867614190464448e?api-version=2016-04-01']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      azure-asyncoperation: ['https://management.azure.com:443/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone636229656398439257f0449aa6?api-version=2016-04-01']
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 22:00:38 GMT']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationResults/delzone636229656398439257f0449aa6?api-version=2016-04-01']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -2313,26 +2330,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2512881e-f54d-11e6-af45-a0b3ccf7272a]
+      x-ms-client-request-id: [838e0d61-f55c-11e6-a9e0-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone6362295903867614190464448e?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsOperationStatuses/delzone636229656398439257f0449aa6?api-version=2016-04-01
   response:
-    body: {string: '{"status":"Succeeded"}'}
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 17 Feb 2017 20:11:06 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 22:01:08 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -1,32 +1,32 @@
 interactions:
 - request:
-    body: '{"location": "global"}'
+    body: !!python/unicode '{"location": "global"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8193d8c2-f498-11e6-9e0d-a0b3ccf7272a]
+      x-ms-client-request-id: [764dfb40-f536-11e6-9d21-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['463']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:33 GMT']
-      ETag: [00000002-0000-0000-364a-ed42a588d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['463']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:14 GMT']
+      etag: [00000002-0000-0000-d8ab-30374389d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -35,57 +35,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [829ff686-f498-11e6-af40-a0b3ccf7272a]
+      x-ms-client-request-id: [776b0400-f536-11e6-9b44-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:34 GMT']
-      ETag: [00000002-0000-0000-364a-ed42a588d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['463']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:16 GMT']
+      etag: [00000002-0000-0000-d8ab-30374389d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "a", "name": "myrsa"}'
+    body: !!python/unicode '{"type": "a", "properties": {"TTL": 3600}, "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['59']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [83599228-f498-11e6-9d04-a0b3ccf7272a]
+      x-ms-client-request-id: [77e479c0-f536-11e6-8956-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d7289747-55d5-4f2e-b11e-54c1e1def441","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"e5635321-8323-48f5-8673-4d10caba2f7d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['328']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:36 GMT']
-      ETag: [d7289747-55d5-4f2e-b11e-54c1e1def441]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:16 GMT']
+      etag: [e5635321-8323-48f5-8673-4d10caba2f7d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -94,61 +94,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [842032c0-f498-11e6-8461-a0b3ccf7272a]
+      x-ms-client-request-id: [78937e70-f536-11e6-8ef7-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d7289747-55d5-4f2e-b11e-54c1e1def441","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"e5635321-8323-48f5-8673-4d10caba2f7d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:36 GMT']
-      ETag: [d7289747-55d5-4f2e-b11e-54c1e1def441]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:17 GMT']
+      etag: [e5635321-8323-48f5-8673-4d10caba2f7d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600},
-      "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "etag": "d7289747-55d5-4f2e-b11e-54c1e1def441", "name": "myrsa"}'
+    body: !!python/unicode '{"etag": "e5635321-8323-48f5-8673-4d10caba2f7d", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [846280ca-f498-11e6-80d5-a0b3ccf7272a]
+      x-ms-client-request-id: [78d2aa4f-f536-11e6-bac2-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48ca7c67-4f9c-4e81-8574-57271cbc8fe6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8581b653-1c5f-46ec-8f22-86c283ceccef","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:37 GMT']
-      ETag: [48ca7c67-4f9c-4e81-8574-57271cbc8fe6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11996']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:18 GMT']
+      etag: [8581b653-1c5f-46ec-8f22-86c283ceccef]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -157,85 +157,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [854e04d2-f498-11e6-acc5-a0b3ccf7272a]
+      x-ms-client-request-id: [799cd821-f536-11e6-8092-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsaalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['172']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:39 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['172']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600},
-      "type": "a", "name": "myrsaalt"}'
+    body: !!python/unicode '{"type": "a", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}], "TTL": 3600}, "name": "myrsaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [859a5cee-f498-11e6-a8be-a0b3ccf7272a]
+      x-ms-client-request-id: [79de26e1-f536-11e6-83dd-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"7b98d8ff-b2ec-4bf8-a55a-95474ed026f9","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"904cf244-040b-4dfc-a732-b52b3c85d701","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['364']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:39 GMT']
-      ETag: [7b98d8ff-b2ec-4bf8-a55a-95474ed026f9]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      cache-control: [private]
+      content-length: ['364']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:20 GMT']
+      etag: [904cf244-040b-4dfc-a732-b52b3c85d701]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "aaaa", "name": "myrsaaaa"}'
+    body: !!python/unicode '{"type": "aaaa", "properties": {"TTL": 3600}, "name":
+      "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['65']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866cc5a4-f498-11e6-af7b-a0b3ccf7272a]
+      x-ms-client-request-id: [7aa76a4f-f536-11e6-926e-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e4d9536c-ac5b-42b1-b4b4-faa923d72a19","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"7ebf2eb6-4611-4c9e-ab3a-9a443346648d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:42 GMT']
-      ETag: [e4d9536c-ac5b-42b1-b4b4-faa923d72a19]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:21 GMT']
+      etag: [7ebf2eb6-4611-4c9e-ab3a-9a443346648d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -244,61 +246,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [87a8b252-f498-11e6-952d-a0b3ccf7272a]
+      x-ms-client-request-id: [7b67ad0f-f536-11e6-b85c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e4d9536c-ac5b-42b1-b4b4-faa923d72a19","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"7ebf2eb6-4611-4c9e-ab3a-9a443346648d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:43 GMT']
-      ETag: [e4d9536c-ac5b-42b1-b4b4-faa923d72a19]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:22 GMT']
+      etag: [7ebf2eb6-4611-4c9e-ab3a-9a443346648d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}]},
-      "type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "etag": "e4d9536c-ac5b-42b1-b4b4-faa923d72a19", "name": "myrsaaaa"}'
+    body: !!python/unicode '{"etag": "7ebf2eb6-4611-4c9e-ab3a-9a443346648d", "type":
+      "Microsoft.Network/dnszones/AAAA", "properties": {"AAAARecords": [{"ipv6Address":
+      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['355']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [88265cb0-f498-11e6-89a1-a0b3ccf7272a]
+      x-ms-client-request-id: [7ba949f0-f536-11e6-aee9-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:44 GMT']
-      ETag: [188f3b1d-e078-489d-8be5-f086455251d6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['384']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:23 GMT']
+      etag: [b471e023-5fc4-4c4e-a164-8629ef877d06]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -307,85 +309,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8935e112-f498-11e6-acdc-a0b3ccf7272a]
+      x-ms-client-request-id: [7c66314f-f536-11e6-a2a0-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaaaaalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsaaaaalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['175']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:45 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['175']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}]},
-      "type": "aaaa", "name": "myrsaaaaalt"}'
+    body: !!python/unicode '{"type": "aaaa", "properties": {"AAAARecords": [{"ipv6Address":
+      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}, "name": "myrsaaaaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [898bf710-f498-11e6-bfd2-a0b3ccf7272a]
+      x-ms-client-request-id: [7c8ea0de-f536-11e6-b122-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"bb4af783-4e50-4789-a221-6d9720fb7906","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"959feca8-0c94-4f4f-aff1-d502ff8746d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['393']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:46 GMT']
-      ETag: [bb4af783-4e50-4789-a221-6d9720fb7906]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:24 GMT']
+      etag: [959feca8-0c94-4f4f-aff1-d502ff8746d6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "cname", "name": "myrscname"}'
+    body: !!python/unicode '{"type": "cname", "properties": {"TTL": 3600}, "name":
+      "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['67']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a757a06-f498-11e6-bf41-a0b3ccf7272a]
+      x-ms-client-request-id: [7d501c21-f536-11e6-bd4d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"61720286-95d3-4d7a-9d8e-1c879a35c472","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"460642ce-85fe-4e39-abc4-39decc168585","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:48 GMT']
-      ETag: [61720286-95d3-4d7a-9d8e-1c879a35c472]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:26 GMT']
+      etag: [460642ce-85fe-4e39-abc4-39decc168585]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -394,61 +398,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b7b93b6-f498-11e6-863f-a0b3ccf7272a]
+      x-ms-client-request-id: [7e0eff4f-f536-11e6-b4c4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"61720286-95d3-4d7a-9d8e-1c879a35c472","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"460642ce-85fe-4e39-abc4-39decc168585","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:49 GMT']
-      ETag: [61720286-95d3-4d7a-9d8e-1c879a35c472]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:27 GMT']
+      etag: [460642ce-85fe-4e39-abc4-39decc168585]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
-      "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "etag": "61720286-95d3-4d7a-9d8e-1c879a35c472", "name": "myrscname"}'
+    body: !!python/unicode '{"etag": "460642ce-85fe-4e39-abc4-39decc168585", "type":
+      "Microsoft.Network/dnszones/CNAME", "properties": {"CNAMERecord": {"cname":
+      "mycname"}, "TTL": 3600}, "name": "myrscname", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8bdf6fc8-f498-11e6-b3f5-a0b3ccf7272a]
+      x-ms-client-request-id: [7e4d19c0-f536-11e6-a7b6-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:50 GMT']
-      ETag: [d3ca537b-0e21-42fd-9aeb-5e6f69437c3d]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:27 GMT']
+      etag: [d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -457,85 +461,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8cd264a6-f498-11e6-b68f-a0b3ccf7272a]
+      x-ms-client-request-id: [7f0964de-f536-11e6-804e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrscnamealt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrscnamealt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['176']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:54 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['176']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:28 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
-      "cname", "name": "myrscnamealt"}'
+    body: !!python/unicode '{"type": "cname", "properties": {"CNAMERecord": {"cname":
+      "mycname"}, "TTL": 3600}, "name": "myrscnamealt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['107']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f49d5b8-f498-11e6-aec1-a0b3ccf7272a]
+      x-ms-client-request-id: [7f34938f-f536-11e6-b890-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"22477145-0695-49fd-bedf-5e7c814fe6e4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a9382639-60ad-4904-83c7-5f244e813b67","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['377']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:55 GMT']
-      ETag: [22477145-0695-49fd-bedf-5e7c814fe6e4]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['377']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:29 GMT']
+      etag: [a9382639-60ad-4904-83c7-5f244e813b67]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "mx", "name": "myrsmx"}'
+    body: !!python/unicode '{"type": "mx", "properties": {"TTL": 3600}, "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [900503d4-f498-11e6-b89a-a0b3ccf7272a]
+      x-ms-client-request-id: [7fdc4540-f536-11e6-83aa-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"3bb9d092-ce4f-4935-add7-e3ef79b52986","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"22c86623-20d5-4453-a979-c2764b2b5ab1","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:56 GMT']
-      ETag: [3bb9d092-ce4f-4935-add7-e3ef79b52986]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:30 GMT']
+      etag: [22c86623-20d5-4453-a979-c2764b2b5ab1]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -544,61 +549,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [90d42868-f498-11e6-bd41-a0b3ccf7272a]
+      x-ms-client-request-id: [809cfd30-f536-11e6-955e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"3bb9d092-ce4f-4935-add7-e3ef79b52986","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"22c86623-20d5-4453-a979-c2764b2b5ab1","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:58 GMT']
-      ETag: [3bb9d092-ce4f-4935-add7-e3ef79b52986]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:31 GMT']
+      etag: [22c86623-20d5-4453-a979-c2764b2b5ab1]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": [{"exchange": "12", "preference":
-      13}]}, "type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "etag": "3bb9d092-ce4f-4935-add7-e3ef79b52986", "name": "myrsmx"}'
+    body: !!python/unicode '{"etag": "22c86623-20d5-4453-a979-c2764b2b5ab1", "type":
+      "Microsoft.Network/dnszones/MX", "properties": {"MXRecords": [{"preference":
+      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmx", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['342']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [913e829e-f498-11e6-9296-a0b3ccf7272a]
+      x-ms-client-request-id: [80c6f361-f536-11e6-a531-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:37:59 GMT']
-      ETag: [c7a5da5c-a17a-4759-8fc6-bc182a17a254]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:31 GMT']
+      etag: [2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -607,85 +612,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [91fac7a6-f498-11e6-82cc-a0b3ccf7272a]
+      x-ms-client-request-id: [81bf5d21-f536-11e6-b3f5-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsmxalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsmxalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['173']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:00 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['173']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": [{"exchange": "12", "preference":
-      13}]}, "type": "mx", "name": "myrsmxalt"}'
+    body: !!python/unicode '{"type": "mx", "properties": {"MXRecords": [{"preference":
+      13, "exchange": "12"}], "TTL": 3600}, "name": "myrsmxalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9244610a-f498-11e6-9431-a0b3ccf7272a]
+      x-ms-client-request-id: [8201bd4f-f536-11e6-b703-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"abb6c9dd-42c5-41d5-9d90-402b85100832","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"cf10167d-b400-4b1f-b6b6-0b12962f0c74","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['376']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:00 GMT']
-      ETag: [abb6c9dd-42c5-41d5-9d90-402b85100832]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['376']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:34 GMT']
+      etag: [cf10167d-b400-4b1f-b6b6-0b12962f0c74]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "ns", "name": "myrsns"}'
+    body: !!python/unicode '{"type": "ns", "properties": {"TTL": 3600}, "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93166aae-f498-11e6-a794-a0b3ccf7272a]
+      x-ms-client-request-id: [82b507c0-f536-11e6-aea8-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"fe9e605c-884f-48b9-88b1-439daf254c52","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"22b3d3c8-e473-4677-9999-60172bcf740a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['334']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:02 GMT']
-      ETag: [fe9e605c-884f-48b9-88b1-439daf254c52]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      cache-control: [private]
+      content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:35 GMT']
+      etag: [22b3d3c8-e473-4677-9999-60172bcf740a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -694,60 +700,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93d4b12c-f498-11e6-bf10-a0b3ccf7272a]
+      x-ms-client-request-id: [83525930-f536-11e6-9bbf-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"fe9e605c-884f-48b9-88b1-439daf254c52","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"22b3d3c8-e473-4677-9999-60172bcf740a","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:03 GMT']
-      ETag: [fe9e605c-884f-48b9-88b1-439daf254c52]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
+      etag: [22b3d3c8-e473-4677-9999-60172bcf740a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"NSRecords": [{"nsdname": "foobar.com"}], "TTL": 3600},
-      "type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "etag": "fe9e605c-884f-48b9-88b1-439daf254c52", "name": "myrsns"}'
+    body: !!python/unicode '{"etag": "22b3d3c8-e473-4677-9999-60172bcf740a", "type":
+      "Microsoft.Network/dnszones/NS", "properties": {"NSRecords": [{"nsdname": "foobar.com"}],
+      "TTL": 3600}, "name": "myrsns", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['331']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93fdb3fa-f498-11e6-8c1e-a0b3ccf7272a]
+      x-ms-client-request-id: [837b3df0-f536-11e6-b88d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:03 GMT']
-      ETag: [e1774943-72fa-4c2d-b8a2-c381216df40f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['358']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
+      etag: [a2d47e7d-262a-45a7-8d0c-70e9ac82635f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -756,84 +762,85 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [94cfd77e-f498-11e6-8bd1-a0b3ccf7272a]
+      x-ms-client-request-id: [841e34b0-f536-11e6-8826-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsnsalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsnsalt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['173']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:09 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['173']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:36 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"NSRecords": [{"nsdname": "foobar.com"}], "TTL": 3600},
-      "type": "ns", "name": "myrsnsalt"}'
+    body: !!python/unicode '{"type": "ns", "properties": {"NSRecords": [{"nsdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsnsalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['106']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [97d2e75c-f498-11e6-83e6-a0b3ccf7272a]
+      x-ms-client-request-id: [844f08b0-f536-11e6-beb4-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"b170e487-a2a6-4172-961a-604139a6f7e7","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['367']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:10 GMT']
-      ETag: [b170e487-a2a6-4172-961a-604139a6f7e7]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      cache-control: [private]
+      content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:37 GMT']
+      etag: [dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "ptr", "name": "myrsptr"}'
+    body: !!python/unicode '{"type": "ptr", "properties": {"TTL": 3600}, "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9893451c-f498-11e6-9397-a0b3ccf7272a]
+      x-ms-client-request-id: [84fc5fae-f536-11e6-babe-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"ed47aeda-3653-4c66-b99d-b1a9f8eb5920","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:12 GMT']
-      ETag: [ed47aeda-3653-4c66-b99d-b1a9f8eb5920]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:38 GMT']
+      etag: [86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -842,61 +849,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [995c2cc8-f498-11e6-a68e-a0b3ccf7272a]
+      x-ms-client-request-id: [85c44391-f536-11e6-8a97-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"ed47aeda-3653-4c66-b99d-b1a9f8eb5920","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:12 GMT']
-      ETag: [ed47aeda-3653-4c66-b99d-b1a9f8eb5920]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:39 GMT']
+      etag: [86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
-      "type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "etag": "ed47aeda-3653-4c66-b99d-b1a9f8eb5920", "name": "myrsptr"}'
+    body: !!python/unicode '{"etag": "86bbb7c5-38d1-4e66-b7eb-c8e3bfca0fbe", "type":
+      "Microsoft.Network/dnszones/PTR", "properties": {"PTRRecords": [{"ptrdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsptr", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [99a48b6e-f498-11e6-8de0-a0b3ccf7272a]
+      x-ms-client-request-id: [8607670f-f536-11e6-b109-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:13 GMT']
-      ETag: [05f53f84-a98d-416c-b1d8-a06865ab0068]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['365']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:41 GMT']
+      etag: [211c88d3-2c90-46a7-852f-db08ace7647f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -905,85 +912,86 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9a742b1c-f498-11e6-b9d2-a0b3ccf7272a]
+      x-ms-client-request-id: [86bd97ae-f536-11e6-9a78-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsptralt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsptralt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:14 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:42 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
-      "type": "ptr", "name": "myrsptralt"}'
+    body: !!python/unicode '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname":
+      "foobar.com"}], "TTL": 3600}, "name": "myrsptralt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9abbf148-f498-11e6-a484-a0b3ccf7272a]
+      x-ms-client-request-id: [86fdadf0-f536-11e6-8d4e-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"b0e6755b-bada-4396-a94f-e58a3c404f58","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"538fba91-048b-4d61-87b6-f39c46a39a1e","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['374']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:15 GMT']
-      ETag: [b0e6755b-bada-4396-a94f-e58a3c404f58]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['374']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:42 GMT']
+      etag: [538fba91-048b-4d61-87b6-f39c46a39a1e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "srv", "name": "myrssrv"}'
+    body: !!python/unicode '{"type": "srv", "properties": {"TTL": 3600}, "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b78d70a-f498-11e6-919d-a0b3ccf7272a]
+      x-ms-client-request-id: [87bcb830-f536-11e6-aef0-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"729d4a26-b7fe-47bd-add5-6f3240bd8719","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"a523796d-ca25-44f6-9847-1c708bdf72a8","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:16 GMT']
-      ETag: [729d4a26-b7fe-47bd-add5-6f3240bd8719]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:44 GMT']
+      etag: [a523796d-ca25-44f6-9847-1c708bdf72a8]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -992,62 +1000,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9c5b4e98-f498-11e6-bc7a-a0b3ccf7272a]
+      x-ms-client-request-id: [888bef0f-f536-11e6-b7e5-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"729d4a26-b7fe-47bd-add5-6f3240bd8719","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"a523796d-ca25-44f6-9847-1c708bdf72a8","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:18 GMT']
-      ETag: [729d4a26-b7fe-47bd-add5-6f3240bd8719]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:44 GMT']
+      etag: [a523796d-ca25-44f6-9847-1c708bdf72a8]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority":
-      1, "weight": 50, "target": "target.com"}]}, "type": "Microsoft.Network/dnszones/SRV",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "etag": "729d4a26-b7fe-47bd-add5-6f3240bd8719", "name": "myrssrv"}'
+    body: !!python/unicode '{"etag": "a523796d-ca25-44f6-9847-1c708bdf72a8", "type":
+      "Microsoft.Network/dnszones/SRV", "properties": {"SRVRecords": [{"priority":
+      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
+      "myrssrv", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['378']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9cc442e2-f498-11e6-a66c-a0b3ccf7272a]
+      x-ms-client-request-id: [88cb4200-f536-11e6-a1a9-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:18 GMT']
-      ETag: [e2760f4e-601c-4aad-a2ad-815bd4b75b8b]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:45 GMT']
+      etag: [32bbbc4c-f0cf-4298-896d-5f01863347a6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1056,85 +1064,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9d9e8f18-f498-11e6-9c1b-a0b3ccf7272a]
+      x-ms-client-request-id: [897d05cf-f536-11e6-9491-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrssrvalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrssrvalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:19 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:45 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority":
-      1, "weight": 50, "target": "target.com"}]}, "type": "srv", "name": "myrssrvalt"}'
+    body: !!python/unicode '{"type": "srv", "properties": {"SRVRecords": [{"priority":
+      1, "port": 1234, "weight": 50, "target": "target.com"}], "TTL": 3600}, "name":
+      "myrssrvalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9e0a2e54-f498-11e6-bc5c-a0b3ccf7272a]
+      x-ms-client-request-id: [89bf17de-f536-11e6-830b-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"dc74cba5-3626-40c6-815b-a6321e6439a7","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"00786d34-636a-485e-9448-8c02f3bf608f","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['409']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:20 GMT']
-      ETag: [dc74cba5-3626-40c6-815b-a6321e6439a7]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['409']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:47 GMT']
+      etag: [00786d34-636a-485e-9448-8c02f3bf608f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "txt", "name": "myrstxt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TTL": 3600}, "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['63']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9f1113dc-f498-11e6-bc97-a0b3ccf7272a]
+      x-ms-client-request-id: [8a7d5ecf-f536-11e6-ad29-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"a396d329-6448-45c4-a629-ecbd7cfeef12","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"ac231f7d-90ff-418c-b61e-bba9463fae77","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['340']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:23 GMT']
-      ETag: [a396d329-6448-45c4-a629-ecbd7cfeef12]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:48 GMT']
+      etag: [ac231f7d-90ff-418c-b61e-bba9463fae77]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1143,61 +1153,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a090ae06-f498-11e6-952f-a0b3ccf7272a]
+      x-ms-client-request-id: [8b233bc0-f536-11e6-ad2e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"a396d329-6448-45c4-a629-ecbd7cfeef12","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"ac231f7d-90ff-418c-b61e-bba9463fae77","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:24 GMT']
-      ETag: [a396d329-6448-45c4-a629-ecbd7cfeef12]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:49 GMT']
+      etag: [ac231f7d-90ff-418c-b61e-bba9463fae77]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
-      "type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "etag": "a396d329-6448-45c4-a629-ecbd7cfeef12", "name": "myrstxt"}'
+    body: !!python/unicode '{"etag": "ac231f7d-90ff-418c-b61e-bba9463fae77", "type":
+      "Microsoft.Network/dnszones/TXT", "properties": {"TXTRecords": [{"value": ["some_text"]}],
+      "TTL": 3600}, "name": "myrstxt", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['335']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0dd20ec-f498-11e6-9805-a0b3ccf7272a]
+      x-ms-client-request-id: [8b737ea1-f536-11e6-87bb-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:25 GMT']
-      ETag: [fd71221b-1134-4a6b-877f-b6b0b0c12f4c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['363']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:49 GMT']
+      etag: [3bc68872-862e-4743-8bb9-442defe71796]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1206,56 +1216,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1b26f80-f498-11e6-8301-a0b3ccf7272a]
+      x-ms-client-request-id: [8c13b640-f536-11e6-a65b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrstxtalt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrstxtalt'' does not exist in resource group ''cli_test_dns'' of
+        subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['174']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:26 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['174']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:50 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
-      "type": "txt", "name": "myrstxtalt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
+      ["some_text"]}], "TTL": 3600}, "name": "myrstxtalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1f31066-f498-11e6-a37d-a0b3ccf7272a]
+      x-ms-client-request-id: [8c5727de-f536-11e6-bc6c-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['372']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:27 GMT']
-      ETag: [b748c7bc-384a-48d0-a23a-cbc63a5cd148]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      cache-control: [private]
+      content-length: ['372']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:51 GMT']
+      etag: [57309cca-7a36-4446-beac-c797f9fbd1c2]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1264,61 +1275,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2ca8148-f498-11e6-8379-a0b3ccf7272a]
+      x-ms-client-request-id: [8cf27d80-f536-11e6-8f1f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48ca7c67-4f9c-4e81-8574-57271cbc8fe6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8581b653-1c5f-46ec-8f22-86c283ceccef","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:28 GMT']
-      ETag: [48ca7c67-4f9c-4e81-8574-57271cbc8fe6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:51 GMT']
+      etag: [8581b653-1c5f-46ec-8f22-86c283ceccef]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
-      "10.0.0.11"}], "TTL": 3600}, "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "etag": "48ca7c67-4f9c-4e81-8574-57271cbc8fe6", "name": "myrsa"}'
+    body: !!python/unicode '{"etag": "8581b653-1c5f-46ec-8f22-86c283ceccef", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}, {"ipv4Address": "10.0.0.11"}], "TTL": 3600}, "name": "myrsa",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['359']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a30e4362-f498-11e6-b778-a0b3ccf7272a]
+      x-ms-client-request-id: [8d2637b0-f536-11e6-85be-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:28 GMT']
-      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:52 GMT']
+      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1327,27 +1339,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a3ee47ec-f498-11e6-be8e-a0b3ccf7272a]
+      x-ms-client-request-id: [8dbf4361-f536-11e6-9729-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6dfda12b-ea56-4b83-bd52-1737b5490ed3","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-04.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e816bc67-505e-4bc7-b356-219770b7dd87","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:29 GMT']
-      ETag: [6dfda12b-ea56-4b83-bd52-1737b5490ed3]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['483']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
+      etag: [e816bc67-505e-4bc7-b356-219770b7dd87]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1356,61 +1368,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a41927cc-f498-11e6-8fb9-a0b3ccf7272a]
+      x-ms-client-request-id: [8e2e31cf-f536-11e6-9e93-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6dfda12b-ea56-4b83-bd52-1737b5490ed3","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-04.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e816bc67-505e-4bc7-b356-219770b7dd87","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:30 GMT']
-      ETag: [6dfda12b-ea56-4b83-bd52-1737b5490ed3]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['483']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
+      etag: [e816bc67-505e-4bc7-b356-219770b7dd87]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"SOARecord": {"expireTime": 30, "refreshTime": 60, "minimumTTL":
-      20, "host": "ns1-04.azure-dns.com.", "retryTime": 90, "serialNumber": 123, "email":
-      "foo.com"}, "TTL": 3600}, "type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
-      "etag": "6dfda12b-ea56-4b83-bd52-1737b5490ed3", "name": "@"}'
+    body: !!python/unicode '{"etag": "e816bc67-505e-4bc7-b356-219770b7dd87", "type":
+      "Microsoft.Network/dnszones/SOA", "properties": {"SOARecord": {"expireTime":
+      30, "email": "foo.com", "minimumTTL": 20, "retryTime": 90, "serialNumber": 123,
+      "host": "ns1-02.azure-dns.com.", "refreshTime": 60}, "TTL": 3600}, "name": "@",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['442']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a44610a4-f498-11e6-899b-a0b3ccf7272a]
+      x-ms-client-request-id: [8e8181f0-f536-11e6-af7a-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb5a847a-980f-4d86-89aa-6234791b3416","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-04.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"85c82917-8056-4766-9905-2678090a3f4d","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:31 GMT']
-      ETag: [fb5a847a-980f-4d86-89aa-6234791b3416]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['450']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:54 GMT']
+      etag: [85c82917-8056-4766-9905-2678090a3f4d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1419,57 +1432,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4e9439c-f498-11e6-8a1e-a0b3ccf7272a]
+      x-ms-client-request-id: [8f517c1e-f536-11e6-a308-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/longtxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''longtxt''
-        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''longtxt'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['171']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:32 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['171']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:56 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
-      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]},
-      "type": "txt", "name": "longtxt"}'
+    body: !!python/unicode '{"type": "txt", "properties": {"TXTRecords": [{"value":
+      ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],
+      "TTL": 3600}, "name": "longtxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['600']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5cace94-f498-11e6-ad58-a0b3ccf7272a]
+      x-ms-client-request-id: [8fa62bcf-f536-11e6-897d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/longtxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['857']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:33 GMT']
-      ETag: [1e4c14a0-626f-440a-8913-46ebe815a22e]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['857']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:57 GMT']
+      etag: [14674cae-a373-46ca-965c-8a7fadade754]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1478,28 +1493,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a6a7df98-f498-11e6-b273-a0b3ccf7272a]
+      x-ms-client-request-id: [90ad1480-f536-11e6-988c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":19}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-d8ab-30374389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":19}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:34 GMT']
-      ETag: [00000002-0000-0000-364a-ed42a588d201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['464']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:58 GMT']
+      etag: [00000002-0000-0000-d8ab-30374389d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1508,28 +1523,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a731825e-f498-11e6-97fa-a0b3ccf7272a]
+      x-ms-client-request-id: [913641b0-f536-11e6-8a2c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:35 GMT']
-      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:28:59 GMT']
+      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1538,26 +1553,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a7b93e82-f498-11e6-9be7-a0b3ccf7272a]
+      x-ms-client-request-id: [91dc93cf-f536-11e6-9728-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/recordsets?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"457f44cd-0da1-4b56-94da-01fe1211ec7b","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-04.azure-dns.com."},{"nsdname":"ns2-04.azure-dns.net."},{"nsdname":"ns3-04.azure-dns.org."},{"nsdname":"ns4-04.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb5a847a-980f-4d86-89aa-6234791b3416","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-04.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"bb4af783-4e50-4789-a221-6d9720fb7906","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"7b98d8ff-b2ec-4bf8-a55a-95474ed026f9","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"22477145-0695-49fd-bedf-5e7c814fe6e4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"abb6c9dd-42c5-41d5-9d90-402b85100832","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"b170e487-a2a6-4172-961a-604139a6f7e7","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"b0e6755b-bada-4396-a94f-e58a3c404f58","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"dc74cba5-3626-40c6-815b-a6321e6439a7","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"2512aab9-9b2c-462e-bc9f-b00c5b93f3cb","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-02.azure-dns.com."},{"nsdname":"ns2-02.azure-dns.net."},{"nsdname":"ns3-02.azure-dns.org."},{"nsdname":"ns4-02.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"85c82917-8056-4766-9905-2678090a3f4d","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"959feca8-0c94-4f4f-aff1-d502ff8746d6","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"904cf244-040b-4dfc-a732-b52b3c85d701","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a9382639-60ad-4904-83c7-5f244e813b67","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"cf10167d-b400-4b1f-b6b6-0b12962f0c74","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"dd7bdf26-b5e6-4d73-bd9e-307d96cd8ed8","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"538fba91-048b-4d61-87b6-f39c46a39a1e","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"00786d34-636a-485e-9448-8c02f3bf608f","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:36 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['7820']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:00 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1566,27 +1581,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a852d2b4-f498-11e6-af46-a0b3ccf7272a]
+      x-ms-client-request-id: [928508cf-f536-11e6-9ea4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"14674cae-a373-46ca-965c-8a7fadade754","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57309cca-7a36-4446-beac-c797f9fbd1c2","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:37 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['1606']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:01 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1595,61 +1610,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a8d6de0a-f498-11e6-8ba6-a0b3ccf7272a]
+      x-ms-client-request-id: [933b1261-f536-11e6-ab1a-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"3781bd0f-f812-46fa-8247-cf4ed6d6f394","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:39 GMT']
-      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['383']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:02 GMT']
+      etag: [3781bd0f-f812-46fa-8247-cf4ed6d6f394]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.11"}], "TTL": 3600},
-      "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "etag": "8b5467df-7ef5-4572-93d7-f70fbed78754", "name": "myrsa"}'
+    body: !!python/unicode '{"etag": "3781bd0f-f812-46fa-8247-cf4ed6d6f394", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.11"}], "TTL": 3600}, "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a91ff054-f498-11e6-8a71-a0b3ccf7272a]
+      x-ms-client-request-id: [938fe921-f536-11e6-bab6-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:38 GMT']
-      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:03 GMT']
+      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1658,61 +1673,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a9c22282-f498-11e6-8957-a0b3ccf7272a]
+      x-ms-client-request-id: [9498315e-f536-11e6-a23b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"b471e023-5fc4-4c4e-a164-8629ef877d06","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:39 GMT']
-      ETag: [188f3b1d-e078-489d-8be5-f086455251d6]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['384']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:05 GMT']
+      etag: [b471e023-5fc4-4c4e-a164-8629ef877d06]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "AAAARecords": []}, "type": "Microsoft.Network/dnszones/AAAA",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "etag": "188f3b1d-e078-489d-8be5-f086455251d6", "name": "myrsaaaa"}'
+    body: !!python/unicode '{"etag": "b471e023-5fc4-4c4e-a164-8629ef877d06", "type":
+      "Microsoft.Network/dnszones/AAAA", "properties": {"AAAARecords": [], "TTL":
+      3600}, "name": "myrsaaaa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['316']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aa09bf6e-f498-11e6-96df-a0b3ccf7272a]
+      x-ms-client-request-id: [94f349b0-f536-11e6-8e04-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"fb8e0b40-dca8-48d3-ae11-93a0a976be8e","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"c608fbeb-bc3d-40ee-8450-fcf6daeddd26","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:40 GMT']
-      ETag: [fb8e0b40-dca8-48d3-ae11-93a0a976be8e]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:06 GMT']
+      etag: [c608fbeb-bc3d-40ee-8450-fcf6daeddd26]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1721,61 +1736,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aac7b2a2-f498-11e6-b0a7-a0b3ccf7272a]
+      x-ms-client-request-id: [95d56c4f-f536-11e6-9877-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:41 GMT']
-      ETag: [d3ca537b-0e21-42fd-9aeb-5e6f69437c3d]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:07 GMT']
+      etag: [d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "Microsoft.Network/dnszones/CNAME",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "etag": "d3ca537b-0e21-42fd-9aeb-5e6f69437c3d", "name": "myrscname"}'
+    body: !!python/unicode '{"etag": "d256cdd0-8c16-4b9f-b01d-0a2e0843b1b1", "type":
+      "Microsoft.Network/dnszones/CNAME", "properties": {"TTL": 3600}, "name": "myrscname",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['301']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aaeebd7a-f498-11e6-94d1-a0b3ccf7272a]
+      x-ms-client-request-id: [96384ccf-f536-11e6-b657-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"c1ee49dd-f0d8-4908-8ac6-9ae637127e25","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"4d6dce7d-3f42-4c03-9895-dd859268aa75","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:42 GMT']
-      ETag: [c1ee49dd-f0d8-4908-8ac6-9ae637127e25]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:07 GMT']
+      etag: [4d6dce7d-3f42-4c03-9895-dd859268aa75]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1784,61 +1799,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [abba4674-f498-11e6-9fce-a0b3ccf7272a]
+      x-ms-client-request-id: [96f02b1e-f536-11e6-ad42-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:43 GMT']
-      ETag: [c7a5da5c-a17a-4759-8fc6-bc182a17a254]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['367']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:09 GMT']
+      etag: [2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": []}, "type": "Microsoft.Network/dnszones/MX",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "etag": "c7a5da5c-a17a-4759-8fc6-bc182a17a254", "name": "myrsmx"}'
+    body: !!python/unicode '{"etag": "2d8bf5c4-4c52-4af8-ace5-4867dc3c8fb3", "type":
+      "Microsoft.Network/dnszones/MX", "properties": {"MXRecords": [], "TTL": 3600},
+      "name": "myrsmx", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['306']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [abe02a5c-f498-11e6-a204-a0b3ccf7272a]
+      x-ms-client-request-id: [97312bc0-f536-11e6-b607-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"929a2d35-ed5a-472e-9f99-cc57bccc1d5b","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9d79fec4-8859-4476-9d9d-5b7da83cb12d","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:43 GMT']
-      ETag: [929a2d35-ed5a-472e-9f99-cc57bccc1d5b]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:09 GMT']
+      etag: [9d79fec4-8859-4476-9d9d-5b7da83cb12d]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1847,60 +1862,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac91006e-f498-11e6-b854-a0b3ccf7272a]
+      x-ms-client-request-id: [97e2534f-f536-11e6-a2af-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a2d47e7d-262a-45a7-8d0c-70e9ac82635f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:45 GMT']
-      ETag: [e1774943-72fa-4c2d-b8a2-c381216df40f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['358']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:10 GMT']
+      etag: [a2d47e7d-262a-45a7-8d0c-70e9ac82635f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"NSRecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/NS",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "etag": "e1774943-72fa-4c2d-b8a2-c381216df40f", "name": "myrsns"}'
+    body: !!python/unicode '{"etag": "a2d47e7d-262a-45a7-8d0c-70e9ac82635f", "type":
+      "Microsoft.Network/dnszones/NS", "properties": {"NSRecords": [], "TTL": 3600},
+      "name": "myrsns", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['306']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [acba5c2c-f498-11e6-9ff3-a0b3ccf7272a]
+      x-ms-client-request-id: [9829475e-f536-11e6-baa1-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"6e36bc0f-8c91-4089-bef6-013019bf1425","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"50a9e4aa-b877-46a2-872a-8c79830dfd0c","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:45 GMT']
-      ETag: [6e36bc0f-8c91-4089-bef6-013019bf1425]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:11 GMT']
+      etag: [50a9e4aa-b877-46a2-872a-8c79830dfd0c]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1909,61 +1924,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad89ae7a-f498-11e6-82bc-a0b3ccf7272a]
+      x-ms-client-request-id: [98d7afcf-f536-11e6-9094-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"211c88d3-2c90-46a7-852f-db08ace7647f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:46 GMT']
-      ETag: [05f53f84-a98d-416c-b1d8-a06865ab0068]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['365']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:12 GMT']
+      etag: [211c88d3-2c90-46a7-852f-db08ace7647f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"PTRRecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/PTR",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "etag": "05f53f84-a98d-416c-b1d8-a06865ab0068", "name": "myrsptr"}'
+    body: !!python/unicode '{"etag": "211c88d3-2c90-46a7-852f-db08ace7647f", "type":
+      "Microsoft.Network/dnszones/PTR", "properties": {"PTRRecords": [], "TTL": 3600},
+      "name": "myrsptr", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['311']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [add40aba-f498-11e6-b471-a0b3ccf7272a]
+      x-ms-client-request-id: [9902694f-f536-11e6-b3c4-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"af69ac14-b26f-4cc2-97b3-4279ef08257a","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"233b47bb-eb87-4892-b06c-e1674f6705d4","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:47 GMT']
-      ETag: [af69ac14-b26f-4cc2-97b3-4279ef08257a]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:12 GMT']
+      etag: [233b47bb-eb87-4892-b06c-e1674f6705d4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1972,61 +1987,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae9de8dc-f498-11e6-ae84-a0b3ccf7272a]
+      x-ms-client-request-id: [99cda88f-f536-11e6-89a4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"32bbbc4c-f0cf-4298-896d-5f01863347a6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:47 GMT']
-      ETag: [e2760f4e-601c-4aad-a2ad-815bd4b75b8b]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:14 GMT']
+      etag: [32bbbc4c-f0cf-4298-896d-5f01863347a6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "SRVRecords": []}, "type": "Microsoft.Network/dnszones/SRV",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "etag": "e2760f4e-601c-4aad-a2ad-815bd4b75b8b", "name": "myrssrv"}'
+    body: !!python/unicode '{"etag": "32bbbc4c-f0cf-4298-896d-5f01863347a6", "type":
+      "Microsoft.Network/dnszones/SRV", "properties": {"SRVRecords": [], "TTL": 3600},
+      "name": "myrssrv", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['311']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aee63a46-f498-11e6-b582-a0b3ccf7272a]
+      x-ms-client-request-id: [9a0d70b0-f536-11e6-b185-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"dabaf73c-9c8d-435b-9e34-2ff1fd00b952","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"76ee8192-4ce9-43a3-a179-35c540c096b4","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:48 GMT']
-      ETag: [dabaf73c-9c8d-435b-9e34-2ff1fd00b952]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:14 GMT']
+      etag: [76ee8192-4ce9-43a3-a179-35c540c096b4]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2035,211 +2050,154 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [afb3c04c-f498-11e6-bc01-a0b3ccf7272a]
+      x-ms-client-request-id: [9acc05c0-f536-11e6-8f33-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"3bc68872-862e-4743-8bb9-442defe71796","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:49 GMT']
-      ETag: [fd71221b-1134-4a6b-877f-b6b0b0c12f4c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['363']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:15 GMT']
+      etag: [3bc68872-862e-4743-8bb9-442defe71796]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": []}, "type": "Microsoft.Network/dnszones/TXT",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "etag": "fd71221b-1134-4a6b-877f-b6b0b0c12f4c", "name": "myrstxt"}'
+    body: !!python/unicode '{"etag": "3bc68872-862e-4743-8bb9-442defe71796", "type":
+      "Microsoft.Network/dnszones/TXT", "properties": {"TXTRecords": [], "TTL": 3600},
+      "name": "myrstxt", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['311']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b0011f52-f498-11e6-b843-a0b3ccf7272a]
+      x-ms-client-request-id: [9b0fc580-f536-11e6-974e-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e38648b8-5788-4796-b376-cdebfa14cc66","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"da1357d3-6a9a-42e8-a9c4-be3e331f3eb2","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:50 GMT']
-      ETag: [e38648b8-5788-4796-b376-cdebfa14cc66]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:15 GMT']
+      etag: [da1357d3-6a9a-42e8-a9c4-be3e331f3eb2]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9bccace1-f536-11e6-98a4-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['355']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:17 GMT']
+      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9c59aaa1-f536-11e6-a30b-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fece3fa7-dc70-4a1b-bc8e-1d0ff535030e","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['355']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:17 GMT']
+      etag: [fece3fa7-dc70-4a1b-bc8e-1d0ff535030e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b0ce9d36-f498-11e6-8b63-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:51 GMT']
-      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b159a948-f498-11e6-87d9-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:52 GMT']
-      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"ARecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/A",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "etag": "bad3346f-63a8-41d9-a4b3-b241bd0ba609", "name": "myrsa"}'
+    body: !!python/unicode '{"etag": "fece3fa7-dc70-4a1b-bc8e-1d0ff535030e", "type":
+      "Microsoft.Network/dnszones/A", "properties": {"ARecords": [], "TTL": 3600},
+      "name": "myrsa", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['301']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b19ce99c-f498-11e6-839d-a0b3ccf7272a]
+      x-ms-client-request-id: [9c9e069e-f536-11e6-beb8-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"733c8f1a-14e9-43f2-bb84-2ece6ac1c226","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"771e1271-2dbb-4c07-8d9a-3da00948647f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:53 GMT']
-      ETag: [733c8f1a-14e9-43f2-bb84-2ece6ac1c226]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
       content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b260b95a-f498-11e6-8ef5-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"733c8f1a-14e9-43f2-bb84-2ece6ac1c226","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:54 GMT']
-      ETag: [733c8f1a-14e9-43f2-bb84-2ece6ac1c226]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:19 GMT']
+      etag: [771e1271-2dbb-4c07-8d9a-3da00948647f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b2e6b4d4-f498-11e6-9ab6-a0b3ccf7272a]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['0']
-      Date: ['Thu, 16 Feb 2017 22:38:56 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2248,25 +2206,83 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b3b7eec2-f498-11e6-a480-a0b3ccf7272a]
+      x-ms-client-request-id: [9d5b8a40-f536-11e6-9b4c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
-        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"771e1271-2dbb-4c07-8d9a-3da00948647f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
-      Cache-Control: [private]
-      Content-Length: ['169']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 22:38:56 GMT']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [private]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:19 GMT']
+      etag: [771e1271-2dbb-4c07-8d9a-3da00948647f]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9df6dfde-f536-11e6-83cb-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      cache-control: [private]
+      content-length: ['0']
+      date: ['Fri, 17 Feb 2017 17:29:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9ec94b0f-f536-11e6-9880-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnsZones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"code":"NotFound","message":"The resource record
+        ''myrsa'' does not exist in resource group ''cli_test_dns'' of subscription
+        ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      cache-control: [private]
+      content-length: ['169']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 17 Feb 2017 17:29:22 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns_zone_import_export.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns_zone_import_export.yaml
@@ -8,19 +8,19 @@ interactions:
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b25702f8-f22d-11e6-9ba5-a0b3ccf7272a]
+      x-ms-client-request-id: [75682a50-f536-11e6-a5cd-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-57b8-7a733a86d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-03.azure-dns.com.","ns2-03.azure-dns.net.","ns3-03.azure-dns.org.","ns4-03.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-0081-5d364389d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:47:56 GMT']
-      ETag: [00000002-0000-0000-57b8-7a733a86d201]
+      Date: ['Fri, 17 Feb 2017 17:28:13 GMT']
+      ETag: [00000002-0000-0000-0081-5d364389d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -29,28 +29,28 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"CNAMERecord": {"cname": "contoso.com."}, "TTL": 3600},
-      "type": "cname", "name": "mycname.zone1.com"}'
+    body: '{"name": "myname.zone1.com", "type": "ptr", "properties": {"PTRRecords":
+      [{"ptrdname": "myptrdname"}], "TTL": 3600}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['117']
+      Content-Length: ['116']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b30d5376-f22d-11e6-95ea-a0b3ccf7272a]
+      x-ms-client-request-id: [764878a6-f536-11e6-8207-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/CNAME/mycname.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myname.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/mycname.zone1.com","name":"mycname.zone1.com","type":"Microsoft.Network\/dnszones\/CNAME","etag":"32708632-89df-4bdf-ada1-5d5cfc823458","properties":{"fqdn":"mycname.zone1.com.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"contoso.com."}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myname.zone1.com","name":"myname.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"02d14445-7e0c-4452-a87a-51be6eeb0fad","properties":{"fqdn":"myname.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"myptrdname"}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['411']
+      Content-Length: ['406']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:47:59 GMT']
-      ETag: [32708632-89df-4bdf-ada1-5d5cfc823458]
+      Date: ['Fri, 17 Feb 2017 17:28:14 GMT']
+      ETag: [02d14445-7e0c-4452-a87a-51be6eeb0fad]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -59,29 +59,28 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 7200, "TXTRecords": [{"value": ["abc def"]}, {"value":
-      ["foo bar"]}]}, "type": "txt", "name": "mytxt2.zone1.com"}'
+    body: '{"name": "myptr.zone1.com", "type": "ptr", "properties": {"PTRRecords":
+      [{"ptrdname": "contoso.com"}], "TTL": 3600}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['136']
+      Content-Length: ['116']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b43d5600-f22d-11e6-a215-a0b3ccf7272a]
+      x-ms-client-request-id: [76cb2d2e-f536-11e6-8d53-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/mytxt2.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/PTR/myptr.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxt2.zone1.com","name":"mytxt2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"923a3db6-db88-40c1-8ef7-10d44aef8a7d","properties":{"fqdn":"mytxt2.zone1.com.myzone.com.","TTL":7200,"TXTRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myptr.zone1.com","name":"myptr.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"0c1f372d-7d9b-4d20-b545-b2dd8da0c116","properties":{"fqdn":"myptr.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"contoso.com"}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['424']
+      Content-Length: ['404']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:47:59 GMT']
-      ETag: [923a3db6-db88-40c1-8ef7-10d44aef8a7d]
+      Date: ['Fri, 17 Feb 2017 17:28:15 GMT']
+      ETag: [0c1f372d-7d9b-4d20-b545-b2dd8da0c116]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -90,8 +89,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}],
-      "TTL": 3600}, "type": "aaaa", "name": "myaaaa.zone1.com"}'
+    body: '{"name": "myaaaa.zone1.com", "type": "aaaa", "properties": {"TTL": 3600,
+      "AAAARecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -99,79 +98,19 @@ interactions:
       Content-Length: ['146']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4db1114-f22d-11e6-bf4f-a0b3ccf7272a]
+      x-ms-client-request-id: [773defa6-f536-11e6-9ccf-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myaaaa.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/AAAA/myaaaa.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myaaaa.zone1.com","name":"myaaaa.zone1.com","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e9fb03fb-4dcf-4011-96aa-f472e4a85052","properties":{"fqdn":"myaaaa.zone1.com.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myaaaa.zone1.com","name":"myaaaa.zone1.com","type":"Microsoft.Network\/dnszones\/AAAA","etag":"a1be04f5-3a80-4fd6-b417-7cfd2499a7e0","properties":{"fqdn":"myaaaa.zone1.com.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['437']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:00 GMT']
-      ETag: [e9fb03fb-4dcf-4011-96aa-f472e4a85052]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["manualtxt"]}]},
-      "type": "txt", "name": "myname2.zone1.com"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['115']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b58922b8-f22d-11e6-9129-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/myname2.zone1.com?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myname2.zone1.com","name":"myname2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"b06a31f7-dd6b-410b-a7e1-52dc751955a3","properties":{"fqdn":"myname2.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["manualtxt"]}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['407']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:01 GMT']
-      ETag: [b06a31f7-dd6b-410b-a7e1-52dc751955a3]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["hi"]}]}, "type":
-      "txt", "name": "mytxtrs.zone1.com"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b60e215a-f22d-11e6-b92b-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/mytxtrs.zone1.com?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxtrs.zone1.com","name":"mytxtrs.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"67185bd4-4d22-4a42-a828-48443888baa5","properties":{"fqdn":"mytxtrs.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["hi"]}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['400']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:02 GMT']
-      ETag: [67185bd4-4d22-4a42-a828-48443888baa5]
+      Date: ['Fri, 17 Feb 2017 17:28:16 GMT']
+      ETag: [a1be04f5-3a80-4fd6-b417-7cfd2499a7e0]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -180,58 +119,28 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"SRVRecords": [{"target": "target.contoso.com.", "port":
-      1234, "priority": 1, "weight": 2}], "TTL": 3600}, "type": "srv", "name": "mysrv.zone1.com"}'
+    body: '{"name": "mytxtrs.zone1.com", "type": "txt", "properties": {"TTL": 3600,
+      "TXTRecords": [{"value": ["hi"]}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['164']
+      Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b68f27c2-f22d-11e6-8013-a0b3ccf7272a]
+      x-ms-client-request-id: [77b3828a-f536-11e6-8f8d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/SRV/mysrv.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/TXT/mytxtrs.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/mysrv.zone1.com","name":"mysrv.zone1.com","type":"Microsoft.Network\/dnszones\/SRV","etag":"a8ecbd83-0e24-4b76-aa8c-4850bee4181c","properties":{"fqdn":"mysrv.zone1.com.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxtrs.zone1.com","name":"mytxtrs.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"05a027dd-a800-4166-a13e-cefb7c2e95d6","properties":{"fqdn":"mytxtrs.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["hi"]}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['446']
+      Content-Length: ['400']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:02 GMT']
-      ETag: [a8ecbd83-0e24-4b76-aa8c-4850bee4181c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "myptrdname"}], "TTL": 3600},
-      "type": "ptr", "name": "myname.zone1.com"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['116']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b701858a-f22d-11e6-ab40-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/PTR/myname.zone1.com?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myname.zone1.com","name":"myname.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"0d22eaae-9bc1-4fc5-b4ba-fa3576ffa897","properties":{"fqdn":"myname.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"myptrdname"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['406']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:04 GMT']
-      ETag: [0d22eaae-9bc1-4fc5-b4ba-fa3576ffa897]
+      Date: ['Fri, 17 Feb 2017 17:28:17 GMT']
+      ETag: [05a027dd-a800-4166-a13e-cefb7c2e95d6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -247,112 +156,18 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b785245a-f22d-11e6-adb5-a0b3ccf7272a]
+      x-ms-client-request-id: [78291408-f536-11e6-9dba-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/@?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"3d87c829-45c8-46df-8562-fcb7126910ff","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"29d8f182-bebd-41f4-90ca-81aecda73179","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:04 GMT']
-      ETag: [3d87c829-45c8-46df-8562-fcb7126910ff]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['477']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/@",
-      "properties": {"NSRecords": [{"nsdname": "ns1-03.azure-dns.com."}, {"nsdname":
-      "ns2-03.azure-dns.net."}, {"nsdname": "ns3-03.azure-dns.org."}, {"nsdname":
-      "ns4-03.azure-dns.info."}], "TTL": 172800}, "type": "NS", "name": "@", "etag":
-      "3d87c829-45c8-46df-8562-fcb7126910ff"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['436']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b7e7a0de-f22d-11e6-a2c2-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/@?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"8684584f-2b56-43b8-ad3a-18bd4d38bd65","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:05 GMT']
-      ETag: [8684584f-2b56-43b8-ad3a-18bd4d38bd65]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['477']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"NSRecords": [{"nsdname": "ns.contoso.com."}], "TTL": 3600},
-      "type": "ns", "name": "myns.zone1.com"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['116']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b869b8d0-f22d-11e6-9083-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/myns.zone1.com?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myns.zone1.com","name":"myns.zone1.com","type":"Microsoft.Network\/dnszones\/NS","etag":"1b2a0c01-39ee-45b8-99e0-cebe6e32f406","properties":{"fqdn":"myns.zone1.com.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"ns.contoso.com."}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['401']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:06 GMT']
-      ETag: [1b2a0c01-39ee-45b8-99e0-cebe6e32f406]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b8f60bc2-f22d-11e6-a500-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"7fdff292-aec6-4cc3-bf6b-84c1c881d0a2","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-03.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:06 GMT']
-      ETag: [7fdff292-aec6-4cc3-bf6b-84c1c881d0a2]
+      Date: ['Fri, 17 Feb 2017 17:28:16 GMT']
+      ETag: [29d8f182-bebd-41f4-90ca-81aecda73179]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -363,9 +178,9 @@ interactions:
       content-length: ['497']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"SOARecord": {"minimumTTL": 300, "serialNumber": 1, "retryTime":
-      300, "expireTime": 2419200, "host": "ns1-03.azure-dns.com.", "email": "azuredns-hostmaster.microsoft.com.",
-      "refreshTime": 3600}, "TTL": 3600}, "type": "soa", "name": "@"}'
+    body: '{"name": "@", "type": "soa", "properties": {"TTL": 3600, "SOARecord": {"retryTime":
+      300, "serialNumber": 1, "refreshTime": 3600, "minimumTTL": 300, "host": "ns1-01.azure-dns.com.",
+      "expireTime": 2419200, "email": "azuredns-hostmaster.microsoft.com."}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -373,18 +188,18 @@ interactions:
       Content-Length: ['252']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b939621a-f22d-11e6-8b5d-a0b3ccf7272a]
+      x-ms-client-request-id: [7850a03a-f536-11e6-9401-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"1e7add35-a2e7-4e28-af52-a4d31fdc00ee","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"ns1-03.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"7051d479-c2a7-4582-a1ce-4d178a558fd6","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:07 GMT']
-      ETag: [1e7add35-a2e7-4e28-af52-a4d31fdc00ee]
+      Date: ['Fri, 17 Feb 2017 17:28:18 GMT']
+      ETag: [7051d479-c2a7-4582-a1ce-4d178a558fd6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -393,41 +208,74 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['498']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600},
-      "type": "a", "name": "manuala.zone1.com"}'
+    body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['115']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9b781c0-f22d-11e6-b69c-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/A/manuala.zone1.com?api-version=2016-04-01
+      x-ms-client-request-id: [78b05d40-f536-11e6-9e32-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/NS/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/manuala.zone1.com","name":"manuala.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"1f34f024-a080-40df-b1b6-2ff4c2cd767b","properties":{"fqdn":"manuala.zone1.com.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"b0ae4cff-3e07-4d76-94bf-d2b54549d9b9","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['405']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:09 GMT']
-      ETag: [1f34f024-a080-40df-b1b6-2ff4c2cd767b]
+      Date: ['Fri, 17 Feb 2017 17:28:18 GMT']
+      ETag: [b0ae4cff-3e07-4d76-94bf-d2b54549d9b9]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
+      content-length: ['477']
+    status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "contoso.com"}], "TTL": 3600},
-      "type": "ptr", "name": "myptr.zone1.com"}'
+    body: '{"etag": "b0ae4cff-3e07-4d76-94bf-d2b54549d9b9", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/@",
+      "name": "@", "type": "NS", "properties": {"TTL": 172800, "NSRecords": [{"nsdname":
+      "ns1-01.azure-dns.com."}, {"nsdname": "ns2-01.azure-dns.net."}, {"nsdname":
+      "ns3-01.azure-dns.org."}, {"nsdname": "ns4-01.azure-dns.info."}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['436']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7909d7a4-f536-11e6-9c58-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/NS/@?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"6ef660dc-7901-49b4-9d79-a8fad3ec1035","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:18 GMT']
+      ETag: [6ef660dc-7901-49b4-9d79-a8fad3ec1035]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['477']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"name": "myns.zone1.com", "type": "ns", "properties": {"TTL": 3600, "NSRecords":
+      [{"nsdname": "ns.contoso.com."}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -435,19 +283,80 @@ interactions:
       Content-Length: ['116']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ba601426-f22d-11e6-9798-a0b3ccf7272a]
+      x-ms-client-request-id: [797ad624-f536-11e6-9348-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/PTR/myptr.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/NS/myns.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myptr.zone1.com","name":"myptr.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"59b0dcd6-d25a-453d-994d-e402a75c6496","properties":{"fqdn":"myptr.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"contoso.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myns.zone1.com","name":"myns.zone1.com","type":"Microsoft.Network\/dnszones\/NS","etag":"ac17eaab-312b-49ec-bd6d-5f36fb34ba8b","properties":{"fqdn":"myns.zone1.com.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"ns.contoso.com."}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['404']
+      Content-Length: ['401']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:10 GMT']
-      ETag: [59b0dcd6-d25a-453d-994d-e402a75c6496]
+      Date: ['Fri, 17 Feb 2017 17:28:20 GMT']
+      ETag: [ac17eaab-312b-49ec-bd6d-5f36fb34ba8b]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "mysrv.zone1.com", "type": "srv", "properties": {"SRVRecords":
+      [{"weight": 2, "priority": 1, "target": "target.contoso.com.", "port": 1234}],
+      "TTL": 3600}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['164']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [79e4b258-f536-11e6-8c99-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/SRV/mysrv.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/mysrv.zone1.com","name":"mysrv.zone1.com","type":"Microsoft.Network\/dnszones\/SRV","etag":"d32f0f1d-110b-419d-bf62-b84dce165af1","properties":{"fqdn":"mysrv.zone1.com.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['446']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:20 GMT']
+      ETag: [d32f0f1d-110b-419d-bf62-b84dce165af1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "mycname.zone1.com", "type": "cname", "properties": {"TTL": 3600,
+      "CNAMERecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['117']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7a537f46-f536-11e6-b75d-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/CNAME/mycname.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/mycname.zone1.com","name":"mycname.zone1.com","type":"Microsoft.Network\/dnszones\/CNAME","etag":"cd524f53-fb7c-4c2c-baae-72ef1ccdec7f","properties":{"fqdn":"mycname.zone1.com.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"contoso.com."}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['411']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:21 GMT']
+      ETag: [cd524f53-fb7c-4c2c-baae-72ef1ccdec7f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -456,8 +365,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"MXRecords": [{"preference": 1, "exchange": "mail.contoso.com."}],
-      "TTL": 3600}, "type": "mx", "name": "mymx.zone1.com"}'
+    body: '{"name": "mya.zone1.com", "type": "a", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.1.0"}, {"ipv4Address": "10.0.1.1"}], "TTL": 0}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -465,49 +374,140 @@ interactions:
       Content-Length: ['136']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb10973e-f22d-11e6-afff-a0b3ccf7272a]
+      x-ms-client-request-id: [7ad23576-f536-11e6-aa03-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/MX/mymx.zone1.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/A/mya.zone1.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/mymx.zone1.com","name":"mymx.zone1.com","type":"Microsoft.Network\/dnszones\/MX","etag":"5f64ad93-49a2-495c-9949-9f37da4c8bee","properties":{"fqdn":"mymx.zone1.com.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"mail.contoso.com.","preference":1}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['419']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:10 GMT']
-      ETag: [5f64ad93-49a2-495c-9949-9f37da4c8bee]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
-      "10.0.1.1"}], "TTL": 0}, "type": "a", "name": "mya.zone1.com"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['136']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bba85de2-f22d-11e6-b34a-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/A/mya.zone1.com?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/mya.zone1.com","name":"mya.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"56130f56-4e30-4558-a1b6-fef23009adb8","properties":{"fqdn":"mya.zone1.com.myzone.com.","TTL":0,"ARecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/mya.zone1.com","name":"mya.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"9bebf4dc-5e0c-47cc-89f7-72d2a6087ab0","properties":{"fqdn":"mya.zone1.com.myzone.com.","TTL":0,"ARecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['416']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:12 GMT']
-      ETag: [56130f56-4e30-4558-a1b6-fef23009adb8]
+      Date: ['Fri, 17 Feb 2017 17:28:21 GMT']
+      ETag: [9bebf4dc-5e0c-47cc-89f7-72d2a6087ab0]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "manuala.zone1.com", "type": "a", "properties": {"ARecords": [{"ipv4Address":
+      "10.0.0.10"}], "TTL": 3600}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['115']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7b495934-f536-11e6-930e-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/A/manuala.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/manuala.zone1.com","name":"manuala.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"d7f80fae-9815-4da5-b51f-39370cd74cab","properties":{"fqdn":"manuala.zone1.com.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['405']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:23 GMT']
+      ETag: [d7f80fae-9815-4da5-b51f-39370cd74cab]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "mymx.zone1.com", "type": "mx", "properties": {"TTL": 3600, "MXRecords":
+      [{"exchange": "mail.contoso.com.", "preference": 1}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['136']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7c0a16b4-f536-11e6-8004-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/MX/mymx.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/mymx.zone1.com","name":"mymx.zone1.com","type":"Microsoft.Network\/dnszones\/MX","etag":"c94ace19-c231-49c3-9974-76ac5ee95990","properties":{"fqdn":"mymx.zone1.com.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"mail.contoso.com.","preference":1}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['419']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:23 GMT']
+      ETag: [c94ace19-c231-49c3-9974-76ac5ee95990]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "myname2.zone1.com", "type": "txt", "properties": {"TTL": 3600,
+      "TXTRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['115']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7c7b8b88-f536-11e6-9c5f-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/TXT/myname2.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myname2.zone1.com","name":"myname2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"95ed083d-3b92-4d85-811a-9eee0d95868a","properties":{"fqdn":"myname2.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["manualtxt"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['407']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:25 GMT']
+      ETag: [95ed083d-3b92-4d85-811a-9eee0d95868a]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"name": "mytxt2.zone1.com", "type": "txt", "properties": {"TTL": 7200,
+      "TXTRecords": [{"value": ["abc def"]}, {"value": ["foo bar"]}]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['136']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7cf0e66c-f536-11e6-92c4-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/TXT/mytxt2.zone1.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxt2.zone1.com","name":"mytxt2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"99926c0c-895f-4285-b09d-57716ae69c07","properties":{"fqdn":"mytxt2.zone1.com.myzone.com.","TTL":7200,"TXTRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['424']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 17 Feb 2017 17:28:27 GMT']
+      ETag: [99926c0c-895f-4285-b09d-57716ae69c07]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -523,18 +523,18 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 dnsmanagementclient/1.0.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bc7f5b64-f22d-11e6-adf1-a0b3ccf7272a]
+      x-ms-client-request-id: [7eff6278-f536-11e6-bb3b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/recordsets?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnsZones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"8684584f-2b56-43b8-ad3a-18bd4d38bd65","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-03.azure-dns.com."},{"nsdname":"ns2-03.azure-dns.net."},{"nsdname":"ns3-03.azure-dns.org."},{"nsdname":"ns4-03.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"1e7add35-a2e7-4e28-af52-a4d31fdc00ee","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"ns1-03.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/manuala.zone1.com","name":"manuala.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"1f34f024-a080-40df-b1b6-2ff4c2cd767b","properties":{"fqdn":"manuala.zone1.com.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/mya.zone1.com","name":"mya.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"56130f56-4e30-4558-a1b6-fef23009adb8","properties":{"fqdn":"mya.zone1.com.myzone.com.","TTL":0,"ARecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myaaaa.zone1.com","name":"myaaaa.zone1.com","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e9fb03fb-4dcf-4011-96aa-f472e4a85052","properties":{"fqdn":"myaaaa.zone1.com.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/mycname.zone1.com","name":"mycname.zone1.com","type":"Microsoft.Network\/dnszones\/CNAME","etag":"32708632-89df-4bdf-ada1-5d5cfc823458","properties":{"fqdn":"mycname.zone1.com.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"contoso.com."}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/mymx.zone1.com","name":"mymx.zone1.com","type":"Microsoft.Network\/dnszones\/MX","etag":"5f64ad93-49a2-495c-9949-9f37da4c8bee","properties":{"fqdn":"mymx.zone1.com.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"mail.contoso.com.","preference":1}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myname.zone1.com","name":"myname.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"0d22eaae-9bc1-4fc5-b4ba-fa3576ffa897","properties":{"fqdn":"myname.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"myptrdname"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myname2.zone1.com","name":"myname2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"b06a31f7-dd6b-410b-a7e1-52dc751955a3","properties":{"fqdn":"myname2.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["manualtxt"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myns.zone1.com","name":"myns.zone1.com","type":"Microsoft.Network\/dnszones\/NS","etag":"1b2a0c01-39ee-45b8-99e0-cebe6e32f406","properties":{"fqdn":"myns.zone1.com.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"ns.contoso.com."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myptr.zone1.com","name":"myptr.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"59b0dcd6-d25a-453d-994d-e402a75c6496","properties":{"fqdn":"myptr.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"contoso.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/mysrv.zone1.com","name":"mysrv.zone1.com","type":"Microsoft.Network\/dnszones\/SRV","etag":"a8ecbd83-0e24-4b76-aa8c-4850bee4181c","properties":{"fqdn":"mysrv.zone1.com.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxt2.zone1.com","name":"mytxt2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"923a3db6-db88-40c1-8ef7-10d44aef8a7d","properties":{"fqdn":"mytxt2.zone1.com.myzone.com.","TTL":7200,"TXTRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxtrs.zone1.com","name":"mytxtrs.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"67185bd4-4d22-4a42-a828-48443888baa5","properties":{"fqdn":"mytxtrs.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["hi"]}]}}]}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"6ef660dc-7901-49b4-9d79-a8fad3ec1035","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"7051d479-c2a7-4582-a1ce-4d178a558fd6","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/manuala.zone1.com","name":"manuala.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"d7f80fae-9815-4da5-b51f-39370cd74cab","properties":{"fqdn":"manuala.zone1.com.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/mya.zone1.com","name":"mya.zone1.com","type":"Microsoft.Network\/dnszones\/A","etag":"9bebf4dc-5e0c-47cc-89f7-72d2a6087ab0","properties":{"fqdn":"mya.zone1.com.myzone.com.","TTL":0,"ARecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myaaaa.zone1.com","name":"myaaaa.zone1.com","type":"Microsoft.Network\/dnszones\/AAAA","etag":"a1be04f5-3a80-4fd6-b417-7cfd2499a7e0","properties":{"fqdn":"myaaaa.zone1.com.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/mycname.zone1.com","name":"mycname.zone1.com","type":"Microsoft.Network\/dnszones\/CNAME","etag":"cd524f53-fb7c-4c2c-baae-72ef1ccdec7f","properties":{"fqdn":"mycname.zone1.com.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"contoso.com."}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/mymx.zone1.com","name":"mymx.zone1.com","type":"Microsoft.Network\/dnszones\/MX","etag":"c94ace19-c231-49c3-9974-76ac5ee95990","properties":{"fqdn":"mymx.zone1.com.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"mail.contoso.com.","preference":1}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myname.zone1.com","name":"myname.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"02d14445-7e0c-4452-a87a-51be6eeb0fad","properties":{"fqdn":"myname.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"myptrdname"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myname2.zone1.com","name":"myname2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"95ed083d-3b92-4d85-811a-9eee0d95868a","properties":{"fqdn":"myname2.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["manualtxt"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myns.zone1.com","name":"myns.zone1.com","type":"Microsoft.Network\/dnszones\/NS","etag":"ac17eaab-312b-49ec-bd6d-5f36fb34ba8b","properties":{"fqdn":"myns.zone1.com.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"ns.contoso.com."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myptr.zone1.com","name":"myptr.zone1.com","type":"Microsoft.Network\/dnszones\/PTR","etag":"0c1f372d-7d9b-4d20-b545-b2dd8da0c116","properties":{"fqdn":"myptr.zone1.com.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"contoso.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/mysrv.zone1.com","name":"mysrv.zone1.com","type":"Microsoft.Network\/dnszones\/SRV","etag":"d32f0f1d-110b-419d-bf62-b84dce165af1","properties":{"fqdn":"mysrv.zone1.com.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxt2.zone1.com","name":"mytxt2.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"99926c0c-895f-4285-b09d-57716ae69c07","properties":{"fqdn":"mytxt2.zone1.com.myzone.com.","TTL":7200,"TXTRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxtrs.zone1.com","name":"mytxtrs.zone1.com","type":"Microsoft.Network\/dnszones\/TXT","etag":"05a027dd-a800-4166-a13e-cefb7c2e95d6","properties":{"fqdn":"mytxtrs.zone1.com.myzone.com.","TTL":3600,"TXTRecords":[{"value":["hi"]}]}}]}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 13 Feb 2017 20:48:12 GMT']
+      Date: ['Fri, 17 Feb 2017 17:28:28 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -1186,14 +1186,12 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_dns', debug=True)
+        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_dns')
 
     def test_network_dns(self):
         self.execute()
 
     def body(self):
-        from azure.cli.core._util import CLIError
-
         zone_name = 'myzone.com'
         rg = self.resource_group
 
@@ -1267,8 +1265,8 @@ class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('network dns record-set {0} remove-record -g {1} --zone-name {2} --record-set-name myrs{0} {3}'
                      .format('a', rg, zone_name, '--ipv4-address 10.0.0.11'))
 
-        with self.assertRaises(CLIError):
-            self.cmd('network dns record-set {0} show -n myrs{0} -g {1} --zone-name {2}'.format('a', rg, zone_name))
+        self.cmd('network dns record-set {0} show -n myrs{0} -g {1} --zone-name {2}'.format('a', rg, zone_name),
+            checks=NoneCheck())
 
         self.cmd('network dns record-set {0} delete -n myrs{0} -g {1} --zone-name {2}'
                  .format('a', rg, zone_name))

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-network==0.30.0',
     'azure-mgmt-trafficmanager==0.30.0rc6',
-    'azure-mgmt-dns==0.30.0rc6',
+    'azure-mgmt-dns==1.0.0',
     'azure-mgmt-resource==0.30.2',
     'azure-cli-core'
 ]


### PR DESCRIPTION
- Update DNS package version to 1.0.0. Fixes #1864. Fixes #2106.
- Remove the entire record set if the last record in the set is removed. This behavior can be suppressed. Fixes #2093.
- Adds overall progress to DNS zone import. Fixes #2133.