### PR TITLE
Updating help docs for missing az acs commands

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -7,15 +7,15 @@ from azure.cli.core.help_files import helps
 
 helps['acs'] = """
      type: group
-     short-summary: Commands to manage Azure container services
+     short-summary: Commands to manage Azure Container Services
  """
 helps['acs dcos'] = """
     type: group
-    short-summary: Commands to manage a DCOS orchestrated Azure container service.
+    short-summary: Commands to manage a DCOS orchestrated Azure Container Service.
 """
 helps['acs kubernetes'] = """
     type: group
-    short-summary: Commands to manage a kubernetes orchestrated Azure container service.
+    short-summary: Commands to manage a Kubernetes orchestrated Azure Container Service.
 """
 helps['acs scale'] = """
     type: command
@@ -23,5 +23,5 @@ helps['acs scale'] = """
 """
 helps['acs install-cli'] = """
     type: command
-    short-summary: Downloads the dcos/kubernetes command line from Mesosphere. Default is dcos.
+    short-summary: Downloads the DCOS/Kubernetes command line.
 """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -13,3 +13,15 @@ helps['acs dcos'] = """
     type: group
     short-summary: Commands to manage a DCOS orchestrated Azure container service.
 """
+helps['acs kubernetes'] = """
+    type: group
+    short-summary: Commands to manage a kubernetes orchestrated Azure container service.
+"""
+helps['acs scale'] = """
+    type: command
+    short-summary: Change private agent count of a container service.
+"""
+helps['acs install-cli'] = """
+    type: command
+    short-summary: Downloads the dcos/kubernetes command line from Mesosphere. Default is dcos.
+"""


### PR DESCRIPTION
**Before:**
```
(env) vishrut@mac azure-cli (master) $ az acs -h

Group
    az acs: Commands to manage Azure container services.

Subgroups:
    dcos       : Commands to manage a DCOS orchestrated Azure container service.
    kubernetes

Commands:
    browse     : Opens a browser to the web interface for the cluster orchestrator.
    create     : Create a new Acs.
    delete     : Deletes the specified container service.
    install-cli
    list       : List Container Services.
    scale
    show       : Gets the properties of the specified container service.
```

**After:**
```
(env) vishrut@mac azure-cli (update-acs-docs) $ az acs -h

Group
    az acs: Commands to manage Azure container services.

Subgroups:
    dcos       : Commands to manage a DCOS orchestrated Azure container service.
    kubernetes : Commands to manage a kubernetes orchestrated Azure container service.

Commands:
    browse     : Opens a browser to the web interface for the cluster orchestrator.
    create     : Create a new Acs.
    delete     : Deletes the specified container service.
    install-cli: Downloads the dcos/kubernetes command line from Mesosphere. Default is dcos.
    list       : List Container Services.
    scale      : Change private agent count of a container service.
    show       : Gets the properties of the specified container service.
```