### PR TITLE
webapp: update help info on plan creation failure and fix tab completion on hostname command

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -111,7 +111,7 @@ register_cli_argument('appservice web config ssl upload', 'certificate_password'
 register_cli_argument('appservice web config ssl upload', 'certificate_file', type=file_type, help='The filepath for the .pfx file')
 register_cli_argument('appservice web config ssl', 'certificate_thumbprint', help='The ssl cert thumbprint')
 
-register_cli_argument('appservice web config hostname', 'webapp', help="webapp name", completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
+register_cli_argument('appservice web config hostname', 'webapp_name', help="webapp name", completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
 register_cli_argument('appservice web config hostname', 'name', arg_type=name_arg_type, completer=get_hostname_completion_list, help="hostname assigned to the site, such as custom domains", id_part='child_name')
 
 register_cli_argument('appservice web config backup', 'storage_account_url', help='URL with SAS token to the blob storage container', options_list=['--container-url'])

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -51,9 +51,9 @@ class AppServiceLongRunningOperation(LongRunningOperation): #pylint: disable=too
             detail = json.loads(ex.response.text)['Message']
             if self._creating_plan:
                 if 'Requested features are not supported in region' in detail:
-                    detail = ("Plan with linux worker is not supported in current region. " +
-                              "Run 'az appservice list-locations --linux-workers-enabled' " +
-                              "to cross check")
+                    detail = ("Plan with linux worker is not supported in current region. For " +
+                              "supported regions, please refer to https://docs.microsoft.com/en-us/"
+                              "azure/app-service-web/app-service-linux-intro")
                 elif 'Not enough available reserved instance servers to satisfy' in detail:
                     detail = ("Plan with Linux worker can only be created in a group " +
                               "which has never contained a Windows worker. Please use " +

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -157,7 +157,7 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
         self.assertTrue('s2' not in result)
         self.assertTrue('s3' in result)
 
-        self.cmd('appservice web config hostname list -g {} --webapp {}'.format(self.resource_group, self.webapp_name), checks=[
+        self.cmd('appservice web config hostname list -g {} --webapp-name {}'.format(self.resource_group, self.webapp_name), checks=[
             JMESPathCheck('length(@)', 1),
             JMESPathCheck('[0].name', '{0}/{0}.azurewebsites.net'.format(self.webapp_name))
             ])


### PR DESCRIPTION
fix #2189, fix partial #2187 (update help to point to a msdn page rather a broken command)