### PR TITLE
[Network] AppGateway Fixes

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -408,6 +408,11 @@ helps['network application-gateway url-path-map'] = """
 helps['network application-gateway url-path-map create'] = """
     type: command
     short-summary: Create a URL path map.
+    long-summary: >
+        The map must be created with at least one rule. This command requires the creation of the
+        first rule at the time the map is created. To create additional rules (using different
+        address pools or HTTP settings) use the 'url-path-map rule create' command. To update the
+        rule created using this command, use the 'url-path-map rule update' command.
 """
 
 helps['network application-gateway url-path-map delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -194,6 +194,7 @@ register_cli_argument('network application-gateway http-listener', 'frontend_ip'
 register_cli_argument('network application-gateway http-listener', 'frontend_port', help='The name or ID of the frontend port.', completer=get_ag_subresource_completion_list('frontend_ports'))
 register_cli_argument('network application-gateway http-listener', 'ssl_cert', help='The name or ID of the SSL certificate to use.', completer=get_ag_subresource_completion_list('ssl_certificates'))
 register_cli_argument('network application-gateway http-listener', 'protocol', ignore_type)
+register_cli_argument('network application-gateway http-listener', 'host_name', help='Host name to use for multisite gateways.')
 
 register_cli_argument('network application-gateway http-settings', 'cookie_based_affinity', cookie_based_affinity_type, help='Enable or disable cookie based affinity.')
 register_cli_argument('network application-gateway http-settings', 'timeout', help='Request timeout in seconds.')
@@ -222,10 +223,10 @@ register_cli_argument('network application-gateway url-path-map create', 'defaul
 register_cli_argument('network application-gateway url-path-map update', 'default_address_pool', help='The name or ID of the default backend address pool.', validator=process_ag_url_path_map_create_namespace, completer=get_ag_subresource_completion_list('backend_address_pools'))
 register_cli_argument('network application-gateway url-path-map update', 'default_http_settings', help='The name or ID of the default HTTP settings.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
 
-register_cli_argument('network application-gateway url-path-map', 'rule_name', help='The name of the url-path-map rule.')
-register_cli_argument('network application-gateway url-path-map', 'paths', nargs='+', help='Space separated list of paths to associate with the rule. Valid paths start and end with "/" (ex: "/bar/")')
-register_cli_argument('network application-gateway url-path-map', 'address_pool', help='The name or ID of the backend address pool to use with the created rule.', completer=get_ag_subresource_completion_list('backend_address_pools'))
-register_cli_argument('network application-gateway url-path-map', 'http_settings', help='The name or ID of the HTTP settings to use with the created rule.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
+register_cli_argument('network application-gateway url-path-map', 'rule_name', help='The name of the url-path-map rule.', arg_group='First Rule')
+register_cli_argument('network application-gateway url-path-map', 'paths', nargs='+', help='Space separated list of paths to associate with the rule. Valid paths start and end with "/" (ex: "/bar/")', arg_group='First Rule')
+register_cli_argument('network application-gateway url-path-map', 'address_pool', help='The name or ID of the backend address pool to use with the created rule.', completer=get_ag_subresource_completion_list('backend_address_pools'), arg_group='First Rule')
+register_cli_argument('network application-gateway url-path-map', 'http_settings', help='The name or ID of the HTTP settings to use with the created rule.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'), arg_group='First Rule')
 
 register_cli_argument('network application-gateway url-path-map rule', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=get_ag_url_map_rule_completion_list(), id_part='grandchild_name')
 register_cli_argument('network application-gateway url-path-map rule create', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=None)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -175,7 +175,8 @@ def update_ag_frontend_port(instance, parent, item_name, port=None): # pylint: d
     return parent
 
 def create_ag_http_listener(resource_group_name, application_gateway_name, item_name,
-                            frontend_ip, frontend_port, ssl_cert=None, no_wait=False):
+                            frontend_ip, frontend_port, host_name=None, ssl_cert=None,
+                            no_wait=False):
     from azure.mgmt.network.models import ApplicationGatewayHttpListener
     ncf = _network_client_factory()
     ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
@@ -183,6 +184,8 @@ def create_ag_http_listener(resource_group_name, application_gateway_name, item_
         name=item_name,
         frontend_ip_configuration=SubResource(frontend_ip),
         frontend_port=SubResource(frontend_port),
+        host_name=host_name,
+        require_server_name_indication=True if ssl_cert and host_name else None,
         protocol='https' if ssl_cert else 'http',
         ssl_certificate=SubResource(ssl_cert) if ssl_cert else None)
     _upsert(ag.http_listeners, new_listener, 'name', item_name)
@@ -190,15 +193,22 @@ def create_ag_http_listener(resource_group_name, application_gateway_name, item_
         resource_group_name, application_gateway_name, ag, raw=no_wait)
 
 def update_ag_http_listener(instance, parent, item_name, frontend_ip=None, frontend_port=None, # pylint: disable=unused-argument
-                            protocol=None, ssl_cert=None):
+                            host_name=None, ssl_cert=None):
     if frontend_ip is not None:
         instance.frontend_ip_configuration = SubResource(frontend_ip)
     if frontend_port is not None:
         instance.frontend_port = SubResource(frontend_port)
-    if protocol is not None:
-        instance.protocol = protocol
     if ssl_cert is not None:
-        instance.ssl_certificate = SubResource(ssl_cert)
+        if ssl_cert:
+            instance.ssl_certificate = SubResource(ssl_cert)
+            instance.protocol = 'Https'
+        else:
+            instance.ssl_certificate = None
+            instance.protocol = 'Http'
+    if host_name is not None:
+        instance.host_name = host_name if host_name else None
+    instance.require_server_name_indication = instance.host_name and \
+        instance.protocol.lower() == 'https'
     return parent
 
 def create_ag_backend_http_settings_collection(resource_group_name, application_gateway_name,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -206,7 +206,7 @@ def update_ag_http_listener(instance, parent, item_name, frontend_ip=None, front
             instance.ssl_certificate = None
             instance.protocol = 'Http'
     if host_name is not None:
-        instance.host_name = host_name if host_name else None
+        instance.host_name = host_name or None
     instance.require_server_name_indication = instance.host_name and \
         instance.protocol.lower() == 'https'
     return parent


### PR DESCRIPTION
Closes #2167. Closes #2177.

- Adds --host-name parameter to `application-gateway http-listener create/update` commands to support multisite operation. Automatically sets the SNI variable based on host-name and protocol.
- Updates help text and argument grouping for `application-gateway url-path-map create` to resolve confusion that may result from the fact that this command does two things.