### PR TITLE
[Install script] On macOS, prefer .bash_profile over .bashrc

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -9,7 +9,7 @@
 # Bash script to install the Azure CLI
 #
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
-INSTALL_SCRIPT_SHA256=a1035b07542822fef195e19396109fb5720499fb2d1b912de2a58e7d95ed9e9c
+INSTALL_SCRIPT_SHA256=097a294e3e200870e250fcb57ada74f06de94b2929f3f347ae0afd78323fafa5
 _TTY=/dev/tty
 
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -199,6 +199,8 @@ def _get_default_rc_file():
     bash_profile_exists = os.path.isfile(USER_BASH_PROFILE)
     if not bashrc_exists and bash_profile_exists:
         return USER_BASH_PROFILE
+    if bashrc_exists and bash_profile_exists and platform.system().lower() == 'darwin':
+        return USER_BASH_PROFILE
     return USER_BASH_RC if bashrc_exists else None
 
 def _find_line_in_file(file_path, search_pattern):


### PR DESCRIPTION
If ~/.bashrc and ~/.bash_profile exist on macOS, prefer .bash_profile.

Previously, we preferred ~/.bashrc but got reports on macOS that users have a ~/.bashrc that isn't sourced in their ~/.bash_profile file.