### PR TITLE
Add --secrets for VM and VMSS

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -8,10 +8,10 @@ import re
 import sys
 import json
 import base64
+import binascii
 from datetime import datetime, timedelta
 from enum import Enum
 
-import binascii
 import six
 import azure.cli.core.azlogging as azlogging
 

--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -11,6 +11,7 @@ import base64
 from datetime import datetime, timedelta
 from enum import Enum
 
+import binascii
 import six
 import azure.cli.core.azlogging as azlogging
 
@@ -174,6 +175,17 @@ def b64encode(s):
         return encoded
     else:
         return encoded.decode('latin-1')
+
+
+def b64_to_hex(s):
+    """
+    Decodes a string to base64 on 2.x and 3.x
+    :param str s: base64 encoded string
+    :return: uppercase hex string
+    :rtype: str
+    """
+    decoded = base64.b64decode(s)
+    return binascii.hexlify(decoded).upper()
 
 
 def random_string(length=16, force_lower=False, digits_only=False):

--- a/src/azure-cli-core/azure/cli/core/extensions/transform.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/transform.py
@@ -5,9 +5,12 @@
 
 import re
 
+from azure.cli.core._util import b64_to_hex
+
 
 def register(application):
     application.register(application.TRANSFORM_RESULT, _resource_group_transform)
+    application.register(application.TRANSFORM_RESULT, _x509_from_base64_to_hex_transform)
 
 
 def _parse_id(strid):
@@ -36,5 +39,24 @@ def _add_resource_group(obj):
             _add_resource_group(obj[item_key])
 
 
+def _add_x509_hex(obj):
+    if isinstance(obj, list):
+        for array_item in obj:
+            _add_x509_hex(array_item)
+    elif isinstance(obj, dict):
+        try:
+            if 'x509ThumbprintHex' not in obj:
+                if obj['x509Thumbprint']:
+                    obj['x509ThumbprintHex'] = b64_to_hex(obj['x509Thumbprint'])
+        except (KeyError, IndexError, TypeError):
+            pass
+        for item_key in obj:
+            _add_x509_hex(obj[item_key])
+
+
 def _resource_group_transform(**kwargs):
     _add_resource_group(kwargs['event_data']['result'])
+
+
+def _x509_from_base64_to_hex_transform(**kwargs):
+    _add_x509_hex(kwargs['event_data']['result'])

--- a/src/azure-cli-core/azure/cli/core/extensions/transform.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/transform.py
@@ -36,7 +36,8 @@ def _add_resource_group(obj):
         except (KeyError, IndexError, TypeError):
             pass
         for item_key in obj:
-            _add_resource_group(obj[item_key])
+            if item_key != 'sourceVault':
+                _add_resource_group(obj[item_key])
 
 
 def _add_x509_hex(obj):

--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -14,6 +14,7 @@ import re
 import shlex
 import sys
 import tempfile
+import traceback
 from random import choice
 from string import digits, ascii_lowercase
 
@@ -452,6 +453,7 @@ class VCRTestBase(unittest.TestCase):  # pylint: disable=too-many-instance-attri
                 print('RECORDING: {}'.format(self.test_name))
                 self._execute_live_or_recording()
         except Exception as ex:
+            traceback.print_exc()
             raise ex
         finally:
             if not self.success and not self.playback and os.path.isfile(self.cassette_path):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -59,7 +59,9 @@ helps['keyvault certificate get-default-policy'] = """
     short-summary: Get a default policy for a self-signed certificate
     long-summary: >
         This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
-        The default policy can also be used as a starting point to create derivative policies.
+        The default policy can also be used as a starting point to create derivative policies. \n
+
+        Also see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
     examples:
         - name: Create a self-signed certificate with a the default policy
           text: >

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -54,6 +54,57 @@ helps['keyvault certificate'] = """
     short-summary: Manage certificates.
 """
 
+helps['keyvault certificate get-default-policy'] = """
+    type: command
+    short-summary: Get a default policy for a self-signed certificate
+    long-summary: >
+        This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
+        The policy can also be used as a base to manipulate to create other permutations of Key Vault certificates.
+    examples:
+        - name: Create a self-signed certificate with a the default policy
+          text: >
+            az keyvault create -g group-name -n vaultname -l westus --enabled-for-deployment true \\
+              --enabled-for-template-deployment true
+
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+"""
+
+helps['keyvault certificate create'] = """
+    type: command
+    long-summary: >
+        Create a Key Vault certificate. Certificates can also be used as a secrets in provisioned virtual machines.
+    examples:
+        - name: Create a self-signed certificate with a the default policy and add to a virtual machine
+          text: >
+            az keyvault create -g group-name -n vaultname -l westus --enabled-for-deployment true \\
+              --enabled-for-template-deployment true
+
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+
+            az vm create -g group-name -n vm-name --admin-username deploy --image debian --secrets \'{secrets}\''
+"""
+
+helps['keyvault secret vm-format'] = """
+    type: command
+    long-summary: >
+        Create a Key Vault certificate. Certificates can also be used as a secrets in provisioned virtual machines.
+    examples:
+        - name: Create a self-signed certificate with a the default policy and add to a virtual machine
+          text: >
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled]")
+
+            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+
+            az vm create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
+"""
+
 helps['keyvault certificate pending'] = """
     type: group
     short-summary: Manage pending certificate creation operations.

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -59,7 +59,7 @@ helps['keyvault certificate get-default-policy'] = """
     short-summary: Get a default policy for a self-signed certificate
     long-summary: >
         This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
-        The policy can also be used as a base to manipulate to create other permutations of Key Vault certificates.
+        The default policy can also be used as a starting point to create derivative policies.
     examples:
         - name: Create a self-signed certificate with a the default policy
           text: >
@@ -77,19 +77,22 @@ helps['keyvault certificate create'] = """
     examples:
         - name: Create a self-signed certificate with a the default policy and add to a virtual machine
           text: >
-            az keyvault create -g group-name -n vaultname -l westus --enabled-for-deployment true \\
-              --enabled-for-template-deployment true
-
             az keyvault certificate create --vault-name vaultname -n cert1 \\
               -p "$(az keyvault certificate get-default-policy)"
 
-            az vm create -g group-name -n vm-name --admin-username deploy --image debian --secrets \'{secrets}\''
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled]")
+
+            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+
+            az vm create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
 """
 
 helps['keyvault secret vm-format'] = """
     type: command
     long-summary: >
-        Create a Key Vault certificate. Certificates can also be used as a secrets in provisioned virtual machines.
+        Transform secrets into a form consumed by VMs via --secrets.
     examples:
         - name: Create a self-signed certificate with a the default policy and add to a virtual machine
           text: >

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -83,7 +83,7 @@ helps['keyvault certificate create'] = """
               -p "$(az keyvault certificate get-default-policy)"
 
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled]")
+              -n cert1 --query "[?attributes.enabled].id" -o tsv)
 
             vm_secrets=$(az vm format-secret -s "$secrets") \n
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -85,26 +85,7 @@ helps['keyvault certificate create'] = """
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
               -n cert1 --query "[?attributes.enabled]")
 
-            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
-
-            az vm create -g group-name -n vm-name --admin-username deploy  \\
-              --image debian --secrets "$vm_secrets"
-"""
-
-helps['keyvault secret vm-format'] = """
-    type: command
-    long-summary: >
-        Transform secrets into a form consumed by VMs via --secrets.
-    examples:
-        - name: Create a self-signed certificate with a the default policy and add to a virtual machine
-          text: >
-            az keyvault certificate create --vault-name vaultname -n cert1 \\
-              -p "$(az keyvault certificate get-default-policy)"
-
-            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled]")
-
-            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+            vm_secrets=$(az vm format-secret -s "$secrets") \n
 
             az vm create -g group-name -n vm-name --admin-username deploy  \\
               --image debian --secrets "$vm_secrets"

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -182,5 +182,3 @@ register_cli_argument('keyvault certificate issuer', 'admin_first_name', arg_gro
 register_cli_argument('keyvault certificate issuer', 'admin_last_name', arg_group='Organization Detail')
 register_cli_argument('keyvault certificate issuer', 'admin_email', arg_group='Organization Detail')
 register_cli_argument('keyvault certificate issuer', 'admin_phone', arg_group='Organization Detail')
-
-register_cli_argument('keyvault secret vm-format', 'secrets', options_list=('--secrets', '-s'), type=get_json_object, help='JSON encoded secrets. Use @{file} to load from a file.')

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -182,3 +182,5 @@ register_cli_argument('keyvault certificate issuer', 'admin_first_name', arg_gro
 register_cli_argument('keyvault certificate issuer', 'admin_last_name', arg_group='Organization Detail')
 register_cli_argument('keyvault certificate issuer', 'admin_email', arg_group='Organization Detail')
 register_cli_argument('keyvault certificate issuer', 'admin_phone', arg_group='Organization Detail')
+
+register_cli_argument('keyvault secret vm-format', 'secrets', options_list=('--secrets', '-s'), type=get_json_object, help='JSON encoded secrets. Use @{file} to load from a file.')

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -111,6 +111,3 @@ cli_keyvault_data_plane_command('keyvault certificate issuer admin delete', cust
 
 # default policy document
 cli_keyvault_data_plane_command('keyvault certificate get-default-policy', custom_path.format('get_default_policy'))
-
-# secret vm formatter
-cli_command(__name__, 'keyvault secret vm-format', custom_path.format('get_vm_format_secret'), factory)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -108,3 +108,9 @@ cli_keyvault_data_plane_command('keyvault certificate issuer delete', convenienc
 cli_keyvault_data_plane_command('keyvault certificate issuer admin list', custom_path.format('list_certificate_issuer_admins'))
 cli_keyvault_data_plane_command('keyvault certificate issuer admin add', custom_path.format('add_certificate_issuer_admin'))
 cli_keyvault_data_plane_command('keyvault certificate issuer admin delete', custom_path.format('delete_certificate_issuer_admin'))
+
+# default policy document
+cli_keyvault_data_plane_command('keyvault certificate get-default-policy', custom_path.format('get_default_policy'))
+
+# secret vm formatter
+cli_command(__name__, 'keyvault secret vm-format', custom_path.format('get_vm_format_secret'), factory)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -131,16 +131,7 @@ def get_vm_format_secret(client, secrets, certificate_store=None):
                   'vaultCertificates': value['vaultCertificates']}
                  for _, value in list(grouped_secrets.items())]
 
-    # This is a hack to dump out json to STDOUT with the exact formatting we
-    # desire. The issue is that this JSON contains a resource id and the default
-    # output adds a resourceGroup to the keys upon formatting for output. We don't
-    # want that to be added since it would be different from what --secrets in vm
-    # and vmss create require.
-    #
-    # Also, vm-format should only produce JSON as it's the only format that makes
-    # sense for this cmd
-    print(json.dumps(formatted, sort_keys=True, indent=2))
-    return None
+    return formatted
 
 
 def get_default_policy(client): #pylint: disable=unused-argument

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_certificate.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_certificate.yaml
@@ -1,30 +1,164 @@
 interactions:
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Self"},
-      "secret_props": {"contentType": "application/x-pem-file"}, "key_props": {"exportable":
-      true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}, "value": "-----BEGIN
-      PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2e24e44a-f95e-11e6-8697-acde48001122]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1269']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 23 Feb 2017 00:22:37 GMT']
+      Duration: ['1148293']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [jMeXskt9lymosnwTTh8V8muHvrdJ0h5SOKqv/Dt6N44=]
+      ocp-aad-session-key: [m8v7ORYf_5szDioYsa5pkoM69fkzNFEP4Ytfg3UBX0blndowajIWt8wQb52AeFVm-j6qZzgzIkHnJtoELtbNtfeD7WY28UVORQeyYm9L0CJVffYXxbvYOQ2pteG4kN4m.IgMCr35q8LCL_tjGUGMZQjEAiQTntzTd5PsX_EpMjKQ]
+      request-id: [79fbc668-7237-45e1-afd8-4eafd9b355ab]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"name": "premium", "family": "A"}, "accessPolicies": [{"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "permissions": {"certificates": ["all"], "keys": ["get", "create", "delete",
+      "list", "update", "import", "backup", "restore"], "secrets": ["all"]}, "objectId":
+      "882b503c-c281-4fe9-a85c-d9e0cd66d376"}]}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['407']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2e4b5954-f95e-11e6-8fd0-acde48001122]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:22:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['710']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4249df5e-f95e-11e6-868c-acde48001122]
+    method: GET
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 23 Feb 2017 00:23:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4249df5e-f95e-11e6-868c-acde48001122]
+    method: GET
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: '{"value":null,"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['30']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:23:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "attributes": {"enabled": true}, "policy": {"secret_props":
+      {"contentType": "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props":
+      {"exportable": true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3132']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9d6ff36-d45c-11e6-9a69-a0b3ccf7272a]
+      x-ms-client-request-id: [43a48cac-f95e-11e6-99e4-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/803629d095f74952a429d348f95494a5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/803629d095f74952a429d348f95494a5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/803629d095f74952a429d348f95494a5","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1483740541,"updated":1483740541},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740541,"updated":1483740541}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aca3a882bda41cf896089fb96f67bea","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aca3a882bda41cf896089fb96f67bea","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aca3a882bda41cf896089fb96f67bea","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1487809395,"updated":1487809395},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809395,"updated":1487809395}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2163']
+      Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:01 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -33,7 +167,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -42,19 +176,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [bacf1ef8-d45c-11e6-a319-a0b3ccf7272a]
+      x-ms-client-request-id: [44e32a22-f95e-11e6-a5d3-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/803629d095f74952a429d348f95494a5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/803629d095f74952a429d348f95494a5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/803629d095f74952a429d348f95494a5","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1483740541,"updated":1483740541},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740541,"updated":1483740541}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aca3a882bda41cf896089fb96f67bea","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aca3a882bda41cf896089fb96f67bea","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aca3a882bda41cf896089fb96f67bea","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1487809395,"updated":1487809395},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809395,"updated":1487809395}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2163']
+      Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:01 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -63,7 +197,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -72,19 +206,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb31e990-d45c-11e6-ae67-a0b3ccf7272a]
+      x-ms-client-request-id: [45964d1c-f95e-11e6-a458-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/803629d095f74952a429d348f95494a5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/803629d095f74952a429d348f95494a5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/803629d095f74952a429d348f95494a5","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1483740541,"updated":1483740541},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740541,"updated":1483740541}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aca3a882bda41cf896089fb96f67bea","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aca3a882bda41cf896089fb96f67bea","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aca3a882bda41cf896089fb96f67bea","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1487809395,"updated":1487809395},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809395,"updated":1487809395}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2163']
+      Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:02 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -93,7 +227,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -103,19 +237,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb84d2de-d45c-11e6-9236-a0b3ccf7272a]
+      x-ms-client-request-id: [463d4236-f95e-11e6-8321-acde48001122]
     method: DELETE
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/803629d095f74952a429d348f95494a5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/803629d095f74952a429d348f95494a5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/803629d095f74952a429d348f95494a5","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1483740541,"updated":1483740541},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740541,"updated":1483740541}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aca3a882bda41cf896089fb96f67bea","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aca3a882bda41cf896089fb96f67bea","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aca3a882bda41cf896089fb96f67bea","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1487809395,"updated":1487809395},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809395,"updated":1487809395}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2163']
+      Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:03 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -124,40 +258,40 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "lifetime_actions": [{"trigger": {"lifetime_percentage":
-      90}, "action": {"action_type": "AutoRenew"}}], "issuer": {"name": "Self"}, "attributes":
-      {"enabled": true}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
-      2048, "reuse_key": false}, "x509_props": {"validity_months": 60, "subject":
-      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Self"},
+      "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props": {"key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
+      "validity_months": 60}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
+      2048, "reuse_key": false}, "attributes": {"enabled": true}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [bbf3ad94-d45c-11e6-8d34-a0b3ccf7272a]
+      x-ms-client-request-id: [4705b838-f95e-11e6-88dc-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5f80+Wr1FHqpKRffrMeJFSmFNJjbqBIOBP4V4CRPGNQlpJWxkB2iafiF4X5aiDSyFEv+ovt8aqfYuD+dd29LMP31A08RekxVBmonmv53f+zfduzjDnv7/b5AVcd47lOTsEWUHj5HIScUHLw8R4ue1jkPRYMN8sNwOLJ/tc7AGdHzB+LcRK2T4220/2GX00fMl+HIYgQsdHriue2mMUyVQRcLcThb1hbxcZUW5nb5rdP0szBseTBSFsypcXqeZV8ugj9GYgF+QrPoGsOsPX/SsuqFiYiYFchI+dqofxSkrrNazoO02TsnZjXbljGmhRR2jlactgz6g5arM9nmRWegcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBnVLfj9KEwciVoPuYLWyibE5MnBhDmZ3GBpctLHdvdEySBeoR1b0s6k4/8DVyjB27h+5IOxCgHazfWYf31T+0jLPXANTmLHfahL9ZL3ks7Dr3fc4/kL2C2J3Vzw0jW8LyRNJ00rL205kEo0qTyLPMeCrjH/OjVsR69fJvIzqx8QsMYLIAwm/U1UAp4aLHtU/tX+p1iU8UtBC0BPlAtn8i/zP0jRdT+lClUqHErhmQKqbE1Yvw4c9W3ivkkUHRXuHuVosi0ghdcNjSFQzLpRQRRCqGttDk2Dm5uKLPFJ4hujyquVHaD7I3vy/evgk3cHBtCfUaP2DaZWvmgZWrSayW+","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALYNGc24tW0yLgWXi4McieR7ucxDCB7N8LQmliAq70kBiv6TGnAfgwT9hmnTrI1We/c0FUNu67gvccE9V2jsTQCVZHwvFSnaNJJBG1bfwfkZM/hB4dwhbI2msw3mYf/8nIjjbh+pockQgscAX7YZFv8AludHAVaqufLlOQje7QBi3+YMhJWwIlFm3NtOmYspekbHaKFPS9WBUYEFPzjDPOcjroetjrsC5f9/jSjc3Sm22+CAcVuELPFmLVDSgHdDXvd9tXRMmNFQatmliCLu+EPrm5FRURq/6pmE+UmXl0bgUmgKNm2dwV1pVT7039jK9osPf0DHfWhaPSBK5jOKQ+kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDEVBYUbPEhbabTkmsIw5/j0ALnrfyh0+Nm48AYSoAmLX//iMSDhTTemkwveP7LPKDt7U6lOWV1UKG+1Ky/xotXrmxpbV5wiQJmN8F7iZ4v+gLzR3h/2zYTb11K/cE3b0sV+kZrf/V/QN6BPr4btGNzSKNqyJfnGnwLNwYZ8p3XQ15yb/GWwC6ePMSCevdORMv2zfgYKFbxan7Y5DSEt8tmzC4b55T/zEq6xOqA7td/yAC2MPRIDAZD4mStT2yRHVhzN5ng7B1J1+iXufQAMcMRpTnm57UvStq7JAyNzEWfyBmywl78ezjR+6aBLcvGKwK9PrbljfTG1gpboeUs4Zj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"ef2f53cde7fe4f899a02e0e10c8da064"}'}
+        time based on the issuer provider. Please check again later.","request_id":"2f87e07761af4ce3816fbe329ea14083"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:20 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=ef2f53cde7fe4f899a02e0e10c8da064']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=2f87e07761af4ce3816fbe329ea14083']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -165,7 +299,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -174,21 +308,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [bcfcc034-d45c-11e6-9cea-a0b3ccf7272a]
+      x-ms-client-request-id: [4805613e-f95e-11e6-acf1-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5f80+Wr1FHqpKRffrMeJFSmFNJjbqBIOBP4V4CRPGNQlpJWxkB2iafiF4X5aiDSyFEv+ovt8aqfYuD+dd29LMP31A08RekxVBmonmv53f+zfduzjDnv7/b5AVcd47lOTsEWUHj5HIScUHLw8R4ue1jkPRYMN8sNwOLJ/tc7AGdHzB+LcRK2T4220/2GX00fMl+HIYgQsdHriue2mMUyVQRcLcThb1hbxcZUW5nb5rdP0szBseTBSFsypcXqeZV8ugj9GYgF+QrPoGsOsPX/SsuqFiYiYFchI+dqofxSkrrNazoO02TsnZjXbljGmhRR2jlactgz6g5arM9nmRWegcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBnVLfj9KEwciVoPuYLWyibE5MnBhDmZ3GBpctLHdvdEySBeoR1b0s6k4/8DVyjB27h+5IOxCgHazfWYf31T+0jLPXANTmLHfahL9ZL3ks7Dr3fc4/kL2C2J3Vzw0jW8LyRNJ00rL205kEo0qTyLPMeCrjH/OjVsR69fJvIzqx8QsMYLIAwm/U1UAp4aLHtU/tX+p1iU8UtBC0BPlAtn8i/zP0jRdT+lClUqHErhmQKqbE1Yvw4c9W3ivkkUHRXuHuVosi0ghdcNjSFQzLpRQRRCqGttDk2Dm5uKLPFJ4hujyquVHaD7I3vy/evgk3cHBtCfUaP2DaZWvmgZWrSayW+","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALYNGc24tW0yLgWXi4McieR7ucxDCB7N8LQmliAq70kBiv6TGnAfgwT9hmnTrI1We/c0FUNu67gvccE9V2jsTQCVZHwvFSnaNJJBG1bfwfkZM/hB4dwhbI2msw3mYf/8nIjjbh+pockQgscAX7YZFv8AludHAVaqufLlOQje7QBi3+YMhJWwIlFm3NtOmYspekbHaKFPS9WBUYEFPzjDPOcjroetjrsC5f9/jSjc3Sm22+CAcVuELPFmLVDSgHdDXvd9tXRMmNFQatmliCLu+EPrm5FRURq/6pmE+UmXl0bgUmgKNm2dwV1pVT7039jK9osPf0DHfWhaPSBK5jOKQ+kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDEVBYUbPEhbabTkmsIw5/j0ALnrfyh0+Nm48AYSoAmLX//iMSDhTTemkwveP7LPKDt7U6lOWV1UKG+1Ky/xotXrmxpbV5wiQJmN8F7iZ4v+gLzR3h/2zYTb11K/cE3b0sV+kZrf/V/QN6BPr4btGNzSKNqyJfnGnwLNwYZ8p3XQ15yb/GWwC6ePMSCevdORMv2zfgYKFbxan7Y5DSEt8tmzC4b55T/zEq6xOqA7td/yAC2MPRIDAZD4mStT2yRHVhzN5ng7B1J1+iXufQAMcMRpTnm57UvStq7JAyNzEWfyBmywl78ezjR+6aBLcvGKwK9PrbljfTG1gpboeUs4Zj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"ef2f53cde7fe4f899a02e0e10c8da064"}'}
+        time based on the issuer provider. Please check again later.","request_id":"2f87e07761af4ce3816fbe329ea14083"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:05 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -197,7 +331,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -206,21 +340,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c30da01e-d45c-11e6-8caf-a0b3ccf7272a]
+      x-ms-client-request-id: [4e1240ec-f95e-11e6-8093-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5f80+Wr1FHqpKRffrMeJFSmFNJjbqBIOBP4V4CRPGNQlpJWxkB2iafiF4X5aiDSyFEv+ovt8aqfYuD+dd29LMP31A08RekxVBmonmv53f+zfduzjDnv7/b5AVcd47lOTsEWUHj5HIScUHLw8R4ue1jkPRYMN8sNwOLJ/tc7AGdHzB+LcRK2T4220/2GX00fMl+HIYgQsdHriue2mMUyVQRcLcThb1hbxcZUW5nb5rdP0szBseTBSFsypcXqeZV8ugj9GYgF+QrPoGsOsPX/SsuqFiYiYFchI+dqofxSkrrNazoO02TsnZjXbljGmhRR2jlactgz6g5arM9nmRWegcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBnVLfj9KEwciVoPuYLWyibE5MnBhDmZ3GBpctLHdvdEySBeoR1b0s6k4/8DVyjB27h+5IOxCgHazfWYf31T+0jLPXANTmLHfahL9ZL3ks7Dr3fc4/kL2C2J3Vzw0jW8LyRNJ00rL205kEo0qTyLPMeCrjH/OjVsR69fJvIzqx8QsMYLIAwm/U1UAp4aLHtU/tX+p1iU8UtBC0BPlAtn8i/zP0jRdT+lClUqHErhmQKqbE1Yvw4c9W3ivkkUHRXuHuVosi0ghdcNjSFQzLpRQRRCqGttDk2Dm5uKLPFJ4hujyquVHaD7I3vy/evgk3cHBtCfUaP2DaZWvmgZWrSayW+","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALYNGc24tW0yLgWXi4McieR7ucxDCB7N8LQmliAq70kBiv6TGnAfgwT9hmnTrI1We/c0FUNu67gvccE9V2jsTQCVZHwvFSnaNJJBG1bfwfkZM/hB4dwhbI2msw3mYf/8nIjjbh+pockQgscAX7YZFv8AludHAVaqufLlOQje7QBi3+YMhJWwIlFm3NtOmYspekbHaKFPS9WBUYEFPzjDPOcjroetjrsC5f9/jSjc3Sm22+CAcVuELPFmLVDSgHdDXvd9tXRMmNFQatmliCLu+EPrm5FRURq/6pmE+UmXl0bgUmgKNm2dwV1pVT7039jK9osPf0DHfWhaPSBK5jOKQ+kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDEVBYUbPEhbabTkmsIw5/j0ALnrfyh0+Nm48AYSoAmLX//iMSDhTTemkwveP7LPKDt7U6lOWV1UKG+1Ky/xotXrmxpbV5wiQJmN8F7iZ4v+gLzR3h/2zYTb11K/cE3b0sV+kZrf/V/QN6BPr4btGNzSKNqyJfnGnwLNwYZ8p3XQ15yb/GWwC6ePMSCevdORMv2zfgYKFbxan7Y5DSEt8tmzC4b55T/zEq6xOqA7td/yAC2MPRIDAZD4mStT2yRHVhzN5ng7B1J1+iXufQAMcMRpTnm57UvStq7JAyNzEWfyBmywl78ezjR+6aBLcvGKwK9PrbljfTG1gpboeUs4Zj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"ef2f53cde7fe4f899a02e0e10c8da064"}'}
+        time based on the issuer provider. Please check again later.","request_id":"2f87e07761af4ce3816fbe329ea14083"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:15 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -229,7 +363,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -238,19 +372,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c95e2c1e-d45c-11e6-9f1d-a0b3ccf7272a]
+      x-ms-client-request-id: [5426b5c6-f95e-11e6-bb88-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5f80+Wr1FHqpKRffrMeJFSmFNJjbqBIOBP4V4CRPGNQlpJWxkB2iafiF4X5aiDSyFEv+ovt8aqfYuD+dd29LMP31A08RekxVBmonmv53f+zfduzjDnv7/b5AVcd47lOTsEWUHj5HIScUHLw8R4ue1jkPRYMN8sNwOLJ/tc7AGdHzB+LcRK2T4220/2GX00fMl+HIYgQsdHriue2mMUyVQRcLcThb1hbxcZUW5nb5rdP0szBseTBSFsypcXqeZV8ugj9GYgF+QrPoGsOsPX/SsuqFiYiYFchI+dqofxSkrrNazoO02TsnZjXbljGmhRR2jlactgz6g5arM9nmRWegcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBnVLfj9KEwciVoPuYLWyibE5MnBhDmZ3GBpctLHdvdEySBeoR1b0s6k4/8DVyjB27h+5IOxCgHazfWYf31T+0jLPXANTmLHfahL9ZL3ks7Dr3fc4/kL2C2J3Vzw0jW8LyRNJ00rL205kEo0qTyLPMeCrjH/OjVsR69fJvIzqx8QsMYLIAwm/U1UAp4aLHtU/tX+p1iU8UtBC0BPlAtn8i/zP0jRdT+lClUqHErhmQKqbE1Yvw4c9W3ivkkUHRXuHuVosi0ghdcNjSFQzLpRQRRCqGttDk2Dm5uKLPFJ4hujyquVHaD7I3vy/evgk3cHBtCfUaP2DaZWvmgZWrSayW+","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"ef2f53cde7fe4f899a02e0e10c8da064"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALYNGc24tW0yLgWXi4McieR7ucxDCB7N8LQmliAq70kBiv6TGnAfgwT9hmnTrI1We/c0FUNu67gvccE9V2jsTQCVZHwvFSnaNJJBG1bfwfkZM/hB4dwhbI2msw3mYf/8nIjjbh+pockQgscAX7YZFv8AludHAVaqufLlOQje7QBi3+YMhJWwIlFm3NtOmYspekbHaKFPS9WBUYEFPzjDPOcjroetjrsC5f9/jSjc3Sm22+CAcVuELPFmLVDSgHdDXvd9tXRMmNFQatmliCLu+EPrm5FRURq/6pmE+UmXl0bgUmgKNm2dwV1pVT7039jK9osPf0DHfWhaPSBK5jOKQ+kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDEVBYUbPEhbabTkmsIw5/j0ALnrfyh0+Nm48AYSoAmLX//iMSDhTTemkwveP7LPKDt7U6lOWV1UKG+1Ky/xotXrmxpbV5wiQJmN8F7iZ4v+gLzR3h/2zYTb11K/cE3b0sV+kZrf/V/QN6BPr4btGNzSKNqyJfnGnwLNwYZ8p3XQ15yb/GWwC6ePMSCevdORMv2zfgYKFbxan7Y5DSEt8tmzC4b55T/zEq6xOqA7td/yAC2MPRIDAZD4mStT2yRHVhzN5ng7B1J1+iXufQAMcMRpTnm57UvStq7JAyNzEWfyBmywl78ezjR+6aBLcvGKwK9PrbljfTG1gpboeUs4Zj","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"2f87e07761af4ce3816fbe329ea14083"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1329']
+      Content-Length: ['1331']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:25 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -259,7 +393,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -268,19 +402,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c9b003da-d45c-11e6-8bae-a0b3ccf7272a]
+      x-ms-client-request-id: [54dffe6e-f95e-11e6-a8c3-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","x5t":"bfIPtLHdn_ADAzOND1vYrQ0ohwc","attributes":{"enabled":true,"nbf":1483739956,"exp":1641506956,"created":1483740556,"updated":1483740556}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"eMVOWvqYvCLun2UAD8DY2toFCqs","attributes":{"enabled":true,"nbf":1487808816,"exp":1645575816,"created":1487809416,"updated":1487809416}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['244']
+      Content-Length: ['245']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:26 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -289,39 +423,40 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "lifetime_actions": [{"trigger": {"lifetime_percentage":
-      90}, "action": {"action_type": "AutoRenew"}}], "issuer": {"name": "Self"}, "attributes":
-      {"enabled": true}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
-      2048, "reuse_key": false}, "x509_props": {"validity_months": 50, "subject":
-      "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage":
-      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Self"},
+      "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props": {"key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com",
+      "validity_months": 50}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
+      2048, "reuse_key": false}, "attributes": {"enabled": true}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['578']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ca089380-d45c-11e6-8301-a0b3ccf7272a]
+      x-ms-client-request-id: [558a9efa-f95e-11e6-a6f7-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBF8p+QLZOwjO5ml4xACY8t2THZuaiYl/oCUmG7f0tcLERGJcWHmYC0cRtRVB1wBupgu7YUaI3DCU/DhLuexXGkPoWxZQaP6GrjHA/iU3FeH26VlLP6a9XoHk5eLdvnMCsVGU9AzAM67inTQV5VEZAEhXMgGh74MrI3Xa1vWLP0b9lZOxvjSlCFSmWylJUkPjw1NjbnR5E8wY0UEUotxX4+twASdE4VCTzYWEbel4wPPI5uCHIe0mPwRub7zcgIschuhcX3TOBR7yzKrL0ybRPdjU8OLDeiYU3K3sv1CDUnKocdRbo6d6bdW5zIrEqSq80J0H0AO0awsjV3o6fZe+g5","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQACeiYkpWf+J4FQnHWsJ3udBAGyfpr9zmNZBuOF8p6IllfbSPeWBlhKTTr+UyjYtG+RTG0eL7o8MOLvc7kVvYcWWqM5E/5bJ0r9a1sLcxtoTEFGH+NWXWP02HyVcVUCLmOJ7HjE758zKLt+is2LnX69GmylOSCBLM+KAEOZySwD/3mMXBIWhNuz+33PkNPGi7hBBeBw8eIhxZ1/DxixlKx9/oTxbokux4O3rteuks7UV3P59Tu/ErJkmNUnqCgYqQkw3JXLSFR6CzMYXQePEKwPIUIN2EObnwdrmf1+s5c2KUA2IEaVPo5APkPi9LYo5sjRQnIUyCZtINkXry7NmZQ2","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"e1de3da13712415489486f71b2d0659c"}'}
+        time based on the issuer provider. Please check again later.","request_id":"3a9a6b84d119484f94fb110d64846f31"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1405']
+      Content-Length: ['1406']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:27 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:45 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=e1de3da13712415489486f71b2d0659c']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=3a9a6b84d119484f94fb110d64846f31']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -329,7 +464,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -338,21 +473,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ca8cceac-d45c-11e6-9f23-a0b3ccf7272a]
+      x-ms-client-request-id: [56a8d29a-f95e-11e6-935b-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBF8p+QLZOwjO5ml4xACY8t2THZuaiYl/oCUmG7f0tcLERGJcWHmYC0cRtRVB1wBupgu7YUaI3DCU/DhLuexXGkPoWxZQaP6GrjHA/iU3FeH26VlLP6a9XoHk5eLdvnMCsVGU9AzAM67inTQV5VEZAEhXMgGh74MrI3Xa1vWLP0b9lZOxvjSlCFSmWylJUkPjw1NjbnR5E8wY0UEUotxX4+twASdE4VCTzYWEbel4wPPI5uCHIe0mPwRub7zcgIschuhcX3TOBR7yzKrL0ybRPdjU8OLDeiYU3K3sv1CDUnKocdRbo6d6bdW5zIrEqSq80J0H0AO0awsjV3o6fZe+g5","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQACeiYkpWf+J4FQnHWsJ3udBAGyfpr9zmNZBuOF8p6IllfbSPeWBlhKTTr+UyjYtG+RTG0eL7o8MOLvc7kVvYcWWqM5E/5bJ0r9a1sLcxtoTEFGH+NWXWP02HyVcVUCLmOJ7HjE758zKLt+is2LnX69GmylOSCBLM+KAEOZySwD/3mMXBIWhNuz+33PkNPGi7hBBeBw8eIhxZ1/DxixlKx9/oTxbokux4O3rteuks7UV3P59Tu/ErJkmNUnqCgYqQkw3JXLSFR6CzMYXQePEKwPIUIN2EObnwdrmf1+s5c2KUA2IEaVPo5APkPi9LYo5sjRQnIUyCZtINkXry7NmZQ2","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"e1de3da13712415489486f71b2d0659c"}'}
+        time based on the issuer provider. Please check again later.","request_id":"3a9a6b84d119484f94fb110d64846f31"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1405']
+      Content-Length: ['1406']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:27 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -361,7 +496,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -370,21 +505,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d0a06e1e-d45c-11e6-98b2-a0b3ccf7272a]
+      x-ms-client-request-id: [5cbae85e-f95e-11e6-9eb0-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBF8p+QLZOwjO5ml4xACY8t2THZuaiYl/oCUmG7f0tcLERGJcWHmYC0cRtRVB1wBupgu7YUaI3DCU/DhLuexXGkPoWxZQaP6GrjHA/iU3FeH26VlLP6a9XoHk5eLdvnMCsVGU9AzAM67inTQV5VEZAEhXMgGh74MrI3Xa1vWLP0b9lZOxvjSlCFSmWylJUkPjw1NjbnR5E8wY0UEUotxX4+twASdE4VCTzYWEbel4wPPI5uCHIe0mPwRub7zcgIschuhcX3TOBR7yzKrL0ybRPdjU8OLDeiYU3K3sv1CDUnKocdRbo6d6bdW5zIrEqSq80J0H0AO0awsjV3o6fZe+g5","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"e1de3da13712415489486f71b2d0659c"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQACeiYkpWf+J4FQnHWsJ3udBAGyfpr9zmNZBuOF8p6IllfbSPeWBlhKTTr+UyjYtG+RTG0eL7o8MOLvc7kVvYcWWqM5E/5bJ0r9a1sLcxtoTEFGH+NWXWP02HyVcVUCLmOJ7HjE758zKLt+is2LnX69GmylOSCBLM+KAEOZySwD/3mMXBIWhNuz+33PkNPGi7hBBeBw8eIhxZ1/DxixlKx9/oTxbokux4O3rteuks7UV3P59Tu/ErJkmNUnqCgYqQkw3JXLSFR6CzMYXQePEKwPIUIN2EObnwdrmf1+s5c2KUA2IEaVPo5APkPi9LYo5sjRQnIUyCZtINkXry7NmZQ2","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"3a9a6b84d119484f94fb110d64846f31"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1405']
+      Content-Length: ['1319']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:38 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -393,7 +526,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -402,19 +535,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d6b16974-d45c-11e6-a86e-a0b3ccf7272a]
+      x-ms-client-request-id: [5d6073f4-f95e-11e6-a7db-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBF8p+QLZOwjO5ml4xACY8t2THZuaiYl/oCUmG7f0tcLERGJcWHmYC0cRtRVB1wBupgu7YUaI3DCU/DhLuexXGkPoWxZQaP6GrjHA/iU3FeH26VlLP6a9XoHk5eLdvnMCsVGU9AzAM67inTQV5VEZAEhXMgGh74MrI3Xa1vWLP0b9lZOxvjSlCFSmWylJUkPjw1NjbnR5E8wY0UEUotxX4+twASdE4VCTzYWEbel4wPPI5uCHIe0mPwRub7zcgIschuhcX3TOBR7yzKrL0ybRPdjU8OLDeiYU3K3sv1CDUnKocdRbo6d6bdW5zIrEqSq80J0H0AO0awsjV3o6fZe+g5","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"e1de3da13712415489486f71b2d0659c"}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4466189ca43246ff975b9012cf18fc66","x5t":"eMVOWvqYvCLun2UAD8DY2toFCqs","attributes":{"enabled":true,"nbf":1487808816,"exp":1645575816,"created":1487809416,"updated":1487809416}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b181ba9d15534b5dab14c6ac37453398","x5t":"MN6I2FNMa6gPRXIhu0cJW04oeu8","attributes":{"enabled":true,"nbf":1487808830,"exp":1619137430,"created":1487809430,"updated":1487809430}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1317']
+      Content-Length: ['529']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:47 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -423,7 +556,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -432,19 +565,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d700f6dc-d45c-11e6-a185-a0b3ccf7272a]
+      x-ms-client-request-id: [5e0a822c-f95e-11e6-a7ed-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/84b054f0ac444d3d8386591dac9975a3","x5t":"bfIPtLHdn_ADAzOND1vYrQ0ohwc","attributes":{"enabled":true,"nbf":1483739956,"exp":1641506956,"created":1483740556,"updated":1483740556}},{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/e1dc56b3f35d48999591f6f849e81b28","x5t":"F9ukVsAt3tXcTQcRLqwlXkLBfFs","attributes":{"enabled":true,"nbf":1483739986,"exp":1615068586,"created":1483740586,"updated":1483740586}}],"nextLink":null}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b181ba9d15534b5dab14c6ac37453398","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b181ba9d15534b5dab14c6ac37453398","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b181ba9d15534b5dab14c6ac37453398","x5t":"MN6I2FNMa6gPRXIhu0cJW04oeu8","cer":"MIID3jCCAsagAwIBAgIQASTACGatQtyw3zqxVt/bEzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDIyMzAwMTM1MFoXDTIxMDQyMzAwMjM1MFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFA80Y/vJ7a6+1RtOMtPYX+cDNYafMB0GA1UdDgQWBBQPNGP7ye2uvtUbTjLT2F/nAzWGnzANBgkqhkiG9w0BAQsFAAOCAQEAfkwHm2V2mmuE9q/iMFPP9/hQvtWmJq17/evxo5Bag30cj0oOeVDZzHre4BWIf7f4M+mZvUuqE0wFwB317wPteXA7yBglaNbQo7hljCFPINbYO04FB4CqiOLQLZUwFgFh5FT76pd1WbpjJxzzEzCrEvB47G0/JR5i3BgHTbvpYMSXYpaTLGDvEBKYpIMY62mBq+QU4a5v10KQ3wFuw+DykGcg2Yyru9zM4cz3qm71nKOUT2E1HQ5Fkes2zLmDOgeBrs49U7dmLSrmpYxbI9X8p5u5pMKqFbmRC7exmwvu5z1WytcfFH8FYuzBEn0SccitX6rNjdPqsAAWRx7W9ckkZg==","attributes":{"enabled":true,"nbf":1487808830,"exp":1619137430,"created":1487809430,"updated":1487809430},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809400,"updated":1487809425}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['527']
+      Content-Length: ['2597']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:48 GMT']
+      Date: ['Thu, 23 Feb 2017 00:23:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -453,7 +587,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -462,20 +596,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d75b5b86-d45c-11e6-85bc-a0b3ccf7272a]
+      x-ms-client-request-id: [5ed586f0-f95e-11e6-add2-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4466189ca43246ff975b9012cf18fc66?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/e1dc56b3f35d48999591f6f849e81b28","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/e1dc56b3f35d48999591f6f849e81b28","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/e1dc56b3f35d48999591f6f849e81b28","x5t":"F9ukVsAt3tXcTQcRLqwlXkLBfFs","cer":"MIID3jCCAsagAwIBAgIQAru+17AIQR2zbEn41sVKyzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDEwNjIxNTk0NloXDTIxMDMwNjIyMDk0NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOqbzy+Mc4l1begihy/LHuHI0/VgMB0GA1UdDgQWBBTqm88vjHOJdW3oIocvyx7hyNP1YDANBgkqhkiG9w0BAQsFAAOCAQEAMvDevs7kTmzI8ucUmKMWmVCkPRpQdEnWldp9JEERevSOM2qPqP1SmeGsgTTGjsuGSR6xDPLi3MLww0foEo/EmY5Q5aO8Qytmj8zSRiggqY8g68Jm5j3glXPS3TJguKYWR/qUqYtnbLuX/H2TdaPQini8e96NLrQbzbvUITUwFgu16v8ooQY1kvYSqHLlhctVAdIIXLinnoJv6qrWrgmHQwF+oCon3ie+c2c7fIQDMV2y8wOczXqZNTT3ZsblZyD8PgbhulG125BhdBriCFv0sBCWdsy58HpSj13ynzoJsUNNYqIJTvmXUvdqQvWvLeqiI4hqCJzfymsTDeEUsiQuxA==","attributes":{"enabled":true,"nbf":1483739986,"exp":1615068586,"created":1483740586,"updated":1483740586},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740544,"updated":1483740567}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4466189ca43246ff975b9012cf18fc66","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/4466189ca43246ff975b9012cf18fc66","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/4466189ca43246ff975b9012cf18fc66","x5t":"eMVOWvqYvCLun2UAD8DY2toFCqs","cer":"MIID8DCCAtigAwIBAgIQGpS2nvShQieUxi7lnYuVnjANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDIyMzAwMTMzNloXDTIyMDIyMzAwMjMzNlowdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALYNGc24tW0yLgWXi4McieR7ucxDCB7N8LQmliAq70kBiv6TGnAfgwT9hmnTrI1We/c0FUNu67gvccE9V2jsTQCVZHwvFSnaNJJBG1bfwfkZM/hB4dwhbI2msw3mYf/8nIjjbh+pockQgscAX7YZFv8AludHAVaqufLlOQje7QBi3+YMhJWwIlFm3NtOmYspekbHaKFPS9WBUYEFPzjDPOcjroetjrsC5f9/jSjc3Sm22+CAcVuELPFmLVDSgHdDXvd9tXRMmNFQatmliCLu+EPrm5FRURq/6pmE+UmXl0bgUmgKNm2dwV1pVT7039jK9osPf0DHfWhaPSBK5jOKQ+kCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJxiDBv2WxyPjk/0pwoS6bfB5kxEMB0GA1UdDgQWBBScYgwb9lscj45P9KcKEum3weZMRDANBgkqhkiG9w0BAQsFAAOCAQEALpMrugwWwgx7mxJqUh66DQCtKd0pjOWwmEkahEa3KMoYwITyMWjg08af9Zmcp3HtAxY4JwsaBHO9ASca6MLMZYv7VQhU8cKfduLi+he7JlKIBiZ4Og85uv8go1PtqBNdagW//QKq7vhQVQKtGyDY1qDJy/9cn54abt8gHlpt5XWtQlnHhUvOxCumOu+CnvYDnLO3K+LHOyBZ2+OOTY274dhtmStoRUr6F4iQloIMGiP5a5IiKqaf3ax+j1uvHLC+1+mpeizwPz33itsNHmTxluFzhrhd6grnJpV7ATqFJqXbNBwIs9HlJ5I7O87ZrjKsv2uLN5hxu+CXMd6q5/dB1g==","attributes":{"enabled":true,"nbf":1487808816,"exp":1645575816,"created":1487809416,"updated":1487809416}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2592']
+      Content-Length: ['1814']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:49 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -484,67 +617,37 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d7b2d99e-d45c-11e6-b916-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/84b054f0ac444d3d8386591dac9975a3?api-version=2016-10-01
-  response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/84b054f0ac444d3d8386591dac9975a3","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/84b054f0ac444d3d8386591dac9975a3","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/84b054f0ac444d3d8386591dac9975a3","x5t":"bfIPtLHdn_ADAzOND1vYrQ0ohwc","cer":"MIID8DCCAtigAwIBAgIQW3scirdARMG6IgT3t+iSxDANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDEwNjIxNTkxNloXDTIyMDEwNjIyMDkxNlowdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5f80+Wr1FHqpKRffrMeJFSmFNJjbqBIOBP4V4CRPGNQlpJWxkB2iafiF4X5aiDSyFEv+ovt8aqfYuD+dd29LMP31A08RekxVBmonmv53f+zfduzjDnv7/b5AVcd47lOTsEWUHj5HIScUHLw8R4ue1jkPRYMN8sNwOLJ/tc7AGdHzB+LcRK2T4220/2GX00fMl+HIYgQsdHriue2mMUyVQRcLcThb1hbxcZUW5nb5rdP0szBseTBSFsypcXqeZV8ugj9GYgF+QrPoGsOsPX/SsuqFiYiYFchI+dqofxSkrrNazoO02TsnZjXbljGmhRR2jlactgz6g5arM9nmRWegcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFKRwXwyYt6ifDN5cfCK53BbDxjcWMB0GA1UdDgQWBBSkcF8MmLeonwzeXHwiudwWw8Y3FjANBgkqhkiG9w0BAQsFAAOCAQEAILfNDRaYuiqFN/isVu22zUjXRuZJ4mXxiH4nyjVY4IlcZr2CKT2geu2uR3qas6wuZdrgXDkbxa0Lo7sDxwJYUO4jFGWojYS6+cUVFZ7LGrC4PU8u0bNf8DaaXzH8E1YGRnT7jYSbDzb2dYdqpBvjpBeZH/QQAyxINkVhlIeDcivh9sFKd8E0GuKv7cAf4SY9hM4nxiq2MMYJHlWVM1ueDXeCXyYBgknFTDex9F16DIIywwKq+NFh05zYI2F2TBhtH6O2mzvqfTFJOAiIUXePY2G3jzg3+X+Aa/yZAjT3qMuekUL8hYENFFasSdD9Mwwa5GKHhdIAlw2B0KQyfn5XsA==","attributes":{"enabled":true,"nbf":1483739956,"exp":1641506956,"created":1483740556,"updated":1483740556}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1811']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"attributes": {"enabled": false}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "lifetime_actions": [{"trigger": {"lifetime_percentage":
-      90}, "action": {"action_type": "AutoRenew"}}], "issuer": {"name": "Self"}, "attributes":
-      {"enabled": true}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
-      2048, "reuse_key": false}, "x509_props": {"validity_months": 60, "subject":
-      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": false}, "policy": {"issuer": {"name": "Self"},
+      "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props": {"key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
+      "validity_months": 60}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
+      2048, "reuse_key": false}, "attributes": {"enabled": true}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['588']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d80af3fa-d45c-11e6-a35a-a0b3ccf7272a]
+      x-ms-client-request-id: [5f8f6e76-f95e-11e6-9e1f-acde48001122]
     method: PATCH
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/e1dc56b3f35d48999591f6f849e81b28","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/e1dc56b3f35d48999591f6f849e81b28","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/e1dc56b3f35d48999591f6f849e81b28","x5t":"F9ukVsAt3tXcTQcRLqwlXkLBfFs","cer":"MIID3jCCAsagAwIBAgIQAru+17AIQR2zbEn41sVKyzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDEwNjIxNTk0NloXDTIxMDMwNjIyMDk0NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOqbzy+Mc4l1begihy/LHuHI0/VgMB0GA1UdDgQWBBTqm88vjHOJdW3oIocvyx7hyNP1YDANBgkqhkiG9w0BAQsFAAOCAQEAMvDevs7kTmzI8ucUmKMWmVCkPRpQdEnWldp9JEERevSOM2qPqP1SmeGsgTTGjsuGSR6xDPLi3MLww0foEo/EmY5Q5aO8Qytmj8zSRiggqY8g68Jm5j3glXPS3TJguKYWR/qUqYtnbLuX/H2TdaPQini8e96NLrQbzbvUITUwFgu16v8ooQY1kvYSqHLlhctVAdIIXLinnoJv6qrWrgmHQwF+oCon3ie+c2c7fIQDMV2y8wOczXqZNTT3ZsblZyD8PgbhulG125BhdBriCFv0sBCWdsy58HpSj13ynzoJsUNNYqIJTvmXUvdqQvWvLeqiI4hqCJzfymsTDeEUsiQuxA==","attributes":{"enabled":false,"nbf":1483739986,"exp":1615068586,"created":1483740586,"updated":1483740591},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740544,"updated":1483740591}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b181ba9d15534b5dab14c6ac37453398","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b181ba9d15534b5dab14c6ac37453398","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b181ba9d15534b5dab14c6ac37453398","x5t":"MN6I2FNMa6gPRXIhu0cJW04oeu8","cer":"MIID3jCCAsagAwIBAgIQASTACGatQtyw3zqxVt/bEzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDIyMzAwMTM1MFoXDTIxMDQyMzAwMjM1MFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFA80Y/vJ7a6+1RtOMtPYX+cDNYafMB0GA1UdDgQWBBQPNGP7ye2uvtUbTjLT2F/nAzWGnzANBgkqhkiG9w0BAQsFAAOCAQEAfkwHm2V2mmuE9q/iMFPP9/hQvtWmJq17/evxo5Bag30cj0oOeVDZzHre4BWIf7f4M+mZvUuqE0wFwB317wPteXA7yBglaNbQo7hljCFPINbYO04FB4CqiOLQLZUwFgFh5FT76pd1WbpjJxzzEzCrEvB47G0/JR5i3BgHTbvpYMSXYpaTLGDvEBKYpIMY62mBq+QU4a5v10KQ3wFuw+DykGcg2Yyru9zM4cz3qm71nKOUT2E1HQ5Fkes2zLmDOgeBrs49U7dmLSrmpYxbI9X8p5u5pMKqFbmRC7exmwvu5z1WytcfFH8FYuzBEn0SccitX6rNjdPqsAAWRx7W9ckkZg==","attributes":{"enabled":false,"nbf":1487808830,"exp":1619137430,"created":1487809430,"updated":1487809442},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809400,"updated":1487809442}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2602']
+      Content-Length: ['2607']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:51 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -553,7 +656,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -562,19 +665,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8a5c854-d45c-11e6-a07a-a0b3ccf7272a]
+      x-ms-client-request-id: [6157ec54-f95e-11e6-a84e-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
     body: {string: '{"error":{"code":"ContactsNotFound","message":"Contacts not found"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['68']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:51 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -583,30 +686,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"contacts": [{"name": "John Doe", "phone": "123-456-7890", "email": "admin@contoso.com"}]}'
+    body: '{"contacts": [{"name": "John Doe", "email": "admin@contoso.com", "phone":
+      "123-456-7890"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['91']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8bcfddc-d45c-11e6-adf0-a0b3ccf7272a]
+      x-ms-client-request-id: [617098f8-f95e-11e6-8b02-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['161']
+      Content-Length: ['162']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:51 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -615,7 +719,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -624,20 +728,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d91a9770-d45c-11e6-acf1-a0b3ccf7272a]
+      x-ms-client-request-id: [62a0c59c-f95e-11e6-aef0-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['161']
+      Content-Length: ['162']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:51 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -646,31 +750,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"contacts": [{"name": "John Doe", "phone": "123-456-7890", "email": "admin@contoso.com"},
-      {"email": "other@contoso.com"}]}'
+    body: '{"contacts": [{"name": "John Doe", "email": "admin@contoso.com", "phone":
+      "123-456-7890"}, {"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d933a1fe-d45c-11e6-bf54-a0b3ccf7272a]
+      x-ms-client-request-id: [62c324ca-f95e-11e6-bb28-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['191']
+      Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:52 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -679,7 +783,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -688,20 +792,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d98f3f74-d45c-11e6-b281-a0b3ccf7272a]
+      x-ms-client-request-id: [643f5094-f95e-11e6-9f9d-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['191']
+      Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:53 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -710,7 +814,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -719,20 +823,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d9de5794-d45c-11e6-962e-a0b3ccf7272a]
+      x-ms-client-request-id: [64ea6c1a-f95e-11e6-8ba1-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['191']
+      Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:53 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -741,7 +845,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: '{"contacts": [{"email": "other@contoso.com"}]}'
@@ -751,19 +855,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['46']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d9fc1df4-d45c-11e6-89ba-a0b3ccf7272a]
+      x-ms-client-request-id: [64ffba8c-f95e-11e6-8e89-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['120']
+      Content-Length: ['121']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:54 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -772,7 +876,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -781,19 +885,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [da58cd02-d45c-11e6-b95f-a0b3ccf7272a]
+      x-ms-client-request-id: [65942e1a-f95e-11e6-a953-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['120']
+      Content-Length: ['121']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:53 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -802,7 +906,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -811,12 +915,12 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [daa80c4a-d45c-11e6-85fe-a0b3ccf7272a]
+      x-ms-client-request-id: [664a80ca-f95e-11e6-8d28-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
     body: {string: '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
         not found"}}'}
@@ -824,7 +928,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['75']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:54 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -833,30 +937,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"org_details": {"admin_details": []}, "attributes": {"enabled": true},
-      "provider": "Test", "credentials": {}}'
+    body: '{"org_details": {"admin_details": []}, "provider": "Test", "credentials":
+      {}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dac0537a-d45c-11e6-857b-a0b3ccf7272a]
+      x-ms-client-request-id: [682cd41a-f95e-11e6-b562-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740595}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809454}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['234']
+      Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:55 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -865,7 +969,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -874,19 +978,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [db20d3ca-d45c-11e6-a066-a0b3ccf7272a]
+      x-ms-client-request-id: [68cb2d86-f95e-11e6-af64-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740595}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809454}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['234']
+      Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:55 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -895,7 +999,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -904,19 +1008,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [db720f22-d45c-11e6-ac60-a0b3ccf7272a]
+      x-ms-client-request-id: [695c79f8-f95e-11e6-8130-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740595}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809454}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['234']
+      Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:56 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -925,7 +1029,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -934,19 +1038,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dbcdac9e-d45c-11e6-9baa-a0b3ccf7272a]
+      x-ms-client-request-id: [69fefc78-f95e-11e6-99a5-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740595}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809454}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['234']
+      Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:57 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -955,30 +1059,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "attributes": {"enabled":
-      true}, "provider": "Test", "credentials": {"account_id": "test_account"}}'
+    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "provider": "Test",
+      "credentials": {"account_id": "test_account"}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dbe7a1c6-d45c-11e6-be02-a0b3ccf7272a]
+      x-ms-client-request-id: [6a16634a-f95e-11e6-8863-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740597}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809459}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['276']
+      Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:56 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -987,7 +1091,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -996,12 +1100,12 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dc40316e-d45c-11e6-8e82-a0b3ccf7272a]
+      x-ms-client-request-id: [6ab99254-f95e-11e6-8768-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
   response:
     body: {string: '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
         not found"}}'}
@@ -1009,7 +1113,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['75']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:58 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1018,7 +1122,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1027,19 +1131,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dcce5946-d45c-11e6-9326-a0b3ccf7272a]
+      x-ms-client-request-id: [6b541e5c-f95e-11e6-9914-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740597}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809459}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['276']
+      Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:58 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1048,30 +1152,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "attributes": {"enabled":
-      true}, "provider": "Test", "credentials": {}}'
+    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "provider": "Test",
+      "credentials": {}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dcef2d7a-d45c-11e6-acfa-a0b3ccf7272a]
+      x-ms-client-request-id: [6b69d222-f95e-11e6-9d78-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740599}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809459}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['249']
+      Content-Length: ['250']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:58 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1080,7 +1184,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1089,19 +1193,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd46ab8a-d45c-11e6-b911-a0b3ccf7272a]
+      x-ms-client-request-id: [6c032f6c-f95e-11e6-9bd9-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['130']
+      Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:59 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1110,7 +1214,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1119,19 +1223,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ddb29f82-d45c-11e6-bfd1-a0b3ccf7272a]
+      x-ms-client-request-id: [6c9e0e1c-f95e-11e6-9dbf-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740599}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809459}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['249']
+      Content-Length: ['250']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:09:59 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1140,31 +1244,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [{"last_name": "Admin", "phone": "123-456-7890",
-      "first_name": "Test", "email": "test@test.com"}], "id": "TestOrg"}, "attributes":
-      {"enabled": true}, "provider": "Test", "credentials": {}}'
+    body: '{"org_details": {"admin_details": [{"first_name": "Test", "last_name":
+      "Admin", "email": "test@test.com", "phone": "123-456-7890"}], "id": "TestOrg"},
+      "provider": "Test", "credentials": {}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ddd7e13e-d45c-11e6-b005-a0b3ccf7272a]
+      x-ms-client-request-id: [6ce30fd8-f95e-11e6-beae-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740600}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809463}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['337']
+      Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:00 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1173,7 +1277,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1182,19 +1286,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [de46bbe4-d45c-11e6-8475-a0b3ccf7272a]
+      x-ms-client-request-id: [6d8212c2-f95e-11e6-b7f7-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740600}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809463}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['337']
+      Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:00 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1203,7 +1307,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1212,19 +1316,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [de9efd5e-d45c-11e6-bbfc-a0b3ccf7272a]
+      x-ms-client-request-id: [6e2095be-f95e-11e6-b868-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740600}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809463}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['337']
+      Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:01 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1233,32 +1337,32 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [{"last_name": "Admin", "phone": "123-456-7890",
-      "first_name": "Test", "email": "test@test.com"}, {"email": "test2@test.com"}],
-      "id": "TestOrg"}, "attributes": {"enabled": true}, "provider": "Test", "credentials":
-      {}}'
+    body: '{"org_details": {"admin_details": [{"first_name": "Test", "last_name":
+      "Admin", "email": "test@test.com", "phone": "123-456-7890"}, {"email": "test2@test.com"}],
+      "id": "TestOrg"}, "provider": "Test", "credentials": {}, "attributes": {"enabled":
+      true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [debc004c-d45c-11e6-8993-a0b3ccf7272a]
+      x-ms-client-request-id: [6e36915c-f95e-11e6-b611-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740602}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809467}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['364']
+      Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:01 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1267,7 +1371,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1276,19 +1380,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [df2003ac-d45c-11e6-bdfd-a0b3ccf7272a]
+      x-ms-client-request-id: [6ece08ca-f95e-11e6-81db-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740602}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809467}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['364']
+      Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:02 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1297,7 +1401,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1306,19 +1410,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [df73b07a-d45c-11e6-b873-a0b3ccf7272a]
+      x-ms-client-request-id: [6f683da2-f95e-11e6-ac15-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740602}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809467}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['364']
+      Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:02 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1327,31 +1431,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: '{"org_details": {"admin_details": [{"email": "test2@test.com"}], "id":
-      "TestOrg"}, "attributes": {"enabled": true}, "provider": "Test", "credentials":
-      {}}'
+      "TestOrg"}, "provider": "Test", "credentials": {}, "attributes": {"enabled":
+      true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [df8f056c-d45c-11e6-9760-a0b3ccf7272a]
+      x-ms-client-request-id: [6f7f3b4a-f95e-11e6-9bfe-acde48001122]
     method: PUT
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740603}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809468}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['275']
+      Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:03 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1360,7 +1464,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1369,19 +1473,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0372074-d45c-11e6-8f18-a0b3ccf7272a]
+      x-ms-client-request-id: [701e78a4-f95e-11e6-8f3c-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740603}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809468}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['275']
+      Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1390,7 +1494,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1400,19 +1504,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e08b909e-d45c-11e6-a9e2-a0b3ccf7272a]
+      x-ms-client-request-id: [70b9fc3e-f95e-11e6-bc92-acde48001122]
     method: DELETE
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1483740595,"updated":1483740603}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1487809454,"updated":1487809468}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['275']
+      Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1421,7 +1525,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1430,19 +1534,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0e8b510-d45c-11e6-b3eb-a0b3ccf7272a]
+      x-ms-client-request-id: [714efba4-f95e-11e6-a7e1-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
     body: {string: '{"value":[],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:05 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1451,37 +1555,37 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Unknown"},
-      "secret_props": {"contentType": "application/x-pkcs12"}, "attributes": {"enabled":
-      true}, "key_props": {"exportable": true, "kty": "RSA", "key_size": 2048, "reuse_key":
-      false}, "x509_props": {"validity_months": 50, "subject": "C=US, ST=WA, L=Redmond,
-      O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
-      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
+      "application/x-pkcs12"}, "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation",
+      "keyEncipherment", "keyAgreement", "keyCertSign"], "subject": "C=US, ST=WA,
+      L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "validity_months":
+      50}, "issuer": {"name": "Unknown"}, "key_props": {"exportable": true, "kty":
+      "RSA", "key_size": 2048, "reuse_key": false}, "attributes": {"enabled": true}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e14319c8-d45c-11e6-a550-a0b3ccf7272a]
+      x-ms-client-request-id: [71eab334-f95e-11e6-91b7-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI+KjuvU9c9Fs1503b63SOC77xMUHJFgv/hR2+KCGZ+uAKW5KYo/0YSXwMm4y9o1VwFqzQOyz5YdwEoi3RV4+jpzaYHoCpSx543prQ9PiSOaIt2oemPOo4gcRwH5v5blt5+R6NLAEXi2pw3YllmiOnYUDsM7rUf6XEELxVjjwCFl3N3sNffo3EoQ28K1rPBl2kvr8fcxXpHq0ZFrCtY4Qab8dSGHaVl7ToLKdq7//bbJSWy2s/ujdHgg+MnEoG/wv2FipqwHFOKXvQoiVIH5EMHo+KASPUBQCHA4S9uDBUbTObfybbnQ6+4Nmu7jreebbFZCkq24S6AtG/8PSmHXuLECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBmnRP8Nk/4oGOYv6dPQaFyQW089iXrAQfHu4+hO1LS0OVNUqfoct5DTM18RCch9bdNala7fcVbqrSQ3pzqgnzBTe81F3xV9pjRqzEgVL9QaOX8fsNTcHXLHViLmNMpROUdp6ko8hdegOfIrpAeCsZYcz0l1LGL915qDupnzpebRCfN/CtEEshHP2A82fP0PSd7WyVrmbz/Spxn8Em3kKSJlTvZddICRKUDElej6INziYNmRTAZMM4jFPkCBH0v3uJPLhqPey8UHPLz/wdQstc1U3VUSTYcQEgq7IWewC+x7cDBn1bCYuoqjKARqPps7M+Ul0zVqKFrqgdyofgFbfGz","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"ea0509a22a8b4c4eb7c84b3a63f4e82f"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOzkH3H9SXD6Vki0gBRcgPJtlM79Nq9MbjFAJr2AaDQeQcAZBkrTakAepuDEQPaqtT2hO6vbV2WdIyzlXf2TxLZTxKb2+WFGotJ7V/VelWiVJRcbaE3pUJpcE3a98gkMbIYOsrOWucE9IhrGhDax4rEnL2ssPwkTNhS4CREgEzfd3iJuPxxfeFiKnb7LP1tlM61eUgdzKJWUnLmt5fdwG+1wkxMFPi0TdVNibKu346wGDUyv2Iol9sIgZDbCRr+/VmNIRwt/xb7Z9sHjqYTM3cWld7diEEfm8kThE0CBhjZ0zoKLQdLqWOhYetu1pdNDYbiCysByh0pWRBGtaMv68ccCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBlppcRxxc0rL2EPN8ck3zj4nK7NpOUj13Ep9nuzI8AxYMFHvXReJGQET8fq79IMwTcEvNZ3Buxpw6IIB739nvMyPIeERVT8wWA4cqD+xHNyN/UUQ91s/odfNbNxGSvWSgaiLuPiiJ/QDNxcd2x/8KCoDW0J+wnZBdPQb5rxNLCSzx4S0LGKoNoFuQBVkqDINMtSiBt53q5Dkta1rigjdLZoTajGkvmDcc5p7PVO6mx7+RSs5njnsuSFLh3vWhqftdGp6JOUc8LxTZMooSdBb5+WnIIlzSyMc0cjicVAp9Xj9fOJKDs18xPvDGEh5g0EsW+5tD5SYtgcagysMa342E3","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"94804f017a0e45908e1467578f19bf84"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1345']
+      Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:07 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:34 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=ea0509a22a8b4c4eb7c84b3a63f4e82f']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=94804f017a0e45908e1467578f19bf84']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -1489,7 +1593,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1498,20 +1602,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1cf93a8-d45c-11e6-92c6-a0b3ccf7272a]
+      x-ms-client-request-id: [730e3d1a-f95e-11e6-816b-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI+KjuvU9c9Fs1503b63SOC77xMUHJFgv/hR2+KCGZ+uAKW5KYo/0YSXwMm4y9o1VwFqzQOyz5YdwEoi3RV4+jpzaYHoCpSx543prQ9PiSOaIt2oemPOo4gcRwH5v5blt5+R6NLAEXi2pw3YllmiOnYUDsM7rUf6XEELxVjjwCFl3N3sNffo3EoQ28K1rPBl2kvr8fcxXpHq0ZFrCtY4Qab8dSGHaVl7ToLKdq7//bbJSWy2s/ujdHgg+MnEoG/wv2FipqwHFOKXvQoiVIH5EMHo+KASPUBQCHA4S9uDBUbTObfybbnQ6+4Nmu7jreebbFZCkq24S6AtG/8PSmHXuLECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBmnRP8Nk/4oGOYv6dPQaFyQW089iXrAQfHu4+hO1LS0OVNUqfoct5DTM18RCch9bdNala7fcVbqrSQ3pzqgnzBTe81F3xV9pjRqzEgVL9QaOX8fsNTcHXLHViLmNMpROUdp6ko8hdegOfIrpAeCsZYcz0l1LGL915qDupnzpebRCfN/CtEEshHP2A82fP0PSd7WyVrmbz/Spxn8Em3kKSJlTvZddICRKUDElej6INziYNmRTAZMM4jFPkCBH0v3uJPLhqPey8UHPLz/wdQstc1U3VUSTYcQEgq7IWewC+x7cDBn1bCYuoqjKARqPps7M+Ul0zVqKFrqgdyofgFbfGz","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"ea0509a22a8b4c4eb7c84b3a63f4e82f"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOzkH3H9SXD6Vki0gBRcgPJtlM79Nq9MbjFAJr2AaDQeQcAZBkrTakAepuDEQPaqtT2hO6vbV2WdIyzlXf2TxLZTxKb2+WFGotJ7V/VelWiVJRcbaE3pUJpcE3a98gkMbIYOsrOWucE9IhrGhDax4rEnL2ssPwkTNhS4CREgEzfd3iJuPxxfeFiKnb7LP1tlM61eUgdzKJWUnLmt5fdwG+1wkxMFPi0TdVNibKu346wGDUyv2Iol9sIgZDbCRr+/VmNIRwt/xb7Z9sHjqYTM3cWld7diEEfm8kThE0CBhjZ0zoKLQdLqWOhYetu1pdNDYbiCysByh0pWRBGtaMv68ccCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBlppcRxxc0rL2EPN8ck3zj4nK7NpOUj13Ep9nuzI8AxYMFHvXReJGQET8fq79IMwTcEvNZ3Buxpw6IIB739nvMyPIeERVT8wWA4cqD+xHNyN/UUQ91s/odfNbNxGSvWSgaiLuPiiJ/QDNxcd2x/8KCoDW0J+wnZBdPQb5rxNLCSzx4S0LGKoNoFuQBVkqDINMtSiBt53q5Dkta1rigjdLZoTajGkvmDcc5p7PVO6mx7+RSs5njnsuSFLh3vWhqftdGp6JOUc8LxTZMooSdBb5+WnIIlzSyMc0cjicVAp9Xj9fOJKDs18xPvDGEh5g0EsW+5tD5SYtgcagysMa342E3","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"94804f017a0e45908e1467578f19bf84"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1345']
+      Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:06 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1520,7 +1624,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1529,20 +1633,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e22b0a14-d45c-11e6-8360-a0b3ccf7272a]
+      x-ms-client-request-id: [73afd05a-f95e-11e6-86e2-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI+KjuvU9c9Fs1503b63SOC77xMUHJFgv/hR2+KCGZ+uAKW5KYo/0YSXwMm4y9o1VwFqzQOyz5YdwEoi3RV4+jpzaYHoCpSx543prQ9PiSOaIt2oemPOo4gcRwH5v5blt5+R6NLAEXi2pw3YllmiOnYUDsM7rUf6XEELxVjjwCFl3N3sNffo3EoQ28K1rPBl2kvr8fcxXpHq0ZFrCtY4Qab8dSGHaVl7ToLKdq7//bbJSWy2s/ujdHgg+MnEoG/wv2FipqwHFOKXvQoiVIH5EMHo+KASPUBQCHA4S9uDBUbTObfybbnQ6+4Nmu7jreebbFZCkq24S6AtG/8PSmHXuLECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBmnRP8Nk/4oGOYv6dPQaFyQW089iXrAQfHu4+hO1LS0OVNUqfoct5DTM18RCch9bdNala7fcVbqrSQ3pzqgnzBTe81F3xV9pjRqzEgVL9QaOX8fsNTcHXLHViLmNMpROUdp6ko8hdegOfIrpAeCsZYcz0l1LGL915qDupnzpebRCfN/CtEEshHP2A82fP0PSd7WyVrmbz/Spxn8Em3kKSJlTvZddICRKUDElej6INziYNmRTAZMM4jFPkCBH0v3uJPLhqPey8UHPLz/wdQstc1U3VUSTYcQEgq7IWewC+x7cDBn1bCYuoqjKARqPps7M+Ul0zVqKFrqgdyofgFbfGz","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"ea0509a22a8b4c4eb7c84b3a63f4e82f"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOzkH3H9SXD6Vki0gBRcgPJtlM79Nq9MbjFAJr2AaDQeQcAZBkrTakAepuDEQPaqtT2hO6vbV2WdIyzlXf2TxLZTxKb2+WFGotJ7V/VelWiVJRcbaE3pUJpcE3a98gkMbIYOsrOWucE9IhrGhDax4rEnL2ssPwkTNhS4CREgEzfd3iJuPxxfeFiKnb7LP1tlM61eUgdzKJWUnLmt5fdwG+1wkxMFPi0TdVNibKu346wGDUyv2Iol9sIgZDbCRr+/VmNIRwt/xb7Z9sHjqYTM3cWld7diEEfm8kThE0CBhjZ0zoKLQdLqWOhYetu1pdNDYbiCysByh0pWRBGtaMv68ccCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBlppcRxxc0rL2EPN8ck3zj4nK7NpOUj13Ep9nuzI8AxYMFHvXReJGQET8fq79IMwTcEvNZ3Buxpw6IIB739nvMyPIeERVT8wWA4cqD+xHNyN/UUQ91s/odfNbNxGSvWSgaiLuPiiJ/QDNxcd2x/8KCoDW0J+wnZBdPQb5rxNLCSzx4S0LGKoNoFuQBVkqDINMtSiBt53q5Dkta1rigjdLZoTajGkvmDcc5p7PVO6mx7+RSs5njnsuSFLh3vWhqftdGp6JOUc8LxTZMooSdBb5+WnIIlzSyMc0cjicVAp9Xj9fOJKDs18xPvDGEh5g0EsW+5tD5SYtgcagysMa342E3","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"94804f017a0e45908e1467578f19bf84"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1345']
+      Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:07 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1551,22 +1655,23 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="]}'
+    body: '{"x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="],
+      "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e27c456c-d45c-11e6-9de5-a0b3ccf7272a]
+      x-ms-client-request-id: [7438caac-f95e-11e6-9de9-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
   response:
     body: {string: '{"error":{"code":"BadParameter","message":"Public key from x509
         certificate and key of this instance doesn''t match"}}'}
@@ -1574,7 +1679,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:08 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1583,7 +1688,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 400, message: Bad Request}
 - request:
     body: null
@@ -1593,20 +1698,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2dee8ee-d45c-11e6-b884-a0b3ccf7272a]
+      x-ms-client-request-id: [74d7acee-f95e-11e6-98d8-acde48001122]
     method: DELETE
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI+KjuvU9c9Fs1503b63SOC77xMUHJFgv/hR2+KCGZ+uAKW5KYo/0YSXwMm4y9o1VwFqzQOyz5YdwEoi3RV4+jpzaYHoCpSx543prQ9PiSOaIt2oemPOo4gcRwH5v5blt5+R6NLAEXi2pw3YllmiOnYUDsM7rUf6XEELxVjjwCFl3N3sNffo3EoQ28K1rPBl2kvr8fcxXpHq0ZFrCtY4Qab8dSGHaVl7ToLKdq7//bbJSWy2s/ujdHgg+MnEoG/wv2FipqwHFOKXvQoiVIH5EMHo+KASPUBQCHA4S9uDBUbTObfybbnQ6+4Nmu7jreebbFZCkq24S6AtG/8PSmHXuLECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBmnRP8Nk/4oGOYv6dPQaFyQW089iXrAQfHu4+hO1LS0OVNUqfoct5DTM18RCch9bdNala7fcVbqrSQ3pzqgnzBTe81F3xV9pjRqzEgVL9QaOX8fsNTcHXLHViLmNMpROUdp6ko8hdegOfIrpAeCsZYcz0l1LGL915qDupnzpebRCfN/CtEEshHP2A82fP0PSd7WyVrmbz/Spxn8Em3kKSJlTvZddICRKUDElej6INziYNmRTAZMM4jFPkCBH0v3uJPLhqPey8UHPLz/wdQstc1U3VUSTYcQEgq7IWewC+x7cDBn1bCYuoqjKARqPps7M+Ul0zVqKFrqgdyofgFbfGz","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"ea0509a22a8b4c4eb7c84b3a63f4e82f"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOzkH3H9SXD6Vki0gBRcgPJtlM79Nq9MbjFAJr2AaDQeQcAZBkrTakAepuDEQPaqtT2hO6vbV2WdIyzlXf2TxLZTxKb2+WFGotJ7V/VelWiVJRcbaE3pUJpcE3a98gkMbIYOsrOWucE9IhrGhDax4rEnL2ssPwkTNhS4CREgEzfd3iJuPxxfeFiKnb7LP1tlM61eUgdzKJWUnLmt5fdwG+1wkxMFPi0TdVNibKu346wGDUyv2Iol9sIgZDbCRr+/VmNIRwt/xb7Z9sHjqYTM3cWld7diEEfm8kThE0CBhjZ0zoKLQdLqWOhYetu1pdNDYbiCysByh0pWRBGtaMv68ccCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBlppcRxxc0rL2EPN8ck3zj4nK7NpOUj13Ep9nuzI8AxYMFHvXReJGQET8fq79IMwTcEvNZ3Buxpw6IIB739nvMyPIeERVT8wWA4cqD+xHNyN/UUQ91s/odfNbNxGSvWSgaiLuPiiJ/QDNxcd2x/8KCoDW0J+wnZBdPQb5rxNLCSzx4S0LGKoNoFuQBVkqDINMtSiBt53q5Dkta1rigjdLZoTajGkvmDcc5p7PVO6mx7+RSs5njnsuSFLh3vWhqftdGp6JOUc8LxTZMooSdBb5+WnIIlzSyMc0cjicVAp9Xj9fOJKDs18xPvDGEh5g0EsW+5tD5SYtgcagysMa342E3","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"94804f017a0e45908e1467578f19bf84"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1345']
+      Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:08 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1615,7 +1720,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1624,12 +1729,12 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e350f876-d45c-11e6-a306-a0b3ccf7272a]
+      x-ms-client-request-id: [758cd44a-f95e-11e6-944c-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
     body: {string: '{"error":{"code":"PendingCertificateNotFound","message":"Pending
         certificate not found: pending-cert"}}'}
@@ -1637,7 +1742,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['103']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:09 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1646,7 +1751,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1656,20 +1761,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3a4cc5a-d45c-11e6-8760-a0b3ccf7272a]
+      x-ms-client-request-id: [762990da-f95e-11e6-9139-acde48001122]
     method: DELETE
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/e1dc56b3f35d48999591f6f849e81b28","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/e1dc56b3f35d48999591f6f849e81b28","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/e1dc56b3f35d48999591f6f849e81b28","x5t":"F9ukVsAt3tXcTQcRLqwlXkLBfFs","cer":"MIID3jCCAsagAwIBAgIQAru+17AIQR2zbEn41sVKyzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDEwNjIxNTk0NloXDTIxMDMwNjIyMDk0NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvJPsxqbAfHSmeNbR4DYBc3xBE8EOSxS5GjeFWoPruOM3G99adhtL2U8N9sNU9Xq6maiR17qGc87csT/cyt/6ueVmdNCtgQ33PvnfFlvo3s56aJRhhwbqrEPl6f8tVn14SnIx3WpnhPnTF5PAkxf0/z2Fcyheol12mfNGZ0YSWhyOPtb9Ia9OkppRx9dqXJgF3d9WVwpJFIeXJ8TfD7pmS8yFHSwb+yBl1VMAc+jYZuEo3B5s06iC06gMkoDGo64Zsgdu/9bG+3wUhYT1AQ40XqP2q6cEqdTRO76+3xjqF0a8QCkkgj3+FbV1MuhNZYlIaoO5z2hKOvB+EcCuIOkMUCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFOqbzy+Mc4l1begihy/LHuHI0/VgMB0GA1UdDgQWBBTqm88vjHOJdW3oIocvyx7hyNP1YDANBgkqhkiG9w0BAQsFAAOCAQEAMvDevs7kTmzI8ucUmKMWmVCkPRpQdEnWldp9JEERevSOM2qPqP1SmeGsgTTGjsuGSR6xDPLi3MLww0foEo/EmY5Q5aO8Qytmj8zSRiggqY8g68Jm5j3glXPS3TJguKYWR/qUqYtnbLuX/H2TdaPQini8e96NLrQbzbvUITUwFgu16v8ooQY1kvYSqHLlhctVAdIIXLinnoJv6qrWrgmHQwF+oCon3ie+c2c7fIQDMV2y8wOczXqZNTT3ZsblZyD8PgbhulG125BhdBriCFv0sBCWdsy58HpSj13ynzoJsUNNYqIJTvmXUvdqQvWvLeqiI4hqCJzfymsTDeEUsiQuxA==","attributes":{"enabled":false,"nbf":1483739986,"exp":1615068586,"created":1483740586,"updated":1483740591},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740544,"updated":1483740591}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b181ba9d15534b5dab14c6ac37453398","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b181ba9d15534b5dab14c6ac37453398","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b181ba9d15534b5dab14c6ac37453398","x5t":"MN6I2FNMa6gPRXIhu0cJW04oeu8","cer":"MIID3jCCAsagAwIBAgIQASTACGatQtyw3zqxVt/bEzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDIyMzAwMTM1MFoXDTIxMDQyMzAwMjM1MFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJPUoiUar+vRFKOl/FTMGf5xHqy9JDPl4eac1K6xwiFfc/NN/OgC53OLxxpTkmu02dxaWzv8Rsplh2v8TuFSz3YSe8revxLacsz0E++K+JrDgeDQcrM4LqByU0ScWTQlKtvl0EKXvN2n4hLau77OamSWrtSvXx76YebAyp3YhIBrfJdOv+knm6wt+U88eAI8SD+i29VmtWscbXrnodfaeEGdkw17tKbu/6/5oUELd0OQJrpO+onS5Bae016a6KpYui8weRRyaB4QgS1F1L56SDFzh9JG6R5y33RzPGMCgCvTJhlNOTVRfDiLMNuOdEjOxhOnyteXTkcBIdYrg9u8xAMCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFA80Y/vJ7a6+1RtOMtPYX+cDNYafMB0GA1UdDgQWBBQPNGP7ye2uvtUbTjLT2F/nAzWGnzANBgkqhkiG9w0BAQsFAAOCAQEAfkwHm2V2mmuE9q/iMFPP9/hQvtWmJq17/evxo5Bag30cj0oOeVDZzHre4BWIf7f4M+mZvUuqE0wFwB317wPteXA7yBglaNbQo7hljCFPINbYO04FB4CqiOLQLZUwFgFh5FT76pd1WbpjJxzzEzCrEvB47G0/JR5i3BgHTbvpYMSXYpaTLGDvEBKYpIMY62mBq+QU4a5v10KQ3wFuw+DykGcg2Yyru9zM4cz3qm71nKOUT2E1HQ5Fkes2zLmDOgeBrs49U7dmLSrmpYxbI9X8p5u5pMKqFbmRC7exmwvu5z1WytcfFH8FYuzBEn0SccitX6rNjdPqsAAWRx7W9ckkZg==","attributes":{"enabled":false,"nbf":1487808830,"exp":1619137430,"created":1487809430,"updated":1487809442},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809400,"updated":1487809442}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2602']
+      Content-Length: ['2607']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:10 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1678,7 +1783,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1687,19 +1792,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e4213df8-d45c-11e6-995b-a0b3ccf7272a]
+      x-ms-client-request-id: [76d94658-f95e-11e6-975f-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
     body: {string: '{"value":[],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:10 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1708,34 +1813,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Self"},
-      "secret_props": {"contentType": "application/x-pem-file"}, "key_props": {"exportable":
-      true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}, "value": "-----BEGIN
-      PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "attributes": {"enabled": true}, "policy": {"secret_props":
+      {"contentType": "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props":
+      {"exportable": true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3132']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e47bf0f4-d45c-11e6-9eeb-a0b3ccf7272a]
+      x-ms-client-request-id: [777321d4-f95e-11e6-b140-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/c37279f4ae304931a74c6b32a25b7a91","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/c37279f4ae304931a74c6b32a25b7a91","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/c37279f4ae304931a74c6b32a25b7a91","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1483740612,"updated":1483740612},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740612,"updated":1483740612}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/7f5e1adf183a419bac977e641f8cf837","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/7f5e1adf183a419bac977e641f8cf837","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/7f5e1adf183a419bac977e641f8cf837","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1487809479,"updated":1487809479},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809479,"updated":1487809479}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2163']
+      Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:12 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1744,34 +1848,35 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
+    body: '{"value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
       CERTIFICATE-----\n-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE6jAcBgoqhkiG9w0BDAEDMA4ECJiLClPM6t5JAgIIAASCBMigL+KlEA9fagX0\nPFhQBeFjDiebJbMuTfa9HcOVZEDyrqmGng2Lfz+TUa3ys/V86okbUp2N9MoGK7gx\ncPqdq7rnu563LT9wGhtn8mUn8Wul0FfV2K56wsBGehJ+MPmlEjs6OZR0nVdXkwAh\ndVIzH9eFdz8mhJZOZI61TQNKCKbCqsR7lslkL2VWrSFgnHCUj5bR/BLIA2oRpQZv\nnw0SeYFQWMRyXgKH4VWMqOlObXm/ELnVOr9dJVzvTG42DRaK5N8BA9NTMsK1+8m+\nenCg4iNI/s81MD8iIy/d7MmsJFh8WQoqzUZmOVxfqNHw0TPgDpbCpCWRNigkRoGS\nRosc7MIlCPPangjPMFZg5QeMuUBrE01fSvJtZ52jSMkyloSfQzQJJb9Aam6q6Dzo\nuPCH32zz1GV/56yJoO8IefOMIujvXFZku/QNzKWiXnuSA+xjFZhGEGQToU5wLtHX\neEhz1cF519c8CkM4Ll/UUHPWtb90vqO2+O2DLug9qUUnoQl7P0O3W2NpAoBCLxUO\nqrfSyLUosms7Eg1DIVo5pwxawPK8qk7gwLntATZc+aTSUR9Y1dn4vJ9j9GZWIu9J\nVKO616gDO7q8R1C3mT72k2oUuUG25TtZOxsl+Y3iJgEyp9N7jo/Rdx5KkcvvB8zt\ngPCh5diKDjbo3LxmYRt62heOLEPs2YDjKByn0Nikco3LqTnedJeXEH2mBc7x1VWE\n0qTV4xqOXL9F7000Mv1cJcE2E88fN6tDge1IpuJbs03Ij0OgpaFRfS57NciBthgm\nBp3lREHYNVa4sqWHlUqakoNtc2H62t9nmpzFV7zXJkqKPPpanKV5Q9zOD0VKgcoF\nyAuMkhuPV4IfOEbG8iiZozayk2nfRrm4+nz7b31/5Him2MEce3wbUtmWR6OPdswr\nB6K58j8TGGzOAEDTdWc9yOf/auSIBVDw+23/TbrVD3xRWdesKa4sj7rMW+3VZ1mh\n3/ghyhVPtvFcUKrAjjBjkdeMl84m+P+KcV9Ov57bojKVQdKc7kHrkpi4F66s4Z/J\nZvWHw4LyK4PRlRFzm8eKtXkYLFssxtTRYRydT4wh6VJaOQD2Ww1cPOc/D74Qr/ap\nwQu/fx1Guqk1artbE+BalJakMNKd5Cu2/MfWt8kEjNctGrAHeDmznk/TbvX2rEpv\n/P16WFcjB4bb1Nee96xfuGPUcHul3fG5TRmKJnaxWeg5FM4H4cP5jmeXyGNqdbDS\nrgqpXChenTBwS5JvAVgv8ZvxJxp4h8fLFlUOKuKUR95gB09nBGnwAtEM4zgjKkcC\nPcvDZ7YpzU40gx6QiCVb2UPtggiEp2WyIrpe8VfzK4C7pQGInLn3Rm4G7mEFacv5\nHlbGJO+2XIk3ibFJYTQvMFYc/ESeRSOw6TDoy1sg3+Yl5BXYC+90lCGR9JK/sBYs\n12eVEqxi8kmoNXJ4on0snfDuRDv/6bIIDpfPAKqZzbTq7h6wzIreoz3wx4Oa8A9V\nrtG8TOkCYaoJRYD5uV1lc6Ok3CpZrI7kTGAfvQNi+H0Obz+sSXGksNtfdwNUzUd6\np4CXrZmc/r6o3j4biteWTURnRQqkh67QM5qHJhmXuWD82sjSKU16MM0KqPze/Tl+\n+Figx8pgk29H6LM+N9Y=\n-----END
-      ENCRYPTED PRIVATE KEY-----", "policy": {"issuer": {"name": "Self"}, "secret_props":
-      {"contentType": "application/x-pem-file"}, "key_props": {"exportable": true,
-      "kty": "RSA", "key_size": 2048, "reuse_key": false}}, "pwd": "1234"}'
+      ENCRYPTED PRIVATE KEY-----", "pwd": "1234", "attributes": {"enabled": true},
+      "policy": {"secret_props": {"contentType": "application/x-pem-file"}, "issuer":
+      {"name": "Self"}, "key_props": {"exportable": true, "kty": "RSA", "key_size":
+      2048, "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3357']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e54d963e-d45c-11e6-b917-a0b3ccf7272a]
+      x-ms-client-request-id: [784e7440-f95e-11e6-9fc4-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/9726b43b38d243138393166ea2cd34ed","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert2/9726b43b38d243138393166ea2cd34ed","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert2/9726b43b38d243138393166ea2cd34ed","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1483740613,"updated":1483740613},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
-        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740613,"updated":1483740613}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/77751969bbf44c51850c12f72722fe94","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/77751969bbf44c51850c12f72722fe94","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/77751969bbf44c51850c12f72722fe94","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1487809483,"updated":1487809483},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
+        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809483,"updated":1487809483}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2263']
+      Content-Length: ['2267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:13 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1780,32 +1885,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"issuer": {"name": "Self"},
-      "secret_props": {"contentType": "application/x-pkcs12"}, "key_props": {"exportable":
-      true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}, "value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n"}'
+    body: '{"value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n",
+      "attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
+      "application/x-pkcs12"}, "issuer": {"name": "Self"}, "key_props": {"exportable":
+      true, "kty": "RSA", "key_size": 2048, "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3836']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e61e50f8-d45c-11e6-acca-a0b3ccf7272a]
+      x-ms-client-request-id: [7965051a-f95e-11e6-a1a2-acde48001122]
     method: POST
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/b70a8a938bc540e6ad50e3f98a323d3e","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pfx-cert/b70a8a938bc540e6ad50e3f98a323d3e","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pfx-cert/b70a8a938bc540e6ad50e3f98a323d3e","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1483740614,"updated":1483740614},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
-        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1483740614,"updated":1483740614}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/bc2b41b6af3542ca830841cf38fcfd76","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/bc2b41b6af3542ca830841cf38fcfd76","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/bc2b41b6af3542ca830841cf38fcfd76","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1487809483,"updated":1487809483},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
+        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1487809483,"updated":1487809483}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['2519']
+      Content-Length: ['2523']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 22:10:15 GMT']
+      Date: ['Thu, 23 Feb 2017 00:24:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1814,6 +1920,6 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_key.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_key.yaml
@@ -1,25 +1,158 @@
 interactions:
 - request:
-    body: '{"kty": "RSA", "attributes": {"enabled": true}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8a823254-f95d-11e6-b05e-acde48001122]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/882b503c-c281-4fe9-a85c-d9e0cd66d376/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1377']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 23 Feb 2017 00:18:03 GMT']
+      Duration: ['5674501']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [R+5lMh6N45vqXr8u5czDtA2s3YGt7KgN1DoL2Lt9swI=]
+      ocp-aad-session-key: [-3sdDtbW4nVZglvUVLWAoKYno2ZjPYNTBvaENvcLcHee3oa_x9vAAo5e06x0KGFC8S0ZFVdhXi6mifuZkY1c-IrYH24zfUj5SQkuGkDM0eIjAa28hx-riRKnxr45oxM-.uNMjomAcCUQ0O4S78h1hGe7oELVSgBjia3Z5kk27x-8]
+      request-id: [23641f24-6fbb-4d2d-8b79-ff9cf5b48c28]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"permissions": {"certificates":
+      ["all"], "keys": ["get", "create", "delete", "list", "update", "import", "backup",
+      "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}]}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['407']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8af968ec-f95d-11e6-bafa-acde48001122]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:18:05 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['703']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8ca2d4e4-f95d-11e6-8e3f-acde48001122]
+    method: GET
+    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 23 Feb 2017 00:18:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8ca2d4e4-f95d-11e6-8e3f-acde48001122]
+    method: GET
+    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: '{"value":null,"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['30']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:18:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"attributes": {"enabled": true}, "kty": "RSA"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0013dba-d457-11e6-b8d6-a0b3ccf7272a]
+      x-ms-client-request-id: [901f1e28-f95d-11e6-a896-acde48001122]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/15180a5638d3413f9db704f3eba73220","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"lJNJDpCKZ6aNN3TtaPE7lHWiou9wTmBNv79zF2NaasK4n91QkK9JpgNgaoDKMU7LlbUj-qhXklHrpB5a-l4Vlg1oCLZo56chXDOhTOSDnXLbzZ6QZeUxGE6DHqfm69DekKUs1W2sv6DdG20KXQR8ceLkVMvJ_HeS8YKtIkUNab756wYFRnzQpebVlR2visTWU5zrDQd9ShbSYzizR2TabgPbuOSmbgRRYiN4iJvd4feYd-QaBLK__08Y-PqCwUFvWBt5uVoDs7Vf_sMipVqmMEiNkAwNGQttOMfQIV83nwntDAsbgqHI1Ouf_DtKln003hSOblUrSW4Olwhr9y9raQ","e":"AQAB"},"attributes":{"enabled":true,"created":1483738457,"updated":1483738457}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f5d6dab5b32245cd82de7136f36fdac1","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7SyHs8MyBi5fT2nV3AZwLgvT30laBSgIOchQgF4Rx8EPNncsYTv-EVSALz09k71EISicb8r309BXVvXnwrjQUsqp7pDHIvurDb6VRf80MmzykhiIJjfDxoV4uyXcOSV2Ps2hDFgrQa7pQ8DlksB-zFmlP1Ojx-CpPnIRC08t7RXyGjC_99UtND7DIkOTYcps9NVC1SwmBDZsPDyDxHuEIlaQdvTywu_lm1DpYWt9AEcSzRpDbA9UdZIAYXWDJehXgE-QcaQzU6jD1DIh4oFFLfRupPD71bFqEyQ_CMQ2lav1K1hOvRlJOonQjYdxITCzoh3lKbkzawNBZZ8wVy6IgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1487809095,"updated":1487809095}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['620']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:17 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -28,7 +161,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -37,19 +170,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0b25d0c-d457-11e6-b1d9-a0b3ccf7272a]
+      x-ms-client-request-id: [914d41f0-f95d-11e6-be75-acde48001122]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1483738457,"updated":1483738457}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1487809095,"updated":1487809095}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['165']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:17 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -58,30 +191,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"test": "foo"}, "kty": "RSA", "attributes": {"enabled": false},
-      "key_ops": ["encrypt", "decrypt"]}'
+    body: '{"attributes": {"enabled": false}, "key_ops": ["encrypt", "decrypt"], "kty":
+      "RSA", "tags": {"test": "foo"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e11d8da2-d457-11e6-9dcc-a0b3ccf7272a]
+      x-ms-client-request-id: [921713d8-f95d-11e6-a638-acde48001122]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"sZiaRJIrmVH7p7l218U6-RitQi0Nf4hHfwo7TzxaUF-B55gH8qxpGRY5z9DhzPUB0oG9VlYMSYOpP0t4Ol_I8dmjoMuJtRRn3CaGdlOgKPe0qEPoLa5N07SHLFltDLUZKaZ4HR2AymJxhsQXMgK1f5B1mfi0mDfZLu6h_0kL-0MLIdgnKINm27O_G5nrTyYgRIqMchIPNASb8qXeBkxxSxNvhBm1CJE6Ye40grqJcnKoltLebzzUqlojuYT_F0ItPMheFVPIt6BrZj8Ixe-v3wTSTz7eLMWW1ssJKWqp9NOwW0w58DTAoNDE_tpALibO3KlReY0Q9Q_E_JCAxhVCNw","e":"AQAB"},"attributes":{"enabled":false,"created":1483738458,"updated":1483738458},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"wxeYPDHVvT8k0GzoXk8Kn22qF7c47wu1MTXgQE1qLmAllJh5M6IEoot--b5gRsVItQuhGCC4umTvw_NA3XkOtJJvxKe4OIqFn91r3eSgDRavaFhIVyStUyVNUhcfARylWr_zoHziZ_Tj-mCpFFrICDHacH-Ev3PWFAleqZNdZ-spXAJjb_5upJtRxgkjNNNBvR93k58Tfg9rWDH32EwY2kfFY3tBvyaGm4NdcE7Y6bpRzHizVhKpk7j62acEm0NUkib4zVCChkGStKUOHwPhWHLpZYYLf38Rrwk3v33CwxDT2qmHcp_aVj5EH6DWi-0t13XMcBj_EWzpYDUpe9UJ2w","e":"AQAB"},"attributes":{"enabled":false,"created":1487809098,"updated":1487809098},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['605']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:18 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -90,7 +223,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -99,19 +232,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e18ed9ba-d457-11e6-8989-a0b3ccf7272a]
+      x-ms-client-request-id: [934ed5e8-f95d-11e6-be3f-acde48001122]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","attributes":{"enabled":false,"created":1483738458,"updated":1483738458},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/15180a5638d3413f9db704f3eba73220","attributes":{"enabled":true,"created":1483738457,"updated":1483738457}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","attributes":{"enabled":false,"created":1487809098,"updated":1487809098},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f5d6dab5b32245cd82de7136f36fdac1","attributes":{"enabled":true,"created":1487809095,"updated":1487809095}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['392']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:19 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -120,7 +253,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -129,19 +262,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1ec7358-d457-11e6-a67c-a0b3ccf7272a]
+      x-ms-client-request-id: [941a4e00-f95d-11e6-91cc-acde48001122]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"sZiaRJIrmVH7p7l218U6-RitQi0Nf4hHfwo7TzxaUF-B55gH8qxpGRY5z9DhzPUB0oG9VlYMSYOpP0t4Ol_I8dmjoMuJtRRn3CaGdlOgKPe0qEPoLa5N07SHLFltDLUZKaZ4HR2AymJxhsQXMgK1f5B1mfi0mDfZLu6h_0kL-0MLIdgnKINm27O_G5nrTyYgRIqMchIPNASb8qXeBkxxSxNvhBm1CJE6Ye40grqJcnKoltLebzzUqlojuYT_F0ItPMheFVPIt6BrZj8Ixe-v3wTSTz7eLMWW1ssJKWqp9NOwW0w58DTAoNDE_tpALibO3KlReY0Q9Q_E_JCAxhVCNw","e":"AQAB"},"attributes":{"enabled":false,"created":1483738458,"updated":1483738458},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"wxeYPDHVvT8k0GzoXk8Kn22qF7c47wu1MTXgQE1qLmAllJh5M6IEoot--b5gRsVItQuhGCC4umTvw_NA3XkOtJJvxKe4OIqFn91r3eSgDRavaFhIVyStUyVNUhcfARylWr_zoHziZ_Tj-mCpFFrICDHacH-Ev3PWFAleqZNdZ-spXAJjb_5upJtRxgkjNNNBvR93k58Tfg9rWDH32EwY2kfFY3tBvyaGm4NdcE7Y6bpRzHizVhKpk7j62acEm0NUkib4zVCChkGStKUOHwPhWHLpZYYLf38Rrwk3v33CwxDT2qmHcp_aVj5EH6DWi-0t13XMcBj_EWzpYDUpe9UJ2w","e":"AQAB"},"attributes":{"enabled":false,"created":1487809098,"updated":1487809098},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['605']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:19 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -150,7 +283,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -159,19 +292,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e240bc80-d457-11e6-bad3-a0b3ccf7272a]
+      x-ms-client-request-id: [94f93f52-f95d-11e6-9a38-acde48001122]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/15180a5638d3413f9db704f3eba73220?api-version=2016-10-01
+    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/f5d6dab5b32245cd82de7136f36fdac1?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/15180a5638d3413f9db704f3eba73220","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"lJNJDpCKZ6aNN3TtaPE7lHWiou9wTmBNv79zF2NaasK4n91QkK9JpgNgaoDKMU7LlbUj-qhXklHrpB5a-l4Vlg1oCLZo56chXDOhTOSDnXLbzZ6QZeUxGE6DHqfm69DekKUs1W2sv6DdG20KXQR8ceLkVMvJ_HeS8YKtIkUNab756wYFRnzQpebVlR2visTWU5zrDQd9ShbSYzizR2TabgPbuOSmbgRRYiN4iJvd4feYd-QaBLK__08Y-PqCwUFvWBt5uVoDs7Vf_sMipVqmMEiNkAwNGQttOMfQIV83nwntDAsbgqHI1Ouf_DtKln003hSOblUrSW4Olwhr9y9raQ","e":"AQAB"},"attributes":{"enabled":true,"created":1483738457,"updated":1483738457}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f5d6dab5b32245cd82de7136f36fdac1","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"7SyHs8MyBi5fT2nV3AZwLgvT30laBSgIOchQgF4Rx8EPNncsYTv-EVSALz09k71EISicb8r309BXVvXnwrjQUsqp7pDHIvurDb6VRf80MmzykhiIJjfDxoV4uyXcOSV2Ps2hDFgrQa7pQ8DlksB-zFmlP1Ojx-CpPnIRC08t7RXyGjC_99UtND7DIkOTYcps9NVC1SwmBDZsPDyDxHuEIlaQdvTywu_lm1DpYWt9AEcSzRpDbA9UdZIAYXWDJehXgE-QcaQzU6jD1DIh4oFFLfRupPD71bFqEyQ_CMQ2lav1K1hOvRlJOonQjYdxITCzoh3lKbkzawNBZZ8wVy6IgQ","e":"AQAB"},"attributes":{"enabled":true,"created":1487809095,"updated":1487809095}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['620']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:20 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -180,7 +313,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: '{"attributes": {"enabled": true}}'
@@ -190,19 +323,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['33']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e299c16e-d457-11e6-a467-a0b3ccf7272a]
+      x-ms-client-request-id: [95d50be8-f95d-11e6-ae66-acde48001122]
     method: PATCH
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"sZiaRJIrmVH7p7l218U6-RitQi0Nf4hHfwo7TzxaUF-B55gH8qxpGRY5z9DhzPUB0oG9VlYMSYOpP0t4Ol_I8dmjoMuJtRRn3CaGdlOgKPe0qEPoLa5N07SHLFltDLUZKaZ4HR2AymJxhsQXMgK1f5B1mfi0mDfZLu6h_0kL-0MLIdgnKINm27O_G5nrTyYgRIqMchIPNASb8qXeBkxxSxNvhBm1CJE6Ye40grqJcnKoltLebzzUqlojuYT_F0ItPMheFVPIt6BrZj8Ixe-v3wTSTz7eLMWW1ssJKWqp9NOwW0w58DTAoNDE_tpALibO3KlReY0Q9Q_E_JCAxhVCNw","e":"AQAB"},"attributes":{"enabled":true,"created":1483738458,"updated":1483738461},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"wxeYPDHVvT8k0GzoXk8Kn22qF7c47wu1MTXgQE1qLmAllJh5M6IEoot--b5gRsVItQuhGCC4umTvw_NA3XkOtJJvxKe4OIqFn91r3eSgDRavaFhIVyStUyVNUhcfARylWr_zoHziZ_Tj-mCpFFrICDHacH-Ev3PWFAleqZNdZ-spXAJjb_5upJtRxgkjNNNBvR93k58Tfg9rWDH32EwY2kfFY3tBvyaGm4NdcE7Y6bpRzHizVhKpk7j62acEm0NUkib4zVCChkGStKUOHwPhWHLpZYYLf38Rrwk3v33CwxDT2qmHcp_aVj5EH6DWi-0t13XMcBj_EWzpYDUpe9UJ2w","e":"AQAB"},"attributes":{"enabled":true,"created":1487809098,"updated":1487809104},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['604']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:21 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -211,7 +344,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -221,19 +354,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e30edec0-d457-11e6-a3bc-a0b3ccf7272a]
+      x-ms-client-request-id: [96ba2248-f95d-11e6-80cd-acde48001122]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/backup?api-version=2016-10-01
   response:
-    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkw4TGxBbVpEMndLd2JETjVIdV9LRlV3Z1FFZS1wbmNzNGQ5OTRCWTFVRG1wMGFweDNFQmpLc1hPQlZzQUlEX25zUGlZeVIzeHFnb3lMSTgyUldULUc0em1vUFRzUUVVYVJfOC1iU3hWcmM3ZHNEUzhGSGgzUU42eEp4RFdBaFUyejJ3ckcxalQ2eVczYndyWUVsdExnemlZYTBIa2FjZnVITTBYMk5mY2Y5dzFtSWVIVkxSWlFzZkNZZjhsdjJMMGI3TmUwSUNXTkNWbVhWYl80azhaaUd0WWpmSEdmUVY0NDdmOVBwczVVMnpFQnlibkNLTjd4dkU4X1kwNXNtczh2NFBGbl9Pak02bkVVR0NtUzlEaXFzZjNiM042SXA3ZGZTeXcyalVVRm9IQ0FScDdlV0tLb19fYmF4NFRXOUtaSEdoTFBBbGlUV1RrbTBwVXkySkQ4Zy44bFRVU056czczSGgwWWhjRFpXeXNRLmVWejVsWDBqOGR4a2JBZ1hxMUk4UXN5dy1LRGhmbUJybUFpcHNTWGFGcW5UZWtkZF9xalNuQTZmcndMRUFaaXJzV2N1blo5VGd1SzRrcUVjLVZuMzJ3QUhFZXVXU3FUbERHYXRoYjV0eWhqeUFOa3pQUVBWUDVQT05Pc0g4aWxCeVN2bElRWG1qSENvZWhZQ3EwOHJ0MmRmZERac0RPRnF3UXEwbFlUeUJXOWJNNlhkQWl0TFpsZGYybFpPU3VkR25VSExpR2Vobk9OZU5PZkxZSTFGc1R2WFJpZjNzU3Budi0zeWxRX01KOXQtT3RrdXJaTkNSb3JWdnNDTnhZQ2lSLVNkMGtVNEI2RlN5X21qZE9ReGVMejZIRXEwZGFEMHItX1dFUFBVcUVNSzlGc1J6WVBuOXpiNnRTQ3cwaF9fYXhYbzJDYjZFLVJrNGUzVkowbkNoRUxCZm9JNzR5T0ZwVUdqVjdBTGdSazVON25rTE9obGN3VFVoTUFVMkVoUFFpVTJMV3VRZzJBQnVWMVZkUGtMX2I4SE9UYmQ2alFTcHZlUlVQQlBWN0tTazFmd3NibW9fZXJIUFNralVGN3BtbTV5ZlFrVk1mY1NSeXJMYnNkbmY5RklqVDM4UEN6bGxjZVdyd0VKUmVxRHlzZGo5LVNBbHUzQ05wUTNnLXdzVUg5X2dGQ0pBWEZUajBPMmFPckVxUUlnbHI0a1hXRGgxZ0cxd2tMcmZUQ0x4MkJ2LTF1dGVTUlFxYnIyUjV0XzM0SzI3dU43Z3hmZVJVQTRxaGdPUGU2VUNTclRmWEVudDdaTzJvOGkwS0t5cjgzUTltZU9ZeTNzX1QxRkdSRTVsWkJCRzY5MUJIYU9pOGQ1eEg3dmM1eWdzcGR3TUVNZXdlY2ZBM3ZaWGtKekdVczVZV2FLMkVqbjdWTjktS1FwX0doeWlmMkMtZDdSYnZ4TzJlclAxTVlqZDRva043ZGdWMGR1T20xTkhNUjAxbXZ3NlAyNzF5WHVtRENzVHRKTUl6Wmx2NWtTQjNmVW1GVk03X3NlM0xZVEZFUGN0b215WUZ0cmFPWkg5MmUyeElxeUpyNTZZV0xPTDg2cGVCdjV2U09KM1pNc0J2dUM4LU5BR1FRd3RhcjBvTDB0dmh4ai1XTU56dEhhUWRDcVZTSlk5QVR3SGF4eWpZYzdNc2RSLVVsWFhFX0R6aXYybzRTTTBKcFJyczNDNnBvY2NVOXFWdVhVOE5YN1VKUGMyMTNuQVZ1NDNlNUZWMno4T3QyazhfNkJIYjBrTHBSTi1yV2R0Vkxqb29qWWNvelc5UmRrNUJFN1JkY3ZJQ1VZYlg2VGIyRWN2S0hlWFAySTR2TFZ6QnZwSlhPOXlYekxDcXFIRHVMX1UxczVVWGNaamZLVzJKcmJSX0c0MXhlZTdtMFgxMnVnRzVlQTdGVWhTZzFtSzdIN3dXZ1pyMEpUODVFaml2aWNUa1ZLbU5sYzNtWXMzWDJua08tRUZFZVdzdEhvQUVpNHNvT0R4eWRhZ2R2ZHdVZHBTV281SHZzVG5scGdkRXNSckJ4aXp6WUVSZUM1Tll0QktZUk9DWF8xM0ExRHNvXzJyYVE4VEo4Tm16WV92aXFxQ0tkenZQcFNvcmpvYmQtYmpsN05zbjZhRHkxdnVwR2VERUt3cENENVRTSFQ4RXVDdHNCZ2p2TVY5SDNfOENIMWZ1Yl8xSUxFWl9mTTdidHNiWWExWkpPdllRZlpNTWYxam04VlhhbjFUMVJFRDVvTUdyT2JLdHlLeGtIWlBISVo5RXE5d1FvWlJkaXdDWnliRlh5QlBTYW9XX2xBZl9vSDNmVGRkS09uNl9uWVZpV1ZXcEFxMWZ1cVJjcGttUkJxd1JZeHI1eXFWQlhNUDBRaFVXMGxhV0xiNS1oYVdxSUVfbUlSOFh0RFVGa21xTEdQS3lfUU9uNUhTVHBJZHZoZ3pTZzdnVmF5V0xEdk9PcVpZLXJQVFo3MTIxYTN2QUpsZXhzRXVZM0FNNmlITDFXaG5RX2VsM1k2T2ZrejVsV3J3eGhVdXN1dF9rYmJWcU5Iek9TMnJadFh0cDhUMzIzMkNTZUN4ZTRkMFZGZFk2ZUNVb3c1dzJQVzh0RUtyTVV4V3ZlcE1FNGVqQ3E1LTNPcWI3N1hpZG1MVjdRenVXd2doeVEwV3JWby1PWTN0bFh3aGJFbXFJZmVXWWR2VlBjaUluU3BBSlBHWWJlcG1oTVpJcERQQU81YkdCNF85eGk2RmxWZnk2eHlrWmxJOGVlQVRHU3FRenVteEQ5R0JDc1lYQmZiRE0yTVJUaXJpemFwaHFrR3RLRVZhNE12Rzh2NkdWV3RmazFoQTZWVUotcFU2ZnVtLVV1UWs4by1iRlRTbzJUdVRrRllxaDRIN29WSUFkUThOSmR5UzVXM0pUUWpOcGZJMXJXRjdQYW5saGNmZ2JCdzNWdnd3c290MnAwc3Qta0F2d1dhOVozczJTZXBDYmMzU0dZbXpGb1lPNzVJY3NXNEsyQjVmenJtSmpVc0JWdEp3R29vcG5GN0d2bE0zclA4WEg5VEEzWUd4LXFJWV9sS1RsRVJBMnR0aV9FRnFVRWIwZDNoN2djdl95c2xsVjVQMDdQWVM4NmJBMUE3VG9TWXFPVmwwTGdLSE9KbS1XOUZjOGo3dXV3cHV3VWplcWNHTno1SUpnNnZyZE5YbmRfbHZiQUkzVWFLUGlvVVA5UzRrTThJamVrdmM5M1o4SnhOU0syUWt1TWdpMnh0RzVGVGlNR3ZFWmpUQTRnY2dsUFNrYjFheDRCZTVCdW14WVY4LWJjWnNBQXBFd1h6V2JOWlZLQ0ZwcjB0bDFkUVFfX0xqb1lqV3JYTG1scWFZZXNjb29IMFlSeGk1RUs1bjNER0pnOFpEM1lQdFluYXc0V3lrOWpaUDQtd3RtNzhlY2N1NzNaOTFsbm9PMXh0cmwzbUpoVmo4elJ4UDlfLWhuN2FNNEhKRnlXdFhvdGZjQ2c2UGVRcGVaSlltYW5NM0szSWFrQnhpWWQwYVdYU0t6Sjk5ajkxNWZaandHVnpPLUtELUlNOWhsdEY5bzBqM19SbmNuM0N0NFJyM0E5TWFmeFMzRXFhM0xRQXBndTVCS2xPU0V2MUxSNWtfLXdzdHMxeFdneUZtaGJVWXYxMFJuc0o0bXhwNDk0TFhybUo1R1RScXBpQWpOR2V2RXRMcE5qTHI2TEViSURjT013Nml5SGlydTNpblc3cGhMVWxpSENBOGZOWFFJRmdtVnE5MU9reVBkdnRZTkdQemZOVmJpZzBmN2JTWHRYLXRzNS1kQ0loY1lsZWR6U3pGbHpBMnlwVHU4Mk0ydUZVNEZ0RlhYRGNjTlJuV0NjTDBSNkhNRm5KYnJ6ajAxU3V4OWdoNjI4ckJEU1ZKQl9CeVQxd1NQTmc0Um1PMUJqaUUxV085czE1NVRHSFZtVkF1OFV2Nl9VaWtCTnNXU0FNc2ZBaHFoVVdiaXZjMVRYV1duVHM4U0JfTmNhMUlkMkZwSlR3ZVRFZmVHN2F4eVBOZDZibUVRSzhGRFhlTHgteE9EQ0d3a1V3eWNoY2dzRVVReFJRTTRkVjYtZXI5SkpfYy14T2RVQnZOcnpTR1FtT1F2SjU1T2ZibU9FNk9DTkJJRV9MR0xpRlFHNDY1cGVCdTNUUUdSUjZJaUM2Wm9rd2JTdGdOQlVnaUtOeHVjckxSV3c4dmM3UlZybGNHbXRhS1ZaUzBYdHI5b1hKNjIwSEdnbmJvUFRlNG5SLW5fcVg2VkVqS3pMYkJxQVV4cmFyNTg3QlJkRlFDWHJLU0xPU1I1TUlXRjYwN0dtX0NscS1mM2xuYWFzTUNCV2JSdzQ0Mnk0WU1uWU1PUm1Wcm9hZ1hnUGswZzY5UG1uaVNhekZyek5peXpBSXVoejQ2VTBiZEh2RHJ4WWlfZG40VEZSZS1mOUhJVUMzV3BicWo2SlJrQ2hvS09GSVJaWW0zLW0zZE4tVmRxZzI2aDJhZ3hscXJEWFJWNUtKa29lLTdySjctLVZfUE11RjZnel9EejA5amlubXg5VVA3NEQ3a0stQTZXQWliQUY3YmZ3WEkyVzB6VFFxLWZpT21QWWpvRU44QThCNUNmSmwtZEwtVjFaTHlFdzNScFVsV2diZTRkX0xWWWd2T2Z5WnZBNFB5bFZubWdDMlc1U3pGbkpMTTU5UWdLbXdoTE1iYWVEWml0cDhMeTdUU011WC1uYWdnZGVnLWpDaWNybzlHMEdaQWhsaEt0YUJfdFNNbURIYVFGTEdYY0RUZDNqVUpfMkluaEVPUXlVMkp1RTBGb2lCa3RlTnBzLWxWUlUzUWZFdnNRRWg2bHlfYXhpYnVlRmdqZ3Y2WDlOMGJaVW9qRU9xaVptVTZpdW5uemE5M1JGZ0ZpZUFIY3FISjF4WThKU3hyQVNGR3JtSUptTWdYWHpEUE8wRWhXald5LTB3ajN6SV9rT1kza3pDc1FySzVnVlFXd0t0TmNZVEFZN0tLeUhFQVVHS3FKYzVxVVJ1cFdFU0gxNEdUZlVPdWxQZjJZRzBzZ28zRXpVdFhkMjg5cTJHX2FXendFc09FRllUbDRnVkhraEJPRlRvZTdqazFXbVEzMklnNWs0XzJpQml1eUk4bWZ6Wko2VEFaa1UyNjBvRk1nRTd5OFFLRHg1bGJKRXpnd3NlU3ZqeUpYZmtYbkN1anVYMEZUOGdUcWpXcVBpNjBndnZydWpIN2lESHg4U2MxaXlyMEU0V0UtRzNZX1BCSHM3dHk1ZWtxM0p5LXI1S1hrWWJoRUlQVjRfVmZKV3VLWVJkY1VNRUZnc1dCTWUyY2NiUDlrVUlNWVFaeGRseEVidXFIMWZuQUxibk80Si1vd0ZRVllZWmlDOV96X3hfYm4zNXVkZnF1dml3anp2V19CUE9TYWZqNW9zX0Ftb0RvcHRqbTAwT1NoWHFtR2pPX1FpcEFMQTUxNnEyU2NlLUh1UWRYWURCWF90WndjZHZGZldRbGJFSUNkXzY4SVpBZV9xVmZqV0ItYW5VQlQ0LVp2UXVTMVZLYkhvbllHbXBpQWRvbnZvMXVSMW11M0YycUt4alIwcGQ1aTJqWEQ0XzFqTmtmdzdKREYtMU1RZlpHUjQ3a0lGME9oNHBJQzBNM3pqM0FsbmFYZmYyTVZfY2Z0Q1E2RGhTbWE3aW9ldXJJTTZLdExETzNySW9OU2cySUJyRkVPYmVpTVllaGNjZjFhVzdsa0N3a25vTmgwMF94d1FOXzhCX2lYT1o5bXlsVm5ucVVwNjV5bjU3SF9ramZFTDhJeHEwT0QySFlzVlp4VDY1c2dzTTVROUFrQkZVTkNTa3dTQlJqWWJqYWNOZS1hS1dnRWxULVBEVzJtQ3RjWjJuUkM1ZnYzei10ZTdWT3FNNHZRY3kxOGJ6SkRSZUlFbjVSTmF1TVVZVTFxSU9MSUk4WV8yb1g3S2JFNlFmUFdndWRtVjVPREJ3RjNnWWVOZmFtVWtxdnhvN3R5dXl4dDNPcnV4TmlaM29xLWR3X1A3X2o0cFY0RDNyQ2R3TE0wajAwdmJuQ2RSNmJKZjB3TGtzQW5XUmxsUUZ0WHo2a01pVjgzTGlLR3dqb29fWWx0UktCWEZ5NDZ4Tl9GbWhuclBackkwVmR0QS05S2Jkb0RrMnNFd1FRSWZXOUg2S1czSWY4NmpZVGlTS1NNZ0ZEeTlGZ3VSem1TX3p5cW15V3BpNkk0T1g1blpyV2xKdEdueFo4MDU2X0JqREFoUk9fZnNlZXVNN2FILTgxUHdnSGZRWlkyeVFxSDVGVXJVSy00TjVCUEJCdGJLb2ROQldMdXNUQlA4YVhndlA0eEZqOVlfNHRXcENZWDcyTGo4N2p6YkFPZWlIb3pMQVhJMk5ENElDODdPa2phMkFBU2JWd2dOd1BudmtDSlRyUXhQdnZLdDFFOS02OXF3ZU5ESzRHaWNEYWdiUG1JQlZJaXI5andmRE5vSmNjTzZoOG1zN2I0UjV0SjlnQW16TlZzYWxHYk92SmEyLWtDZ3NlQUNvb3JibWlKM1pZS08yRS14Slg3cmdGWGdWaXYzNy12Q2FRRDJDTkpKTDZkSkxqOVJVWlAwY29wQ0pOc0dTT2hLbmxfZ2lmNFJHUUZlUzE0YjJIMk9wU1IwbmxvWFVqQTdKOHlTbWd0a09oWENGZmw1dlhkUVJycTdHSVprS3ZKWVpxTG5ySnpJZktEaG9vV293bnF6bE9BN3ItUFVlVHFmMFVHaFA4Sm56WFVlSHRrS1lHUkVpX0VoX29nTmxnclNUZ3Ywd2dxdFJHeERVaWJUX2t3eENDVzdlcm1EU3FxN2l3Tjl6c1pHSEdZSi00TWs0S3pvSU5vS3gweGNULUM5R3R2S1ZxSTFMRlhoR19JX3Y2T24wZHRrREZGUU5ubGVKR192aFpiSmI1R0V1WTk1OUhMVFJDQmV4cWlwR2s1S2hMU2ZCS1Q1cUtIdGx4aG5zUFFMblRwWUo3cnJNQWpONXd1Qm5MamJya3BqY2hnaWlIbE1nUkhLTm5OWDdpeTVhM29JeTZmZEM2NUR6MWVPekNVZDBHRUdvNkpTWmN3bUFHWF9ibGNVMFVpNVhtU216RHBLUllkSmxSR0tFOE1yUjllRkpoenJPdHJSdFBCU3BVNHJlaHo0OFNLN3hGWHNUWXBMWUlBSFp3TVlsQk5raHhDSjEzSEg1dnJXcW5yZzNSWjlOcERDd3FTSTRfV0N4LXFjdHhtUHBxSUxsQkZjNWtYS0NKV1BUTm9jYkxlM2lSNlZHaWRTMmxwZXF2RVVNdG1aZkV6STg4aHlucFJkd3NIS2duMGJWOXlFaEhwNk84VnZ1OXgzLUFrcENzZzJ3Y1g1RmVZQjZQVVRUWm05blVRM1g1Q0JHalBQeF9ZVURzemFnenRjUWUzRmxtcGVYamdMWm1aRWtudTRlSFZqRXFvWUVMM1ZpVndtSG96MlcwMGNrU3d3S19EWk1UUDZjZ0VEQWU5LUluOTlpOUFHNXFOSlozekZXdUNIVWNNRUxGWDQ2bXdJX0VhNDQtbDlKTHhxWjE1cy1tX05OMGt0UDJ2dFhLYnB2bjJURENLSjZpczRlVDVXMnJxLW80WEVsbWVZUDhZVmh0VjdVeG5ya043UHV3UWxhZTRyckgtelB3VVNxeGRMVlpkMHJRVUtndXpJMUFJLUNPQUJVNXo2c01ZcDI0ck5rbmVpdEtWOTZTSFFYd19aN09CUDJtOWE4OXUwQU5hX2VuZGw3S25nMnNYZ0J1dDV1UkFxUW9HNGtQTXBZWmRfUF9CSUFxdm93OVdtTEliUk80ckRDcmVlYjF2VlYxWWUzeWJObDFPT1RhZUE3TkttNnc1V2kyWWxyVzg1cU5QYzhmR1F1TWd3R3lYa2dGb1ZZRW5waVd3NXBrNUVySm1BRVNzTU1jd19fdk44cy1LVWdFcXN2cWR3QzFoNE11Tk1GT1hRaEF5QzVBeGRfMXExaENROGVXRkQ1bVpibE11X2ZLVlAyVTJ1a3ZxOWoxWUd5ZHJpQ1lneFRXZmFSWUxmek5pNDYzZXpXQUk4WGg0aTZZTUQ4YmVrazUwUGE1enRoRms3QWdSWFV0OVBxVVZjSUZmRmN4cWoxTEQ1bU9VdFZPenYtNXhBdl9vMk52b19IcERGRkdhckNxbVZ3X1hGd2NlNURwM2dRSXFLcE5KTXRhSE1oREdvT3hudFpZSlJkbjJnSENYVkZ0U1F1TjhDS1VhOWM2YklpcGRnSU4wMENGS0dVX0ppaFVZREtEekpUQU5qV0FEVXZzSXhXTU9qYWxtNnAzWmNJaVdvNThad0xWSXlSU3dIWHh4WVNzSC1SbDk5WmtRbTJ3cFdvb2hyRW1HWnpPZVlQX3RBY0VYek5SRGNfcTJURnh0WTFkQUZZTmdYMk9sd0tFY1FHUEI1RVhnejl5bFF2bFhfR1dlOWNsRjliU0tSLVExcjIwLUZ4em1fbWdPZTU5b1Brc2QxTUVFTmx2YldYVGw1NmZGUVVxVUJqZTR4Z0I1WHdJNkN2aVBaWi1oWlVNMVFzQlNqV0pDZy1pU3FuUF9PT1ZzNnUydkVFWndFMGxablNEaC1DSjQ4eFVUa0ZjRks3OGVYbkxMSERlMEVWUFgtMXpsZzFXTTVNMzNGU3JmZFV5eFN5TmVDTW40MTVsSDFOd2dQc2RETF9BQ3RjeVZrX2N6OTVqZ0xaZU9GN3JYM1FaRC1uTm9RUUlWYUJXdkFkSE9zdHNqa2FmVnlYV0FUQlVMX3NyMGhKLVBfaVExdVY0SC1iZjEzQ0F4V3o1czhNVXkwSktDb1Bsak1vbzVxNnNRNW9XajZMbHBrcGZNT0pxa3BBbVVKSWhScEk3M1ZMNFlzbUlqcGxWdGRONU5fWjQ3bG5PWDBCQy1Hem5UeHFUbEhKRW4za01QOTVJQmUtNVMzVENINGxYUnJXZ182RU1maWF6aVZuOHQ3TThlN2NFd2RNVXVXZTdTcnlvZFlvS2NqakJ2SlExU2dSb2VjU0l3NW0zYnUzWFJ5bE5BTEZpaXNlbU5yNHZtTm82SENEMWVreThJUHFOVFd4SzNUWUN6N1ZYazJhMGZ1dGh5SEdFeTlIOEpaRDAyNGl5ZDJveUR6ZU00N1FOODJibG1mQndJalFEVDZQY0hRR0plY2RkYUZ5MXFmcHNQNU5tQWdFdkoxbHNtaUpIQmhyRE93Z05VekdfUUkwLXdZTzBMaThKekF3aVB1SGx5dDFpYlYtUkVuTHktNnBMSWM5Rk1kMDNqcWl5QUhldmlZSGJ6LU1USjF4ZTVmT3ZiOFFHUmVEaUtHOFdpc2pSSktGYlktYXlud2VVa3V4M040S3pIY1VwbDJkcFcyczMwVlE1WFM5dkFfQlh3eG43bzJsYzJtRTZsVlA5cG9TUWRYU2E5NHh6bEVJTUlwZWRsdjBPVE1BbFppSmdRajNLZE5BX1N1RjBGSHprUnQxN19VZnNqSDRJNGdiR0NNdmk1Y2I2anpKMExGU1lyaUI0ZllBbWNJN25oWHU3RHY3R3ZnckxDSmpicEtDQm5ZVkRfaXZrSVJlZHAwTDB2TzhETGdlcWF3cUJURlpuT1JsUmxKVDh1R0xRVGpHOG4ySy1CRjJnZEhhRWFwOU82Qkc4V1RzWGE3aUlRSnFNYnctUVlIbmFkdHE2cktvLWFBYmNBcURSb2J1Z1FzS2d6UllSV19sYTh0djJZdEpIamZCOFhVUkdVS1ZNNklqN0NVWi1scXdLc1duRG1mZzd1VnNBUVNuNTNnbzlMd2xNMDc2Y29XN0YxdE9OdUpOeHdzdzlGdDhKdmlZNENJeFRYUDM3N0FWUDh1Y05IMXVBdHplM1lGVVhqZlhma3BuanJMaTVLMjcyYXoyUDM0NTFkLVk0dzlnamM4dHpGNF9rSmhwb0s0bjh0ZU5xS2VBLTNNXzdGQ0lUdzFCUDRCWDVWZzFja1ZoU2gzYlFXdmw4RWNrQTFSQ0RWV09mZlg1cGxxcDJPU3lHNGhWNVFDRDB2czdnM3Qtbml4QlNVbEZ6NDVueTdvd2dpNnk1c1AyaW15eUVhR1U5c0ZsOTZnc3FzNU1xUTVTQUM2b29DcHpXT2hNaHV4Vmpzd3ZBZTlCN3h3N2RMaE52SUxOOVFtZ0JuSzhpRTBqZUNvaXI2Sk85SUo5cWtlNnhCTGN6SkgtdjBNWUl5STd2cU12Q2ZjRFNzNXdsa3I4TEhfeVhyTmtjYnRxc2Z1UXozalZIRnRGUHBqdkJqMlZoRXQ1TzZNZmxxY2ZFSUt5NklvU1lGQkVMVG5NdHhONFBDT0s2dDdrZU5uTEQyY0hBX2YxZThlUHpldEdFblhaNWJQYkpkdjB5c3lwUm5SYmdEM2pMUUNuWkZyV3B0Q1R0bEVSSHo2YmVrSmNkVWY3M1Q0S2xycnNOR251WXZYRG5EN2FhN3E2SjF2MnFKaU9zbEhtU2RrSnZuSTdGcnZTUVlYdVk0MDE5QlNPQkFNNkM2dDFGQzN5MFppTGNjcWNyaU14dFFuYURhRkZaWmtKakRKOWZBWG5RUTRXakhDcXVhSDdZSEJlY2dWZEJ1OXRMZzYyaDBEOUdtT2toYlB0TEN3VTM3TEx5a05NRk9ScmVhekEyYUowelBoaVR4TTV5b2JnZlczazFjT2xUYlZsd3lINE9EZVNyYUlsaElReFlQbFBuaklqaDdDQmttNzFmdmJGMkJXZEdJUUpDa3BNV1hVR0QxQnFKck1ENjFzTWkyZEQxTVM5QkdwUGI2Y1gtQmlsZXNxazRJZnozRUh5bXhCal9ITWxKSzMxZ3haX3JQajRBMUFRbDJWWEVBS1prZFQwdWlHLVF2alhENU4yVUh6VkdqUGx2VkRJZlRUYVFDQ3pKeEo0QTI4VjVCRVd4Tl9QYlZZcXlqSWNfd2VKb3RoNzV2czFER2VucDVsejAxQ1hRaS1tSzhtdFBHQWZuVG9EdnpIMk5NME5nR3NnNjhRSFRLN3F6d2tjdXV1OE12U013bzR5czM0cnZyQ0pSSEZVSkZZUUFWSGRGazM1QnctRzFFNllhV3V0eEhidDFzTENHeDdwUi16RFNYT1dzSGFMczdpWjdFZmtBWE91QXJsd2JPZmd1SFRYMnA5amYtZ2FkVi1Fc2NmV3VQXy1NZVhnM0s4UF9HNFcxT2Ixc3Q1dnVzMWQyYVN3QS1jWHgzMHBzcnFLZk5mampnMnJhNTE1eEtEX05sN3NPWk4yU0JHbWtYbGphWkRGR0ZqNjgxYmJ4bzl3cGY5akpVLTFsT3pKTWZHeEU0WVJobGZfYXVoT0E5cFEyenItYmpnaEl1c2RyNWpRRVBDdDRJaUpockdsLmlKSWtmcFF4OWd0cDdhOVhCT2RLVnc"}'}
+    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLmI1My1iOHJIRm8yeVBsQXVLMXh5bDhPaFhXWG05U0dpeWx4S3MxNVNDeE5kbFU4ejEwVURJOVN3eC0teVVRY1VMYWhqd1N0TkcweVRDSjFNZUNSMTdoVVRWVDAtaFFncmdpRXlCdjRCZ0ZTLXVZS2pYZllBUE1hZERQMEpxakk0ZjdfTUJYdmJtZURnemEtVHJ3SldaYkM2YXBBbkN4anJ6TllOSndMM1RnUlhnZEpXLVhhZ05pbDg0d2diaHdUSzdETTV3VVdLUk5NSTNidlNqb28wTVhYUkp4SnpfSm1VdE1aeXEwdTQ2aWwwclZkTjhfek9FYjV2NEhlclp5ak1rcXE3R3VwOXRDdERJU05LM0s1UjF6Qml0WGlCbkllMFRrOGRGeTNPdGJrZW82QmpSamVYWmJjQVl1bFNiME51c1pxNjVGYWF0NHdwUDNERUk4NGp6QS5QRGUtVWZhWmpLTEJORWRpZ1F2ZVd3LjhaTGJjVFZvVXgtaGxmLUxxY0g2RGtlSXBjaVZyTmdtXzVDZnR1eC1ITFZiWW1MV0FqRnBwcDl4SVl4dmMycUlfcnVHRXlIMDVWRFpiVTlPU2ZkOWRERkdVeE92ckxFWVpZeEhkaXlfUUpMN0Y2QllKRTdwdUlSX3lzX2R2ekpIZklXNERxMHlKNm0yWURjUmdYRi1sX0o2QkVpTUlNOEwxeTJpb0xPSERSbUhUdmpJRU9rdmVYd19PWFgySDBUYmRnYWtGVDFOUXRwTWxEU3RqQ3pPNVZZek5XT2YtVTh0NnAtY25fM01TTTY2b2JUX2JReFBsdFdxMGtTVERscE9HbHFPVV9JRHV2QWNxYUI5NDB5YkppNktfMk5GTEcwWGpJU1VBYnlWMXl0T2pSWVgzd3FjVk0xNktoWGlaT1pIcTFfR2VWeWRBTU9KNVk4Vlg1TzFoejNnWFdIRm5MSVFxQ0FoenhKcy1zN3FfV0VhZXp3NEU2T3BZUm4xQzN3SzZTMjFrQ1VQdTI2Rmc1MlZNMERyNnd5WV9ZUlViY3pHeWVoRkFESkttc3JzQThvOERIMEFiQTBHX2RyR2dPWmVJOFE2VTU4cnZkTnNoTmZHZTVqazV5UW52R0ctUGJMRE1POGR3d0c4ZndQam5hSjJYQmpQd2NIeWdITEEta0Y5clhraTBYV2VQcmFhdDJLWHFReXViQTlDU0dkVUhjaEE5SGE0ZzRpa1hXTG92SkxwREtEV0tCay1kcTM5X1FzRUJxOTBzbmVRUnlFWWhISXg3aWU4aE9KQjY5WVlpS3hlX2VEM2xGUEVhdm55ZTVJUm16WlA0WjdMbEhHbFRnamZTSUo0YjBWYnNhTTlBUnN4bUNUekpYb1ltbVhRV3FqNmZQVDhwRzlCd0w0TzNBamQybTdITFFIaVlRb3BJdDF5VkFPdEg5VVlnbW9EY2NCVVNWa2FZdlhRQTF2enNyNXJ5SmpWSkZJUUowakk5UEZNMEVWXzdsNFRlX0RtVlBwc0djemZuMnRSQmxPaFotX0VhU3JSLUxjemdmdHNXYjhVeWhlRjdoNGpuSGRSakZHNTBLY01ucVROY1B0SlgxNldaWG9BUDR1QWg0OHplbnRrTG9RdG9vUVA0OVFzX2c4c2tRZ3cwcHZCTHBhUW9GY3ZXdU1sTFBlQUJCREZqd05LQ3N6V0tqdl9nWFg0Qlc0ZG1sb0ZjYmJWVkxETGZaNnpub3F3YWJzLXVXc3QxSzluWHJqNjV0SXFxRXkxUFRnTEdsdFVHTE1uSDc4RXdmcGpGN3UxRUNDSDMwSkJ6dkV4ZEdRRVhRNmtYckhsRVYwOXVnQUxRMnRQbW9nSndrU0ZIYkd2Zm5QWkhhUGxFbkVDeF9BOW10RDhieGtwbi1pbGhJWHl0TFo2R2lfMnpxRm5aUkpRODVSRkNHUzZmVWREc1M4RWUyak1EaThyREQ2MW4xVUhibjE5WndZTmZKd2RvdlhTX0JvNXJ2Sy1JejZRMUZsZlZreGNZOWkyLXBrZTRES1Z4a0NIVTg0QnhYbWZaZ09QWUVvMWVtRy0xVWxMSDRqeUhDTVktNWQtZmFSaDl6cVZ0Qy04a2JrbGhEN1EydVVpMDVTckhFdDlWLXhpWlF6TXMwTURJUkgyV3FiVmRUN1o4eHNsQnAtanlFWnpGdmNQZGhjZ09CMWU1eE9BRVFkbW1obHJHVTJqYzJaMVhOX1N6eFM5WS05UlVybnNFV2Eta0hQbXJkYmNPclc2SllCVTNnYVJ4TGxGQ0FlY3drRE14QlNFU2s3UHJZUndlNWVQX21jczlob1JGbWtJTmxJRzZhUkVxemt6eXZOLW9KaUUxalp6ODJ5aXJERG1NVHpSQ0hHLWxkd2h0M18yTERsVUJ3VTRCUkVILTZiX0UtS0FobHVhWjlYSkU1c3hMOGJjSkR4c3lBeEhOM2k1RGJsRU40WG1CSzBrM3A1NXY3ampBTEhsMWFzSFN0a2RsS0hlN0JkR2NoYld1Y21ld1dCdU1FRlFIOHRaOS00SmxMYjQ1NmhZSHhkMmtmRGtkYWMwOXpBX3Y2VVJOY2EwbVFCYzBLQkhzVFhKMTF4SUowbUxNVnJhQVFVZXNSckRMSTRsbGJpNjJRaEczekM3ZDZBQ3ZneFhTVWs3X2k2WW1ZYnBnNHFsVUliWjh2M3Z2QTk4QTRTUzlxS05MNUZxcFowOF9mQnRWdFBnc3JMU0VWb1hPNkZLSWhuc3k3ZVdGTHdrWU9BU0EyaUx3UFZmVkp1QjdiWl8zakpTeGlOMXk2dzA1RXRNZ2pHQVF2RngzTXUxUWxvYVZfTWxDMGpfNTZDODVFT3M3YlpsbEcwNWJzeVgwd3hNckl4Mm5qSTZSZ1IwaHdWRnRSVmJfelZXTlROcHphX3JYZjNGUzAzYVI3Q0QxaWo0Z3RNb3ZNZHYzcE9BSVBiWmlBMWgzSVRINGl4Sk9MYktHWjdhc0I4U3E3WXlVaEE1a0d6aEhNY3ozdTBLYjVweks5VEVHQ19ReDZtN2l4a3E1ekc1a0R3VDRTdzZIVnl5eExjUXpzSE1Wc29oYXJmT20xN2ZqcWcwTE5nZTV4VzFqUnUyNnNQcnVNem9mcGFTX2hsYmFJMmhBX0V2WkRLcjZfSHNpT1Boc2swMHpvaGxRaEpBdHNXMklVSVEyV1JqOHFYZGlMSXpRc05OWjhZem1CeDhhdFNQenVQVDFOYTFReU1mdVI0S2VTTmNKSU5JQzJfRDhDLWNjVWZLRVVtVjdYR1Z3bnlUQS1OWHVMcHRtSklQN2xLWWZOcUxZVF9aN0s2cGtVUHowc2YzSDNfXzdqOXg1WVZzNk95UlZRV3lZSzk3MFRQa25nbFlGODMzd2pzUGozVFRyb3ZaTm9RRUlzYTdkS3labnJJaFNmNXlxTmpNdjdkc3psOHY3ejVZMmtJYWVpS0RGc1Y2WTBxSG5MOTUwZ0d6czQwcm95cUVpczBneS1VOWplWGpkeHBDMWRxUjd6V2UwcTVIM0VmQTZqTGdaR1E4OWlEUWZnQ01MYVRGSTVmSVo1djllcTR4TmNVTmctcUdnZXpqbXhtcTJraGRnN1pRZnlxTHFOdHUxTlowZVNfbENRVm9SVU9sTUs4anhRdjFZS1JmSGxDMlZwSmdqcUp1T0ZOVmFJNTM1TGFBTms4TFZxbU10NDNiWElJSnVuZzdEdDhxN183Yi1VelFDS2hlVVhqQW45RjRSaDFwS3REZEtXTkZNUnJnV1JMWkVHaWpJRVdoejhfeFpIVjJwZnZrWlFVU2JIN1JaWUxOX0NmdFFOT3RlSURWa0lrbjFXeHpUeUxYeFgtcTBnU18zdmtWYTBTa0l5Rm5TRzdXNktPV19pS0pUeXp6SXBWSnpRNzN6MDlzdEEwTzFKR3EzWTdqTGF0QXlwby1QS09IYndWNGpORWh1dE42TGFPMHloZWNhT3hKRTVuZnZPbWlneVAtZFQ1VjM5YXNMWmgwTzlDUXpLT0tlWTMzUk1BNDhZTldZR3VodC1NNUlvZTB1SWdMQ2lWUWpVR3BUZkVKWnNWNVNOeks5RUJBQ1RlcHZHbjg3enotWVUzeWx1VnJNd0lYLTRXM3RpMGpTZjNJNElMQmNPSE1fdlJ6YTRoZ09uWkI0bVFVaVBnVTV1VlVPOUdBdEZ3N3JlUTlVSmNvZnBIU3haWkRsRDMzNHA2OEZ1OGgweDRtXzZMVXlQa0JwdE5oNTdIcDJuVVFBbzh3OUFSTHU1ZDZmMnZQVEhiYnJyZHExdjNhV3lhSVNiaEVzWDkzMEJNMVVDTVhCYnNhaGhsSGV6UE84QkdnRmplTldSTElJSWtOekMzSXRCU1BpU3ZtVUY5c3BhQzRza1FNQ0xNekVGSGlJV2NnR21Ec3NmQktZM0d1V0FxOE5xYnVVcVFTalNOckVDWkE2TWc0dERndFA0R28yMGpiX1R4dGM3Z20wRU5hT2cwZGhReDFyQVl0SlJ4WEpoUVhvRy1yNFVJYUJjZXFUZ0dTblJqdlJpdmZZMVJDUGlxcE9fRzZLbGR0SkhKODJwT2c3WGJqcUk4cDN6RTE4d2J0ekkwVWdPZkc5c0xJSDl2Ry1JcmNHMWc1WTFEdDJmanlxMUN6WGhfenVIMllnZVpNR042b24wRG41Z1R5OWtweVR0YXVpcHhSNzVfRVhSMGtKR01pR21EeGRMbG45ZmpQaUg0RlJpYmRsMXBSRkxUUVRTcTVCMzFQbk9STWhkREpoR1U5UDVFYzFBMmY4NHJESmNSb0FFOEk3N0N0a3Z5MTBPVnlPRzNOaFRUS2hTWHlRMDZfdGlUNnQwMy10R0M5Rmhfc2xiTmdONlZ4Skk2eU5fTlRUbXN1SDdvYjU2NWlPOWlraWEtY1ViN1NaWUJsaHdra0VnVGYwVllPQXJzOE1PNjIwdldBUnI1Y3hlbGh6UW5qOVdPODlzOHI4Ynkwc3U4X0lBU2J5cTNoNTRLYjNxR2lYcFhUNEhMSUE5eFZycUdxRGtXZ3RKZTZoVHIzb3lXZjloeW1pR1V2WHdhOVdfTjFJaThJdTJ2QVFvOVQyVGgySm5LWnhGQ0FCMjRMVVFYVEw2bDVCZHNpVEJkeGk5dU10NmY1S1lGUXAybzdtVk4tSk0yY1kwUFZiTkVMbkNaODN5VWFxU09hSlR4Y19yRkJpSVF2SDZYODVsY3FpZURlV2Vua3A5VnBBX3dEdm1QMlp2M2NGVF94cXBRcXY0dVBYOWtmNURBWGFqNkJ2RzNydXp5TkVPM2ktZjhyTWNEY3J3aHJ5bXZ2QmhfYUpULU1iazhWUy1iLU42ZFJ3NWM2ZnBuZjNDeG5HS29faEJ3aUhZbEg1WWp2aWplQ2ZXSjRkWUdkWGVTWEFqTFE2cFpPeWJfa3QyblpXVmRtd2hlSUo2bjFEV0g3SWEwcnFLenRUX2dhTFFGTDBzOU1WM0RXR1lKbnJoVVNnbDIxUlNNeE04SGtxWnlNdHJRWlJ4dmFXcDBEaVY0UkZJNUU4dWpTYXM0emNuRU5STm9oclR3Tk5CMHp4S2NJNHBxOTNuakEtSndKWUZyNUxucWlvdmxVRGNLRXZBb0NaQkw0dzdGRkU0M1BkWklKSDlWUDdhWUttWUJFMnBpTlVDQ2wyTlh5cVZrTkhFWGstYXBtY1BpNGlBWFh5cENqcm1SU19ZaVh2S0FCSkx5YlROT3FGNGc5cWI2a3ZVVlJSc3hROC1TS1lfVlNxV0ZScWZUTTkweklYWFNfWUVNa2Q1ak5INXRqak83OUs2bllaa2dwSWw0ZENOdHhmS1ZZdEIwRFJNV1hXdkphdV9sMlF1QlVxWW15Rnh4RHpNOUVMOTJ4dFRjWUpnNXZqb2NpRHdWUkU5NGE2WDY2clVkcVM2TmplakotWHVSRjIxaUNTdFV0S2Q5djFMdmd5c2g0eUN3VG9PZXRLdjZoLU1EYndIbUZpY3VZZ0w4bTlwUVJVck5LWklMM2tlVnE4dGRKTThablFhRzhLMzNCQ3VPNG5OY1pud29tUUVlZzFTeHpHWlZYMzg3MlVSX0I1RmdvamVvT3Y2ZUhsZ2xfaUI2Nk9UR2lnaHdQaDV6bWJXSk1tSHM3a0haV2YwVW9rX0NHc05GMmh3SHl3aHRIM0RSSDdNOXVNQW5DSlFaX0JnR0o1OHZqemtLY2tZTWhXcHZpV05yenhPWk15X3RWRGJ1REFaR1VJZmFDVm1pMC1HdjhsbXB0R1FETnFNN1h6M3dSZ3hSVjJaQmZ4Y3RDZ212R2RxTDR6NFZfaklrWTVsTWxZSnRYcERURGhHYVZsb1A0a1gwd3U0Q0pYcXhIZE84Y0ZIQ1R4b2FPbGRpNDBwTTB3WkUzU0RPYlVFSHBBdzRUX2xRLW9Fa1NhWmJ0alVPLXFCcG91Z0xLWmdiNmVXRUN4eG8tVFVIV2dZckk1anJkNWJPX0RjWm5fdDY5QUNhbFVHU2thMXNsaVpkOUxhNGZJYVZTQ1RQYTdrd2pDSjdMb2Ytb0RHd0lmSmFhRWNib3NVNUlaR3BrQkV1b2Zrek1rZENaSUNDZmNOT3ZkZnlPU0xrVUxVbGg3NFpkbWRHdjNDbkJMaGNoZ0tubmw0bldOdmpoWWxxeEVVeWctRzg5REh2RWFBV0ZrVUdTOVNHeHFESFpPWlZwMnZLV0RmVWduTTJYZDdoVEpFNzV1dDhadXRNeFdQdEd4R1lBRjFCd1BwcHFlQjN4aHd3bnM4ak8yN0dfc0VYb1lvbWphaWpCQUd4bnFLZmNjSEt6bDkxYk5NVUgxQXdRRlFyUzZ1Z3JhUTBxNEFsRXlFcmNIUlRhcnFWVTh6ekxEbUs3MWxzc2lJZkI5Ul9QbWlGUTkyY19rb0dLSzhpUUY5eEo3Nk8yeWNpcUpwT2pKdnlVRk5WSkltbl9MS2toazFrRHNNWkcwcHQza29fYUZOQ0E1MzVXQXhtNFRwY2pOU3BHMVJFVlBReHB6di1ER3htOHpzODNtRWNCcFkzbjlIUGpGUGZhckpRdUZFUlU0dEF6eXU1aFFFWGNFa2d2WFRkOVJELXpHaGVjTE5RU0NSV3hkOEJGNkJUZEMzcDNQX1Z2T21aZG5Vby12VzlXRGZ1VWtnT2lBM1ItVWdOYVhnNXJ3b3pKLVZBRDUwSUVHUnlTcGpnT1A2d0U3cDBUVkdiODRGYlZDQThlQWR1VE9zdWwxLTBaMGVjdFMzaXRLc2RtRks4SzkySUVMVVFFQ1pWdTlfQ1I4Qy12SC1mVm5Ick9XWk1xLUJ6eWNIaGVVNi1Rcy1tYjZZdHJTWTRkM05yeDkxeDM5dFVVMWY2SHBiV3pQNlpHMjh4R2lhQ214cmxQUkRTa0NrQXh6QThYRk5CN3ZxMXhZLTVucUxtYmFGaWN2UlRHaEN5SHoyUExfMUVFMzBNbWdOUHZ3bHhNWmVBWFpqd2RoRGpfUDV6SzNUUmk5UGc0bEtfdXpzRUlINzFOOXY3RzhuTy01THFUTUp4bkpUaUZFQjhzZkdtLVZsNTdQVVJpVXp6ckNqaHlqNTRfbXlDb1lqenMwdUlPNDBPZElrNUpfVG5YdktscFZOa25hU1Jwc1Z6eWkxVnJ4T19mV294TV80XzQxMVIwS29QTkpRNlZqblhZVUttTlJqby1nOGlDVHFhTWNEYWpTTWJMRDF0WW5HUmVWclY1TEtrRzRsQ2laN0doR1oyaUg3WUJlZFVtZVU5Z2ZpVzBKMC16QmtfSzIxbXMxa3AzRVF6TTBzZU1qWkVLZC0yWXBNN2pXSXVseTJLdC1qMnktYm5sYkhTWl9od1J4Y3ZuWnpKdDg4TndJNXpzMnZvRFFDbTFKRTNlQXl6X2xtdWZMR1QyRjJlejJCSnlPOUJQNTh5alJTQktJZGo0eXZPREJDUGxSQm94YS1xZ2VKdHNaMzlQY3JyMC1Wa0s4bHNoZjlyTnBpb3FaMHBoSDFISTNKTHRGQ1lkdzZONW1aRU5MckhhNzc0dFlLVDVDeHk4NmRlRmpTOENZVmlsaDZFaU1fbTZMNUJVd3VaNDljQkIyNFIySGwycXNiUUNpUUtNZTYxaUdQeGRYWFhocGxZQmhkamRqOGJaYzV2SU9yRVhWd2R1SjdNNWNvZE95Z1ZIZm1vNXQ1WlYwZG5TS1MwTF9BWHJhdUh2QlpCejlNeHFPZTVDMnBIS3BWTzBLeFdUVURMejhQc08tbVp4dnpxZlNRNndOX0dIOUVGRUxGWlV1NFpPVUxhR1lrUERUYWV3eHVTQmJEU1hxaHhiYUtlSlE5eW9lZ3BwNUV1VndUWkFaRk9lbDZ6aHR6SERKZmpERnNJcTAzM3RRSHdLYUhtSTl2S0NQNU5Ea3A3ZXczY3FVVzhoS0FJUkFNZHdpRWpiYmdnWVcyVlpDalctTnl4MTFLUHoxbXRrSnhsNDJNZGNDYWNzRDVRNGEzY01fVERHTFZrVTI4NXZjbEV0RlZpZVMtMmFORkdRRXJfekZsaU8tdHFydkJnOThLNkJKSTV6bUFZc29PazBfT0NIODdvcG5yZ250bl9wU0FnbmtGdTBEREdOdlNIbzNXZEtFQ1FGbXdPR29ad1RCdXJQa0hZbXV6MUM1TDBFZ2VzWWxDd2s4SlFCV3JBM1I5UTNGbWhDLWRnOHNHWVdnMGtncE5kV2llM3BveXkyRzZ1VjFxdmJ5WnM1M3VuS1NTRDdxdktVamJCYlpWXzd4TzVkYXdyYkdDVllkVEpzdmpqU1g5SEFtWDJXRXRRbGc0YjBPUHVXSFdCQU9UNWg2UWVjcWhJV3pJbVVzMzdGdzFJOUFvVm04V3VrYVl3VVU1RTRXX0V0YTNrOFdSZlROQ19aTjZRbnlyckMxTlBhQXhvaEs3d0ZkYUtwMFJtNEdEWVpXUjVOMUtvWF9EZk9pWWxwYTZuUjF5SlBNRVhFNnp4Ui1LdkdRdVdKS2k2V1ZqM2hVOFhkZnhWSkJYc2JHbGRyRnE1X0ExeXFoeGMtODJncGt5TEJIbnJZd3Jta0xERlRBaWQwVFRsN1F4RXkwS1lRQmxRRUU3VHJxSUZJMmYwakJXemluOE1ZUlNwV0Frcm16QUlxQ0RwSG55QmFELTdOdTltSFJFOFdJUFlIY2JkbUNYR0laQ2s5UjZmUXBUWVU4Y2JKSEt1QXpidkJ1LXotbi1CSTEwQ090YUc0b25SSUdBTmVodjZZY21Nc2h1cjNqUXFicUtrNWRidmF3WkpsSVhtdUJFNWRXRE9HMU5DamtkSzFoNmR5Rk56SlpwZlFpdS0zWV9pVFE1TGxWc2xkVUgwSlQzX1ZVcGliV3NQQ1JjcTVXNjltbTgwbXBtdVB0ZUNPNHY4NlRVaHFtQkZnQjVtRlF3MWE1R2MxTUQxZDR5bmcxV1RlXzJ4Z1RVdUE4WW9IZ19SVkhNWE5pV0F6YXIzSEpOTFg3bXYxT01sZjNlZVlVN0FWVk9FMlpzdXNrMXZneWdHR01lUldpNmFPRmlNTkNTVE53VE5jeTNOMmcwOExVMEFZODZXV0pfNE5hMV9DaEdjaFF1SDFNUGRLbzRQbmxDbzlJOVBhSVRsVW1CMzMta0Zzd1drbV90aDV6UFRNNmlIQ1BaS0FhcDJEOTlYOUk1UUhKX2pnY3RIVUFYZnpoc01XbEtyV3NMMjB5eG1rMlRnVGtfa1ozTmppdHBlMU9ZNlRUc3pnbjJQdEkyTU5sb1BySmQwYXNtMmdNd1lsTjh4cUtWbFV4cWZWN1AxQS1lSHdiVGxkREstZms2ejJaQ2ZNU1dkN3lqNlduMzUyN3dMaVFsMlRpRzlXbUhlS21wWUNELW5qT1YtNDlib0NFSk04ZHRZOXFNMzhLUV9UOWZBVVpyYTh3RlN6LTR2R3RIYk9CWlRCODFDaVI3WmZ1VzRFdEowdXZnU0J6NzVRNHJWcWtyX0lmc0tHSVEwOGVRNngtS3pnakgwYlllQWl2VmdtV3VUeUFhSnpqV3R2cmpUM1gtR3lhSGZZd21xNUpHMlQwakxpRENBbWhmUEltOW5adEFlZDFTQ054b3FXemMzbjZtMk41bXJFWDQtQVlwME9pdWtRUjk4ckg1cW56ZkgyZDBHM05RcG94X0xRUjBoLUxTUW9nM055MF9zeWE1blU4dVRpQVRwTFRCN3RmLUlBVzNrVjh1VF9OVmRLRXp6OUJ2dnUwVXFVRWZpbjBIRTRSMVE1X29JN3U2ZmltbGNiM1Rhd3p6cGZjT19TNXhMYm51MldSUmF1MXBPWE1rSEltUGZrQ2Y3NGJGT05EVFZnUm15YU0wVm5HU2JTWS1JaVNuSnZWTXZqRTFpalpFTlpyV1VlSFJEUEhXSTBwclZheG12NHY4eGxVTFJQeDZEaV9FVEFTTnc1YUdoYXNXNVdncThYUjgtTXhUY3hEQTgtSEthd1ktN0t2a0RRYk5JaFpXT0RqN2xKTi1ZN0ptMG5WNURnSk9QbnNha29MTHpod0U2SkpNVm5hdnpfVkhFVVRUUmJ3amF3ZVFXcGVJSkIwdU5VZjhpR1p1a0djWnRQdmZlYXJtNmN5Qm9YeWJGdDFmR0E2MHBKMXUtVFowaXRiZ2lWdk5vUjBvNHctMll0RjB5OG5BckJOZmdpWEtfclNWY2FQMHcxRDBQNGx0WXFCSk91cV9ZZlBLY2RiVFJEaC1aUzhZR1ZpRXh1eTU5c0Y1c3VESHh5UHlEQnBFUmNibVJHZ2ctSS04MU9yQVkzeWU0LUlJTGF6NHpjOVdBXzNScHhWNElWQ0Q2dWVULWNiNmsxZDF4bVhCTkZDSnlJSUdQZXc5TDN4Y0FXTVJrU2trSXNmSnk3RUs2NTNVNXY3bi1jVWVRazFEMmNIbEpIUXFHVGJuSU85NjZxeGIzY3dlM2kzN3J1TXhVVkRTSEExQ3lYZUx5MnJ5eXBvdUVmX3dpUVhoZVNhd2IxSHViZHgyWFJsLTBUSERlZWMtTWFSTmtxTzJFc0pqLUhJcV9tX0ZOeEw0OHFKYlhlLTEtbVpwYXpQUU00RFVxMUdLYnoyR2V4ejlXTHpyNENDTk1UVVd1UlhrVFYtVkVPUGhUSVlHaXVXZEJ6Z1FaYWRkeWxDNUtIcE44VkVVYVF6TjByLXRUSDNjeUVhTGdSOFduektQeVkwTWhHdENLR01NRFNTR2VrNUpEMkUtZUt2ZmlZT2VWdE5IaWZHUlk0YWFsZVRVaXZScVllOFZJV180T2F2VndtSVZWaVFkR1BuOEUyTlVZU2dmanVCaEdaQk15NWYtWTNFaEl2NlhfbjM0eGd5azdUVlZsdHFfYVh6WHlQRjBTajlVc1l2Ny1ydFZNNmYyVUtMT2cwa21jODZLREQzMXBkMlI1cFV6U0x0ZUUwODFQQUFfNV9ZUE9HNVhsR3ZXTG15R2VpT3k1SW9PcGVKazJVSXlIbHNEay5kTjV0bzNranZjS3pmQWJXLUVBQnhR"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['11659']
+      Content-Length: ['11716']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:21 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -242,7 +375,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -252,19 +385,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e37f1936-d457-11e6-b3b1-a0b3ccf7272a]
+      x-ms-client-request-id: [97aae2be-f95d-11e6-af21-acde48001122]
     method: DELETE
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"sZiaRJIrmVH7p7l218U6-RitQi0Nf4hHfwo7TzxaUF-B55gH8qxpGRY5z9DhzPUB0oG9VlYMSYOpP0t4Ol_I8dmjoMuJtRRn3CaGdlOgKPe0qEPoLa5N07SHLFltDLUZKaZ4HR2AymJxhsQXMgK1f5B1mfi0mDfZLu6h_0kL-0MLIdgnKINm27O_G5nrTyYgRIqMchIPNASb8qXeBkxxSxNvhBm1CJE6Ye40grqJcnKoltLebzzUqlojuYT_F0ItPMheFVPIt6BrZj8Ixe-v3wTSTz7eLMWW1ssJKWqp9NOwW0w58DTAoNDE_tpALibO3KlReY0Q9Q_E_JCAxhVCNw","e":"AQAB"},"attributes":{"enabled":true,"created":1483738458,"updated":1483738461},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"wxeYPDHVvT8k0GzoXk8Kn22qF7c47wu1MTXgQE1qLmAllJh5M6IEoot--b5gRsVItQuhGCC4umTvw_NA3XkOtJJvxKe4OIqFn91r3eSgDRavaFhIVyStUyVNUhcfARylWr_zoHziZ_Tj-mCpFFrICDHacH-Ev3PWFAleqZNdZ-spXAJjb_5upJtRxgkjNNNBvR93k58Tfg9rWDH32EwY2kfFY3tBvyaGm4NdcE7Y6bpRzHizVhKpk7j62acEm0NUkib4zVCChkGStKUOHwPhWHLpZYYLf38Rrwk3v33CwxDT2qmHcp_aVj5EH6DWi-0t13XMcBj_EWzpYDUpe9UJ2w","e":"AQAB"},"attributes":{"enabled":true,"created":1487809098,"updated":1487809104},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['604']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:22 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -273,7 +406,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -282,10 +415,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3e95f2e-d457-11e6-b8f1-a0b3ccf7272a]
+      x-ms-client-request-id: [9884828a-f95d-11e6-b8f5-acde48001122]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -294,7 +427,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:22 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -303,29 +436,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkw4TGxBbVpEMndLd2JETjVIdV9LRlV3Z1FFZS1wbmNzNGQ5OTRCWTFVRG1wMGFweDNFQmpLc1hPQlZzQUlEX25zUGlZeVIzeHFnb3lMSTgyUldULUc0em1vUFRzUUVVYVJfOC1iU3hWcmM3ZHNEUzhGSGgzUU42eEp4RFdBaFUyejJ3ckcxalQ2eVczYndyWUVsdExnemlZYTBIa2FjZnVITTBYMk5mY2Y5dzFtSWVIVkxSWlFzZkNZZjhsdjJMMGI3TmUwSUNXTkNWbVhWYl80azhaaUd0WWpmSEdmUVY0NDdmOVBwczVVMnpFQnlibkNLTjd4dkU4X1kwNXNtczh2NFBGbl9Pak02bkVVR0NtUzlEaXFzZjNiM042SXA3ZGZTeXcyalVVRm9IQ0FScDdlV0tLb19fYmF4NFRXOUtaSEdoTFBBbGlUV1RrbTBwVXkySkQ4Zy44bFRVU056czczSGgwWWhjRFpXeXNRLmVWejVsWDBqOGR4a2JBZ1hxMUk4UXN5dy1LRGhmbUJybUFpcHNTWGFGcW5UZWtkZF9xalNuQTZmcndMRUFaaXJzV2N1blo5VGd1SzRrcUVjLVZuMzJ3QUhFZXVXU3FUbERHYXRoYjV0eWhqeUFOa3pQUVBWUDVQT05Pc0g4aWxCeVN2bElRWG1qSENvZWhZQ3EwOHJ0MmRmZERac0RPRnF3UXEwbFlUeUJXOWJNNlhkQWl0TFpsZGYybFpPU3VkR25VSExpR2Vobk9OZU5PZkxZSTFGc1R2WFJpZjNzU3Budi0zeWxRX01KOXQtT3RrdXJaTkNSb3JWdnNDTnhZQ2lSLVNkMGtVNEI2RlN5X21qZE9ReGVMejZIRXEwZGFEMHItX1dFUFBVcUVNSzlGc1J6WVBuOXpiNnRTQ3cwaF9fYXhYbzJDYjZFLVJrNGUzVkowbkNoRUxCZm9JNzR5T0ZwVUdqVjdBTGdSazVON25rTE9obGN3VFVoTUFVMkVoUFFpVTJMV3VRZzJBQnVWMVZkUGtMX2I4SE9UYmQ2alFTcHZlUlVQQlBWN0tTazFmd3NibW9fZXJIUFNralVGN3BtbTV5ZlFrVk1mY1NSeXJMYnNkbmY5RklqVDM4UEN6bGxjZVdyd0VKUmVxRHlzZGo5LVNBbHUzQ05wUTNnLXdzVUg5X2dGQ0pBWEZUajBPMmFPckVxUUlnbHI0a1hXRGgxZ0cxd2tMcmZUQ0x4MkJ2LTF1dGVTUlFxYnIyUjV0XzM0SzI3dU43Z3hmZVJVQTRxaGdPUGU2VUNTclRmWEVudDdaTzJvOGkwS0t5cjgzUTltZU9ZeTNzX1QxRkdSRTVsWkJCRzY5MUJIYU9pOGQ1eEg3dmM1eWdzcGR3TUVNZXdlY2ZBM3ZaWGtKekdVczVZV2FLMkVqbjdWTjktS1FwX0doeWlmMkMtZDdSYnZ4TzJlclAxTVlqZDRva043ZGdWMGR1T20xTkhNUjAxbXZ3NlAyNzF5WHVtRENzVHRKTUl6Wmx2NWtTQjNmVW1GVk03X3NlM0xZVEZFUGN0b215WUZ0cmFPWkg5MmUyeElxeUpyNTZZV0xPTDg2cGVCdjV2U09KM1pNc0J2dUM4LU5BR1FRd3RhcjBvTDB0dmh4ai1XTU56dEhhUWRDcVZTSlk5QVR3SGF4eWpZYzdNc2RSLVVsWFhFX0R6aXYybzRTTTBKcFJyczNDNnBvY2NVOXFWdVhVOE5YN1VKUGMyMTNuQVZ1NDNlNUZWMno4T3QyazhfNkJIYjBrTHBSTi1yV2R0Vkxqb29qWWNvelc5UmRrNUJFN1JkY3ZJQ1VZYlg2VGIyRWN2S0hlWFAySTR2TFZ6QnZwSlhPOXlYekxDcXFIRHVMX1UxczVVWGNaamZLVzJKcmJSX0c0MXhlZTdtMFgxMnVnRzVlQTdGVWhTZzFtSzdIN3dXZ1pyMEpUODVFaml2aWNUa1ZLbU5sYzNtWXMzWDJua08tRUZFZVdzdEhvQUVpNHNvT0R4eWRhZ2R2ZHdVZHBTV281SHZzVG5scGdkRXNSckJ4aXp6WUVSZUM1Tll0QktZUk9DWF8xM0ExRHNvXzJyYVE4VEo4Tm16WV92aXFxQ0tkenZQcFNvcmpvYmQtYmpsN05zbjZhRHkxdnVwR2VERUt3cENENVRTSFQ4RXVDdHNCZ2p2TVY5SDNfOENIMWZ1Yl8xSUxFWl9mTTdidHNiWWExWkpPdllRZlpNTWYxam04VlhhbjFUMVJFRDVvTUdyT2JLdHlLeGtIWlBISVo5RXE5d1FvWlJkaXdDWnliRlh5QlBTYW9XX2xBZl9vSDNmVGRkS09uNl9uWVZpV1ZXcEFxMWZ1cVJjcGttUkJxd1JZeHI1eXFWQlhNUDBRaFVXMGxhV0xiNS1oYVdxSUVfbUlSOFh0RFVGa21xTEdQS3lfUU9uNUhTVHBJZHZoZ3pTZzdnVmF5V0xEdk9PcVpZLXJQVFo3MTIxYTN2QUpsZXhzRXVZM0FNNmlITDFXaG5RX2VsM1k2T2ZrejVsV3J3eGhVdXN1dF9rYmJWcU5Iek9TMnJadFh0cDhUMzIzMkNTZUN4ZTRkMFZGZFk2ZUNVb3c1dzJQVzh0RUtyTVV4V3ZlcE1FNGVqQ3E1LTNPcWI3N1hpZG1MVjdRenVXd2doeVEwV3JWby1PWTN0bFh3aGJFbXFJZmVXWWR2VlBjaUluU3BBSlBHWWJlcG1oTVpJcERQQU81YkdCNF85eGk2RmxWZnk2eHlrWmxJOGVlQVRHU3FRenVteEQ5R0JDc1lYQmZiRE0yTVJUaXJpemFwaHFrR3RLRVZhNE12Rzh2NkdWV3RmazFoQTZWVUotcFU2ZnVtLVV1UWs4by1iRlRTbzJUdVRrRllxaDRIN29WSUFkUThOSmR5UzVXM0pUUWpOcGZJMXJXRjdQYW5saGNmZ2JCdzNWdnd3c290MnAwc3Qta0F2d1dhOVozczJTZXBDYmMzU0dZbXpGb1lPNzVJY3NXNEsyQjVmenJtSmpVc0JWdEp3R29vcG5GN0d2bE0zclA4WEg5VEEzWUd4LXFJWV9sS1RsRVJBMnR0aV9FRnFVRWIwZDNoN2djdl95c2xsVjVQMDdQWVM4NmJBMUE3VG9TWXFPVmwwTGdLSE9KbS1XOUZjOGo3dXV3cHV3VWplcWNHTno1SUpnNnZyZE5YbmRfbHZiQUkzVWFLUGlvVVA5UzRrTThJamVrdmM5M1o4SnhOU0syUWt1TWdpMnh0RzVGVGlNR3ZFWmpUQTRnY2dsUFNrYjFheDRCZTVCdW14WVY4LWJjWnNBQXBFd1h6V2JOWlZLQ0ZwcjB0bDFkUVFfX0xqb1lqV3JYTG1scWFZZXNjb29IMFlSeGk1RUs1bjNER0pnOFpEM1lQdFluYXc0V3lrOWpaUDQtd3RtNzhlY2N1NzNaOTFsbm9PMXh0cmwzbUpoVmo4elJ4UDlfLWhuN2FNNEhKRnlXdFhvdGZjQ2c2UGVRcGVaSlltYW5NM0szSWFrQnhpWWQwYVdYU0t6Sjk5ajkxNWZaandHVnpPLUtELUlNOWhsdEY5bzBqM19SbmNuM0N0NFJyM0E5TWFmeFMzRXFhM0xRQXBndTVCS2xPU0V2MUxSNWtfLXdzdHMxeFdneUZtaGJVWXYxMFJuc0o0bXhwNDk0TFhybUo1R1RScXBpQWpOR2V2RXRMcE5qTHI2TEViSURjT013Nml5SGlydTNpblc3cGhMVWxpSENBOGZOWFFJRmdtVnE5MU9reVBkdnRZTkdQemZOVmJpZzBmN2JTWHRYLXRzNS1kQ0loY1lsZWR6U3pGbHpBMnlwVHU4Mk0ydUZVNEZ0RlhYRGNjTlJuV0NjTDBSNkhNRm5KYnJ6ajAxU3V4OWdoNjI4ckJEU1ZKQl9CeVQxd1NQTmc0Um1PMUJqaUUxV085czE1NVRHSFZtVkF1OFV2Nl9VaWtCTnNXU0FNc2ZBaHFoVVdiaXZjMVRYV1duVHM4U0JfTmNhMUlkMkZwSlR3ZVRFZmVHN2F4eVBOZDZibUVRSzhGRFhlTHgteE9EQ0d3a1V3eWNoY2dzRVVReFJRTTRkVjYtZXI5SkpfYy14T2RVQnZOcnpTR1FtT1F2SjU1T2ZibU9FNk9DTkJJRV9MR0xpRlFHNDY1cGVCdTNUUUdSUjZJaUM2Wm9rd2JTdGdOQlVnaUtOeHVjckxSV3c4dmM3UlZybGNHbXRhS1ZaUzBYdHI5b1hKNjIwSEdnbmJvUFRlNG5SLW5fcVg2VkVqS3pMYkJxQVV4cmFyNTg3QlJkRlFDWHJLU0xPU1I1TUlXRjYwN0dtX0NscS1mM2xuYWFzTUNCV2JSdzQ0Mnk0WU1uWU1PUm1Wcm9hZ1hnUGswZzY5UG1uaVNhekZyek5peXpBSXVoejQ2VTBiZEh2RHJ4WWlfZG40VEZSZS1mOUhJVUMzV3BicWo2SlJrQ2hvS09GSVJaWW0zLW0zZE4tVmRxZzI2aDJhZ3hscXJEWFJWNUtKa29lLTdySjctLVZfUE11RjZnel9EejA5amlubXg5VVA3NEQ3a0stQTZXQWliQUY3YmZ3WEkyVzB6VFFxLWZpT21QWWpvRU44QThCNUNmSmwtZEwtVjFaTHlFdzNScFVsV2diZTRkX0xWWWd2T2Z5WnZBNFB5bFZubWdDMlc1U3pGbkpMTTU5UWdLbXdoTE1iYWVEWml0cDhMeTdUU011WC1uYWdnZGVnLWpDaWNybzlHMEdaQWhsaEt0YUJfdFNNbURIYVFGTEdYY0RUZDNqVUpfMkluaEVPUXlVMkp1RTBGb2lCa3RlTnBzLWxWUlUzUWZFdnNRRWg2bHlfYXhpYnVlRmdqZ3Y2WDlOMGJaVW9qRU9xaVptVTZpdW5uemE5M1JGZ0ZpZUFIY3FISjF4WThKU3hyQVNGR3JtSUptTWdYWHpEUE8wRWhXald5LTB3ajN6SV9rT1kza3pDc1FySzVnVlFXd0t0TmNZVEFZN0tLeUhFQVVHS3FKYzVxVVJ1cFdFU0gxNEdUZlVPdWxQZjJZRzBzZ28zRXpVdFhkMjg5cTJHX2FXendFc09FRllUbDRnVkhraEJPRlRvZTdqazFXbVEzMklnNWs0XzJpQml1eUk4bWZ6Wko2VEFaa1UyNjBvRk1nRTd5OFFLRHg1bGJKRXpnd3NlU3ZqeUpYZmtYbkN1anVYMEZUOGdUcWpXcVBpNjBndnZydWpIN2lESHg4U2MxaXlyMEU0V0UtRzNZX1BCSHM3dHk1ZWtxM0p5LXI1S1hrWWJoRUlQVjRfVmZKV3VLWVJkY1VNRUZnc1dCTWUyY2NiUDlrVUlNWVFaeGRseEVidXFIMWZuQUxibk80Si1vd0ZRVllZWmlDOV96X3hfYm4zNXVkZnF1dml3anp2V19CUE9TYWZqNW9zX0Ftb0RvcHRqbTAwT1NoWHFtR2pPX1FpcEFMQTUxNnEyU2NlLUh1UWRYWURCWF90WndjZHZGZldRbGJFSUNkXzY4SVpBZV9xVmZqV0ItYW5VQlQ0LVp2UXVTMVZLYkhvbllHbXBpQWRvbnZvMXVSMW11M0YycUt4alIwcGQ1aTJqWEQ0XzFqTmtmdzdKREYtMU1RZlpHUjQ3a0lGME9oNHBJQzBNM3pqM0FsbmFYZmYyTVZfY2Z0Q1E2RGhTbWE3aW9ldXJJTTZLdExETzNySW9OU2cySUJyRkVPYmVpTVllaGNjZjFhVzdsa0N3a25vTmgwMF94d1FOXzhCX2lYT1o5bXlsVm5ucVVwNjV5bjU3SF9ramZFTDhJeHEwT0QySFlzVlp4VDY1c2dzTTVROUFrQkZVTkNTa3dTQlJqWWJqYWNOZS1hS1dnRWxULVBEVzJtQ3RjWjJuUkM1ZnYzei10ZTdWT3FNNHZRY3kxOGJ6SkRSZUlFbjVSTmF1TVVZVTFxSU9MSUk4WV8yb1g3S2JFNlFmUFdndWRtVjVPREJ3RjNnWWVOZmFtVWtxdnhvN3R5dXl4dDNPcnV4TmlaM29xLWR3X1A3X2o0cFY0RDNyQ2R3TE0wajAwdmJuQ2RSNmJKZjB3TGtzQW5XUmxsUUZ0WHo2a01pVjgzTGlLR3dqb29fWWx0UktCWEZ5NDZ4Tl9GbWhuclBackkwVmR0QS05S2Jkb0RrMnNFd1FRSWZXOUg2S1czSWY4NmpZVGlTS1NNZ0ZEeTlGZ3VSem1TX3p5cW15V3BpNkk0T1g1blpyV2xKdEdueFo4MDU2X0JqREFoUk9fZnNlZXVNN2FILTgxUHdnSGZRWlkyeVFxSDVGVXJVSy00TjVCUEJCdGJLb2ROQldMdXNUQlA4YVhndlA0eEZqOVlfNHRXcENZWDcyTGo4N2p6YkFPZWlIb3pMQVhJMk5ENElDODdPa2phMkFBU2JWd2dOd1BudmtDSlRyUXhQdnZLdDFFOS02OXF3ZU5ESzRHaWNEYWdiUG1JQlZJaXI5andmRE5vSmNjTzZoOG1zN2I0UjV0SjlnQW16TlZzYWxHYk92SmEyLWtDZ3NlQUNvb3JibWlKM1pZS08yRS14Slg3cmdGWGdWaXYzNy12Q2FRRDJDTkpKTDZkSkxqOVJVWlAwY29wQ0pOc0dTT2hLbmxfZ2lmNFJHUUZlUzE0YjJIMk9wU1IwbmxvWFVqQTdKOHlTbWd0a09oWENGZmw1dlhkUVJycTdHSVprS3ZKWVpxTG5ySnpJZktEaG9vV293bnF6bE9BN3ItUFVlVHFmMFVHaFA4Sm56WFVlSHRrS1lHUkVpX0VoX29nTmxnclNUZ3Ywd2dxdFJHeERVaWJUX2t3eENDVzdlcm1EU3FxN2l3Tjl6c1pHSEdZSi00TWs0S3pvSU5vS3gweGNULUM5R3R2S1ZxSTFMRlhoR19JX3Y2T24wZHRrREZGUU5ubGVKR192aFpiSmI1R0V1WTk1OUhMVFJDQmV4cWlwR2s1S2hMU2ZCS1Q1cUtIdGx4aG5zUFFMblRwWUo3cnJNQWpONXd1Qm5MamJya3BqY2hnaWlIbE1nUkhLTm5OWDdpeTVhM29JeTZmZEM2NUR6MWVPekNVZDBHRUdvNkpTWmN3bUFHWF9ibGNVMFVpNVhtU216RHBLUllkSmxSR0tFOE1yUjllRkpoenJPdHJSdFBCU3BVNHJlaHo0OFNLN3hGWHNUWXBMWUlBSFp3TVlsQk5raHhDSjEzSEg1dnJXcW5yZzNSWjlOcERDd3FTSTRfV0N4LXFjdHhtUHBxSUxsQkZjNWtYS0NKV1BUTm9jYkxlM2lSNlZHaWRTMmxwZXF2RVVNdG1aZkV6STg4aHlucFJkd3NIS2duMGJWOXlFaEhwNk84VnZ1OXgzLUFrcENzZzJ3Y1g1RmVZQjZQVVRUWm05blVRM1g1Q0JHalBQeF9ZVURzemFnenRjUWUzRmxtcGVYamdMWm1aRWtudTRlSFZqRXFvWUVMM1ZpVndtSG96MlcwMGNrU3d3S19EWk1UUDZjZ0VEQWU5LUluOTlpOUFHNXFOSlozekZXdUNIVWNNRUxGWDQ2bXdJX0VhNDQtbDlKTHhxWjE1cy1tX05OMGt0UDJ2dFhLYnB2bjJURENLSjZpczRlVDVXMnJxLW80WEVsbWVZUDhZVmh0VjdVeG5ya043UHV3UWxhZTRyckgtelB3VVNxeGRMVlpkMHJRVUtndXpJMUFJLUNPQUJVNXo2c01ZcDI0ck5rbmVpdEtWOTZTSFFYd19aN09CUDJtOWE4OXUwQU5hX2VuZGw3S25nMnNYZ0J1dDV1UkFxUW9HNGtQTXBZWmRfUF9CSUFxdm93OVdtTEliUk80ckRDcmVlYjF2VlYxWWUzeWJObDFPT1RhZUE3TkttNnc1V2kyWWxyVzg1cU5QYzhmR1F1TWd3R3lYa2dGb1ZZRW5waVd3NXBrNUVySm1BRVNzTU1jd19fdk44cy1LVWdFcXN2cWR3QzFoNE11Tk1GT1hRaEF5QzVBeGRfMXExaENROGVXRkQ1bVpibE11X2ZLVlAyVTJ1a3ZxOWoxWUd5ZHJpQ1lneFRXZmFSWUxmek5pNDYzZXpXQUk4WGg0aTZZTUQ4YmVrazUwUGE1enRoRms3QWdSWFV0OVBxVVZjSUZmRmN4cWoxTEQ1bU9VdFZPenYtNXhBdl9vMk52b19IcERGRkdhckNxbVZ3X1hGd2NlNURwM2dRSXFLcE5KTXRhSE1oREdvT3hudFpZSlJkbjJnSENYVkZ0U1F1TjhDS1VhOWM2YklpcGRnSU4wMENGS0dVX0ppaFVZREtEekpUQU5qV0FEVXZzSXhXTU9qYWxtNnAzWmNJaVdvNThad0xWSXlSU3dIWHh4WVNzSC1SbDk5WmtRbTJ3cFdvb2hyRW1HWnpPZVlQX3RBY0VYek5SRGNfcTJURnh0WTFkQUZZTmdYMk9sd0tFY1FHUEI1RVhnejl5bFF2bFhfR1dlOWNsRjliU0tSLVExcjIwLUZ4em1fbWdPZTU5b1Brc2QxTUVFTmx2YldYVGw1NmZGUVVxVUJqZTR4Z0I1WHdJNkN2aVBaWi1oWlVNMVFzQlNqV0pDZy1pU3FuUF9PT1ZzNnUydkVFWndFMGxablNEaC1DSjQ4eFVUa0ZjRks3OGVYbkxMSERlMEVWUFgtMXpsZzFXTTVNMzNGU3JmZFV5eFN5TmVDTW40MTVsSDFOd2dQc2RETF9BQ3RjeVZrX2N6OTVqZ0xaZU9GN3JYM1FaRC1uTm9RUUlWYUJXdkFkSE9zdHNqa2FmVnlYV0FUQlVMX3NyMGhKLVBfaVExdVY0SC1iZjEzQ0F4V3o1czhNVXkwSktDb1Bsak1vbzVxNnNRNW9XajZMbHBrcGZNT0pxa3BBbVVKSWhScEk3M1ZMNFlzbUlqcGxWdGRONU5fWjQ3bG5PWDBCQy1Hem5UeHFUbEhKRW4za01QOTVJQmUtNVMzVENINGxYUnJXZ182RU1maWF6aVZuOHQ3TThlN2NFd2RNVXVXZTdTcnlvZFlvS2NqakJ2SlExU2dSb2VjU0l3NW0zYnUzWFJ5bE5BTEZpaXNlbU5yNHZtTm82SENEMWVreThJUHFOVFd4SzNUWUN6N1ZYazJhMGZ1dGh5SEdFeTlIOEpaRDAyNGl5ZDJveUR6ZU00N1FOODJibG1mQndJalFEVDZQY0hRR0plY2RkYUZ5MXFmcHNQNU5tQWdFdkoxbHNtaUpIQmhyRE93Z05VekdfUUkwLXdZTzBMaThKekF3aVB1SGx5dDFpYlYtUkVuTHktNnBMSWM5Rk1kMDNqcWl5QUhldmlZSGJ6LU1USjF4ZTVmT3ZiOFFHUmVEaUtHOFdpc2pSSktGYlktYXlud2VVa3V4M040S3pIY1VwbDJkcFcyczMwVlE1WFM5dkFfQlh3eG43bzJsYzJtRTZsVlA5cG9TUWRYU2E5NHh6bEVJTUlwZWRsdjBPVE1BbFppSmdRajNLZE5BX1N1RjBGSHprUnQxN19VZnNqSDRJNGdiR0NNdmk1Y2I2anpKMExGU1lyaUI0ZllBbWNJN25oWHU3RHY3R3ZnckxDSmpicEtDQm5ZVkRfaXZrSVJlZHAwTDB2TzhETGdlcWF3cUJURlpuT1JsUmxKVDh1R0xRVGpHOG4ySy1CRjJnZEhhRWFwOU82Qkc4V1RzWGE3aUlRSnFNYnctUVlIbmFkdHE2cktvLWFBYmNBcURSb2J1Z1FzS2d6UllSV19sYTh0djJZdEpIamZCOFhVUkdVS1ZNNklqN0NVWi1scXdLc1duRG1mZzd1VnNBUVNuNTNnbzlMd2xNMDc2Y29XN0YxdE9OdUpOeHdzdzlGdDhKdmlZNENJeFRYUDM3N0FWUDh1Y05IMXVBdHplM1lGVVhqZlhma3BuanJMaTVLMjcyYXoyUDM0NTFkLVk0dzlnamM4dHpGNF9rSmhwb0s0bjh0ZU5xS2VBLTNNXzdGQ0lUdzFCUDRCWDVWZzFja1ZoU2gzYlFXdmw4RWNrQTFSQ0RWV09mZlg1cGxxcDJPU3lHNGhWNVFDRDB2czdnM3Qtbml4QlNVbEZ6NDVueTdvd2dpNnk1c1AyaW15eUVhR1U5c0ZsOTZnc3FzNU1xUTVTQUM2b29DcHpXT2hNaHV4Vmpzd3ZBZTlCN3h3N2RMaE52SUxOOVFtZ0JuSzhpRTBqZUNvaXI2Sk85SUo5cWtlNnhCTGN6SkgtdjBNWUl5STd2cU12Q2ZjRFNzNXdsa3I4TEhfeVhyTmtjYnRxc2Z1UXozalZIRnRGUHBqdkJqMlZoRXQ1TzZNZmxxY2ZFSUt5NklvU1lGQkVMVG5NdHhONFBDT0s2dDdrZU5uTEQyY0hBX2YxZThlUHpldEdFblhaNWJQYkpkdjB5c3lwUm5SYmdEM2pMUUNuWkZyV3B0Q1R0bEVSSHo2YmVrSmNkVWY3M1Q0S2xycnNOR251WXZYRG5EN2FhN3E2SjF2MnFKaU9zbEhtU2RrSnZuSTdGcnZTUVlYdVk0MDE5QlNPQkFNNkM2dDFGQzN5MFppTGNjcWNyaU14dFFuYURhRkZaWmtKakRKOWZBWG5RUTRXakhDcXVhSDdZSEJlY2dWZEJ1OXRMZzYyaDBEOUdtT2toYlB0TEN3VTM3TEx5a05NRk9ScmVhekEyYUowelBoaVR4TTV5b2JnZlczazFjT2xUYlZsd3lINE9EZVNyYUlsaElReFlQbFBuaklqaDdDQmttNzFmdmJGMkJXZEdJUUpDa3BNV1hVR0QxQnFKck1ENjFzTWkyZEQxTVM5QkdwUGI2Y1gtQmlsZXNxazRJZnozRUh5bXhCal9ITWxKSzMxZ3haX3JQajRBMUFRbDJWWEVBS1prZFQwdWlHLVF2alhENU4yVUh6VkdqUGx2VkRJZlRUYVFDQ3pKeEo0QTI4VjVCRVd4Tl9QYlZZcXlqSWNfd2VKb3RoNzV2czFER2VucDVsejAxQ1hRaS1tSzhtdFBHQWZuVG9EdnpIMk5NME5nR3NnNjhRSFRLN3F6d2tjdXV1OE12U013bzR5czM0cnZyQ0pSSEZVSkZZUUFWSGRGazM1QnctRzFFNllhV3V0eEhidDFzTENHeDdwUi16RFNYT1dzSGFMczdpWjdFZmtBWE91QXJsd2JPZmd1SFRYMnA5amYtZ2FkVi1Fc2NmV3VQXy1NZVhnM0s4UF9HNFcxT2Ixc3Q1dnVzMWQyYVN3QS1jWHgzMHBzcnFLZk5mampnMnJhNTE1eEtEX05sN3NPWk4yU0JHbWtYbGphWkRGR0ZqNjgxYmJ4bzl3cGY5akpVLTFsT3pKTWZHeEU0WVJobGZfYXVoT0E5cFEyenItYmpnaEl1c2RyNWpRRVBDdDRJaUpockdsLmlKSWtmcFF4OWd0cDdhOVhCT2RLVnc"}'
+    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLmI1My1iOHJIRm8yeVBsQXVLMXh5bDhPaFhXWG05U0dpeWx4S3MxNVNDeE5kbFU4ejEwVURJOVN3eC0teVVRY1VMYWhqd1N0TkcweVRDSjFNZUNSMTdoVVRWVDAtaFFncmdpRXlCdjRCZ0ZTLXVZS2pYZllBUE1hZERQMEpxakk0ZjdfTUJYdmJtZURnemEtVHJ3SldaYkM2YXBBbkN4anJ6TllOSndMM1RnUlhnZEpXLVhhZ05pbDg0d2diaHdUSzdETTV3VVdLUk5NSTNidlNqb28wTVhYUkp4SnpfSm1VdE1aeXEwdTQ2aWwwclZkTjhfek9FYjV2NEhlclp5ak1rcXE3R3VwOXRDdERJU05LM0s1UjF6Qml0WGlCbkllMFRrOGRGeTNPdGJrZW82QmpSamVYWmJjQVl1bFNiME51c1pxNjVGYWF0NHdwUDNERUk4NGp6QS5QRGUtVWZhWmpLTEJORWRpZ1F2ZVd3LjhaTGJjVFZvVXgtaGxmLUxxY0g2RGtlSXBjaVZyTmdtXzVDZnR1eC1ITFZiWW1MV0FqRnBwcDl4SVl4dmMycUlfcnVHRXlIMDVWRFpiVTlPU2ZkOWRERkdVeE92ckxFWVpZeEhkaXlfUUpMN0Y2QllKRTdwdUlSX3lzX2R2ekpIZklXNERxMHlKNm0yWURjUmdYRi1sX0o2QkVpTUlNOEwxeTJpb0xPSERSbUhUdmpJRU9rdmVYd19PWFgySDBUYmRnYWtGVDFOUXRwTWxEU3RqQ3pPNVZZek5XT2YtVTh0NnAtY25fM01TTTY2b2JUX2JReFBsdFdxMGtTVERscE9HbHFPVV9JRHV2QWNxYUI5NDB5YkppNktfMk5GTEcwWGpJU1VBYnlWMXl0T2pSWVgzd3FjVk0xNktoWGlaT1pIcTFfR2VWeWRBTU9KNVk4Vlg1TzFoejNnWFdIRm5MSVFxQ0FoenhKcy1zN3FfV0VhZXp3NEU2T3BZUm4xQzN3SzZTMjFrQ1VQdTI2Rmc1MlZNMERyNnd5WV9ZUlViY3pHeWVoRkFESkttc3JzQThvOERIMEFiQTBHX2RyR2dPWmVJOFE2VTU4cnZkTnNoTmZHZTVqazV5UW52R0ctUGJMRE1POGR3d0c4ZndQam5hSjJYQmpQd2NIeWdITEEta0Y5clhraTBYV2VQcmFhdDJLWHFReXViQTlDU0dkVUhjaEE5SGE0ZzRpa1hXTG92SkxwREtEV0tCay1kcTM5X1FzRUJxOTBzbmVRUnlFWWhISXg3aWU4aE9KQjY5WVlpS3hlX2VEM2xGUEVhdm55ZTVJUm16WlA0WjdMbEhHbFRnamZTSUo0YjBWYnNhTTlBUnN4bUNUekpYb1ltbVhRV3FqNmZQVDhwRzlCd0w0TzNBamQybTdITFFIaVlRb3BJdDF5VkFPdEg5VVlnbW9EY2NCVVNWa2FZdlhRQTF2enNyNXJ5SmpWSkZJUUowakk5UEZNMEVWXzdsNFRlX0RtVlBwc0djemZuMnRSQmxPaFotX0VhU3JSLUxjemdmdHNXYjhVeWhlRjdoNGpuSGRSakZHNTBLY01ucVROY1B0SlgxNldaWG9BUDR1QWg0OHplbnRrTG9RdG9vUVA0OVFzX2c4c2tRZ3cwcHZCTHBhUW9GY3ZXdU1sTFBlQUJCREZqd05LQ3N6V0tqdl9nWFg0Qlc0ZG1sb0ZjYmJWVkxETGZaNnpub3F3YWJzLXVXc3QxSzluWHJqNjV0SXFxRXkxUFRnTEdsdFVHTE1uSDc4RXdmcGpGN3UxRUNDSDMwSkJ6dkV4ZEdRRVhRNmtYckhsRVYwOXVnQUxRMnRQbW9nSndrU0ZIYkd2Zm5QWkhhUGxFbkVDeF9BOW10RDhieGtwbi1pbGhJWHl0TFo2R2lfMnpxRm5aUkpRODVSRkNHUzZmVWREc1M4RWUyak1EaThyREQ2MW4xVUhibjE5WndZTmZKd2RvdlhTX0JvNXJ2Sy1JejZRMUZsZlZreGNZOWkyLXBrZTRES1Z4a0NIVTg0QnhYbWZaZ09QWUVvMWVtRy0xVWxMSDRqeUhDTVktNWQtZmFSaDl6cVZ0Qy04a2JrbGhEN1EydVVpMDVTckhFdDlWLXhpWlF6TXMwTURJUkgyV3FiVmRUN1o4eHNsQnAtanlFWnpGdmNQZGhjZ09CMWU1eE9BRVFkbW1obHJHVTJqYzJaMVhOX1N6eFM5WS05UlVybnNFV2Eta0hQbXJkYmNPclc2SllCVTNnYVJ4TGxGQ0FlY3drRE14QlNFU2s3UHJZUndlNWVQX21jczlob1JGbWtJTmxJRzZhUkVxemt6eXZOLW9KaUUxalp6ODJ5aXJERG1NVHpSQ0hHLWxkd2h0M18yTERsVUJ3VTRCUkVILTZiX0UtS0FobHVhWjlYSkU1c3hMOGJjSkR4c3lBeEhOM2k1RGJsRU40WG1CSzBrM3A1NXY3ampBTEhsMWFzSFN0a2RsS0hlN0JkR2NoYld1Y21ld1dCdU1FRlFIOHRaOS00SmxMYjQ1NmhZSHhkMmtmRGtkYWMwOXpBX3Y2VVJOY2EwbVFCYzBLQkhzVFhKMTF4SUowbUxNVnJhQVFVZXNSckRMSTRsbGJpNjJRaEczekM3ZDZBQ3ZneFhTVWs3X2k2WW1ZYnBnNHFsVUliWjh2M3Z2QTk4QTRTUzlxS05MNUZxcFowOF9mQnRWdFBnc3JMU0VWb1hPNkZLSWhuc3k3ZVdGTHdrWU9BU0EyaUx3UFZmVkp1QjdiWl8zakpTeGlOMXk2dzA1RXRNZ2pHQVF2RngzTXUxUWxvYVZfTWxDMGpfNTZDODVFT3M3YlpsbEcwNWJzeVgwd3hNckl4Mm5qSTZSZ1IwaHdWRnRSVmJfelZXTlROcHphX3JYZjNGUzAzYVI3Q0QxaWo0Z3RNb3ZNZHYzcE9BSVBiWmlBMWgzSVRINGl4Sk9MYktHWjdhc0I4U3E3WXlVaEE1a0d6aEhNY3ozdTBLYjVweks5VEVHQ19ReDZtN2l4a3E1ekc1a0R3VDRTdzZIVnl5eExjUXpzSE1Wc29oYXJmT20xN2ZqcWcwTE5nZTV4VzFqUnUyNnNQcnVNem9mcGFTX2hsYmFJMmhBX0V2WkRLcjZfSHNpT1Boc2swMHpvaGxRaEpBdHNXMklVSVEyV1JqOHFYZGlMSXpRc05OWjhZem1CeDhhdFNQenVQVDFOYTFReU1mdVI0S2VTTmNKSU5JQzJfRDhDLWNjVWZLRVVtVjdYR1Z3bnlUQS1OWHVMcHRtSklQN2xLWWZOcUxZVF9aN0s2cGtVUHowc2YzSDNfXzdqOXg1WVZzNk95UlZRV3lZSzk3MFRQa25nbFlGODMzd2pzUGozVFRyb3ZaTm9RRUlzYTdkS3labnJJaFNmNXlxTmpNdjdkc3psOHY3ejVZMmtJYWVpS0RGc1Y2WTBxSG5MOTUwZ0d6czQwcm95cUVpczBneS1VOWplWGpkeHBDMWRxUjd6V2UwcTVIM0VmQTZqTGdaR1E4OWlEUWZnQ01MYVRGSTVmSVo1djllcTR4TmNVTmctcUdnZXpqbXhtcTJraGRnN1pRZnlxTHFOdHUxTlowZVNfbENRVm9SVU9sTUs4anhRdjFZS1JmSGxDMlZwSmdqcUp1T0ZOVmFJNTM1TGFBTms4TFZxbU10NDNiWElJSnVuZzdEdDhxN183Yi1VelFDS2hlVVhqQW45RjRSaDFwS3REZEtXTkZNUnJnV1JMWkVHaWpJRVdoejhfeFpIVjJwZnZrWlFVU2JIN1JaWUxOX0NmdFFOT3RlSURWa0lrbjFXeHpUeUxYeFgtcTBnU18zdmtWYTBTa0l5Rm5TRzdXNktPV19pS0pUeXp6SXBWSnpRNzN6MDlzdEEwTzFKR3EzWTdqTGF0QXlwby1QS09IYndWNGpORWh1dE42TGFPMHloZWNhT3hKRTVuZnZPbWlneVAtZFQ1VjM5YXNMWmgwTzlDUXpLT0tlWTMzUk1BNDhZTldZR3VodC1NNUlvZTB1SWdMQ2lWUWpVR3BUZkVKWnNWNVNOeks5RUJBQ1RlcHZHbjg3enotWVUzeWx1VnJNd0lYLTRXM3RpMGpTZjNJNElMQmNPSE1fdlJ6YTRoZ09uWkI0bVFVaVBnVTV1VlVPOUdBdEZ3N3JlUTlVSmNvZnBIU3haWkRsRDMzNHA2OEZ1OGgweDRtXzZMVXlQa0JwdE5oNTdIcDJuVVFBbzh3OUFSTHU1ZDZmMnZQVEhiYnJyZHExdjNhV3lhSVNiaEVzWDkzMEJNMVVDTVhCYnNhaGhsSGV6UE84QkdnRmplTldSTElJSWtOekMzSXRCU1BpU3ZtVUY5c3BhQzRza1FNQ0xNekVGSGlJV2NnR21Ec3NmQktZM0d1V0FxOE5xYnVVcVFTalNOckVDWkE2TWc0dERndFA0R28yMGpiX1R4dGM3Z20wRU5hT2cwZGhReDFyQVl0SlJ4WEpoUVhvRy1yNFVJYUJjZXFUZ0dTblJqdlJpdmZZMVJDUGlxcE9fRzZLbGR0SkhKODJwT2c3WGJqcUk4cDN6RTE4d2J0ekkwVWdPZkc5c0xJSDl2Ry1JcmNHMWc1WTFEdDJmanlxMUN6WGhfenVIMllnZVpNR042b24wRG41Z1R5OWtweVR0YXVpcHhSNzVfRVhSMGtKR01pR21EeGRMbG45ZmpQaUg0RlJpYmRsMXBSRkxUUVRTcTVCMzFQbk9STWhkREpoR1U5UDVFYzFBMmY4NHJESmNSb0FFOEk3N0N0a3Z5MTBPVnlPRzNOaFRUS2hTWHlRMDZfdGlUNnQwMy10R0M5Rmhfc2xiTmdONlZ4Skk2eU5fTlRUbXN1SDdvYjU2NWlPOWlraWEtY1ViN1NaWUJsaHdra0VnVGYwVllPQXJzOE1PNjIwdldBUnI1Y3hlbGh6UW5qOVdPODlzOHI4Ynkwc3U4X0lBU2J5cTNoNTRLYjNxR2lYcFhUNEhMSUE5eFZycUdxRGtXZ3RKZTZoVHIzb3lXZjloeW1pR1V2WHdhOVdfTjFJaThJdTJ2QVFvOVQyVGgySm5LWnhGQ0FCMjRMVVFYVEw2bDVCZHNpVEJkeGk5dU10NmY1S1lGUXAybzdtVk4tSk0yY1kwUFZiTkVMbkNaODN5VWFxU09hSlR4Y19yRkJpSVF2SDZYODVsY3FpZURlV2Vua3A5VnBBX3dEdm1QMlp2M2NGVF94cXBRcXY0dVBYOWtmNURBWGFqNkJ2RzNydXp5TkVPM2ktZjhyTWNEY3J3aHJ5bXZ2QmhfYUpULU1iazhWUy1iLU42ZFJ3NWM2ZnBuZjNDeG5HS29faEJ3aUhZbEg1WWp2aWplQ2ZXSjRkWUdkWGVTWEFqTFE2cFpPeWJfa3QyblpXVmRtd2hlSUo2bjFEV0g3SWEwcnFLenRUX2dhTFFGTDBzOU1WM0RXR1lKbnJoVVNnbDIxUlNNeE04SGtxWnlNdHJRWlJ4dmFXcDBEaVY0UkZJNUU4dWpTYXM0emNuRU5STm9oclR3Tk5CMHp4S2NJNHBxOTNuakEtSndKWUZyNUxucWlvdmxVRGNLRXZBb0NaQkw0dzdGRkU0M1BkWklKSDlWUDdhWUttWUJFMnBpTlVDQ2wyTlh5cVZrTkhFWGstYXBtY1BpNGlBWFh5cENqcm1SU19ZaVh2S0FCSkx5YlROT3FGNGc5cWI2a3ZVVlJSc3hROC1TS1lfVlNxV0ZScWZUTTkweklYWFNfWUVNa2Q1ak5INXRqak83OUs2bllaa2dwSWw0ZENOdHhmS1ZZdEIwRFJNV1hXdkphdV9sMlF1QlVxWW15Rnh4RHpNOUVMOTJ4dFRjWUpnNXZqb2NpRHdWUkU5NGE2WDY2clVkcVM2TmplakotWHVSRjIxaUNTdFV0S2Q5djFMdmd5c2g0eUN3VG9PZXRLdjZoLU1EYndIbUZpY3VZZ0w4bTlwUVJVck5LWklMM2tlVnE4dGRKTThablFhRzhLMzNCQ3VPNG5OY1pud29tUUVlZzFTeHpHWlZYMzg3MlVSX0I1RmdvamVvT3Y2ZUhsZ2xfaUI2Nk9UR2lnaHdQaDV6bWJXSk1tSHM3a0haV2YwVW9rX0NHc05GMmh3SHl3aHRIM0RSSDdNOXVNQW5DSlFaX0JnR0o1OHZqemtLY2tZTWhXcHZpV05yenhPWk15X3RWRGJ1REFaR1VJZmFDVm1pMC1HdjhsbXB0R1FETnFNN1h6M3dSZ3hSVjJaQmZ4Y3RDZ212R2RxTDR6NFZfaklrWTVsTWxZSnRYcERURGhHYVZsb1A0a1gwd3U0Q0pYcXhIZE84Y0ZIQ1R4b2FPbGRpNDBwTTB3WkUzU0RPYlVFSHBBdzRUX2xRLW9Fa1NhWmJ0alVPLXFCcG91Z0xLWmdiNmVXRUN4eG8tVFVIV2dZckk1anJkNWJPX0RjWm5fdDY5QUNhbFVHU2thMXNsaVpkOUxhNGZJYVZTQ1RQYTdrd2pDSjdMb2Ytb0RHd0lmSmFhRWNib3NVNUlaR3BrQkV1b2Zrek1rZENaSUNDZmNOT3ZkZnlPU0xrVUxVbGg3NFpkbWRHdjNDbkJMaGNoZ0tubmw0bldOdmpoWWxxeEVVeWctRzg5REh2RWFBV0ZrVUdTOVNHeHFESFpPWlZwMnZLV0RmVWduTTJYZDdoVEpFNzV1dDhadXRNeFdQdEd4R1lBRjFCd1BwcHFlQjN4aHd3bnM4ak8yN0dfc0VYb1lvbWphaWpCQUd4bnFLZmNjSEt6bDkxYk5NVUgxQXdRRlFyUzZ1Z3JhUTBxNEFsRXlFcmNIUlRhcnFWVTh6ekxEbUs3MWxzc2lJZkI5Ul9QbWlGUTkyY19rb0dLSzhpUUY5eEo3Nk8yeWNpcUpwT2pKdnlVRk5WSkltbl9MS2toazFrRHNNWkcwcHQza29fYUZOQ0E1MzVXQXhtNFRwY2pOU3BHMVJFVlBReHB6di1ER3htOHpzODNtRWNCcFkzbjlIUGpGUGZhckpRdUZFUlU0dEF6eXU1aFFFWGNFa2d2WFRkOVJELXpHaGVjTE5RU0NSV3hkOEJGNkJUZEMzcDNQX1Z2T21aZG5Vby12VzlXRGZ1VWtnT2lBM1ItVWdOYVhnNXJ3b3pKLVZBRDUwSUVHUnlTcGpnT1A2d0U3cDBUVkdiODRGYlZDQThlQWR1VE9zdWwxLTBaMGVjdFMzaXRLc2RtRks4SzkySUVMVVFFQ1pWdTlfQ1I4Qy12SC1mVm5Ick9XWk1xLUJ6eWNIaGVVNi1Rcy1tYjZZdHJTWTRkM05yeDkxeDM5dFVVMWY2SHBiV3pQNlpHMjh4R2lhQ214cmxQUkRTa0NrQXh6QThYRk5CN3ZxMXhZLTVucUxtYmFGaWN2UlRHaEN5SHoyUExfMUVFMzBNbWdOUHZ3bHhNWmVBWFpqd2RoRGpfUDV6SzNUUmk5UGc0bEtfdXpzRUlINzFOOXY3RzhuTy01THFUTUp4bkpUaUZFQjhzZkdtLVZsNTdQVVJpVXp6ckNqaHlqNTRfbXlDb1lqenMwdUlPNDBPZElrNUpfVG5YdktscFZOa25hU1Jwc1Z6eWkxVnJ4T19mV294TV80XzQxMVIwS29QTkpRNlZqblhZVUttTlJqby1nOGlDVHFhTWNEYWpTTWJMRDF0WW5HUmVWclY1TEtrRzRsQ2laN0doR1oyaUg3WUJlZFVtZVU5Z2ZpVzBKMC16QmtfSzIxbXMxa3AzRVF6TTBzZU1qWkVLZC0yWXBNN2pXSXVseTJLdC1qMnktYm5sYkhTWl9od1J4Y3ZuWnpKdDg4TndJNXpzMnZvRFFDbTFKRTNlQXl6X2xtdWZMR1QyRjJlejJCSnlPOUJQNTh5alJTQktJZGo0eXZPREJDUGxSQm94YS1xZ2VKdHNaMzlQY3JyMC1Wa0s4bHNoZjlyTnBpb3FaMHBoSDFISTNKTHRGQ1lkdzZONW1aRU5MckhhNzc0dFlLVDVDeHk4NmRlRmpTOENZVmlsaDZFaU1fbTZMNUJVd3VaNDljQkIyNFIySGwycXNiUUNpUUtNZTYxaUdQeGRYWFhocGxZQmhkamRqOGJaYzV2SU9yRVhWd2R1SjdNNWNvZE95Z1ZIZm1vNXQ1WlYwZG5TS1MwTF9BWHJhdUh2QlpCejlNeHFPZTVDMnBIS3BWTzBLeFdUVURMejhQc08tbVp4dnpxZlNRNndOX0dIOUVGRUxGWlV1NFpPVUxhR1lrUERUYWV3eHVTQmJEU1hxaHhiYUtlSlE5eW9lZ3BwNUV1VndUWkFaRk9lbDZ6aHR6SERKZmpERnNJcTAzM3RRSHdLYUhtSTl2S0NQNU5Ea3A3ZXczY3FVVzhoS0FJUkFNZHdpRWpiYmdnWVcyVlpDalctTnl4MTFLUHoxbXRrSnhsNDJNZGNDYWNzRDVRNGEzY01fVERHTFZrVTI4NXZjbEV0RlZpZVMtMmFORkdRRXJfekZsaU8tdHFydkJnOThLNkJKSTV6bUFZc29PazBfT0NIODdvcG5yZ250bl9wU0FnbmtGdTBEREdOdlNIbzNXZEtFQ1FGbXdPR29ad1RCdXJQa0hZbXV6MUM1TDBFZ2VzWWxDd2s4SlFCV3JBM1I5UTNGbWhDLWRnOHNHWVdnMGtncE5kV2llM3BveXkyRzZ1VjFxdmJ5WnM1M3VuS1NTRDdxdktVamJCYlpWXzd4TzVkYXdyYkdDVllkVEpzdmpqU1g5SEFtWDJXRXRRbGc0YjBPUHVXSFdCQU9UNWg2UWVjcWhJV3pJbVVzMzdGdzFJOUFvVm04V3VrYVl3VVU1RTRXX0V0YTNrOFdSZlROQ19aTjZRbnlyckMxTlBhQXhvaEs3d0ZkYUtwMFJtNEdEWVpXUjVOMUtvWF9EZk9pWWxwYTZuUjF5SlBNRVhFNnp4Ui1LdkdRdVdKS2k2V1ZqM2hVOFhkZnhWSkJYc2JHbGRyRnE1X0ExeXFoeGMtODJncGt5TEJIbnJZd3Jta0xERlRBaWQwVFRsN1F4RXkwS1lRQmxRRUU3VHJxSUZJMmYwakJXemluOE1ZUlNwV0Frcm16QUlxQ0RwSG55QmFELTdOdTltSFJFOFdJUFlIY2JkbUNYR0laQ2s5UjZmUXBUWVU4Y2JKSEt1QXpidkJ1LXotbi1CSTEwQ090YUc0b25SSUdBTmVodjZZY21Nc2h1cjNqUXFicUtrNWRidmF3WkpsSVhtdUJFNWRXRE9HMU5DamtkSzFoNmR5Rk56SlpwZlFpdS0zWV9pVFE1TGxWc2xkVUgwSlQzX1ZVcGliV3NQQ1JjcTVXNjltbTgwbXBtdVB0ZUNPNHY4NlRVaHFtQkZnQjVtRlF3MWE1R2MxTUQxZDR5bmcxV1RlXzJ4Z1RVdUE4WW9IZ19SVkhNWE5pV0F6YXIzSEpOTFg3bXYxT01sZjNlZVlVN0FWVk9FMlpzdXNrMXZneWdHR01lUldpNmFPRmlNTkNTVE53VE5jeTNOMmcwOExVMEFZODZXV0pfNE5hMV9DaEdjaFF1SDFNUGRLbzRQbmxDbzlJOVBhSVRsVW1CMzMta0Zzd1drbV90aDV6UFRNNmlIQ1BaS0FhcDJEOTlYOUk1UUhKX2pnY3RIVUFYZnpoc01XbEtyV3NMMjB5eG1rMlRnVGtfa1ozTmppdHBlMU9ZNlRUc3pnbjJQdEkyTU5sb1BySmQwYXNtMmdNd1lsTjh4cUtWbFV4cWZWN1AxQS1lSHdiVGxkREstZms2ejJaQ2ZNU1dkN3lqNlduMzUyN3dMaVFsMlRpRzlXbUhlS21wWUNELW5qT1YtNDlib0NFSk04ZHRZOXFNMzhLUV9UOWZBVVpyYTh3RlN6LTR2R3RIYk9CWlRCODFDaVI3WmZ1VzRFdEowdXZnU0J6NzVRNHJWcWtyX0lmc0tHSVEwOGVRNngtS3pnakgwYlllQWl2VmdtV3VUeUFhSnpqV3R2cmpUM1gtR3lhSGZZd21xNUpHMlQwakxpRENBbWhmUEltOW5adEFlZDFTQ054b3FXemMzbjZtMk41bXJFWDQtQVlwME9pdWtRUjk4ckg1cW56ZkgyZDBHM05RcG94X0xRUjBoLUxTUW9nM055MF9zeWE1blU4dVRpQVRwTFRCN3RmLUlBVzNrVjh1VF9OVmRLRXp6OUJ2dnUwVXFVRWZpbjBIRTRSMVE1X29JN3U2ZmltbGNiM1Rhd3p6cGZjT19TNXhMYm51MldSUmF1MXBPWE1rSEltUGZrQ2Y3NGJGT05EVFZnUm15YU0wVm5HU2JTWS1JaVNuSnZWTXZqRTFpalpFTlpyV1VlSFJEUEhXSTBwclZheG12NHY4eGxVTFJQeDZEaV9FVEFTTnc1YUdoYXNXNVdncThYUjgtTXhUY3hEQTgtSEthd1ktN0t2a0RRYk5JaFpXT0RqN2xKTi1ZN0ptMG5WNURnSk9QbnNha29MTHpod0U2SkpNVm5hdnpfVkhFVVRUUmJ3amF3ZVFXcGVJSkIwdU5VZjhpR1p1a0djWnRQdmZlYXJtNmN5Qm9YeWJGdDFmR0E2MHBKMXUtVFowaXRiZ2lWdk5vUjBvNHctMll0RjB5OG5BckJOZmdpWEtfclNWY2FQMHcxRDBQNGx0WXFCSk91cV9ZZlBLY2RiVFJEaC1aUzhZR1ZpRXh1eTU5c0Y1c3VESHh5UHlEQnBFUmNibVJHZ2ctSS04MU9yQVkzeWU0LUlJTGF6NHpjOVdBXzNScHhWNElWQ0Q2dWVULWNiNmsxZDF4bVhCTkZDSnlJSUdQZXc5TDN4Y0FXTVJrU2trSXNmSnk3RUs2NTNVNXY3bi1jVWVRazFEMmNIbEpIUXFHVGJuSU85NjZxeGIzY3dlM2kzN3J1TXhVVkRTSEExQ3lYZUx5MnJ5eXBvdUVmX3dpUVhoZVNhd2IxSHViZHgyWFJsLTBUSERlZWMtTWFSTmtxTzJFc0pqLUhJcV9tX0ZOeEw0OHFKYlhlLTEtbVpwYXpQUU00RFVxMUdLYnoyR2V4ejlXTHpyNENDTk1UVVd1UlhrVFYtVkVPUGhUSVlHaXVXZEJ6Z1FaYWRkeWxDNUtIcE44VkVVYVF6TjByLXRUSDNjeUVhTGdSOFduektQeVkwTWhHdENLR01NRFNTR2VrNUpEMkUtZUt2ZmlZT2VWdE5IaWZHUlk0YWFsZVRVaXZScVllOFZJV180T2F2VndtSVZWaVFkR1BuOEUyTlVZU2dmanVCaEdaQk15NWYtWTNFaEl2NlhfbjM0eGd5azdUVlZsdHFfYVh6WHlQRjBTajlVc1l2Ny1ydFZNNmYyVUtMT2cwa21jODZLREQzMXBkMlI1cFV6U0x0ZUUwODFQQUFfNV9ZUE9HNVhsR3ZXTG15R2VpT3k1SW9PcGVKazJVSXlIbHNEay5kTjV0bzNranZjS3pmQWJXLUVBQnhR"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['11660']
+      Content-Length: ['11717']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e43f7d6e-d457-11e6-8d2a-a0b3ccf7272a]
+      x-ms-client-request-id: [995ce376-f95d-11e6-a911-acde48001122]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/restore?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"sZiaRJIrmVH7p7l218U6-RitQi0Nf4hHfwo7TzxaUF-B55gH8qxpGRY5z9DhzPUB0oG9VlYMSYOpP0t4Ol_I8dmjoMuJtRRn3CaGdlOgKPe0qEPoLa5N07SHLFltDLUZKaZ4HR2AymJxhsQXMgK1f5B1mfi0mDfZLu6h_0kL-0MLIdgnKINm27O_G5nrTyYgRIqMchIPNASb8qXeBkxxSxNvhBm1CJE6Ye40grqJcnKoltLebzzUqlojuYT_F0ItPMheFVPIt6BrZj8Ixe-v3wTSTz7eLMWW1ssJKWqp9NOwW0w58DTAoNDE_tpALibO3KlReY0Q9Q_E_JCAxhVCNw","e":"AQAB"},"attributes":{"enabled":true,"created":1483738458,"updated":1483738461},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"wxeYPDHVvT8k0GzoXk8Kn22qF7c47wu1MTXgQE1qLmAllJh5M6IEoot--b5gRsVItQuhGCC4umTvw_NA3XkOtJJvxKe4OIqFn91r3eSgDRavaFhIVyStUyVNUhcfARylWr_zoHziZ_Tj-mCpFFrICDHacH-Ev3PWFAleqZNdZ-spXAJjb_5upJtRxgkjNNNBvR93k58Tfg9rWDH32EwY2kfFY3tBvyaGm4NdcE7Y6bpRzHizVhKpk7j62acEm0NUkib4zVCChkGStKUOHwPhWHLpZYYLf38Rrwk3v33CwxDT2qmHcp_aVj5EH6DWi-0t13XMcBj_EWzpYDUpe9UJ2w","e":"AQAB"},"attributes":{"enabled":true,"created":1487809098,"updated":1487809104},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['604']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:24 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -334,7 +467,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -343,19 +476,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e4d439b8-d457-11e6-9419-a0b3ccf7272a]
+      x-ms-client-request-id: [9a563fc2-f95d-11e6-a3f6-acde48001122]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/032a0969d7f44abf9d0de79c2945be43","attributes":{"enabled":true,"created":1483738458,"updated":1483738461},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/15180a5638d3413f9db704f3eba73220","attributes":{"enabled":true,"created":1483738457,"updated":1483738457}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/e5179f2c3f8b4496ba34640e448d518d","attributes":{"enabled":true,"created":1487809098,"updated":1487809104},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f5d6dab5b32245cd82de7136f36fdac1","attributes":{"enabled":true,"created":1487809095,"updated":1487809095}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['391']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:23 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -364,36 +497,35 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"key": {"kty": "RSA", "q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
-      "dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
-      "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
+    body: '{"attributes": {"enabled": true}, "Hsm": false, "key": {"p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0",
+      "e": "AQAB", "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
       "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1",
-      "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
-      "e": "AQAB", "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
-      "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0"},
-      "attributes": {"enabled": true}, "Hsm": false}'
+      "kty": "RSA", "dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
+      "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
+      "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
+      "q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['926']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e53c70ac-d457-11e6-a617-a0b3ccf7272a]
+      x-ms-client-request-id: [9b4f392e-f95d-11e6-82a9-acde48001122]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/211ff83009f0400c80b3b6d4ef9a711e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1483738465,"updated":1483738465}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/8480ad96e7da49d99aa4aa24c16b2dbc","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1487809111,"updated":1487809111}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['462']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:25 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -402,36 +534,35 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"key": {"kty": "RSA", "q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
-      "dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
-      "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
+    body: '{"attributes": {"enabled": true}, "Hsm": false, "key": {"p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL",
+      "e": "AQAB", "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
       "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE",
-      "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
-      "e": "AQAB", "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
-      "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL"},
-      "attributes": {"enabled": true}, "Hsm": false}'
+      "kty": "RSA", "dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
+      "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
+      "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
+      "q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1693']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5bc64de-d457-11e6-99c2-a0b3ccf7272a]
+      x-ms-client-request-id: [9bf6e26e-f95d-11e6-9400-acde48001122]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/848eb0758ac84281a97213297253e025","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1483738466,"updated":1483738466}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/275c7a2450b24e0e861997dd500cc126","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1487809113,"updated":1487809113}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['637']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:25 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -440,7 +571,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: '{"key": {"kty": "RSA-HSM", "key_hsm": "QBlUZW5hbnRHZW5lcmF0ZWRLZXlEZXRhaWxzCQFpKWh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlQA1TY2hlbWFWZXJzaW9uiQJADFRlbmFudEJwb3NJZJkgMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTBAB1ZhdWx0SWSBQAdLZXlCbG9ioM0RQAtCWU9LS2V5QmxvYgkBaSlodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZUAMS2V5VG9rZW5UeXBlmRRuQ29yZUtleVByb3RlY3RlZEtleUAYU2VjdXJpdHlXb3JsZEVudmlyb25tZW50mQpQcm9kdWN0aW9uQBRTZWN1cml0eVdvcmxkVmVyc2lvbpkoZThkMzIzZjdjYTk1OTRkNDk2M2ViYjJkMmI0NDU1Yjc5YzYwNjA4NEAIS2V5VG9rZW6gLxBuQ2lwaGVyIEtNIGRhdGFmaWxlAAAAAABuDBFYDQAAAAkAAAAEAAAAeGZlcggAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAGUAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAMwAAAAUAAAA0Cuga_VfEgfw7SAUKjFvt8MYOxvIAAAAqAQAAAkAAACEBAAAhAQAAAABAAB0gG6diDcaCBCbyLYaRDnz7LwLxz5w58hi18n0tnX9DpYY2NikXNEh3mtijUh2FmiaKjsBhfdlvA_9ijQkLmnvoUEG-UJ8b-s8XBxl3jca06eefYOrjbcfVWuZ_ZiiT8FSNsmE62u70nS9H6Rb05q-xHEhgF_MYa6qBwx5wBjccsK-pxw4Jli7Vhck4UCecbjmJNtvs3eo5gCY0QMtVcKRrXrjL7BLbil9ttue645coCL1CdfaAMnqyn_On8WhTmF_y--Gsh2cVqUKAvKgIcfAB6qNfF_VfYglcwUJfpMgHkqQsLCncAucDXTzD3dGFpXWxDRZzZMlR3guq80Zqv2nrbQMPWUfclHBcEOYcEAN5osbvxmCbeVJTAD1jegPO7pxcRFJW3BhOKJ1519JDzPlBeTnEP3nQkDvD5DaDm3dcvnLctQTARKfx32kbTusDwntrGbgrQGoXfe-McQPufr8xG_ooNaGLwdu9Q415h0BLWfmTOhUWguNP_dJ-KvXGJfl-8uxZCdc6vQ9v6TLEWCuvhOtVSusoIr82NJqSLGWefEBsUgmd7HZZ9iTvwYdxaK_zt5pgXS09NqYinGXgC2s2dpxKQteUtKTfU7eL4_AMMCk7FMQl7-dI1WNv6S5Be-29FYc-rUVume4GuZhX3ZAlrsE6qbydPpKLoQZ02_HtaTIJrPRxmSFCHmlJr4bp-qyamotVOFC8vNr_HQRf0ma-Y9fomij3dIzXgC-qzTu-9LHo4BsUJwk7AWAHw4K8dJ7LwTGuZlCW0u9LbgrrsBe2tRmH267ImKWfXouElC5SzsjTaugEzERIg7Ps2l17qrUdwbrbFfUmdF53RNJ1e8b_MbOGOv78WnBcGtBC6fAnrZfM2bgWYuzWjTLxBoDJyz-gyyr0pzATleTcBbeXaE-zuQ6dSmKbnAqktzZZ62uM8pZ0Y0hBuPK-R7taR0VDi0UlcI9GSiAC0E43euWNt6u0nbZKFshM6363R8detNQeS0dDk1G1ZhvYlFSn7YCzOGVp1-trTeP7J_yi46x8U6Gj8_0Iffie-q3gXUIyMrrSl4JEL32slwdgYsZB7X8CfrmL7wdfKgvme6TBYvgBXswbsEo1QK6PqxB5WIlaH7QYiTm3f5kHJMiriiAw1i9UafKRtd_KmqVEBwjv-aIqRB6fJdENGXn3IlpqRRaMBX3qnPiD1GXEabtDFcTf-M9acPzuzaNdICzUWKL64R4vIeGZutps5sHspFGySKVkXBhiAEB0joBBNnBStLr0MR57o_ulfb7YizGf37lOR_tdZXirkbt02244ZvnGtK1z-ic_1NhvrJKdnM2IrLVOeewfcTZOP-FQyqQkkCs1lCKiR9GwvL-8WPXEZFACbvHOyRA97jdAmdeGs2P4QCDFbT2ZkXHO45rbqsekoW1yrNuUOwfqKgKgXp9vC_bIYrgxzDwLPYqjgrUAM-cSbZfGgVSK5sNSzT5GfVaCk9PD0BL9wk0D-Mc4naIMsHfHimNBx6hjCVVPPvf-NRHfwrVUCqOSTcN_uxCUa4fSNyYUgzA9v24fNhJh5UAAIAtAQAAvAEAAAUAAAB4AQAAmAEAAGCZMjznblVgOMQfO3_hCqfX_OJ4bcG0lWfHxkcE2PvwNdY46lKF2i5kd3xZZymnS9DaHxTgNUq5r_dXiC4yEbFTKLHcgUhFtUSC-OtZ0Icv4JwJDFgcA4d0YByIEIC_GwOOU2s5mRdt1eQWn3my94txvaxBvT2TRbflLt5aTM_aIOrgeYYIl2I1D4AgsiwMBsi5XszOnrSY6yGxquEigOj9L-apNbLggRVAqesXmP0WwIF6cGxQ-HKFaNG-tk3S0D73lLJgmKbmz2KAdL34cktkLRIpA2QziDArRBZLJYKh027IRkALBtImz8vYs1nQhRj50T7fVQ9uqnrmyQ0crNuKdRXGrlSiik_vMSkn-zr29RTms7xobMIb0ThzMboQiMtBu9Re8zReO50YKtRx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyg5nRgq93HX-Bp8Q-zSETsoOZ0YKvdx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyhXpi6gU4oCWsoPsksuak-rCRt3r6rxFb-0w5wztMypwB1XIgG-Uz68ifMP3Y8_rGyjOVvwAgAAADEBAABUAAAARFNBIDlkYjVjMWQ5NGQyZWM3YjMxNjM2ZWYzM2MxNDQxMDM3MDQ4NDNlZDcgOGYzMmFiNDMyOTRjZmIxNGQ5OTA0ZTIxZjQwMjM3MDhhZWVjYTZmMgEAAAgBAAACAAAAAAAAAAIAAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAEAAAABAAAAK7UAAAAAAAABAAAAAQAAAAoNBi4vXFmbgqoB36DcmiZO4Q8BAQAAAAEAAAACAAAABwAAAKguzTXTQ9jeYOS3tl07jVQr8XBDAwAAAAAAAAADAAAAAQAAAH0gAAACAAAAIwAAAAMAAAAAAAAAAAAAACxQlW3zsI67wvS4LjOVEX1rkEj-AAAAAAEAAAABAAAA11RPixBxfBwAqwxziDuQyd_QgokBAAAAAQAAAAMAAAABAAAAmAAAAIt0hPH7wP06zsM6O2x7pykTHR2-0Cuga_VfEgfw7SAUKjFvt8MYOxu6AAAADgAAAEM2RTItMEYzMy02NDMwAAAwAQAAVAIAAAUAAAAQAgAAMAIAAB_RO40YWSHshjD_nAwFEKNv2dXQbIWcFhGajKgazEE1y3TwUYo0ZqBgnKSbrBr71gyhaRHZVRDWFyZBnZpWW2pI-wHAipUk-MUHw5AIpoLINHbdg4K9A_acM3aCY8jI4_jiHqjtAY2dY_rce6bXLHcLmAtFEkrB8nevB_75bZ5WwpkvPjwm8cPK-0uVaR2i5oXluNE0wMtEfGstg6UX2WBlZ3kuOFkuKFJR5Svt1vqAJ2-4NfLwYFet0AOsQcK-9a-EMA1jBkAJll6qbizbxLm18OXKBrs5h175PvxpzSABcmgXeO9nF-vWhhPcfF4UyGNHV4op2dhgOceu-uD9PkhjBY88FYhc09-iW9TFgcuXZHXsw-72_h-hj0VSCe5nK6pa2r__yExgkAUjxUXOkTS6fcusYtwfKECeADMiBhsba3q9Nu9Oh1s21YhaULoUEAXiMMdzusPgrZ1lqXX0dj1SoejBYFDczcqzey9eVGjL0ABZI3MvvAhcTCCIp8BRwG0FDvooa-DzywfsLxZovz196RwSN1Qz6RNxdgZHFW3CFv0FDANKhRo_Apg3OB51frLWCqHcYK67XRqk7CX6xpEHCdz5h9FZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XAUJ3Pmk0VllBBdYkpH-eVwFCdz5pNFZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XOPR1sCh9NUF12rh1xdXHOz3p8wbjTM7XazayR2mSnmxHVciAb5TPryJ8w_djz-sbKM5W_ACAAAA0gAAAFUAAABEU0EgNjg1YjAzNTIxM2E1ZWNiNTkwM2Q2MDFiM2NkZjdmYjQ0NjJmZGIxNCAxMDViMzdmYTQwZWIzMGMzZTgyNjczYjc4ZjFmMDhhMGUxNDBlNTI5AAAANgEAAFUAAABEU0EgN2FlMDJlYzMxMzg5MjhkZDBkNjM1NDIxYzQ0ODQ3YjVkYmY3OWY1ZiAzYjBjNzY4YTliOTZiMGEwYTNkMmI0OGI1MTIzYzMyZmU3ZGUyY2E4AAAANwEAACQEAAAEAAAAAAAAAAUAAAACAAAADwAAAEM2RTItMEYzMy02NDMwAAADAAAAjk1RfgZf1R_8A57vXNxdwH_ihO4DAAAAgAAAAAuGoHd-tMQPlUD0fAutd27moUrisH7-4RcGpSHp22kuitX6YVc46FWYatocYEgQ4C6nUAd7flUy8QY3SFvoVO35kDaIjKOtNRdRiu7WAbbB1qiTNrlX8enguHhoaMCggXM6B-bms-NRWP_1jF_D-QNgUziXeq7_wsf-EyuXEm7lFAAAALeUqwX3mGldp-bGrbgmG3ADb8a6gAAAAM-BnRsV6vzlILw_9wkBMYpi_1ZiA9mVDTBR9QtqgXB3PrLjf3ZRro2GQxKOiIMcHCatj4Nv9sllnHLg1-ikrxQ5TQYniKrkJPh6_Rn5thMlfwxIJ5rqOpL9DGWxD9PJILOc_VdVb1QlPMKwRFBeJvD7C_7nuWKHwcBA0F9jQPkagAAAALp9jfmfGa06ZT9J3ZG128OE1bEza-aKT_OOrEgSwaYJHgcoRz4vAR61GvWn5_P3aInUctEasdZWx8RdlQgilIseTLllhXYbW_zmn5nlkQc1eKECKmdgfoWYYmhB28YPssoBHt9Eugf921UeyqOFP-C-D7nD6PLSwz3OMHVGJEjeCgAAAAQAAADoEYehs28sQEWqzJblqeAsJNpQWAMAAACAAAAAC4agd360xA-VQPR8C613buahSuKwfv7hFwalIenbaS6K1fphVzjoVZhq2hxgSBDgLqdQB3t-VTLxBjdIW-hU7fmQNoiMo601F1GK7tYBtsHWqJM2uVfx6eC4eGhowKCBczoH5uaz41FY__WMX8P5A2BTOJd6rv_Cx_4TK5cSbuUUAAAAt5SrBfeYaV2n5satuCYbcANvxrqAAAAAz4GdGxXq_OUgvD_3CQEximL_VmID2ZUNMFH1C2qBcHc-suN_dlGujYZDEo6IgxwcJq2Pg2_2yWWccuDX6KSvFDlNBieIquQk-Hr9Gfm2EyV_DEgnmuo6kv0MZbEP08kgs5z9V1VvVCU8wrBEUF4m8PsL_ue5YofBwEDQX2NA-RqAAAAA17VcyMlv24n13tkNnZ_V2_qsFQE5sWsCLwlWYIwa7ft_Q87Tk_e508-7GpytTy__UAcAvDGWs_zpt4hlEZV-P3lH4ESChA9bbQ0d3CI6FlkHZaCg2xF_On_g0LyuCfJ16pK1L1ANYCOb4I9UNJPz04mXjG_zksWqjxV01YcPr40KAAAABQAAACxQlW3zsI67wvS4LjOVEX1rkEj-T04AAAYAAAADAAAAnV8PC1whObYArS3iIOqwV5CgO6aJAAAASQAAAB1XIgG-Uz68ifMP3Y8_rGyjOVvwhAAAACUAAACoLs0100PY3mDkt7ZdO41UK_FwQ4kAAABJAACfAQBAEEtleVRva2VuRmlsZU5hbWWZU2tleV94ZmVyXzAyMGIxZjY0NzExYmYwNGRkYWFlYzNjYjkyNzJmMDk1OTA2ZGU1ZDNkN2NjNmQ4MTI4OWFiOGQ1ZWJiNjgwOGI3ZTk5ZTNhNWNhQBhLZXlFeGNoYW5nZUtleUlkZW50aWZpZXKZGnhmZXJ3cmFwcGluZyxrZWstcHJvZC1uYS0xQBJLZXlFeGNoYW5nZUtleUhhc2ieEg3-7EJRrh9I3JhSDMD2_bh82J8CSYcBAUALR2xvYmFsS2V5SWSZSjAyMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTA2REU1RDNEN0NDNkQ4MTI4OUFCOEQ1RUJCNjgwOEI3RTk5RTNBNUNBQAlQdWJsaWNLZXmhFAEGAgAAACQAAFJTQTEACAAAAQABALfXlEXHlqJgFPMI-hvgm8cNzb39ddxpubJ1efgninUpvpuyeyNBhxopiGOZcC_Snn2oW-AtxbRHdmwIvniWBniUAyEdgKP5UmV3VKnArzrBovI9rZA3_7OuxbLPC8slQyOp0ZdDqyZniAOROcQdAz0rQ47haCWl-FVre7kGoKH9uyOeAt-iP8CSyU0GcY6R6Pm-vs5O7OlQp-tGclehzuaXv7aeYzamPBzC_x7I9z4hGEEpfSnWPQrIB-pPF3LE-aSPxEKlqk5h0bKO6vRPKHGd9pWwciYvGL_-RBF2g9nOqUakJWKKi6q-GtTnEOGXpPUCBUe4f0QuZx4nvOR7fKFADENyZWF0aW9uVGltZZdzjWVf2_3TiEAPS2V5RnJpZW5kbHlOYW1lmUxLZXktVmF1bHQtQllPSy1LZXlfU3ViLTBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MF9FbnYtTkFfU2l6ZS0yMDQ4QAlTaWduYXR1cmWe_ybf6ysRwd4l3gRDKGBJ2GW_woEOsAz5XszkYdn-nsBtkGO4aTbhagHEa4SASJ5Kz69CeC-yoEFmWBNEsXwLIRkQULkPG3uBaySgeBWouarheAkxZOIuI1hjXBQxulTw1jbvlqHxM7l_LOAdYKCQFRZ3sFxuj71yU0fRHNOXECt-8bKRpGgZSchxNplRUsNNSvTu2oPeBPMszrwmK50seVdvO33D2Z964gnUXpgFUPuuwhK-X8kswAx8Vx03RaK9iEycX-_vIbMaLjEusMAell7l-BXHQmkiOFz5IR1fUobqZaRzP7p52x_aBfVN9kc1-on3fe0YfUTwEbkAV_sKUZ8B5wE"},

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_mgmt.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_mgmt.yaml
@@ -6,59 +6,58 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e89ab04a-d457-11e6-85e2-a0b3ccf7272a]
+      x-ms-client-request-id: [9e6fa902-f95d-11e6-a18a-acde48001122]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/882b503c-c281-4fe9-a85c-d9e0cd66d376/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1233']
+      Content-Length: ['1377']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Fri, 06 Jan 2017 21:34:29 GMT']
-      Duration: ['1269297']
+      Date: ['Thu, 23 Feb 2017 00:18:37 GMT']
+      Duration: ['878209']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [ziul/EJ8d7Mt967WHZCAf2Nrk0kJtsDec1DemBxlc/0=]
-      ocp-aad-session-key: [56BB7H0ghb33o-kKKVHBA-GEFBjTiovA77r8oykLUqMep4E0c-7HTLjQt3f9sBrzCsiPyWu2FlfaeXYSkKQP0FuIyLU43EdzomdsFfM2Av6i7xAI4FBUx7PlxYoM9dzG.b8GxZFB_FjGnDESlfnfr2-TFPuAUMZs-n1W8gUilrrU]
-      request-id: [fa3d5c97-841f-4662-a5cf-ffe531187b70]
+      ocp-aad-diagnostics-server-name: [6icUGGpPrSmxpPfGPb278Jglsmi9Q1PrPdqNC+Gtpmw=]
+      ocp-aad-session-key: [01Vx1o5uY25xBf_7tdBcswgm-57xImBuGW6JY-IWzuUOd56Ex-Uzn66gdAWu2pmWMUVw5s7YIdsMLuidqrgCwgG9GL_N89GrC9WB14vt2zNK28lT6VVK0gMwjscU_1mG.YMgPnt6TYGYvUDTnrSIhfMlHjPLrOwZJixOjVP_tCOE]
+      request-id: [d79a27a0-ab7a-4fed-9c1e-9a0a68348080]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"certificates": ["all"], "secrets": ["all"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore"]}, "objectId":
-      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "standard"}}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "standard"}, "accessPolicies": [{"permissions": {"certificates":
+      ["all"], "keys": ["get", "create", "delete", "list", "update", "import", "backup",
+      "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['408']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e8c4adc6-d457-11e6-a372-a0b3ccf7272a]
+      x-ms-client-request-id: [9e94192e-f95d-11e6-9832-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:31 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -69,8 +68,8 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['702']
-      x-ms-keyvault-service-version: [1.0.0.148]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -79,24 +78,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9d6e9be-d457-11e6-9ca6-a0b3ccf7272a]
+      x-ms-client-request-id: [9f9fc870-f95d-11e6-a0f2-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_zeyu_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg9b9912262/providers/Microsoft.KeyVault/vaults/graphvault","name":"graphvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kvrg/providers/Microsoft.KeyVault/vaults/keyvault-tjp","name":"keyvault-tjp","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kvrg/providers/Microsoft.KeyVault/vaults/python-sdk-test-keyvault","name":"python-sdk-test-keyvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_f3u6_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:32 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['1211']
+      content-length: ['526']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -105,19 +104,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9ebfc0a-d457-11e6-9d96-a0b3ccf7272a]
+      x-ms-client-request-id: [9fcdd2f8-f95d-11e6-a118-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:33 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -128,7 +127,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['703']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -137,19 +136,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea5ea7e4-d457-11e6-b982-a0b3ccf7272a]
+      x-ms-client-request-id: [a10ab6c2-f95d-11e6-aa88-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA="}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA="}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:34 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -160,7 +159,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['951']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -169,11 +168,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea7ae768-d457-11e6-9b13-a0b3ccf7272a]
+      x-ms-client-request-id: [a17c7af0-f95d-11e6-80d5-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA=
   response:
@@ -181,7 +180,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:33 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -192,7 +191,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['12']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -201,19 +200,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ead859f0-d457-11e6-8aa9-a0b3ccf7272a]
+      x-ms-client-request-id: [a23e0828-f95d-11e6-8592-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:34 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -224,34 +223,34 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['703']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"certificates": ["all"], "secrets": ["all"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore"]}, "objectId":
-      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "enabledForDeployment": false, "sku": {"family": "A", "name": "premium"}, "vaultUri":
-      "https://cli-keyvault-12345-0.vault.azure.net/"}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"permissions": {"certificates":
+      ["all"], "keys": ["get", "create", "delete", "list", "update", "import", "backup",
+      "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}], "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "enabledForDeployment": false}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['499']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb01e226-d457-11e6-8261-a0b3ccf7272a]
+      x-ms-client-request-id: [a266e7c0-f95d-11e6-9915-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:34 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -262,7 +261,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['702']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -272,19 +271,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb7949cc-d457-11e6-9753-a0b3ccf7272a]
+      x-ms-client-request-id: [a3097f58-f95d-11e6-9003-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:35 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -295,34 +294,34 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['702']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {}, "properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"certificates": ["get", "list"], "secrets": ["all"], "keys":
-      ["get", "create", "delete", "list", "update", "import", "backup", "restore"]},
-      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "enabledForDeployment": false, "sku": {"family": "A", "name": "premium"}, "vaultUri":
-      "https://cli-keyvault-12345-0.vault.azure.net/"}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"permissions": {"certificates":
+      ["get", "list"], "keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}], "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "enabledForDeployment": false}, "location": "westus", "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['519']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ebb216f0-d457-11e6-a384-a0b3ccf7272a]
+      x-ms-client-request-id: [a33789ca-f95d-11e6-a899-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["get","list"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["get","list"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:36 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -333,8 +332,8 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['709']
-      x-ms-keyvault-service-version: [1.0.0.148]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -343,19 +342,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec2f9a28-d457-11e6-9c14-a0b3ccf7272a]
+      x-ms-client-request-id: [a41943ba-f95d-11e6-8f2c-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["get","list"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["get","list"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:37 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -366,31 +365,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['709']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {}, "properties": {"accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "enabledForDeployment": false, "sku": {"family": "A", "name": "premium"}, "vaultUri":
-      "https://cli-keyvault-12345-0.vault.azure.net/"}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [], "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "enabledForDeployment": false}, "location": "westus", "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['259']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec63f9b6-d457-11e6-acce-a0b3ccf7272a]
+      x-ms-client-request-id: [a4a1e3fa-f95d-11e6-b866-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:37 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -401,7 +400,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['467']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -411,24 +410,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecccdfe2-d457-11e6-bd11-a0b3ccf7272a]
+      x-ms-client-request-id: [a59106b0-f95d-11e6-9b19-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_zeyu_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg9b9912262/providers/Microsoft.KeyVault/vaults/graphvault","name":"graphvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kvrg/providers/Microsoft.KeyVault/vaults/keyvault-tjp","name":"keyvault-tjp","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kvrg/providers/Microsoft.KeyVault/vaults/python-sdk-test-keyvault","name":"python-sdk-test-keyvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_f3u6_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:37 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['1211']
+      content-length: ['526']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -438,11 +437,11 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecddf9e2-d457-11e6-b36b-a0b3ccf7272a]
+      x-ms-client-request-id: [a5b6fc30-f95d-11e6-b2a1-acde48001122]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
@@ -450,7 +449,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Fri, 06 Jan 2017 21:34:38 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -458,8 +457,8 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.148]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -468,11 +467,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [edb85340-d457-11e6-b689-a0b3ccf7272a]
+      x-ms-client-request-id: [a7339eb0-f95d-11e6-8d67-acde48001122]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01
   response:
@@ -480,7 +479,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:38 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -488,27 +487,27 @@ interactions:
       content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "standard"}}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "standard"}, "accessPolicies": []}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['156']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ee019e02-d457-11e6-9069-a0b3ccf7272a]
+      x-ms-client-request-id: [a7d08482-f95d-11e6-8d4a-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:40 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -519,7 +518,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['467']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -529,59 +528,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eed00e68-d457-11e6-9ff4-a0b3ccf7272a]
+      x-ms-client-request-id: [a9bde480-f95d-11e6-ba7c-acde48001122]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/5963f50c-7c43-405c-af7e-53294de76abd/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/882b503c-c281-4fe9-a85c-d9e0cd66d376/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1341']
+      Content-Length: ['1377']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Fri, 06 Jan 2017 21:34:41 GMT']
-      Duration: ['1375875']
+      Date: ['Thu, 23 Feb 2017 00:18:55 GMT']
+      Duration: ['550743']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [zxZYDEawz21AvHC3yeYwNfuOWtipMdX6XXjfoHwII3k=]
-      ocp-aad-session-key: [1Q1f_7W3q8OhxQ-W6NqTY1JPkX6E0a05KZgVw6QigLI6e4GuEkcZrE5i26s7RKM4-ArH-eqsfvzGnbM8Qd-L9Zn7g_5lsihma6n0LOXZ26eFdeyVw2AuB2G4_Bl1XhWO.7uxkJm5PQrsJrPRVfyELxHGbaxnL6F3fWWxnPb70Kb8]
-      request-id: [84a1ec3a-a9d7-4ff5-8e73-bd492f9131cb]
+      ocp-aad-diagnostics-server-name: [lcz6A9FyPn3jZ2b3Po7PhRsDaDaC5MePaYEAO/XnXfw=]
+      ocp-aad-session-key: [HzPNuN2J1uDgrQQiJzBsWWk4aS93Dqsy-50PS91C01WlaMg4Fbmhp9eBHb3ybX2jTbMv4PPNp9SCmi7J8qoaHZFVAstZYkgfPTkAzP0jEr5UlqiphJoma4OB6YnUjz1_.1iuWtAoowzuwCBJuv0cxp022EoOZ5zNHpsqa_P1gobY]
+      request-id: [4cadd9b8-08bd-45a9-85d0-795e8e1a91e7]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"certificates": ["all"], "secrets": ["all"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore"]}, "objectId":
-      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "standard"}, "enabledForDeployment": true, "enabledForDiskEncryption":
-      true, "enabledForTemplateDeployment": true}, "location": "westus"}'
+    body: '{"properties": {"enabledForDiskEncryption": true, "enabledForTemplateDeployment":
+      true, "enabledForDeployment": true, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"permissions":
+      {"certificates": ["all"], "keys": ["get", "create", "delete", "list", "update",
+      "import", "backup", "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['510']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eefccb7a-d457-11e6-a1ca-a0b3ccf7272a]
+      x-ms-client-request-id: [a9d8f84a-f95d-11e6-8a69-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2","name":"cli-keyvault-12345-2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-12345-2.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2","name":"cli-keyvault-12345-2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-12345-2.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:42 GMT']
+      Date: ['Thu, 23 Feb 2017 00:18:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -592,7 +591,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['769']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -602,58 +601,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [efefba38-d457-11e6-b942-a0b3ccf7272a]
+      x-ms-client-request-id: [ac0fa0a8-f95d-11e6-9fb9-acde48001122]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/5963f50c-7c43-405c-af7e-53294de76abd/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/882b503c-c281-4fe9-a85c-d9e0cd66d376/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1341']
+      Content-Length: ['1377']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Fri, 06 Jan 2017 21:34:43 GMT']
-      Duration: ['1832619']
+      Date: ['Thu, 23 Feb 2017 00:19:00 GMT']
+      Duration: ['13280769']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [VbwAPpHBrDNXWFpR18OzHh/NfNdUKGwRD1NUkhGV+bc=]
-      ocp-aad-session-key: [gCobgBEsFO0sGl9WZjDosb5A3-BsNLyBmGCGEuzIKiKyqImzUrbbaPxaSZkVmlsmqZ_NbmO-yOX_uvD923V2x9qNB4PeMtMFM8rmM_LhPcvJ9oV97YUTgIQwzJVBc1Ce.UxTx3pAWwCig35jYlpUiUEdqz4e7uQIjvG7hKo2QJLk]
-      request-id: [47e77a94-fb30-43b6-91c7-250f570aea19]
+      ocp-aad-diagnostics-server-name: [NrbDzJUy9CjYwxxKkWiK6Vnp9LT4b4UpJ7HSwM856vI=]
+      ocp-aad-session-key: [A5hPpcFpyMdpJZ2bmIw4aNbFVgxPEHKCqUtYHTAyQG54Wl28C-lXt__3z2Cm6ZLHEOagMQyaLhaFdpHqxSWqOeOegkwuBA1LDr1ikvD7SKaOkNoNu1TkPCIjJkEBY_Rp.HjzgBrnqb7qG3NSwOuMIDS6egm81O9paoc6q5f3u9V0]
+      request-id: [d88e9647-3d91-4d96-a5f1-040c8109b20e]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"certificates": ["all"], "secrets": ["all"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore"]}, "objectId":
-      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "premium"}}, "location": "westus"}'
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"permissions": {"certificates":
+      ["all"], "keys": ["get", "create", "delete", "list", "update", "import", "backup",
+      "restore"], "secrets": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991",
+      "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376"}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['407']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f02292d8-d457-11e6-a5b2-a0b3ccf7272a]
+      x-ms-client-request-id: [aced62be-f95d-11e6-b8dc-acde48001122]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3","name":"cli-keyvault-12345-3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-3.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3","name":"cli-keyvault-12345-3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-3.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:34:44 GMT']
+      Date: ['Thu, 23 Feb 2017 00:19:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -664,7 +664,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['701']
-      x-ms-keyvault-service-version: [1.0.0.148]
+      x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_secret.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_secret.yaml
@@ -1,26 +1,160 @@
 interactions:
 - request:
-    body: '{"value": "ABC123", "tags": {"file-encoding": "utf-8"}, "attributes": {"enabled":
-      true}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [35f1e3f6-f95d-11e6-9959-acde48001122]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1269']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 23 Feb 2017 00:15:41 GMT']
+      Duration: ['763790']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [PaJePVTroOTPJc6jKFg0Tmd8/p4hSkQ9d/J3RIPbrks=]
+      ocp-aad-session-key: [aGbsK3pywJlG4zm16DXHUNWfl42jk7tEhB8SHvRm7Vl_VG-RQsv5AITep7X5GBqQG2XkUgXO0DGEfnTYF3zUKi_xMi3vHRay6F8GaH--34V5qD5grkKw8hzPZuInu-jE.sWRhA_yvdCWBxsUSGlpgBnM7LPPez_aKf96zPR1WODo]
+      request-id: [d1d83171-fa1f-460e-8577-10e983fd0c15]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "accessPolicies":
+      [{"tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
+      "permissions": {"secrets": ["all"], "keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore"], "certificates": ["all"]}}], "sku":
+      {"family": "A", "name": "premium"}}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['407']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [36374cca-f95d-11e6-b239-acde48001122]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"certificates":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-secret.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:15:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['715']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [37dec9d8-f95d-11e6-a1f9-acde48001122]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 23 Feb 2017 00:15:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [37dec9d8-f95d-11e6-a1f9-acde48001122]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
+  response:
+    body: {string: '{"value":null,"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['30']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 23 Feb 2017 00:15:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"attributes": {"enabled": true}, "value": "ABC123", "tags": {"file-encoding":
+      "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3e403e2e-d458-11e6-86f8-a0b3ccf7272a]
+      x-ms-client-request-id: [3bac77d4-f95d-11e6-ac8b-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/1f736de685794d0f87b545c54e415f6c","attributes":{"enabled":true,"created":1483738614,"updated":1483738614},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f21863c4dd1e46599718e253a1468f5e","attributes":{"enabled":true,"created":1487808950,"updated":1487808950},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:54 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -29,7 +163,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -38,19 +172,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3eafdc4c-d458-11e6-9c2c-a0b3ccf7272a]
+      x-ms-client-request-id: [3c4123ca-f95d-11e6-bad3-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1483738614,"updated":1483738614},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1487808950,"updated":1487808950},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['206']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:54 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -59,30 +193,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "DEF456", "tags": {"file-encoding": "utf-8", "test": "foo"},
-      "attributes": {"enabled": true}, "contentType": "test type"}'
+    body: '{"attributes": {"enabled": true}, "value": "DEF456", "tags": {"file-encoding":
+      "utf-8", "test": "foo"}, "contentType": "test type"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f0eae9e-d458-11e6-b379-a0b3ccf7272a]
+      x-ms-client-request-id: [3ce24cdc-f95d-11e6-a64e-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/23a638d428614c49a2bc528bd4b46805","attributes":{"enabled":true,"created":1483738616,"updated":1483738616},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d8695e6c12c84bbca85cd582cc980f45","attributes":{"enabled":true,"created":1487808951,"updated":1487808951},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:55 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -91,7 +225,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -100,20 +234,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f78a66e-d458-11e6-b503-a0b3ccf7272a]
+      x-ms-client-request-id: [3d8fa99a-f95d-11e6-91c3-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/1f736de685794d0f87b545c54e415f6c","attributes":{"enabled":true,"created":1483738614,"updated":1483738614},"tags":{"file-encoding":"utf-8"}},{"contentType":"test
-        type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/23a638d428614c49a2bc528bd4b46805","attributes":{"enabled":true,"created":1483738616,"updated":1483738616},"tags":{"file-encoding":"utf-8","test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d8695e6c12c84bbca85cd582cc980f45","attributes":{"enabled":true,"created":1487808951,"updated":1487808951},"tags":{"file-encoding":"utf-8","test":"foo"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f21863c4dd1e46599718e253a1468f5e","attributes":{"enabled":true,"created":1487808950,"updated":1487808950},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['490']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:56 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -122,7 +255,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -131,19 +264,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3febeeae-d458-11e6-a175-a0b3ccf7272a]
+      x-ms-client-request-id: [3e7a55be-f95d-11e6-9505-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/23a638d428614c49a2bc528bd4b46805","attributes":{"enabled":true,"created":1483738616,"updated":1483738616},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d8695e6c12c84bbca85cd582cc980f45","attributes":{"enabled":true,"created":1487808951,"updated":1487808951},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:57 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -152,7 +285,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -161,19 +294,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [40414978-d458-11e6-9505-a0b3ccf7272a]
+      x-ms-client-request-id: [3f01f080-f95d-11e6-8998-acde48001122]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/1f736de685794d0f87b545c54e415f6c?api-version=2016-10-01
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f21863c4dd1e46599718e253a1468f5e?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/1f736de685794d0f87b545c54e415f6c","attributes":{"enabled":true,"created":1483738614,"updated":1483738614},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f21863c4dd1e46599718e253a1468f5e","attributes":{"enabled":true,"created":1487808950,"updated":1487808950},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:58 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -182,7 +315,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: '{"attributes": {"enabled": false}}'
@@ -192,19 +325,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [40b22058-d458-11e6-8560-a0b3ccf7272a]
+      x-ms-client-request-id: [3f9db2ae-f95d-11e6-a4f6-acde48001122]
     method: PATCH
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/23a638d428614c49a2bc528bd4b46805","attributes":{"enabled":false,"created":1483738616,"updated":1483738618},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d8695e6c12c84bbca85cd582cc980f45","attributes":{"enabled":false,"created":1487808951,"updated":1487808957},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:58 GMT']
+      Date: ['Thu, 23 Feb 2017 00:15:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -213,7 +346,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -223,19 +356,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4117f8ba-d458-11e6-a95e-a0b3ccf7272a]
+      x-ms-client-request-id: [4040135a-f95d-11e6-944e-acde48001122]
     method: DELETE
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/23a638d428614c49a2bc528bd4b46805","attributes":{"enabled":false,"created":1483738616,"updated":1483738618},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d8695e6c12c84bbca85cd582cc980f45","attributes":{"enabled":false,"created":1487808951,"updated":1487808957},"tags":{"file-encoding":"utf-8","test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:59 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -244,7 +377,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -253,10 +386,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4176a3f0-d458-11e6-9507-a0b3ccf7272a]
+      x-ms-client-request-id: [40cb340a-f95d-11e6-8045-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
@@ -265,7 +398,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:36:59 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -274,30 +407,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
-      "utf-8"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [41db91da-d458-11e6-8cfd-a0b3ccf7272a]
+      x-ms-client-request-id: [439d7292-f95d-11e6-b9be-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/9b7e9fb88c1741debdda9f9a879f69eb","attributes":{"enabled":true,"created":1483738620,"updated":1483738620},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/9a6f71edf16748f49fa634237e87261e","attributes":{"enabled":true,"created":1487808967,"updated":1487808967},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:00 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -306,7 +439,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -315,19 +448,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42400a74-d458-11e6-92b7-a0b3ccf7272a]
+      x-ms-client-request-id: [44478b4a-f95d-11e6-99b6-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/9b7e9fb88c1741debdda9f9a879f69eb","attributes":{"enabled":true,"created":1483738620,"updated":1483738620},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/9a6f71edf16748f49fa634237e87261e","attributes":{"enabled":true,"created":1487808967,"updated":1487808967},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:00 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -336,30 +469,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
-      "utf-16le"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-16le"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [429cb976-d458-11e6-8f79-a0b3ccf7272a]
+      x-ms-client-request-id: [44e254b8-f95d-11e6-a3a8-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/94c5e28e98494637bf2a50fbcb88ba56","attributes":{"enabled":true,"created":1483738622,"updated":1483738622},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/db3a0b11b15d411e81bfcf19ba95e1cf","attributes":{"enabled":true,"created":1487808968,"updated":1487808968},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:01 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -368,7 +501,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -377,19 +510,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42f8cc2c-d458-11e6-bb2a-a0b3ccf7272a]
+      x-ms-client-request-id: [456e170a-f95d-11e6-9c44-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/94c5e28e98494637bf2a50fbcb88ba56","attributes":{"enabled":true,"created":1483738622,"updated":1483738622},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/db3a0b11b15d411e81bfcf19ba95e1cf","attributes":{"enabled":true,"created":1487808968,"updated":1487808968},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:02 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -398,30 +531,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
-      "utf-16be"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-16be"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [435ad36c-d458-11e6-b52b-a0b3ccf7272a]
+      x-ms-client-request-id: [460ee5fe-f95d-11e6-9772-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/12d643dcf6ed4d60ba696ee05641174f","attributes":{"enabled":true,"created":1483738623,"updated":1483738623},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/33d4bd19fb91485d97fec099e7d1f7ef","attributes":{"enabled":true,"created":1487808967,"updated":1487808967},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:03 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -430,7 +563,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -439,19 +572,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [43b55f3e-d458-11e6-b59b-a0b3ccf7272a]
+      x-ms-client-request-id: [46ac659a-f95d-11e6-b6be-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/12d643dcf6ed4d60ba696ee05641174f","attributes":{"enabled":true,"created":1483738623,"updated":1483738623},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/33d4bd19fb91485d97fec099e7d1f7ef","attributes":{"enabled":true,"created":1487808967,"updated":1487808967},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -460,30 +593,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
-      "ascii"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "ascii"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4410fca8-d458-11e6-9f8e-a0b3ccf7272a]
+      x-ms-client-request-id: [4741361e-f95d-11e6-8712-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/6b879cdd2ce942feaa8a0d1275905f4f","attributes":{"enabled":true,"created":1483738624,"updated":1483738624},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/128504d3c7be44c59ccc8ad427a96689","attributes":{"enabled":true,"created":1487808969,"updated":1487808969},"tags":{"file-encoding":"ascii"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -492,7 +625,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -501,19 +634,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [446dabb8-d458-11e6-9bce-a0b3ccf7272a]
+      x-ms-client-request-id: [47d2a880-f95d-11e6-bf9c-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/6b879cdd2ce942feaa8a0d1275905f4f","attributes":{"enabled":true,"created":1483738624,"updated":1483738624},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/128504d3c7be44c59ccc8ad427a96689","attributes":{"enabled":true,"created":1487808969,"updated":1487808969},"tags":{"file-encoding":"ascii"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -522,30 +655,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n",
-      "tags": {"file-encoding": "base64"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldAo=\n",
+      "tags": {"file-encoding": "base64"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44cbba9e-d458-11e6-abb1-a0b3ccf7272a]
+      x-ms-client-request-id: [4869a62c-f95d-11e6-868a-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/ffb89eeecd874cd8b8ed343e018a797f","attributes":{"enabled":true,"created":1483738625,"updated":1483738625},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldAo=\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/b0fd85eaa13e44a98a6fde8730b2ccc9","attributes":{"enabled":true,"created":1487808971,"updated":1487808971},"tags":{"file-encoding":"base64"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['289']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:04 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -554,7 +687,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -563,19 +696,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45266d76-d458-11e6-ab1d-a0b3ccf7272a]
+      x-ms-client-request-id: [4905bd64-f95d-11e6-8670-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/ffb89eeecd874cd8b8ed343e018a797f","attributes":{"enabled":true,"created":1483738625,"updated":1483738625},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldAo=\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/b0fd85eaa13e44a98a6fde8730b2ccc9","attributes":{"enabled":true,"created":1487808971,"updated":1487808971},"tags":{"file-encoding":"base64"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['289']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:05 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -584,30 +717,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a",
-      "tags": {"file-encoding": "hex"}, "attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}, "value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740a",
+      "tags": {"file-encoding": "hex"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['164']
+      Content-Length: ['162']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45814782-d458-11e6-a5c9-a0b3ccf7272a]
+      x-ms-client-request-id: [498c0694-f95d-11e6-9881-acde48001122]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/031719f66190437397f2150ec617da36","attributes":{"enabled":true,"created":1483738626,"updated":1483738626},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/d6448273a2ff47278bc94427466f113f","attributes":{"enabled":true,"created":1487808975,"updated":1487808975},"tags":{"file-encoding":"hex"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['309']
+      Content-Length: ['307']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:06 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -616,7 +749,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -625,19 +758,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45fd1cba-d458-11e6-ab43-a0b3ccf7272a]
+      x-ms-client-request-id: [4a2ae89a-f95d-11e6-9cd3-acde48001122]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/031719f66190437397f2150ec617da36","attributes":{"enabled":true,"created":1483738626,"updated":1483738626},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/d6448273a2ff47278bc94427466f113f","attributes":{"enabled":true,"created":1487808975,"updated":1487808975},"tags":{"file-encoding":"hex"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['309']
+      Content-Length: ['307']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 06 Jan 2017 21:37:07 GMT']
+      Date: ['Thu, 23 Feb 2017 00:16:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -646,6 +779,6 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.793]
+      x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -22,6 +22,25 @@ name_group_example = """        - name: {0} by Name and Group
           text: az {1} -n name -g MyResourceGroup
 """
 
+helps['vm format-secret'] = """
+    type: command
+    long-summary: >
+        Transform secrets into a form consumed by VMs and VMSS create via --secrets.
+    examples:
+        - name: Create a self-signed certificate with a the default policy and add to a virtual machine
+          text: >
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled]")
+
+            vm_secrets=$(az vm format-secret -s "$secrets") \n
+
+            az vm create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
+"""
+
 helps['vm create'] = """
     type: command
     short-summary: Create an Azure Virtual Machine.
@@ -76,7 +95,7 @@ helps['vm create'] = """
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
               -n cert1 --query "[?attributes.enabled]")
 
-            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+            vm_secrets=$(az vm format-secret -s "$secrets") \n
 
             az vm create -g group-name -n vm-name --admin-username deploy  \\
               --image debian --secrets "$vm_secrets"
@@ -115,7 +134,7 @@ helps['vmss create'] = """
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
               -n cert1 --query "[?attributes.enabled]")
 
-            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+            vm_secrets=$(az vm format-secret -s "$secrets") \n
 
             az vmss create -g group-name -n vm-name --admin-username deploy  \\
               --image debian --secrets "$vm_secrets"

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -68,6 +68,18 @@ helps['vm create'] = """
             az vm create -n MyVm -g MyResourceGroup
             --public-ip-address-dns-name MyUniqueDnsName --image ubuntults --data-disk-sizes-gb 10 20
             --size Standard_DS2_v2 --generate-ssh-keys
+        - name: Create an Debian VM and with Key Vault secrets. The secrets are placed in /var/lib/waagent and each certificate file is named with the hex thumbprint.
+          text: >
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled]")
+
+            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+
+            az vm create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
 """.format(image_long_summary)
 
 helps['vmss create'] = """
@@ -95,6 +107,18 @@ helps['vmss create'] = """
         - name: Create a Linux VM scale set with a cloud-init script (https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init).
           text: >
             az vmss create -g MyResourceGroup -n MyVmss --image debian --custom_data MyCloudInitScript.yml
+        - name: Create an Debian VM scaleset and with Key Vault secrets. The secrets are placed in /var/lib/waagent and each certificate file is named with the hex thumbprint.
+          text: >
+            az keyvault certificate create --vault-name vaultname -n cert1 \\
+              -p "$(az keyvault certificate get-default-policy)"
+
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled]")
+
+            vm_secrets=$(az keyvault secret vm-format -s "$secrets") \n
+
+            az vmss create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
 """.format(image_long_summary)
 
 helps['vm availability-set create'] = """

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -33,7 +33,7 @@ helps['vm format-secret'] = """
               -p "$(az keyvault certificate get-default-policy)"
 
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled]")
+              -n cert1 --query "[?attributes.enabled].id" -o tsv)
 
             vm_secrets=$(az vm format-secret -s "$secrets") \n
 
@@ -93,7 +93,7 @@ helps['vm create'] = """
               -p "$(az keyvault certificate get-default-policy)"
 
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled]")
+              -n cert1 --query "[?attributes.enabled].id" -o tsv)
 
             vm_secrets=$(az vm format-secret -s "$secrets") \n
 
@@ -132,7 +132,7 @@ helps['vmss create'] = """
               -p "$(az keyvault certificate get-default-policy)"
 
             secrets=$(az keyvault secret list-versions --vault-name vaultname \\
-              -n cert1 --query "[?attributes.enabled]")
+              -n cert1 --query "[?attributes.enabled].id" -o tsv)
 
             vm_secrets=$(az vm format-secret -s "$secrets") \n
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -10,7 +10,6 @@ from azure.mgmt.compute.models import (CachingTypes,
                                        UpgradeMode)
 from azure.mgmt.storage.models import SkuName
 
-from azure.cli.core._util import get_json_object
 from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
 from azure.cli.core.commands.parameters import \
     (location_type, get_one_of_subscription_locations,
@@ -274,4 +273,4 @@ for scope in ['disk', 'snapshot']:
     register_cli_argument(scope, 'size_gb', options_list=('--size-gb', '-z'), help='size in GB.')
     register_cli_argument(scope, 'duration_in_seconds', help='Time duration in seconds until the SAS access expires')
 
-register_cli_argument('vm format-secret', 'secrets', options_list=('--secrets', '-s'), type=get_json_object, help='JSON encoded secrets as an array of secrets [], or a single secret {}. Use @{file} to load from a file.')
+register_cli_argument('vm format-secret', 'secrets', multi_ids_type, options_list=('--secrets', '-s'), help='Space separated list of Key Vault secret URIs. Perhaps, produced by \'az keyvault secret list-versions --vault-name vaultname -n cert1 --query "[?attributes.enabled].id" -o tsv\'')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -213,6 +213,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'public_ip_address', help='Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None.', arg_group='Network')
     register_cli_argument(scope, 'public_ip_address_allocation', help=None, arg_group='Network', **enum_choice_list(['dynamic', 'static']))
     register_cli_argument(scope, 'public_ip_address_dns_name', help='Globally unique DNS name for a newly created Public IP.', arg_group='Network')
+    register_cli_argument(scope, 'secrets', help='Key Vault secrets as a JSON string or file \'[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]\'', completer=FilesCompleter(), type=file_type)
 
 register_cli_argument('vm create', 'vm_name', name_arg_type, id_part=None, help='Name of the virtual machine.', validator=process_vm_create_namespace)
 register_cli_argument('vm create', 'attach_os_disk', help='Attach an existing OS disk to the VM. Can use the name or ID of a managed disk or the URI to an unmanaged disk VHD.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -214,7 +214,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'public_ip_address', help='Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None.', arg_group='Network')
     register_cli_argument(scope, 'public_ip_address_allocation', help=None, arg_group='Network', **enum_choice_list(['dynamic', 'static']))
     register_cli_argument(scope, 'public_ip_address_dns_name', help='Globally unique DNS name for a newly created Public IP.', arg_group='Network')
-    register_cli_argument(scope, 'secrets', help='Key Vault secrets as a JSON string or file \'[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]\'', completer=FilesCompleter(), type=file_type)
+    register_cli_argument(scope, 'secrets', multi_ids_type, help='One or many Key Vault secrets as JSON strings or files via \'@<file path>\' containing \'[{ "sourceVault": { "id": "value" }, "vaultCertificates": [{ "certificateUrl": "value", "certificateStore": "cert store name (only on windows)"}] }]\'', type=file_type, completer=FilesCompleter())
 
 register_cli_argument('vm create', 'vm_name', name_arg_type, id_part=None, help='Name of the virtual machine.', validator=process_vm_create_namespace)
 register_cli_argument('vm create', 'attach_os_disk', help='Attach an existing OS disk to the VM. Can use the name or ID of a managed disk or the URI to an unmanaged disk VHD.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -9,6 +9,8 @@ from argcomplete.completers import FilesCompleter
 from azure.mgmt.compute.models import (CachingTypes,
                                        UpgradeMode)
 from azure.mgmt.storage.models import SkuName
+
+from azure.cli.core._util import get_json_object
 from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
 from azure.cli.core.commands.parameters import \
     (location_type, get_one_of_subscription_locations,
@@ -271,3 +273,5 @@ for scope in ['disk', 'snapshot']:
     register_cli_argument(scope, 'source_snapshot', ignore_type)
     register_cli_argument(scope, 'size_gb', options_list=('--size-gb', '-z'), help='size in GB.')
     register_cli_argument(scope, 'duration_in_seconds', help='Time duration in seconds until the SAS access expires')
+
+register_cli_argument('vm format-secret', 'secrets', options_list=('--secrets', '-s'), type=get_json_object, help='JSON encoded secrets as an array of secrets [], or a single secret {}. Use @{file} to load from a file.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -502,7 +502,7 @@ def build_vmss_resource(name, naming_prefix, location, tags, overprovision, upgr
                         image=None, admin_password=None, ssh_key_value=None, ssh_key_path=None,
                         os_publisher=None, os_offer=None, os_sku=None, os_version=None,
                         backend_address_pool_id=None, inbound_nat_pool_id=None,
-                        single_placement_group=None, custom_data=None):
+                        single_placement_group=None, custom_data=None, secrets=None):
 
     # Build IP configuration
     ip_configuration = {
@@ -584,6 +584,9 @@ def build_vmss_resource(name, naming_prefix, location, tags, overprovision, upgr
 
     if custom_data:
         os_profile['customData'] = b64encode(custom_data)
+
+    if secrets:
+        os_profile['secrets'] = secrets
 
     if single_placement_group is None:  # this should never happen, but just in case
         raise ValueError('single_placement_group was not set by validators')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -256,7 +256,7 @@ def build_vm_resource(  # pylint: disable=too-many-locals
         storage_caching=None, storage_sku=None,
         os_publisher=None, os_offer=None, os_sku=None, os_version=None, os_vhd_uri=None,
         attach_os_disk=None, data_disk_sizes_gb=None, image_data_disks=None,
-        custom_data=None):
+        custom_data=None, secrets=None):
 
     def _build_os_profile():
 
@@ -283,6 +283,9 @@ def build_vm_resource(  # pylint: disable=too-many-locals
                     ]
                 }
             }
+
+        if secrets:
+            os_profile['secrets'] = secrets
 
         return os_profile
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -97,11 +97,12 @@ def _validate_secrets(secrets, os_type):
         if 'sourceVault' in secret and 'id' not in secret['sourceVault']:
             errors.append('Secret is missing sourceVault.id key at index {0}'.format(idx))
         if 'vaultCertificates' not in secret or not secret['vaultCertificates']:
-            errors.append('Secret is missing vaultCertificates array or it is empty at index {0}'.format(idx))
+            err = 'Secret is missing vaultCertificates array or it is empty at index {0}'
+            errors.append(err.format(idx))
         else:
             for jdx, cert in enumerate(secret['vaultCertificates']):
-                message = 'Secret is missing {0} within vaultCertificates array at secret index {1} and ' \
-                          'vaultCertificate index {2}'
+                message = 'Secret is missing {0} within vaultCertificates array at secret ' \
+                          'index {1} and vaultCertificate index {2}'
                 if 'certificateUrl' not in cert:
                     errors.append(message.format('certificateUrl', idx, jdx))
                 if is_windows and 'certificateStore' not in cert:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -103,29 +103,34 @@ def _validate_secrets(secrets, os_type):
     errors = []
 
     try:
-        loaded_secret = load_json(secrets)
+        loaded_secret = [load_json(secret) for secret in secrets]
     except Exception as err:
         raise CLIError('Error decoding secrets: {0}'.format(err))
 
-    for idx, secret in enumerate(loaded_secret):
-        if 'sourceVault' not in secret:
-            errors.append('Secret is missing sourceVault key at index {0}'.format(idx))
-        if 'sourceVault' in secret and 'id' not in secret['sourceVault']:
-            errors.append('Secret is missing sourceVault.id key at index {0}'.format(idx))
-        if 'vaultCertificates' not in secret or not secret['vaultCertificates']:
-            err = 'Secret is missing vaultCertificates array or it is empty at index {0}'
-            errors.append(err.format(idx))
-        else:
-            for jdx, cert in enumerate(secret['vaultCertificates']):
-                message = 'Secret is missing {0} within vaultCertificates array at secret ' \
-                          'index {1} and vaultCertificate index {2}'
-                if 'certificateUrl' not in cert:
-                    errors.append(message.format('certificateUrl', idx, jdx))
-                if is_windows and 'certificateStore' not in cert:
-                    errors.append(message.format('certificateStore', idx, jdx))
+    for idx_arg, narg_secret in enumerate(loaded_secret):
+        for idx, secret in enumerate(narg_secret):
+            if 'sourceVault' not in secret:
+                errors.append(
+                    'Secret is missing sourceVault key at index {0} in arg {1}'.format(
+                        idx, idx_arg))
+            if 'sourceVault' in secret and 'id' not in secret['sourceVault']:
+                errors.append(
+                    'Secret is missing sourceVault.id key at index {0}  in arg {1}'.format(
+                        idx, idx_arg))
+            if 'vaultCertificates' not in secret or not secret['vaultCertificates']:
+                err = 'Secret is missing vaultCertificates array or it is empty at index {0} in ' \
+                      'arg {1} '
+                errors.append(err.format(idx, idx_arg))
+            else:
+                for jdx, cert in enumerate(secret['vaultCertificates']):
+                    message = 'Secret is missing {0} within vaultCertificates array at secret ' \
+                              'index {1} and vaultCertificate index {2} in arg {3}'
+                    if 'certificateUrl' not in cert:
+                        errors.append(message.format('certificateUrl', idx, jdx, idx_arg))
+                    if is_windows and 'certificateStore' not in cert:
+                        errors.append(message.format('certificateStore', idx, jdx, idx_arg))
 
     if errors:
-        errors.append(secrets)
         raise CLIError('\n'.join(errors))
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-from json import JSONDecodeError
 
 from msrestazure.azure_exceptions import CloudError
 
@@ -88,7 +87,7 @@ def _validate_secrets(secrets, os_type):
 
     try:
         loaded_secret = load_json(secrets)
-    except JSONDecodeError as err:
+    except Exception as err:
         raise CLIError('Error decoding secrets: {0}'.format(err))
 
     for idx, secret in enumerate(loaded_secret):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -100,6 +100,7 @@ cli_command(__name__, 'vm list', custom_path.format('list_vm'), table_transforme
 cli_command(__name__, 'vm resize', custom_path.format('resize_vm'))
 cli_command(__name__, 'vm capture', custom_path.format('capture_vm'))
 cli_command(__name__, 'vm open-port', custom_path.format('vm_open_port'))
+cli_command(__name__, 'vm format-secret', custom_path.format('get_vm_format_secret'))
 cli_generic_update_command(__name__, 'vm update',
                            mgmt_path.format(op_var, op_class, 'get'),
                            mgmt_path.format(op_var, op_class, 'create_or_update'),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1431,7 +1431,7 @@ def create_vm(vm_name, resource_group_name, image=None,
               subnet=None, subnet_address_prefix='10.0.0.0/24', storage_profile=None,
               os_publisher=None, os_offer=None, os_sku=None, os_version=None,
               storage_account_type=None, vnet_type=None, nsg_type=None, public_ip_type=None,
-              nic_type=None, validate=False, custom_data=None):
+              nic_type=None, validate=False, custom_data=None, secrets=None):
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.cli.core._util import random_string
     from azure.cli.command_modules.vm._template_builder import (
@@ -1535,11 +1535,14 @@ def create_vm(vm_name, resource_group_name, image=None,
     if custom_data:
         custom_data = read_content_if_is_file(custom_data)
 
+    if secrets:
+        secrets = load_json(secrets)
+
     vm_resource = build_vm_resource(
         vm_name, location, tags, size, storage_profile, nics, admin_username, availability_set,
         admin_password, ssh_key_value, ssh_dest_key_path, image, os_disk_name,
         os_type, storage_caching, storage_sku, os_publisher, os_offer, os_sku, os_version,
-        os_vhd_uri, attach_os_disk, data_disk_sizes_gb, image_data_disks, custom_data)
+        os_vhd_uri, attach_os_disk, data_disk_sizes_gb, image_data_disks, custom_data, secrets)
     vm_resource['dependsOn'] = vm_dependencies
 
     master_template.add_resource(vm_resource)
@@ -1583,7 +1586,7 @@ def create_vmss(vmss_name, resource_group_name, image,
                 subnet=None, subnet_address_prefix=None,
                 os_offer=None, os_publisher=None, os_sku=None, os_version=None,
                 load_balancer_type=None, vnet_type=None, public_ip_type=None, storage_profile=None,
-                single_placement_group=None, custom_data=None):
+                single_placement_group=None, custom_data=None, secrets=None):
     from azure.cli.core.commands.client_factory import get_subscription_id
     from azure.cli.core._util import random_string
     from azure.cli.command_modules.vm._template_builder import (

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1777,12 +1777,10 @@ def get_vm_format_secret(secrets, certificate_store=None):
     from azure.mgmt.keyvault import KeyVaultManagementClient
     client = get_mgmt_service_client(KeyVaultManagementClient).vaults
     grouped_secrets = {}
-    if isinstance(secrets, dict):
-        secrets = [secrets]
 
     # group secrets by source vault
     for secret in secrets:
-        parsed = parse_secret_id(secret['id'])
+        parsed = parse_secret_id(secret)
         match = re.search('://(.+?)\\.', parsed.vault)
         vault_name = match.group(1)
         if vault_name not in grouped_secrets:
@@ -1791,7 +1789,7 @@ def get_vm_format_secret(secrets, certificate_store=None):
                 'id': _get_vault_id_from_name(client, vault_name)
             }
 
-        vault_cert = {'certificateUrl': secret['id']}
+        vault_cert = {'certificateUrl': secret}
         if certificate_store:
             vault_cert['certificateStore'] = certificate_store
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1681,6 +1681,9 @@ def create_vmss(vmss_name, resource_group_name, image,
     if custom_data:
         custom_data = read_content_if_is_file(custom_data)
 
+    if secrets:
+        secrets = load_json(secrets)
+
     vmss_resource = build_vmss_resource(vmss_name, naming_prefix, location, tags,
                                         not disable_overprovision, upgrade_policy_mode,
                                         vm_sku, instance_count,
@@ -1693,7 +1696,7 @@ def create_vmss(vmss_name, resource_group_name, image,
                                         os_publisher, os_offer, os_sku, os_version,
                                         backend_address_pool_id, inbound_nat_pool_id,
                                         single_placement_group=single_placement_group,
-                                        custom_data=custom_data)
+                                        custom_data=custom_data, secrets=secrets)
     vmss_resource['dependsOn'] = vmss_dependencies
 
     master_template.add_resource(vmss_resource)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/keyvault/policy.json
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/keyvault/policy.json
@@ -1,0 +1,42 @@
+{
+  "attributes": {
+    "enabled": true,
+    "expires": null,
+    "not_before": null
+  },
+  "issuer_parameters": {
+    "name": "Self"
+  },
+  "key_properties": {
+    "exportable": true,
+    "key_size": 2048,
+    "key_type": "RSA",
+    "reuse_key": false
+  },
+  "lifetime_actions": [
+    {
+      "action": {
+        "action_type": "AutoRenew"
+      },
+      "trigger": {
+        "lifetime_percentage": 90
+      }
+    }
+  ],
+  "secret_properties": {
+    "content_type": "application/x-pkcs12"
+  },
+  "x509_certificate_properties": {
+    "ekus": null,
+    "key_usage": [
+      "digitalSignature",
+      "nonRepudiation",
+      "keyEncipherment",
+      "keyAgreement",
+      "keyCertSign"
+    ],
+    "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
+    "subject_alternative_names": null,
+    "validity_in_months": 60
+  }
+}

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_linux_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_linux_secrets.yaml
@@ -1,0 +1,904 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\":{},\n
+        \ \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"metadata\":{\n
+        \       \"description\":\"This list of aliases is used by Azure XPLAT CLI,
+        Azure Powershell, and Azure Portal as shorthands for commonly used VM images.
+        If you change this file, please verify that this doesn't break VMSS creation
+        from Portal :).\"\n      },\n      \"type\":\"object\",\n      \"value\":{\n\n
+        \       \"Linux\":{\n          \"CentOS\":{\n            \"publisher\":\"OpenLogic\",\n
+        \           \"offer\":\"CentOS\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\",\n
+        \           \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Debian\":{\n            \"publisher\":\"credativ\",\n
+        \           \"offer\":\"Debian\",\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n
+        \         },\n          \"openSUSE\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"openSUSE\",\n            \"sku\":\"13.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"RHEL\":{\n            \"publisher\":\"RedHat\",\n
+        \           \"offer\":\"RHEL\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"SLES\",\n            \"sku\":\"12-SP1\",\n            \"version\":\"latest\"\n
+        \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
+        \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
+        \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
+        \         \"Win2012R2Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2012-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2008R2SP1\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n
+        \           \"version\":\"latest\"\n          }\n        }\n      }\n    }\n
+        \ }\n}\n"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:35 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Sat, 18 Feb 2017 01:42:35 GMT']
+      Source-Age: ['0']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [MISS]
+      X-Cache-Hits: ['0']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [626e0e7c0d5684504237fb668542ccd304d5f160]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['4522:623E:4838DA2:4A85820:58A7A55E']
+      X-Served-By: [cache-den6025-DEN]
+      X-Timer: ['S1487381855.893443,VS0,VE62']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d33c4730-f57a-11e6-9d7a-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d3c98e46-f57a-11e6-8d90-784f436a2ed2]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1269']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Sat, 18 Feb 2017 01:37:36 GMT']
+      Duration: ['797739']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [F5xVwd2x128IiCLsfld6kotlx+lzXyTkyHXM7YA9uMo=]
+      ocp-aad-session-key: [D9nmEewNDpYv9rW9dhW-b6kvrz7t7pAG9A2mIWoLP3EVeDyP2G7CeMP5C8dPSyAo_M2aOfFzNROstZ0r8AMfE4SNkWx7dowPQqfMLmSBqf-JS5htbin05SuqM-oTq5TQ.6Jq307K9Y9030Ck9FunudcykPtRJn-l7T6woirVNueY]
+      request-id: [07fd757e-f17f-4908-aa49-75cb9a82a44b]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
+      "permissions": {"secrets": ["all"], "keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore"], "certificates": ["all"]}, "tenantId":
+      "9148c3a5-1e1b-4e0a-87c2-302229534991"}], "enabledForTemplateDeployment": true,
+      "sku": {"family": "A", "name": "standard"}, "enabledForDeployment": true, "tenantId":
+      "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['476']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d41ff7e8-f57a-11e6-8030-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007","name":"vmcreatelinuxsecret007","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret007.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['753']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"policy": {"lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
+      "action": {"action_type": "AutoRenew"}}], "attributes": {"enabled": true}, "x509_props":
+      {"validity_months": 60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
+      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
+      "keyEncipherment", "keyAgreement", "keyCertSign"]}, "issuer": {"name": "Self"},
+      "secret_props": {"contentType": "application/x-pkcs12"}, "key_props": {"exportable":
+      true, "reuse_key": false, "key_size": 2048, "kty": "RSA"}}, "attributes": {"enabled":
+      true}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d5f07714-f57a-11e6-b9cc-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sat, 18 Feb 2017 01:37:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: '{"policy": {"lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
+      "action": {"action_type": "AutoRenew"}}], "attributes": {"enabled": true}, "x509_props":
+      {"validity_months": 60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
+      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
+      "keyEncipherment", "keyAgreement", "keyCertSign"]}, "issuer": {"name": "Self"},
+      "secret_props": {"contentType": "application/x-pkcs12"}, "key_props": {"exportable":
+      true, "reuse_key": false, "key_size": 2048, "kty": "RSA"}}, "attributes": {"enabled":
+      true}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d5f07714-f57a-11e6-b9cc-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:46 GMT']
+      Expires: ['-1']
+      Location: ['https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=9fc618b79e91438991dd5b262df9543d']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d8b89224-f57a-11e6-969e-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ded08022-f57a-11e6-8f77-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:37:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e4e01b08-f57a-11e6-ad30-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1329']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e563ff68-f57a-11e6-817f-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c35fd7a05ded4f22bfb3933b40b98f4a","managed":true,"attributes":{"enabled":false,"nbf":1487381266,"exp":1645148266,"created":1487381866,"updated":1487381866}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c","managed":true,"attributes":{"enabled":true,"nbf":1487381275,"exp":1645148275,"created":1487381876,"updated":1487381876}}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['550']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\":{},\n
+        \ \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"metadata\":{\n
+        \       \"description\":\"This list of aliases is used by Azure XPLAT CLI,
+        Azure Powershell, and Azure Portal as shorthands for commonly used VM images.
+        If you change this file, please verify that this doesn't break VMSS creation
+        from Portal :).\"\n      },\n      \"type\":\"object\",\n      \"value\":{\n\n
+        \       \"Linux\":{\n          \"CentOS\":{\n            \"publisher\":\"OpenLogic\",\n
+        \           \"offer\":\"CentOS\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\",\n
+        \           \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Debian\":{\n            \"publisher\":\"credativ\",\n
+        \           \"offer\":\"Debian\",\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n
+        \         },\n          \"openSUSE\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"openSUSE\",\n            \"sku\":\"13.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"RHEL\":{\n            \"publisher\":\"RedHat\",\n
+        \           \"offer\":\"RHEL\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"SLES\",\n            \"sku\":\"12-SP1\",\n            \"version\":\"latest\"\n
+        \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
+        \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
+        \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
+        \         \"Win2012R2Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2012-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2008R2SP1\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n
+        \           \"version\":\"latest\"\n          }\n        }\n      }\n    }\n
+        \ }\n}\n"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:07 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Sat, 18 Feb 2017 01:43:07 GMT']
+      Source-Age: ['32']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [3083299dea70f33a84bbb07d4d43af4e9be2ca1f]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['4522:623E:4838DA2:4A85820:58A7A55E']
+      X-Served-By: [cache-den6024-DEN]
+      X-Timer: ['S1487381887.651347,VS0,VE0']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e61e988a-f57a-11e6-b585-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {}, "variables": {}, "outputs": {},
+      "resources": [{"tags": {}, "dependsOn": [], "name": "vm-nameVNET", "location":
+      "westus", "apiVersion": "2015-06-15", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "subnets": [{"name": "vm-nameSubnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}]}, "type": "Microsoft.Network/virtualNetworks"}, {"tags": {},
+      "dependsOn": [], "name": "vm-nameNSG", "location": "westus", "apiVersion": "2015-06-15",
+      "properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
+      {"sourceAddressPrefix": "*", "priority": 1000, "access": "Allow", "destinationAddressPrefix":
+      "*", "destinationPortRange": "22", "sourcePortRange": "*", "direction": "Inbound",
+      "protocol": "Tcp"}}]}, "type": "Microsoft.Network/networkSecurityGroups"}, {"tags":
+      {}, "dependsOn": [], "name": "vm-namePublicIP", "location": "westus", "apiVersion":
+      "2015-06-15", "properties": {"publicIPAllocationMethod": "dynamic"}, "type":
+      "Microsoft.Network/publicIPAddresses"}, {"tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vm-nameVNET",
+      "Microsoft.Network/networkSecurityGroups/vm-nameNSG", "Microsoft.Network/publicIpAddresses/vm-namePublicIP"],
+      "name": "vm-nameVMNic", "location": "westus", "apiVersion": "2015-06-15", "properties":
+      {"networkSecurityGroup": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG"},
+      "ipConfigurations": [{"name": "ipconfigvm-name", "properties": {"publicIPAddress":
+      {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP"},
+      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"}}}]},
+      "type": "Microsoft.Network/networkInterfaces"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
+      "name": "vm-name", "location": "westus", "apiVersion": "2016-04-30-preview",
+      "properties": {"osProfile": {"computerName": "vm-name", "linuxConfiguration":
+      {"ssh": {"publicKeys": [{"path": "/home/ubuntu/.ssh/authorized_keys", "keyData":
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\n"}]}, "disablePasswordAuthentication": true}, "secrets": [{"vaultCertificates":
+      [{"certificateUrl": "https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c"}],
+      "sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007"}}],
+      "adminUsername": "ubuntu"}, "networkProfile": {"networkInterfaces": [{"id":
+      "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]},
+      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
+      "Canonical", "sku": "14.04.4-LTS", "version": "latest"}, "osDisk": {"managedDisk":
+      {"storageAccountType": "Premium_LRS"}, "createOption": "fromImage", "caching":
+      "ReadWrite", "name": "osdisk_W1HIoyuQ2B"}}, "hardwareProfile": {"vmSize": "Standard_DS1"}},
+      "type": "Microsoft.Compute/virtualMachines"}]}, "parameters": {}, "mode": "Incremental"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4318']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","name":"vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","properties":{"templateHash":"7151056166255818598","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-18T01:38:09.5245864Z","duration":"PT0.8201874S","correlationId":"a6ff0490-a68a-4bfc-a2d6-2de943f543ed","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH/operationStatuses/08587142249967793728?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2490']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:38:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:39:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:39:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:40:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:40:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","name":"vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","properties":{"templateHash":"7151056166255818598","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-18T01:40:49.7107934Z","duration":"PT2M41.0063944S","correlationId":"a6ff0490-a68a-4bfc-a2d6-2de943f543ed","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['2812']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [58f2d1ca-f57b-11e6-afd7-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview&$expand=instanceView
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8b2cc2f-5070-4049-a90c-f82934ad53ad\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_W1HIoyuQ2B\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_W1HIoyuQ2B\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"ubuntu\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/ubuntu/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+        test@example.com\\n\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n
+        \     \"secrets\": [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007\"\r\n
+        \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
+        \"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \           \"time\": \"2017-02-18T01:41:01+00:00\"\r\n          }\r\n        ],\r\n
+        \       \"extensionHandlers\": []\r\n      },\r\n      \"statuses\": [\r\n
+        \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \         \"time\": \"2017-02-18T01:40:33.4554454+00:00\"\r\n        },\r\n
+        \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
+        \     ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\",\r\n
+        \ \"name\": \"vm-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['3768']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [5930f662-f57b-11e6-9e80-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-nameVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\",\r\n
+        \ \"etag\": \"W/\\\"b2c927a0-c220-4b25-bbfe-8466576f85a0\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"8f97200a-aeb7-4840-add8-b5b492ce1637\",\r\n
+        \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-name\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\",\r\n
+        \       \"etag\": \"W/\\\"b2c927a0-c220-4b25-bbfe-8466576f85a0\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"zuc5rl0zniqupp2x21ygp5e3fa.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-34-EF-AC\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:20 GMT']
+      ETag: [W/"b2c927a0-c220-4b25-bbfe-8466576f85a0"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2313']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [596d8dc0-f57b-11e6-b558-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-namePublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\",\r\n
+        \ \"etag\": \"W/\\\"6dd568b7-e314-4641-8b2a-a5621f1fc559\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"70864669-3aee-41a5-acfb-ec78343bb871\",\r\n    \"ipAddress\":
+        \"13.64.67.107\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
+        {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\"\r\n
+        \   }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:20 GMT']
+      ETag: [W/"6dd568b7-e314-4641-8b2a-a5621f1fc559"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['880']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [5a4dc0dc-f57b-11e6-ad54-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8b2cc2f-5070-4049-a90c-f82934ad53ad\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_W1HIoyuQ2B\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_W1HIoyuQ2B\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"ubuntu\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/ubuntu/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+        test@example.com\\n\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n
+        \     \"secrets\": [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007\"\r\n
+        \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
+        \"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\",\r\n
+        \ \"name\": \"vm-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sat, 18 Feb 2017 01:41:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2938']
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_linux_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_linux_secrets.yaml
@@ -30,39 +30,41 @@ interactions:
         \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
         \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
         \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
-        \         \"Win2012R2Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
-        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n
-        \           \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\":{\n
+        \         \"Win2016Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\":{\n
         \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
-        \           \"sku\":\"2012-Datacenter\",\n            \"version\":\"latest\"\n
-        \         },\n          \"Win2008R2SP1\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
-        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n
-        \           \"version\":\"latest\"\n          }\n        }\n      }\n    }\n
-        \ }\n}\n"}
+        \           \"sku\":\"2012-R2-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2012Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2008-R2-SP1\",\n            \"version\":\"latest\"\n
+        \         }\n        }\n      }\n    }\n  }\n}\n"}
     headers:
       Accept-Ranges: [bytes]
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [max-age=300]
       Connection: [close]
-      Content-Length: ['2297']
+      Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:35 GMT']
-      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      Expires: ['Sat, 18 Feb 2017 01:42:35 GMT']
-      Source-Age: ['0']
+      Date: ['Wed, 22 Feb 2017 21:04:51 GMT']
+      ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
+      Expires: ['Wed, 22 Feb 2017 21:09:51 GMT']
+      Source-Age: ['188']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
       Via: [1.1 varnish]
-      X-Cache: [MISS]
-      X-Cache-Hits: ['0']
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [626e0e7c0d5684504237fb668542ccd304d5f160]
+      X-Fastly-Request-ID: [79288848ea9e5ffc7d26fc16e30fee999ce28243]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['4522:623E:4838DA2:4A85820:58A7A55E']
-      X-Served-By: [cache-den6025-DEN]
-      X-Timer: ['S1487381855.893443,VS0,VE62']
+      X-GitHub-Request-Id: ['DE30:6242:182EA82:19100EB:58ADFC38']
+      X-Served-By: [cache-den6023-DEN]
+      X-Timer: ['S1487797491.824015,VS0,VE0']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -73,9 +75,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d33c4730-f57a-11e6-9d7a-784f436a2ed2]
+      x-ms-client-request-id: [8d8433f0-f942-11e6-8a47-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
@@ -83,7 +85,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:35 GMT']
+      Date: ['Wed, 22 Feb 2017 21:04:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -100,7 +102,7 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d3c98e46-f57a-11e6-8d90-784f436a2ed2]
+      x-ms-client-request-id: [8f8bd54a-f942-11e6-80df-24f49a5003ca]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
@@ -112,26 +114,26 @@ interactions:
       Content-Length: ['1269']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Sat, 18 Feb 2017 01:37:36 GMT']
-      Duration: ['797739']
+      Date: ['Wed, 22 Feb 2017 21:04:55 GMT']
+      Duration: ['848925']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [F5xVwd2x128IiCLsfld6kotlx+lzXyTkyHXM7YA9uMo=]
-      ocp-aad-session-key: [D9nmEewNDpYv9rW9dhW-b6kvrz7t7pAG9A2mIWoLP3EVeDyP2G7CeMP5C8dPSyAo_M2aOfFzNROstZ0r8AMfE4SNkWx7dowPQqfMLmSBqf-JS5htbin05SuqM-oTq5TQ.6Jq307K9Y9030Ck9FunudcykPtRJn-l7T6woirVNueY]
-      request-id: [07fd757e-f17f-4908-aa49-75cb9a82a44b]
+      ocp-aad-diagnostics-server-name: [C1+jyrBknmm5YVJufCYdyoyLV7GsaRNIlxjG0T/m/7Q=]
+      ocp-aad-session-key: [r09KImjC5xMueJz00h4Sjx_fYrto3xjgcurB1xHzLayJFeh61n3tCRvYC06Vh8qpyrr4rK24CoEUcap-wTu-BLMzOFjt3tRxBdJtlYcg8MP9HZonWoE7I9vwWcrs1R8x.DzH4OB8JQb0v5RWvQ4Wz8A0mNT-jlmZq6b1qLMDjR98]
+      request-id: [43c3e86b-0336-4f73-8e90-9383eca079fa]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
-      "permissions": {"secrets": ["all"], "keys": ["get", "create", "delete", "list",
-      "update", "import", "backup", "restore"], "certificates": ["all"]}, "tenantId":
-      "9148c3a5-1e1b-4e0a-87c2-302229534991"}], "enabledForTemplateDeployment": true,
-      "sku": {"family": "A", "name": "standard"}, "enabledForDeployment": true, "tenantId":
-      "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
+    body: '{"properties": {"accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
+      "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "permissions": {"secrets":
+      ["all"], "certificates": ["all"], "keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore"]}}], "enabledForDeployment": true, "enabledForTemplateDeployment":
+      true, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991", "sku": {"name": "standard",
+      "family": "A"}}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -140,17 +142,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d41ff7e8-f57a-11e6-8030-784f436a2ed2]
+      x-ms-client-request-id: [8fc3fea2-f942-11e6-a8c3-24f49a5003ca]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007?api-version=2015-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007","name":"vmcreatelinuxsecret007","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"secrets":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret007.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777","name":"vmcreatelinuxsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"secrets":["all"],"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret7777.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:39 GMT']
+      Date: ['Wed, 22 Feb 2017 21:04:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -160,18 +162,18 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['753']
+      content-length: ['756']
       x-ms-keyvault-service-version: [1.0.0.151]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
-    body: '{"policy": {"lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
-      "action": {"action_type": "AutoRenew"}}], "attributes": {"enabled": true}, "x509_props":
-      {"validity_months": 60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
-      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
-      "keyEncipherment", "keyAgreement", "keyCertSign"]}, "issuer": {"name": "Self"},
-      "secret_props": {"contentType": "application/x-pkcs12"}, "key_props": {"exportable":
-      true, "reuse_key": false, "key_size": 2048, "kty": "RSA"}}, "attributes": {"enabled":
+    body: '{"policy": {"x509_props": {"validity_months": 60, "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "subject":
+      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"},
+      "attributes": {"enabled": true}, "key_props": {"key_size": 2048, "exportable":
+      true, "reuse_key": false, "kty": "RSA"}, "issuer": {"name": "Self"}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "lifetime_actions": [{"action": {"action_type":
+      "AutoRenew"}, "trigger": {"lifetime_percentage": 90}}]}, "attributes": {"enabled":
       true}}'
     headers:
       Accept: [application/json]
@@ -182,15 +184,15 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d5f07714-f57a-11e6-b9cc-784f436a2ed2]
+      x-ms-client-request-id: [924cb652-f942-11e6-a863-24f49a5003ca]
     method: POST
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 18 Feb 2017 01:37:44 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -204,13 +206,13 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 401, message: Unauthorized}
 - request:
-    body: '{"policy": {"lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
-      "action": {"action_type": "AutoRenew"}}], "attributes": {"enabled": true}, "x509_props":
-      {"validity_months": 60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
-      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
-      "keyEncipherment", "keyAgreement", "keyCertSign"]}, "issuer": {"name": "Self"},
-      "secret_props": {"contentType": "application/x-pkcs12"}, "key_props": {"exportable":
-      true, "reuse_key": false, "key_size": 2048, "kty": "RSA"}}, "attributes": {"enabled":
+    body: '{"policy": {"x509_props": {"validity_months": 60, "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "subject":
+      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"},
+      "attributes": {"enabled": true}, "key_props": {"key_size": 2048, "exportable":
+      true, "reuse_key": false, "kty": "RSA"}, "issuer": {"name": "Self"}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "lifetime_actions": [{"action": {"action_type":
+      "AutoRenew"}, "trigger": {"lifetime_percentage": 90}}]}, "attributes": {"enabled":
       true}}'
     headers:
       Accept: [application/json]
@@ -221,20 +223,20 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d5f07714-f57a-11e6-b9cc-784f436a2ed2]
+      x-ms-client-request-id: [924cb652-f942-11e6-a863-24f49a5003ca]
     method: POST
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANAwF6g8qQSW0/al5I7YzjNB43gGnBwTqmeFHdUhWudQEY8iRFjPCkvSW10E3Ki3ICiWXbJVzUStIP4igURVU1tCEV5Gn+amA++nBiCLt7RNXRU+3dB5jkwi7ZN8dlnXk6SXJ8+KMZGAAPuMjHAC95sZmdPGzZ7d3gCd3PRz5A1RDy7V/qIK7hpoXkRf7H3jFaFCtsbd72MMMCjymcoyE3Tpv+bILm5CYYK1Uns0kUgiB/GyOLXUjF8/fItn5ABmFVO0tX4cbqwDnKwruerjxquiFFc4JzOkvox4RJq3+ji2sPfoRQQWoyU56jwoYo2pj/382TeLxlp3bZeN5CAd9Q0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBYZ97udNRg/sIq0PlzG/Ng5xrXpAhSwXySNYR90QM5/phwiE1BO1lU4JLCiWyqu5a3IhOdHxwWlFOKK/B+SKSWA5aSnCou1D+TfN3VUwkE7o/RkqGkiY7GtzOlQIXcI2/Tmlr5FK4Xv4qEjxhkHn+8IDRnRBsUt5mNykdfr4l6rYx29j5ypBngLKUAADm1Sv3kCfop18oFY+iicjFHwyh9L7f9lwgp6vihPkRCXdZSvH4Ejn07lhTnOaYjd7It+p+uZ8TF6z5ZwTPL8LW37SLmsvIMNxFnuh4ia0MuvtFtt9PksrLGxDJoYjxvJ85jX3VuVrBIxUuUQ0TgHwNDj5FX","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"4a639473b48a4323b10736b1c17017fa"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:46 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:05 GMT']
       Expires: ['-1']
-      Location: ['https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=9fc618b79e91438991dd5b262df9543d']
+      Location: ['https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=4a639473b48a4323b10736b1c17017fa']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -254,18 +256,18 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8b89224-f57a-11e6-969e-784f436a2ed2]
+      x-ms-client-request-id: [95302bc2-f942-11e6-ab53-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANAwF6g8qQSW0/al5I7YzjNB43gGnBwTqmeFHdUhWudQEY8iRFjPCkvSW10E3Ki3ICiWXbJVzUStIP4igURVU1tCEV5Gn+amA++nBiCLt7RNXRU+3dB5jkwi7ZN8dlnXk6SXJ8+KMZGAAPuMjHAC95sZmdPGzZ7d3gCd3PRz5A1RDy7V/qIK7hpoXkRf7H3jFaFCtsbd72MMMCjymcoyE3Tpv+bILm5CYYK1Uns0kUgiB/GyOLXUjF8/fItn5ABmFVO0tX4cbqwDnKwruerjxquiFFc4JzOkvox4RJq3+ji2sPfoRQQWoyU56jwoYo2pj/382TeLxlp3bZeN5CAd9Q0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBYZ97udNRg/sIq0PlzG/Ng5xrXpAhSwXySNYR90QM5/phwiE1BO1lU4JLCiWyqu5a3IhOdHxwWlFOKK/B+SKSWA5aSnCou1D+TfN3VUwkE7o/RkqGkiY7GtzOlQIXcI2/Tmlr5FK4Xv4qEjxhkHn+8IDRnRBsUt5mNykdfr4l6rYx29j5ypBngLKUAADm1Sv3kCfop18oFY+iicjFHwyh9L7f9lwgp6vihPkRCXdZSvH4Ejn07lhTnOaYjd7It+p+uZ8TF6z5ZwTPL8LW37SLmsvIMNxFnuh4ia0MuvtFtt9PksrLGxDJoYjxvJ85jX3VuVrBIxUuUQ0TgHwNDj5FX","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"4a639473b48a4323b10736b1c17017fa"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:44 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -286,18 +288,18 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ded08022-f57a-11e6-8f77-784f436a2ed2]
+      x-ms-client-request-id: [9b49011c-f942-11e6-b53e-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANAwF6g8qQSW0/al5I7YzjNB43gGnBwTqmeFHdUhWudQEY8iRFjPCkvSW10E3Ki3ICiWXbJVzUStIP4igURVU1tCEV5Gn+amA++nBiCLt7RNXRU+3dB5jkwi7ZN8dlnXk6SXJ8+KMZGAAPuMjHAC95sZmdPGzZ7d3gCd3PRz5A1RDy7V/qIK7hpoXkRf7H3jFaFCtsbd72MMMCjymcoyE3Tpv+bILm5CYYK1Uns0kUgiB/GyOLXUjF8/fItn5ABmFVO0tX4cbqwDnKwruerjxquiFFc4JzOkvox4RJq3+ji2sPfoRQQWoyU56jwoYo2pj/382TeLxlp3bZeN5CAd9Q0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBYZ97udNRg/sIq0PlzG/Ng5xrXpAhSwXySNYR90QM5/phwiE1BO1lU4JLCiWyqu5a3IhOdHxwWlFOKK/B+SKSWA5aSnCou1D+TfN3VUwkE7o/RkqGkiY7GtzOlQIXcI2/Tmlr5FK4Xv4qEjxhkHn+8IDRnRBsUt5mNykdfr4l6rYx29j5ypBngLKUAADm1Sv3kCfop18oFY+iicjFHwyh9L7f9lwgp6vihPkRCXdZSvH4Ejn07lhTnOaYjd7It+p+uZ8TF6z5ZwTPL8LW37SLmsvIMNxFnuh4ia0MuvtFtt9PksrLGxDJoYjxvJ85jX3VuVrBIxUuUQ0TgHwNDj5FX","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"4a639473b48a4323b10736b1c17017fa"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:37:56 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -318,16 +320,16 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e4e01b08-f57a-11e6-ad30-784f436a2ed2]
+      x-ms-client-request-id: [a16678b0-f942-11e6-822f-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaO65+4lRCgOZ+pKhoHOrD5gIb89KI6xPoZ8y3P0ILVn3hNhArQesmKE0XqKBBpp/k/0yeFoXuSsCt/YftGbi4GIk3aFTBTP6QDmwC/s7ZaTJuJ4rgZ/UhrvTPC320KHs/cqPQb+7dpuzZx+nO5e+yD8kfV4z8XC57efs5j/6PYHY9bbUIxSCES/ktHDyJCwEslW4c3J6POlhQ29i6LByeVjHOefmbGMkiBVsymMJjJXomtr66rveUJi9QFckpm6YJDyZKCdTUf6hUZMPed8f/tqglkHks06RWRaXgwfOrG4tm1Qdi2IdS9FeeJmN7ot9zCqVBpknRfJg1yc0gfaxkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCO1g2LCGGkRLOvbfwi7ya7UvDvU0QiqxtzgeEyec/pgAabFkuOUM5zo98IFzslrOuOWXIzdR4VaFQbfBR7nu0XRnlCphwV/SwkFob3VdgCjFunsO/H1lIpQJN+byqNhLmZubRW6Djo//IPCxtKOcta2Koqm7zjOX2rEnjU+LaP2TB9IcxWnKVCB/lKzlE4STBzCb4TcTiDlwBwUUHIRkyYcbvpYWVt8irzBOG5gTls7Lbw2qrzvk3SSzdSxHKNvjhjCU2LZXAOn5hLdz9L/Dly5lJoQTQ2wpRn8vZtL+seug00vLOKlcfXgwhQSYd7YLdm8d8R9TBvmEdNKs9JkJwv","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret007.vault.azure.net/certificates/cert1","request_id":"9fc618b79e91438991dd5b262df9543d"}'}
+    body: {string: '{"id":"https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANAwF6g8qQSW0/al5I7YzjNB43gGnBwTqmeFHdUhWudQEY8iRFjPCkvSW10E3Ki3ICiWXbJVzUStIP4igURVU1tCEV5Gn+amA++nBiCLt7RNXRU+3dB5jkwi7ZN8dlnXk6SXJ8+KMZGAAPuMjHAC95sZmdPGzZ7d3gCd3PRz5A1RDy7V/qIK7hpoXkRf7H3jFaFCtsbd72MMMCjymcoyE3Tpv+bILm5CYYK1Uns0kUgiB/GyOLXUjF8/fItn5ABmFVO0tX4cbqwDnKwruerjxquiFFc4JzOkvox4RJq3+ji2sPfoRQQWoyU56jwoYo2pj/382TeLxlp3bZeN5CAd9Q0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBYZ97udNRg/sIq0PlzG/Ng5xrXpAhSwXySNYR90QM5/phwiE1BO1lU4JLCiWyqu5a3IhOdHxwWlFOKK/B+SKSWA5aSnCou1D+TfN3VUwkE7o/RkqGkiY7GtzOlQIXcI2/Tmlr5FK4Xv4qEjxhkHn+8IDRnRBsUt5mNykdfr4l6rYx29j5ypBngLKUAADm1Sv3kCfop18oFY+iicjFHwyh9L7f9lwgp6vihPkRCXdZSvH4Ejn07lhTnOaYjd7It+p+uZ8TF6z5ZwTPL8LW37SLmsvIMNxFnuh4ia0MuvtFtt9PksrLGxDJoYjxvJ85jX3VuVrBIxUuUQ0TgHwNDj5FX","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret7777.vault.azure.net/certificates/cert1","request_id":"4a639473b48a4323b10736b1c17017fa"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1329']
+      Content-Length: ['1331']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:06 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -348,16 +350,134 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e563ff68-f57a-11e6-817f-784f436a2ed2]
+      x-ms-client-request-id: [a3889e34-f942-11e6-9b6f-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c35fd7a05ded4f22bfb3933b40b98f4a","managed":true,"attributes":{"enabled":false,"nbf":1487381266,"exp":1645148266,"created":1487381866,"updated":1487381866}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c","managed":true,"attributes":{"enabled":true,"nbf":1487381275,"exp":1645148275,"created":1487381876,"updated":1487381876}}],"nextLink":null}'}
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/627a6542b5214b27bd338b203bcbd881","managed":true,"attributes":{"enabled":false,"nbf":1487796904,"exp":1645563904,"created":1487797504,"updated":1487797504}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b","managed":true,"attributes":{"enabled":true,"nbf":1487796923,"exp":1645563923,"created":1487797523,"updated":1487797523}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['550']
+      Content-Length: ['552']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:07 GMT']
+      Date: ['Wed, 22 Feb 2017 21:05:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a5ae65c2-f942-11e6-bea0-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777","name":"vmcreatelinuxsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:05:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['284']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a5c608ee-f942-11e6-b4c5-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777","name":"vmcreatelinuxsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"secrets":["all"],"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret7777.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:05:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['757']
+      x-ms-keyvault-service-version: [1.0.0.151]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c2427c78-f942-11e6-b6e6-24f49a5003ca]
+    method: GET
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/627a6542b5214b27bd338b203bcbd881","managed":true,"attributes":{"enabled":false,"nbf":1487796904,"exp":1645563904,"created":1487797504,"updated":1487797504}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b","managed":true,"attributes":{"enabled":true,"nbf":1487796923,"exp":1645563923,"created":1487797523,"updated":1487797523}}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['552']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:06:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c547e7a2-f942-11e6-af1e-24f49a5003ca]
+    method: GET
+    uri: https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/627a6542b5214b27bd338b203bcbd881","managed":true,"attributes":{"enabled":false,"nbf":1487796904,"exp":1645563904,"created":1487797504,"updated":1487797504}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b","managed":true,"attributes":{"enabled":true,"nbf":1487796923,"exp":1645563923,"created":1487797523,"updated":1487797523}}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['552']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:06:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -399,39 +519,41 @@ interactions:
         \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
         \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
         \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
-        \         \"Win2012R2Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
-        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-R2-Datacenter\",\n
-        \           \"version\":\"latest\"\n          },\n          \"Win2012Datacenter\":{\n
+        \         \"Win2016Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\":{\n
         \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
-        \           \"sku\":\"2012-Datacenter\",\n            \"version\":\"latest\"\n
-        \         },\n          \"Win2008R2SP1\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
-        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2008-R2-SP1\",\n
-        \           \"version\":\"latest\"\n          }\n        }\n      }\n    }\n
-        \ }\n}\n"}
+        \           \"sku\":\"2012-R2-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2012Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2008-R2-SP1\",\n            \"version\":\"latest\"\n
+        \         }\n        }\n      }\n    }\n  }\n}\n"}
     headers:
       Accept-Ranges: [bytes]
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [max-age=300]
       Connection: [close]
-      Content-Length: ['2297']
+      Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:07 GMT']
-      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      Expires: ['Sat, 18 Feb 2017 01:43:07 GMT']
-      Source-Age: ['32']
+      Date: ['Wed, 22 Feb 2017 21:07:22 GMT']
+      ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
+      Expires: ['Wed, 22 Feb 2017 21:12:22 GMT']
+      Source-Age: ['0']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
       Via: [1.1 varnish]
-      X-Cache: [HIT]
-      X-Cache-Hits: ['1']
+      X-Cache: [MISS]
+      X-Cache-Hits: ['0']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [3083299dea70f33a84bbb07d4d43af4e9be2ca1f]
+      X-Fastly-Request-ID: [e69304e3b61f4d4bd738ec64fe99bd7a631db2dc]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['4522:623E:4838DA2:4A85820:58A7A55E']
-      X-Served-By: [cache-den6024-DEN]
-      X-Timer: ['S1487381887.651347,VS0,VE0']
+      X-GitHub-Request-Id: ['7722:623E:6674352:69D2935:58ADFD88']
+      X-Served-By: [cache-sjc3144-SJC]
+      X-Timer: ['S1487797642.371259,VS0,VE91']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -442,9 +564,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e61e988a-f57a-11e6-b585-784f436a2ed2]
+      x-ms-client-request-id: [e74e274c-f942-11e6-aae9-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
@@ -452,7 +574,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:06 GMT']
+      Date: ['Wed, 22 Feb 2017 21:07:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -460,66 +582,67 @@ interactions:
       content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {}, "variables": {}, "outputs": {},
-      "resources": [{"tags": {}, "dependsOn": [], "name": "vm-nameVNET", "location":
-      "westus", "apiVersion": "2015-06-15", "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}, "subnets": [{"name": "vm-nameSubnet", "properties": {"addressPrefix":
-      "10.0.0.0/24"}}]}, "type": "Microsoft.Network/virtualNetworks"}, {"tags": {},
-      "dependsOn": [], "name": "vm-nameNSG", "location": "westus", "apiVersion": "2015-06-15",
-      "properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
-      {"sourceAddressPrefix": "*", "priority": 1000, "access": "Allow", "destinationAddressPrefix":
-      "*", "destinationPortRange": "22", "sourcePortRange": "*", "direction": "Inbound",
-      "protocol": "Tcp"}}]}, "type": "Microsoft.Network/networkSecurityGroups"}, {"tags":
-      {}, "dependsOn": [], "name": "vm-namePublicIP", "location": "westus", "apiVersion":
-      "2015-06-15", "properties": {"publicIPAllocationMethod": "dynamic"}, "type":
-      "Microsoft.Network/publicIPAddresses"}, {"tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vm-nameVNET",
-      "Microsoft.Network/networkSecurityGroups/vm-nameNSG", "Microsoft.Network/publicIpAddresses/vm-namePublicIP"],
-      "name": "vm-nameVMNic", "location": "westus", "apiVersion": "2015-06-15", "properties":
-      {"networkSecurityGroup": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG"},
-      "ipConfigurations": [{"name": "ipconfigvm-name", "properties": {"publicIPAddress":
-      {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP"},
-      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"}}}]},
-      "type": "Microsoft.Network/networkInterfaces"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
-      "name": "vm-name", "location": "westus", "apiVersion": "2016-04-30-preview",
-      "properties": {"osProfile": {"computerName": "vm-name", "linuxConfiguration":
-      {"ssh": {"publicKeys": [{"path": "/home/ubuntu/.ssh/authorized_keys", "keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\n"}]}, "disablePasswordAuthentication": true}, "secrets": [{"vaultCertificates":
-      [{"certificateUrl": "https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c"}],
-      "sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007"}}],
-      "adminUsername": "ubuntu"}, "networkProfile": {"networkInterfaces": [{"id":
-      "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]},
-      "storageProfile": {"imageReference": {"offer": "UbuntuServer", "publisher":
-      "Canonical", "sku": "14.04.4-LTS", "version": "latest"}, "osDisk": {"managedDisk":
-      {"storageAccountType": "Premium_LRS"}, "createOption": "fromImage", "caching":
-      "ReadWrite", "name": "osdisk_W1HIoyuQ2B"}}, "hardwareProfile": {"vmSize": "Standard_DS1"}},
-      "type": "Microsoft.Compute/virtualMachines"}]}, "parameters": {}, "mode": "Incremental"}}'
+    body: '{"properties": {"parameters": {}, "mode": "Incremental", "template": {"variables":
+      {}, "outputs": {}, "parameters": {}, "contentVersion": "1.0.0.0", "$schema":
+      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "location": "westus", "apiVersion": "2015-06-15",
+      "properties": {"subnets": [{"name": "vm-nameSubnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "type":
+      "Microsoft.Network/virtualNetworks", "dependsOn": [], "name": "vm-nameVNET"},
+      {"dependsOn": [], "location": "westus", "tags": {}, "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups", "properties": {"securityRules":
+      [{"name": "default-allow-ssh", "properties": {"destinationPortRange": "22",
+      "direction": "Inbound", "access": "Allow", "sourceAddressPrefix": "*", "protocol":
+      "Tcp", "sourcePortRange": "*", "priority": 1000, "destinationAddressPrefix":
+      "*"}}]}, "name": "vm-nameNSG"}, {"dependsOn": [], "location": "westus", "tags":
+      {}, "type": "Microsoft.Network/publicIPAddresses", "apiVersion": "2015-06-15",
+      "properties": {"publicIPAllocationMethod": "dynamic"}, "name": "vm-namePublicIP"},
+      {"dependsOn": ["Microsoft.Network/virtualNetworks/vm-nameVNET", "Microsoft.Network/networkSecurityGroups/vm-nameNSG",
+      "Microsoft.Network/publicIpAddresses/vm-namePublicIP"], "location": "westus",
+      "tags": {}, "type": "Microsoft.Network/networkInterfaces", "apiVersion": "2015-06-15",
+      "properties": {"ipConfigurations": [{"name": "ipconfigvm-name", "properties":
+      {"publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP"},
+      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG"}},
+      "name": "vm-nameVMNic"}, {"dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
+      "location": "westus", "tags": {}, "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2016-04-30-preview", "properties": {"networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"adminUsername":
+      "ubuntu", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777"},
+      "vaultCertificates": [{"certificateUrl": "https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b"}]}],
+      "linuxConfiguration": {"ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\n", "path": "/home/ubuntu/.ssh/authorized_keys"}]}, "disablePasswordAuthentication":
+      true}, "computerName": "vm-name"}, "storageProfile": {"imageReference": {"publisher":
+      "Canonical", "version": "latest", "offer": "UbuntuServer", "sku": "14.04.4-LTS"},
+      "osDisk": {"createOption": "fromImage", "managedDisk": {"storageAccountType":
+      "Premium_LRS"}, "caching": "ReadWrite", "name": "osdisk_uOUeMWeEKL"}}}, "name":
+      "vm-name"}]}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['4318']
+      Content-Length: ['4323']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","name":"vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","properties":{"templateHash":"7151056166255818598","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-18T01:38:09.5245864Z","duration":"PT0.8201874S","correlationId":"a6ff0490-a68a-4bfc-a2d6-2de943f543ed","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_tmFi5DLlAM37wADIv6XgH3aN9BpB7tM0","name":"vm_deploy_tmFi5DLlAM37wADIv6XgH3aN9BpB7tM0","properties":{"templateHash":"3622819215585014372","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-22T21:07:28.1275177Z","duration":"PT0.4864626S","correlationId":"17a7fec6-95a6-4ed9-8e60-db5d07952593","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH/operationStatuses/08587142249967793728?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_tmFi5DLlAM37wADIv6XgH3aN9BpB7tM0/operationStatuses/08587138092378366150?api-version=2016-09-01']
       Cache-Control: [no-cache]
       Content-Length: ['2490']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:09 GMT']
+      Date: ['Wed, 22 Feb 2017 21:07:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -530,17 +653,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:38:39 GMT']
+      Date: ['Wed, 22 Feb 2017 21:07:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -556,17 +679,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:39:12 GMT']
+      Date: ['Wed, 22 Feb 2017 21:08:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -582,17 +705,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:39:43 GMT']
+      Date: ['Wed, 22 Feb 2017 21:08:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -608,17 +731,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:40:14 GMT']
+      Date: ['Wed, 22 Feb 2017 21:09:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -634,17 +757,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:40:47 GMT']
+      Date: ['Wed, 22 Feb 2017 21:09:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -660,17 +783,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587142249967793728?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138092378366150?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:18 GMT']
+      Date: ['Wed, 22 Feb 2017 21:10:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -686,22 +809,22 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e63177de-f57a-11e6-ace9-784f436a2ed2]
+      x-ms-client-request-id: [e9da9b3a-f942-11e6-80b7-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","name":"vm_deploy_RRgbmk0JOzy8QSJobn3O9T9zhIECiulH","properties":{"templateHash":"7151056166255818598","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-18T01:40:49.7107934Z","duration":"PT2M41.0063944S","correlationId":"a6ff0490-a68a-4bfc-a2d6-2de943f543ed","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Resources/deployments/vm_deploy_tmFi5DLlAM37wADIv6XgH3aN9BpB7tM0","name":"vm_deploy_tmFi5DLlAM37wADIv6XgH3aN9BpB7tM0","properties":{"templateHash":"3622819215585014372","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-22T21:10:28.7424127Z","duration":"PT3M1.1013576S","correlationId":"17a7fec6-95a6-4ed9-8e60-db5d07952593","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:18 GMT']
+      Date: ['Wed, 22 Feb 2017 21:10:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['2812']
+      content-length: ['2811']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -711,21 +834,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58f2d1ca-f57b-11e6-afd7-784f436a2ed2]
+      x-ms-client-request-id: [57ddb790-f943-11e6-bae1-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview&$expand=instanceView
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8b2cc2f-5070-4049-a90c-f82934ad53ad\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"410cd059-295e-493b-96c3-ec25316e6fc5\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
-        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_W1HIoyuQ2B\",\r\n
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_uOUeMWeEKL\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_W1HIoyuQ2B\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_uOUeMWeEKL\"\r\n
         \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
         {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"ubuntu\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
@@ -734,9 +858,9 @@ interactions:
         \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
         test@example.com\\n\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n
         \     \"secrets\": [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007\"\r\n
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777\"\r\n
         \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
-        \"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c\"\r\n
+        \"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
@@ -744,11 +868,11 @@ interactions:
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \           \"time\": \"2017-02-18T01:41:01+00:00\"\r\n          }\r\n        ],\r\n
+        \           \"time\": \"2017-02-22T21:10:25+00:00\"\r\n          }\r\n        ],\r\n
         \       \"extensionHandlers\": []\r\n      },\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2017-02-18T01:40:33.4554454+00:00\"\r\n        },\r\n
+        \         \"time\": \"2017-02-22T21:10:25.0861225+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
         \     ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
@@ -757,14 +881,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:19 GMT']
+      Date: ['Wed, 22 Feb 2017 21:10:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3768']
+      content-length: ['3773']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -774,19 +898,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5930f662-f57b-11e6-9e80-784f436a2ed2]
+      x-ms-client-request-id: [5809a538-f943-11e6-9bc9-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"vm-nameVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\",\r\n
-        \ \"etag\": \"W/\\\"b2c927a0-c220-4b25-bbfe-8466576f85a0\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"79fc7602-350e-44b4-bfec-a11a1fdc95ab\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"8f97200a-aeb7-4840-add8-b5b492ce1637\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"ffdc1100-51ac-4611-b0a4-242029671ab9\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-name\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\",\r\n
-        \       \"etag\": \"W/\\\"b2c927a0-c220-4b25-bbfe-8466576f85a0\\\"\",\r\n
+        \       \"etag\": \"W/\\\"79fc7602-350e-44b4-bfec-a11a1fdc95ab\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\"\r\n
@@ -794,8 +918,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"zuc5rl0zniqupp2x21ygp5e3fa.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-34-EF-AC\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"vwinpkepo1jefo2ilyodq5gord.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-36-FD-2B\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -804,8 +928,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:20 GMT']
-      ETag: [W/"b2c927a0-c220-4b25-bbfe-8466576f85a0"]
+      Date: ['Wed, 22 Feb 2017 21:10:31 GMT']
+      ETag: [W/"79fc7602-350e-44b4-bfec-a11a1fdc95ab"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -822,33 +946,33 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [596d8dc0-f57b-11e6-b558-784f436a2ed2]
+      x-ms-client-request-id: [582692f6-f943-11e6-9f89-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"vm-namePublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\",\r\n
-        \ \"etag\": \"W/\\\"6dd568b7-e314-4641-8b2a-a5621f1fc559\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"f654c35a-b757-4378-a600-92f777567206\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"westus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"70864669-3aee-41a5-acfb-ec78343bb871\",\r\n    \"ipAddress\":
-        \"13.64.67.107\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \   \"resourceGuid\": \"3752cb1d-11bd-4193-89ef-e3edf432d986\",\r\n    \"ipAddress\":
+        \"13.64.65.97\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
         \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
         {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\"\r\n
         \   }\r\n  }\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:20 GMT']
-      ETag: [W/"6dd568b7-e314-4641-8b2a-a5621f1fc559"]
+      Date: ['Wed, 22 Feb 2017 21:10:31 GMT']
+      ETag: [W/"f654c35a-b757-4378-a600-92f777567206"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['880']
+      content-length: ['879']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -858,21 +982,22 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5a4dc0dc-f57b-11e6-ad54-784f436a2ed2]
+      x-ms-client-request-id: [5a2846b4-f943-11e6-b6d5-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"f8b2cc2f-5070-4049-a90c-f82934ad53ad\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"410cd059-295e-493b-96c3-ec25316e6fc5\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
-        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_W1HIoyuQ2B\",\r\n
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk_uOUeMWeEKL\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_W1HIoyuQ2B\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Compute/disks/osdisk_uOUeMWeEKL\"\r\n
         \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
         {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"ubuntu\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
@@ -881,9 +1006,9 @@ interactions:
         \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
         test@example.com\\n\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n
         \     \"secrets\": [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret007\"\r\n
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret7777\"\r\n
         \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
-        \"https://vmcreatelinuxsecret007.vault.azure.net/secrets/cert1/c49e8f49e330469789476d1cfb00510c\"\r\n
+        \"https://vmcreatelinuxsecret7777.vault.azure.net/secrets/cert1/af56053c667f4b4d92859262f070180b\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_linux_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
@@ -892,13 +1017,13 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 18 Feb 2017 01:41:22 GMT']
+      Date: ['Wed, 22 Feb 2017 21:10:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2938']
+      content-length: ['2943']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_windows_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_windows_secrets.yaml
@@ -1,0 +1,1001 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\":{},\n
+        \ \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"metadata\":{\n
+        \       \"description\":\"This list of aliases is used by Azure XPLAT CLI,
+        Azure Powershell, and Azure Portal as shorthands for commonly used VM images.
+        If you change this file, please verify that this doesn't break VMSS creation
+        from Portal :).\"\n      },\n      \"type\":\"object\",\n      \"value\":{\n\n
+        \       \"Linux\":{\n          \"CentOS\":{\n            \"publisher\":\"OpenLogic\",\n
+        \           \"offer\":\"CentOS\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\",\n
+        \           \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Debian\":{\n            \"publisher\":\"credativ\",\n
+        \           \"offer\":\"Debian\",\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n
+        \         },\n          \"openSUSE\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"openSUSE\",\n            \"sku\":\"13.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"RHEL\":{\n            \"publisher\":\"RedHat\",\n
+        \           \"offer\":\"RHEL\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"SLES\",\n            \"sku\":\"12-SP1\",\n            \"version\":\"latest\"\n
+        \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
+        \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
+        \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
+        \         \"Win2016Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2012-R2-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2012Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2008-R2-SP1\",\n            \"version\":\"latest\"\n
+        \         }\n        }\n      }\n    }\n  }\n}\n"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2497']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:40 GMT']
+      ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
+      Expires: ['Tue, 21 Feb 2017 16:00:40 GMT']
+      Source-Age: ['223']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['2']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [e9fa39b0f18582a9a726f3712aaf2cba88bf2998]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['5B5A:623E:5E76CB8:618E1F0:58AC621D']
+      X-Served-By: [cache-den6027-DEN]
+      X-Timer: ['S1487692540.135239,VS0,VE0']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [316bf7be-f84e-11e6-95a3-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [32424e2c-f84e-11e6-9e4b-784f436a2ed2]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1269']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Tue, 21 Feb 2017 15:55:40 GMT']
+      Duration: ['599165']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [qi2YQMBV0FBplgBybwKunll/0jBKrZwkspgPfnRlKiw=]
+      ocp-aad-session-key: [IWpnsbvUwuAcTtyieDoyTBaHzct6NvKhlUh6RllLEM32ULZGUwBhwof0kKJYtZpccOTLUKOZvUKjfZKxeCk9upFIRYQPPajcnlLFSzPhfSkoZoOTv_QOE-mjH-vOPLhd.XuQ9onNOjZZgdzSqbtcsqyXxQmFHjZjMNiG3P3lsyBw]
+      request-id: [10cbbd7b-14c7-41b2-a844-15b6abd94bef]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore"], "certificates": ["all"], "secrets": ["all"]}, "tenantId":
+      "9148c3a5-1e1b-4e0a-87c2-302229534991"}], "enabledForTemplateDeployment": true,
+      "sku": {"name": "standard", "family": "A"}, "enabledForDeployment": true, "tenantId":
+      "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['476']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [326a5f02-f84e-11e6-816f-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005","name":"vmcreatewinsecret005","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"certificates":["all"],"secrets":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatewinsecret005.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['749']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
+      "application/x-pkcs12"}, "attributes": {"enabled": true}, "issuer": {"name":
+      "Self"}, "key_props": {"kty": "RSA", "exportable": true, "reuse_key": false,
+      "key_size": 2048}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"},
+      "trigger": {"lifetime_percentage": 90}}], "x509_props": {"validity_months":
+      60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
+      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"]}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [338f33e4-f84e-11e6-9136-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Tue, 21 Feb 2017 15:55:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
+      "application/x-pkcs12"}, "attributes": {"enabled": true}, "issuer": {"name":
+      "Self"}, "key_props": {"kty": "RSA", "exportable": true, "reuse_key": false,
+      "key_size": 2048}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"},
+      "trigger": {"lifetime_percentage": 90}}], "x509_props": {"validity_months":
+      60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
+      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"]}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [338f33e4-f84e-11e6-9136-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1415']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:44 GMT']
+      Expires: ['-1']
+      Location: ['https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=d5f3871eac834f65b3220b30131042b3']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [345c1940-f84e-11e6-a821-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1415']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3a6ad84c-f84e-11e6-8417-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1415']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:55:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [407a6d24-f84e-11e6-9503-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"completed","target":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1325']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [419a081a-f84e-11e6-bee9-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/1a38241551d04ebdb59a466f76890353","managed":true,"attributes":{"enabled":false,"nbf":1487691944,"exp":1645458944,"created":1487692544,"updated":1487692544}},{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2","managed":true,"attributes":{"enabled":true,"nbf":1487691955,"exp":1645458955,"created":1487692555,"updated":1487692555}}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['546']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\":{},\n
+        \ \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"metadata\":{\n
+        \       \"description\":\"This list of aliases is used by Azure XPLAT CLI,
+        Azure Powershell, and Azure Portal as shorthands for commonly used VM images.
+        If you change this file, please verify that this doesn't break VMSS creation
+        from Portal :).\"\n      },\n      \"type\":\"object\",\n      \"value\":{\n\n
+        \       \"Linux\":{\n          \"CentOS\":{\n            \"publisher\":\"OpenLogic\",\n
+        \           \"offer\":\"CentOS\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\",\n
+        \           \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Debian\":{\n            \"publisher\":\"credativ\",\n
+        \           \"offer\":\"Debian\",\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n
+        \         },\n          \"openSUSE\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"openSUSE\",\n            \"sku\":\"13.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"RHEL\":{\n            \"publisher\":\"RedHat\",\n
+        \           \"offer\":\"RHEL\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"SLES\",\n            \"sku\":\"12-SP1\",\n            \"version\":\"latest\"\n
+        \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
+        \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
+        \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
+        \         \"Win2016Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2012-R2-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2012Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2008-R2-SP1\",\n            \"version\":\"latest\"\n
+        \         }\n        }\n      }\n    }\n  }\n}\n"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2497']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
+      Expires: ['Tue, 21 Feb 2017 16:01:08 GMT']
+      Source-Age: ['251']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [462a845799ede3febb58240c5b322dfb140e8615]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['5B5A:623E:5E76CB8:618E1F0:58AC621D']
+      X-Served-By: [cache-den6025-DEN]
+      X-Timer: ['S1487692568.432340,VS0,VE0']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [424aa30a-f84e-11e6-acdd-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"template": {"contentVersion": "1.0.0.0", "parameters":
+      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}, "outputs": {}, "resources": [{"location": "westus", "dependsOn":
+      [], "apiVersion": "2015-06-15", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
+      "name": "vm-nameSubnet"}]}, "name": "vm-nameVNET", "tags": {}, "type": "Microsoft.Network/virtualNetworks"},
+      {"location": "westus", "dependsOn": [], "apiVersion": "2015-06-15", "properties":
+      {"securityRules": [{"properties": {"access": "Allow", "sourceAddressPrefix":
+      "*", "sourcePortRange": "*", "direction": "Inbound", "priority": 1000, "protocol":
+      "Tcp", "destinationAddressPrefix": "*", "destinationPortRange": "3389"}, "name":
+      "rdp"}]}, "name": "vm-nameNSG", "tags": {}, "type": "Microsoft.Network/networkSecurityGroups"},
+      {"location": "westus", "dependsOn": [], "name": "vm-namePublicIP", "properties":
+      {"publicIPAllocationMethod": "dynamic"}, "apiVersion": "2015-06-15", "tags":
+      {}, "type": "Microsoft.Network/publicIPAddresses"}, {"location": "westus", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vm-nameVNET", "Microsoft.Network/networkSecurityGroups/vm-nameNSG",
+      "Microsoft.Network/publicIpAddresses/vm-namePublicIP"], "name": "vm-nameVMNic",
+      "properties": {"ipConfigurations": [{"properties": {"privateIPAllocationMethod":
+      "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"},
+      "publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP"}},
+      "name": "ipconfigvm-name"}], "networkSecurityGroup": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG"}},
+      "apiVersion": "2015-06-15", "tags": {}, "type": "Microsoft.Network/networkInterfaces"},
+      {"location": "westus", "dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
+      "name": "vm-name", "properties": {"storageProfile": {"osDisk": {"createOption":
+      "fromImage", "name": "osdisk_qN6muVZCMK", "caching": "ReadWrite", "managedDisk":
+      {"storageAccountType": "Premium_LRS"}}, "imageReference": {"version": "latest",
+      "sku": "2012-R2-Datacenter", "offer": "WindowsServer", "publisher": "MicrosoftWindowsServer"}},
+      "hardwareProfile": {"vmSize": "Standard_DS1"}, "networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]},
+      "osProfile": {"adminPassword": "VerySecret!12", "computerName": "vm-name", "adminUsername":
+      "windowsUser", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005"},
+      "vaultCertificates": [{"certificateStore": "My", "certificateUrl": "https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2"}]}]}},
+      "apiVersion": "2016-04-30-preview", "tags": {}, "type": "Microsoft.Compute/virtualMachines"}]},
+      "parameters": {}, "mode": "Incremental"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3505']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","name":"vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","properties":{"templateHash":"11984531987702820250","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-21T15:56:10.2805532Z","duration":"PT0.7183912S","correlationId":"8eebe458-ceb7-454c-bc62-79b6bd67ffb1","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB/operationStatuses/08587139143159155182?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2505']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:56:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:57:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:57:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:58:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:58:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:59:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 15:59:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:00:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:00:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","name":"vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","properties":{"templateHash":"11984531987702820250","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-21T16:00:48.8915483Z","duration":"PT4M39.3293863S","correlationId":"8eebe458-ceb7-454c-bc62-79b6bd67ffb1","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['2827']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f978bda8-f84e-11e6-aceb-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview&$expand=instanceView
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"06b59851-f9c6-49fc-9078-461cf8ca38c3\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk_qN6muVZCMK\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
+        \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\":
+        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_qN6muVZCMK\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"windowsUser\",\r\n
+        \     \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n
+        \       \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\":
+        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005\"\r\n
+        \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
+        \"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2\",\r\n
+        \             \"certificateStore\": \"My\"\r\n            }\r\n          ]\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2017-02-21T16:01:15+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"time\": \"2017-02-21T16:00:45.2512014+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\",\r\n
+        \ \"name\": \"vm-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2893']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f9b0982e-f84e-11e6-b90b-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-nameVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\",\r\n
+        \ \"etag\": \"W/\\\"c38ac5ce-48f2-47de-b643-975474f87439\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"603e6016-63ef-43bc-8aca-ea0c7a01ac45\",\r\n
+        \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-name\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\",\r\n
+        \       \"etag\": \"W/\\\"c38ac5ce-48f2-47de-b643-975474f87439\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"f1d54ygcr4jutpoqdmcs4gh4sc.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-33-E4-61\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:15 GMT']
+      ETag: [W/"c38ac5ce-48f2-47de-b643-975474f87439"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2325']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f9e8fa5c-f84e-11e6-ba9f-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-namePublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\",\r\n
+        \ \"etag\": \"W/\\\"00bfc86a-8bf2-459f-b928-7fdb780cb236\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"4e20d2bf-c489-4d19-bd83-a83c553df328\",\r\n    \"ipAddress\":
+        \"13.64.198.134\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
+        {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\"\r\n
+        \   }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:16 GMT']
+      ETag: [W/"00bfc86a-8bf2-459f-b928-7fdb780cb236"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['885']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [faacb1e8-f84e-11e6-8b49-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"06b59851-f9c6-49fc-9078-461cf8ca38c3\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk_qN6muVZCMK\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
+        \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\":
+        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_qN6muVZCMK\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"windowsUser\",\r\n
+        \     \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n
+        \       \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\":
+        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005\"\r\n
+        \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
+        \"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2\",\r\n
+        \             \"certificateStore\": \"My\"\r\n            }\r\n          ]\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name\",\r\n
+        \ \"name\": \"vm-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 21 Feb 2017 16:01:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2109']
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_windows_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_windows_secrets.yaml
@@ -49,22 +49,22 @@ interactions:
       Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:40 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:05 GMT']
       ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
-      Expires: ['Tue, 21 Feb 2017 16:00:40 GMT']
-      Source-Age: ['223']
+      Expires: ['Wed, 22 Feb 2017 21:27:05 GMT']
+      Source-Age: ['149']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
       Via: [1.1 varnish]
       X-Cache: [HIT]
-      X-Cache-Hits: ['2']
+      X-Cache-Hits: ['1']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [e9fa39b0f18582a9a726f3712aaf2cba88bf2998]
+      X-Fastly-Request-ID: [bf3d51ebc2fae2d43ad9510ef2e5f4dd6f882619]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['5B5A:623E:5E76CB8:618E1F0:58AC621D']
-      X-Served-By: [cache-den6027-DEN]
-      X-Timer: ['S1487692540.135239,VS0,VE0']
+      X-GitHub-Request-Id: ['2108:623E:6682096:69E0EC4:58AE0067']
+      X-Served-By: [cache-sjc3120-SJC]
+      X-Timer: ['S1487798525.005124,VS0,VE0']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -75,9 +75,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [316bf7be-f84e-11e6-95a3-784f436a2ed2]
+      x-ms-client-request-id: [f554df82-f944-11e6-afbc-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
@@ -85,7 +85,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:39 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -102,7 +102,7 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [32424e2c-f84e-11e6-9e4b-784f436a2ed2]
+      x-ms-client-request-id: [f817af4c-f944-11e6-a93f-24f49a5003ca]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
@@ -114,8 +114,8 @@ interactions:
       Content-Length: ['1269']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Tue, 21 Feb 2017 15:55:40 GMT']
-      Duration: ['599165']
+      Date: ['Wed, 22 Feb 2017 21:22:09 GMT']
+      Duration: ['658603']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -123,16 +123,16 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
       ocp-aad-diagnostics-server-name: [qi2YQMBV0FBplgBybwKunll/0jBKrZwkspgPfnRlKiw=]
-      ocp-aad-session-key: [IWpnsbvUwuAcTtyieDoyTBaHzct6NvKhlUh6RllLEM32ULZGUwBhwof0kKJYtZpccOTLUKOZvUKjfZKxeCk9upFIRYQPPajcnlLFSzPhfSkoZoOTv_QOE-mjH-vOPLhd.XuQ9onNOjZZgdzSqbtcsqyXxQmFHjZjMNiG3P3lsyBw]
-      request-id: [10cbbd7b-14c7-41b2-a844-15b6abd94bef]
+      ocp-aad-session-key: [ro1PLQ8-BBsMtuPp0-kG5xXY8vh1hLRbsepZd-qNpwTpN__aom3fuY1jfA6Hd4vOquwfcRXN_ls30iIX7f0vomy5WSSQcOoh1hjQw3oKCaChxUwenj2PFE9o0UrYphde.R1cjLZ1gnmyj3ca94FK9EnsyYh2D-dzLzE__1hu5-Lw]
+      request-id: [1d5686b8-82f1-4051-930c-fd92793b5b35]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "certificates": ["all"], "secrets": ["all"]}, "tenantId":
-      "9148c3a5-1e1b-4e0a-87c2-302229534991"}], "enabledForTemplateDeployment": true,
-      "sku": {"name": "standard", "family": "A"}, "enabledForDeployment": true, "tenantId":
+    body: '{"location": "westus", "properties": {"enabledForTemplateDeployment": true,
+      "accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376", "permissions":
+      {"keys": ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}],
+      "enabledForDeployment": true, "sku": {"family": "A", "name": "standard"}, "tenantId":
       "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
     headers:
       Accept: [application/json]
@@ -142,17 +142,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [326a5f02-f84e-11e6-816f-784f436a2ed2]
+      x-ms-client-request-id: [f8402be6-f944-11e6-9a38-24f49a5003ca]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005?api-version=2015-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005","name":"vmcreatewinsecret005","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"certificates":["all"],"secrets":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatewinsecret005.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777","name":"vmcreatewinsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatewinsecret7777.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:42 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -162,19 +162,18 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['749']
+      content-length: ['752']
       x-ms-keyvault-service-version: [1.0.0.151]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "attributes": {"enabled": true}, "issuer": {"name":
-      "Self"}, "key_props": {"kty": "RSA", "exportable": true, "reuse_key": false,
-      "key_size": 2048}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"},
-      "trigger": {"lifetime_percentage": 90}}], "x509_props": {"validity_months":
-      60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "secret_props": {"contentType": "application/x-pkcs12"}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}], "issuer": {"name": "Self"}, "x509_props": {"validity_months": 60, "key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -184,15 +183,15 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [338f33e4-f84e-11e6-9136-784f436a2ed2]
+      x-ms-client-request-id: [fa296848-f944-11e6-9a8a-24f49a5003ca]
     method: POST
-    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Tue, 21 Feb 2017 15:55:41 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -206,14 +205,13 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.800]
     status: {code: 401, message: Unauthorized}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "attributes": {"enabled": true}, "issuer": {"name":
-      "Self"}, "key_props": {"kty": "RSA", "exportable": true, "reuse_key": false,
-      "key_size": 2048}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"},
-      "trigger": {"lifetime_percentage": 90}}], "x509_props": {"validity_months":
-      60, "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "secret_props": {"contentType": "application/x-pkcs12"}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}], "issuer": {"name": "Self"}, "x509_props": {"validity_months": 60, "key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -223,20 +221,20 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [338f33e4-f84e-11e6-9136-784f436a2ed2]
+      x-ms-client-request-id: [fa296848-f944-11e6-9a8a-24f49a5003ca]
     method: POST
-    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALtP0vRXbUzSLD50I2O8H5+RX9TFGeFOQ9fOCwoY+3xxEKAInQaGlEhB6Y4ZyiOMr4bafGSlACAu78bQBr14hS7Zu9PCF87+0I/nr9uP0HE0r1SFrnnAtwElA9CqMTAQDVmmOfrEO5lc6EnFkZc8L34GuCTv/RclnxDiRyra7aTy5RjbbK3l0kmq0H4pW8qFOWbPbnN8a2e3dP38Lu3oGX/8iUJ6jIgJg6dSHUjgeoV1b09kXlBxuTIL4LQ6y3oRYkBmLf2X4ibbzWuuw2u3uk/sc5mU+QMfdsdV5cUNUVwfsKePp2lnmTce0IyxUVUcAOQBdezqU+aIsnJ3V3mItUECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBi82MOFhoSCPQJVJAuKA9PXR9IOJUIxR4KR9EJVxLytFl6tqT816Lhsmxetw8PyBhWGnNe5lCmTzBy3UCnYKyS1nPpwGt53U9sdf3U22Jtv4H7wA+xnaWDPLqOkTzrt1MvRYPk8wKXs7p55KWMuU8/5ImwWphYwZevX2REpcXff7R4wO07P2J24Po0MMDzpdd6GhW07b1AHEIcsAKhCCnTH1s69A0jEzgb0Xh5UkP+BOaVluk3RHEPFPtj1TjrqucOyuZ7yyZ3L1VwK9XCeQwvoxqy3fQlFRvUMVDzOJZ1lB0aP9GGDygzfSzksE3nwPiiQisbJ8Qg/WC14YHbnq6J","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+        time based on the issuer provider. Please check again later.","request_id":"1300919997cf49c7864050d35692b0b2"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1415']
+      Content-Length: ['1416']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:44 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:16 GMT']
       Expires: ['-1']
-      Location: ['https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=d5f3871eac834f65b3220b30131042b3']
+      Location: ['https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=1300919997cf49c7864050d35692b0b2']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -256,18 +254,18 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [345c1940-f84e-11e6-a821-784f436a2ed2]
+      x-ms-client-request-id: [fda0e7da-f944-11e6-a985-24f49a5003ca]
     method: GET
-    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALtP0vRXbUzSLD50I2O8H5+RX9TFGeFOQ9fOCwoY+3xxEKAInQaGlEhB6Y4ZyiOMr4bafGSlACAu78bQBr14hS7Zu9PCF87+0I/nr9uP0HE0r1SFrnnAtwElA9CqMTAQDVmmOfrEO5lc6EnFkZc8L34GuCTv/RclnxDiRyra7aTy5RjbbK3l0kmq0H4pW8qFOWbPbnN8a2e3dP38Lu3oGX/8iUJ6jIgJg6dSHUjgeoV1b09kXlBxuTIL4LQ6y3oRYkBmLf2X4ibbzWuuw2u3uk/sc5mU+QMfdsdV5cUNUVwfsKePp2lnmTce0IyxUVUcAOQBdezqU+aIsnJ3V3mItUECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBi82MOFhoSCPQJVJAuKA9PXR9IOJUIxR4KR9EJVxLytFl6tqT816Lhsmxetw8PyBhWGnNe5lCmTzBy3UCnYKyS1nPpwGt53U9sdf3U22Jtv4H7wA+xnaWDPLqOkTzrt1MvRYPk8wKXs7p55KWMuU8/5ImwWphYwZevX2REpcXff7R4wO07P2J24Po0MMDzpdd6GhW07b1AHEIcsAKhCCnTH1s69A0jEzgb0Xh5UkP+BOaVluk3RHEPFPtj1TjrqucOyuZ7yyZ3L1VwK9XCeQwvoxqy3fQlFRvUMVDzOJZ1lB0aP9GGDygzfSzksE3nwPiiQisbJ8Qg/WC14YHbnq6J","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+        time based on the issuer provider. Please check again later.","request_id":"1300919997cf49c7864050d35692b0b2"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1415']
+      Content-Length: ['1416']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:45 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -288,18 +286,16 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3a6ad84c-f84e-11e6-8417-784f436a2ed2]
+      x-ms-client-request-id: [03ae37e8-f945-11e6-a9ec-24f49a5003ca]
     method: GET
-    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    body: {string: '{"id":"https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALtP0vRXbUzSLD50I2O8H5+RX9TFGeFOQ9fOCwoY+3xxEKAInQaGlEhB6Y4ZyiOMr4bafGSlACAu78bQBr14hS7Zu9PCF87+0I/nr9uP0HE0r1SFrnnAtwElA9CqMTAQDVmmOfrEO5lc6EnFkZc8L34GuCTv/RclnxDiRyra7aTy5RjbbK3l0kmq0H4pW8qFOWbPbnN8a2e3dP38Lu3oGX/8iUJ6jIgJg6dSHUjgeoV1b09kXlBxuTIL4LQ6y3oRYkBmLf2X4ibbzWuuw2u3uk/sc5mU+QMfdsdV5cUNUVwfsKePp2lnmTce0IyxUVUcAOQBdezqU+aIsnJ3V3mItUECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBi82MOFhoSCPQJVJAuKA9PXR9IOJUIxR4KR9EJVxLytFl6tqT816Lhsmxetw8PyBhWGnNe5lCmTzBy3UCnYKyS1nPpwGt53U9sdf3U22Jtv4H7wA+xnaWDPLqOkTzrt1MvRYPk8wKXs7p55KWMuU8/5ImwWphYwZevX2REpcXff7R4wO07P2J24Po0MMDzpdd6GhW07b1AHEIcsAKhCCnTH1s69A0jEzgb0Xh5UkP+BOaVluk3RHEPFPtj1TjrqucOyuZ7yyZ3L1VwK9XCeQwvoxqy3fQlFRvUMVDzOJZ1lB0aP9GGDygzfSzksE3nwPiiQisbJ8Qg/WC14YHbnq6J","cancellation_requested":false,"status":"completed","target":"https://vmcreatewinsecret7777.vault.azure.net/certificates/cert1","request_id":"1300919997cf49c7864050d35692b0b2"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1415']
+      Content-Length: ['1327']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:55:55 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -320,16 +316,16 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [407a6d24-f84e-11e6-9503-784f436a2ed2]
+      x-ms-client-request-id: [045e3d70-f945-11e6-bac4-24f49a5003ca]
     method: GET
-    uri: https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ584+xBAp+yQKAxA2vyXf85s2PpNQGnujMajqK5CufMgL53TmbugKB0OT2/aSP2dip8plc637sS0SojgyLZBAhBpwp0uxIkUFeAxmDcmg9LeuADpPgqSHTiQRsC1CFOyNwXcGtn7/nv+TZ7PReE6NM0yeskrHPPNU77QWkCpAYgpoC0E56NfJBp9qW+61SSGBwgv5d4U4VGwFehUNmkGOApWzgwzrvZCoZMj5u8EaMiVYOqF1jz8lc+FT0UryD5Apb6FZqJuBpGsRL+BOYW/qHAtgZoiwKX9Huq61+FmTCOnYsnYLo/R25CtWdYJq/k/9H/GLqcPAvt89K+n+84JcUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBvaihvfCSsEB6ADT9uwtrKtnQRJWtluYvHzQ2mpCo+uSRLWgSXpZDiiddKcoZVfXP9T6kvwUUq5PfaQhR5fjtzUzB6x/JG0w9nhXP4AetZDbvoMQjklH8cmgX4S4Vw3MzfD423yD+g5YfI3XkLnIUXyXcJbPN8dHb3rqBeRm5wj55+guax0/L1E3eeKDtCWFCJOWQRmNxR7Z5WHnvH9DsDD0bbE4fUUaf8lfz0c0iWcwp1yvDLYtAoaidoc23GtVEI+/BBWDLrFi2+kTHD09vjbSVl78Rnjl2Q6fwYAwvybgLy36ElDC8UyQAxY7oiejwvhQi0Q4+p3C94kEOuF2r4","cancellation_requested":false,"status":"completed","target":"https://vmcreatewinsecret005.vault.azure.net/certificates/cert1","request_id":"d5f3871eac834f65b3220b30131042b3"}'}
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/0725410b16b944a18b47703d4a02ec7e","managed":true,"attributes":{"enabled":false,"nbf":1487797935,"exp":1645564935,"created":1487798535,"updated":1487798535}},{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/b7a7028dfedb4af1b124197dd4144bdd","managed":true,"attributes":{"enabled":true,"nbf":1487797945,"exp":1645564945,"created":1487798545,"updated":1487798545}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1325']
+      Content-Length: ['548']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:07 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -348,27 +344,55 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [419a081a-f84e-11e6-bee9-784f436a2ed2]
+      x-ms-client-request-id: [04fada10-f945-11e6-a1a9-24f49a5003ca]
     method: GET
-    uri: https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/1a38241551d04ebdb59a466f76890353","managed":true,"attributes":{"enabled":false,"nbf":1487691944,"exp":1645458944,"created":1487692544,"updated":1487692544}},{"contentType":"application/x-pkcs12","id":"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2","managed":true,"attributes":{"enabled":true,"nbf":1487691955,"exp":1645458955,"created":1487692555,"updated":1487692555}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777","name":"vmcreatewinsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['546']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['282']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [054aefd0-f945-11e6-8cc9-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777","name":"vmcreatewinsecret7777","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatewinsecret7777.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.800]
+      content-length: ['753']
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -420,22 +444,22 @@ interactions:
       Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:33 GMT']
       ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
-      Expires: ['Tue, 21 Feb 2017 16:01:08 GMT']
-      Source-Age: ['251']
+      Expires: ['Wed, 22 Feb 2017 21:27:33 GMT']
+      Source-Age: ['0']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
       Via: [1.1 varnish]
-      X-Cache: [HIT]
-      X-Cache-Hits: ['1']
+      X-Cache: [MISS]
+      X-Cache-Hits: ['0']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [462a845799ede3febb58240c5b322dfb140e8615]
+      X-Fastly-Request-ID: [591f68bffa1023efa59e49585779dda133d7465b]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['5B5A:623E:5E76CB8:618E1F0:58AC621D']
-      X-Served-By: [cache-den6025-DEN]
-      X-Timer: ['S1487692568.432340,VS0,VE0']
+      X-GitHub-Request-Id: ['BF7C:623E:668550A:69E4552:58AE0119']
+      X-Served-By: [cache-den6026-DEN]
+      X-Timer: ['S1487798553.596422,VS0,VE62']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -446,9 +470,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [424aa30a-f84e-11e6-acdd-784f436a2ed2]
+      x-ms-client-request-id: [0668db98-f945-11e6-b5eb-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
@@ -456,7 +480,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:08 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -464,64 +488,64 @@ interactions:
       content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"template": {"contentVersion": "1.0.0.0", "parameters":
-      {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "outputs": {}, "resources": [{"location": "westus", "dependsOn":
-      [], "apiVersion": "2015-06-15", "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}, "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
-      "name": "vm-nameSubnet"}]}, "name": "vm-nameVNET", "tags": {}, "type": "Microsoft.Network/virtualNetworks"},
-      {"location": "westus", "dependsOn": [], "apiVersion": "2015-06-15", "properties":
-      {"securityRules": [{"properties": {"access": "Allow", "sourceAddressPrefix":
-      "*", "sourcePortRange": "*", "direction": "Inbound", "priority": 1000, "protocol":
-      "Tcp", "destinationAddressPrefix": "*", "destinationPortRange": "3389"}, "name":
-      "rdp"}]}, "name": "vm-nameNSG", "tags": {}, "type": "Microsoft.Network/networkSecurityGroups"},
-      {"location": "westus", "dependsOn": [], "name": "vm-namePublicIP", "properties":
-      {"publicIPAllocationMethod": "dynamic"}, "apiVersion": "2015-06-15", "tags":
-      {}, "type": "Microsoft.Network/publicIPAddresses"}, {"location": "westus", "dependsOn":
-      ["Microsoft.Network/virtualNetworks/vm-nameVNET", "Microsoft.Network/networkSecurityGroups/vm-nameNSG",
-      "Microsoft.Network/publicIpAddresses/vm-namePublicIP"], "name": "vm-nameVMNic",
-      "properties": {"ipConfigurations": [{"properties": {"privateIPAllocationMethod":
-      "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"},
+    body: '{"properties": {"mode": "Incremental", "template": {"contentVersion": "1.0.0.0",
+      "variables": {}, "outputs": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "properties": {"subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "vm-nameSubnet"}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "type": "Microsoft.Network/virtualNetworks", "location":
+      "westus", "apiVersion": "2015-06-15", "dependsOn": [], "name": "vm-nameVNET"},
+      {"tags": {}, "properties": {"securityRules": [{"properties": {"access": "Allow",
+      "sourcePortRange": "*", "sourceAddressPrefix": "*", "direction": "Inbound",
+      "priority": 1000, "protocol": "Tcp", "destinationPortRange": "3389", "destinationAddressPrefix":
+      "*"}, "name": "rdp"}]}, "type": "Microsoft.Network/networkSecurityGroups", "location":
+      "westus", "apiVersion": "2015-06-15", "dependsOn": [], "name": "vm-nameNSG"},
+      {"tags": {}, "properties": {"publicIPAllocationMethod": "dynamic"}, "type":
+      "Microsoft.Network/publicIPAddresses", "location": "westus", "apiVersion": "2015-06-15",
+      "dependsOn": [], "name": "vm-namePublicIP"}, {"tags": {}, "properties": {"ipConfigurations":
+      [{"properties": {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET/subnets/vm-nameSubnet"},
       "publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP"}},
       "name": "ipconfigvm-name"}], "networkSecurityGroup": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG"}},
-      "apiVersion": "2015-06-15", "tags": {}, "type": "Microsoft.Network/networkInterfaces"},
-      {"location": "westus", "dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
-      "name": "vm-name", "properties": {"storageProfile": {"osDisk": {"createOption":
-      "fromImage", "name": "osdisk_qN6muVZCMK", "caching": "ReadWrite", "managedDisk":
-      {"storageAccountType": "Premium_LRS"}}, "imageReference": {"version": "latest",
-      "sku": "2012-R2-Datacenter", "offer": "WindowsServer", "publisher": "MicrosoftWindowsServer"}},
-      "hardwareProfile": {"vmSize": "Standard_DS1"}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]},
-      "osProfile": {"adminPassword": "VerySecret!12", "computerName": "vm-name", "adminUsername":
-      "windowsUser", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005"},
-      "vaultCertificates": [{"certificateStore": "My", "certificateUrl": "https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2"}]}]}},
-      "apiVersion": "2016-04-30-preview", "tags": {}, "type": "Microsoft.Compute/virtualMachines"}]},
-      "parameters": {}, "mode": "Incremental"}}'
+      "type": "Microsoft.Network/networkInterfaces", "location": "westus", "apiVersion":
+      "2015-06-15", "dependsOn": ["Microsoft.Network/virtualNetworks/vm-nameVNET",
+      "Microsoft.Network/networkSecurityGroups/vm-nameNSG", "Microsoft.Network/publicIpAddresses/vm-namePublicIP"],
+      "name": "vm-nameVMNic"}, {"tags": {}, "properties": {"osProfile": {"computerName":
+      "vm-name", "adminPassword": "VerySecret!12", "adminUsername": "windowsUser",
+      "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777"},
+      "vaultCertificates": [{"certificateUrl": "https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/b7a7028dfedb4af1b124197dd4144bdd",
+      "certificateStore": "My"}]}]}, "storageProfile": {"osDisk": {"managedDisk":
+      {"storageAccountType": "Premium_LRS"}, "createOption": "fromImage", "caching":
+      "ReadWrite", "name": "osdisk_0y3k2fOHXe"}, "imageReference": {"offer": "WindowsServer",
+      "publisher": "MicrosoftWindowsServer", "version": "latest", "sku": "2012-R2-Datacenter"}},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic"}]}},
+      "type": "Microsoft.Compute/virtualMachines", "location": "westus", "apiVersion":
+      "2016-04-30-preview", "dependsOn": ["Microsoft.Network/networkInterfaces/vm-nameVMNic"],
+      "name": "vm-name"}], "parameters": {}}, "parameters": {}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3505']
+      Content-Length: ['3510']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","name":"vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","properties":{"templateHash":"11984531987702820250","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-21T15:56:10.2805532Z","duration":"PT0.7183912S","correlationId":"8eebe458-ceb7-454c-bc62-79b6bd67ffb1","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_ALYpeZOxMxPhwFETMCxIfrUQJhgPEM1X","name":"vm_deploy_ALYpeZOxMxPhwFETMCxIfrUQJhgPEM1X","properties":{"templateHash":"12275846392420725027","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-22T21:22:35.581462Z","duration":"PT0.765874S","correlationId":"181ad0df-e9f2-4767-bb40-600a10f9e4b6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB/operationStatuses/08587139143159155182?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_ALYpeZOxMxPhwFETMCxIfrUQJhgPEM1X/operationStatuses/08587138083306620728?api-version=2016-09-01']
       Cache-Control: [no-cache]
-      Content-Length: ['2505']
+      Content-Length: ['2503']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:09 GMT']
+      Date: ['Wed, 22 Feb 2017 21:22:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -532,17 +556,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:56:40 GMT']
+      Date: ['Wed, 22 Feb 2017 21:23:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -558,17 +582,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:57:10 GMT']
+      Date: ['Wed, 22 Feb 2017 21:23:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -584,17 +608,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:57:41 GMT']
+      Date: ['Wed, 22 Feb 2017 21:24:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -610,17 +634,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:58:10 GMT']
+      Date: ['Wed, 22 Feb 2017 21:24:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -636,17 +660,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:58:41 GMT']
+      Date: ['Wed, 22 Feb 2017 21:25:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -662,17 +686,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:59:11 GMT']
+      Date: ['Wed, 22 Feb 2017 21:25:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -688,95 +712,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 15:59:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:00:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:00:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587139143159155182?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138083306620728?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:14 GMT']
+      Date: ['Wed, 22 Feb 2017 21:26:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -792,17 +738,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [428ab512-f84e-11e6-9a93-784f436a2ed2]
+      x-ms-client-request-id: [068eda52-f945-11e6-908c-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","name":"vm_deploy_yHjYxnCnoyyHaj3vVgcStANqewQ7hdbB","properties":{"templateHash":"11984531987702820250","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-21T16:00:48.8915483Z","duration":"PT4M39.3293863S","correlationId":"8eebe458-ceb7-454c-bc62-79b6bd67ffb1","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Resources/deployments/vm_deploy_ALYpeZOxMxPhwFETMCxIfrUQJhgPEM1X","name":"vm_deploy_ALYpeZOxMxPhwFETMCxIfrUQJhgPEM1X","properties":{"templateHash":"12275846392420725027","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-22T21:26:16.8245777Z","duration":"PT3M42.0089897S","correlationId":"181ad0df-e9f2-4767-bb40-600a10f9e4b6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/virtualNetworks/vm-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm-nameNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIpAddresses/vm-namePublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vm-namePublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-nameVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-name"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-name"},{"id":"Microsoft.Network/networkInterfaces/vm-nameVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-nameNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-namePublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-nameVNET"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:14 GMT']
+      Date: ['Wed, 22 Feb 2017 21:26:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -817,28 +763,29 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f978bda8-f84e-11e6-aceb-784f436a2ed2]
+      x-ms-client-request-id: [8c74ddf4-f945-11e6-b716-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"06b59851-f9c6-49fc-9078-461cf8ca38c3\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"dd106a02-898d-48c5-91ad-78c7917e42d2\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
         \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk_qN6muVZCMK\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
+        \"osdisk_0y3k2fOHXe\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
         \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\":
-        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_qN6muVZCMK\"\r\n
+        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_0y3k2fOHXe\"\r\n
         \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
         {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"windowsUser\",\r\n
         \     \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n
         \       \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\":
-        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005\"\r\n
+        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777\"\r\n
         \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
-        \"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2\",\r\n
+        \"https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/b7a7028dfedb4af1b124197dd4144bdd\",\r\n
         \             \"certificateStore\": \"My\"\r\n            }\r\n          ]\r\n
         \       }\r\n      ]\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
@@ -846,10 +793,10 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2017-02-21T16:01:15+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2017-02-22T21:26:16+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
         \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"time\": \"2017-02-21T16:00:45.2512014+00:00\"\r\n
+        \"Provisioning succeeded\",\r\n          \"time\": \"2017-02-22T21:26:06.2106908+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
@@ -858,14 +805,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:15 GMT']
+      Date: ['Wed, 22 Feb 2017 21:26:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2893']
+      content-length: ['2898']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -875,19 +822,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9b0982e-f84e-11e6-b90b-784f436a2ed2]
+      x-ms-client-request-id: [8c90f75a-f945-11e6-bc07-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"vm-nameVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\",\r\n
-        \ \"etag\": \"W/\\\"c38ac5ce-48f2-47de-b643-975474f87439\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"46b92d5a-835e-4f2f-a599-cccb907b7674\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"603e6016-63ef-43bc-8aca-ea0c7a01ac45\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"0276c0f4-78e9-411a-b4eb-b22b44b8d15a\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-name\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\",\r\n
-        \       \"etag\": \"W/\\\"c38ac5ce-48f2-47de-b643-975474f87439\\\"\",\r\n
+        \       \"etag\": \"W/\\\"46b92d5a-835e-4f2f-a599-cccb907b7674\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
         \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\"\r\n
@@ -895,8 +842,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"f1d54ygcr4jutpoqdmcs4gh4sc.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-33-E4-61\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"mmuw4nntxzju5hgo05tj0iu5ig.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-36-0C-6C\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkSecurityGroups/vm-nameNSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -905,8 +852,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:15 GMT']
-      ETag: [W/"c38ac5ce-48f2-47de-b643-975474f87439"]
+      Date: ['Wed, 22 Feb 2017 21:26:18 GMT']
+      ETag: [W/"46b92d5a-835e-4f2f-a599-cccb907b7674"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -923,33 +870,33 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9e8fa5c-f84e-11e6-ba9f-784f436a2ed2]
+      x-ms-client-request-id: [8ca56df4-f945-11e6-9413-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"vm-namePublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/publicIPAddresses/vm-namePublicIP\",\r\n
-        \ \"etag\": \"W/\\\"00bfc86a-8bf2-459f-b928-7fdb780cb236\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ffc8b742-e51f-41e6-95e4-21f7cf7e8bb8\\\"\",\r\n  \"type\":
         \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"westus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"4e20d2bf-c489-4d19-bd83-a83c553df328\",\r\n    \"ipAddress\":
-        \"13.64.198.134\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \   \"resourceGuid\": \"68f1954e-dfd9-455c-aaba-5d72a10c14f1\",\r\n    \"ipAddress\":
+        \"40.86.185.86\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
         \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\":
         {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic/ipConfigurations/ipconfigvm-name\"\r\n
         \   }\r\n  }\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:16 GMT']
-      ETag: [W/"00bfc86a-8bf2-459f-b928-7fdb780cb236"]
+      Date: ['Wed, 22 Feb 2017 21:26:18 GMT']
+      ETag: [W/"ffc8b742-e51f-41e6-95e4-21f7cf7e8bb8"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['885']
+      content-length: ['884']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -959,28 +906,29 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [faacb1e8-f84e-11e6-8b49-784f436a2ed2]
+      x-ms-client-request-id: [8d4ebf40-f945-11e6-bd0e-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/virtualMachines/vm-name?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"06b59851-f9c6-49fc-9078-461cf8ca38c3\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n    },\r\n
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"dd106a02-898d-48c5-91ad-78c7917e42d2\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
         \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk_qN6muVZCMK\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
+        \"osdisk_0y3k2fOHXe\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\":
         \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\":
-        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_qN6muVZCMK\"\r\n
+        \"Premium_LRS\",\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Compute/disks/osdisk_0y3k2fOHXe\"\r\n
         \       }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
         {\r\n      \"computerName\": \"vm-name\",\r\n      \"adminUsername\": \"windowsUser\",\r\n
         \     \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n
         \       \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\":
-        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret005\"\r\n
+        [\r\n        {\r\n          \"sourceVault\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.KeyVault/vaults/vmcreatewinsecret7777\"\r\n
         \         },\r\n          \"vaultCertificates\": [\r\n            {\r\n              \"certificateUrl\":
-        \"https://vmcreatewinsecret005.vault.azure.net/secrets/cert1/ff0846a7d4864648b0e0d768e69877d2\",\r\n
+        \"https://vmcreatewinsecret7777.vault.azure.net/secrets/cert1/b7a7028dfedb4af1b124197dd4144bdd\",\r\n
         \             \"certificateStore\": \"My\"\r\n            }\r\n          ]\r\n
         \       }\r\n      ]\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_windows_secrets/providers/Microsoft.Network/networkInterfaces/vm-nameVMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
@@ -989,13 +937,13 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 21 Feb 2017 16:01:17 GMT']
+      Date: ['Wed, 22 Feb 2017 21:26:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2109']
+      content-length: ['2114']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_create_linux_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_create_linux_secrets.yaml
@@ -1,0 +1,733 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e12e1dda-f925-11e6-a96b-784f436a2ed2]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"David
+        Justice","facsimileTelephoneNumber":null,"givenName":"David","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"david_devigned.com#EXT#","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["david@devigned.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2014-05-21T18:21:24Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Justice","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/882b503c-c281-4fe9-a85c-d9e0cd66d376/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"david_devigned.com#EXT#@daviddevigned.onmicrosoft.com","userType":"Member"}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1377']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Wed, 22 Feb 2017 17:39:38 GMT']
+      Duration: ['537925']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [QOMoo8NjwimYpHGkqNG/c0nG4ec9dCHmWvHZLVnyejI=]
+      ocp-aad-session-key: [rb61AQAWR9lMXYjwFYQgQ4SKvPFjM-Y0WXMUi434ENFqiKpl1IaarOBNTGS-jWoOehWVYyrBMQmPvj7zLFz23QbNIvmXJ4fzfkACHtqEmKRrtfgUab5_wavrMUSRKcAB.Bm9oVI_p6nm6QcunrLaqxV7iQzLRYsAUVMemlMZrGFU]
+      request-id: [70053ca3-9b05-4fda-92a7-f7f65399e6ea]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"enabledForDeployment": true, "accessPolicies":
+      [{"permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}, "objectId":
+      "882b503c-c281-4fe9-a85c-d9e0cd66d376", "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}],
+      "enabledForTemplateDeployment": true, "sku": {"family": "A", "name": "standard"},
+      "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['476']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e159eb4a-f925-11e6-8cf7-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003","name":"vmcreatelinuxsecret003","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret003.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:39:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['755']
+      x-ms-keyvault-service-version: [1.0.0.151]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "issuer": {"name": "Self"}, "x509_props": {"subject": "C=US, ST=WA, L=Redmon,
+      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60,
+      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"]}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
+      "action": {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
+      "key_props": {"kty": "RSA", "key_size": 2048, "exportable": true, "reuse_key":
+      false}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e42b9f50-f925-11e6-9a06-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 22 Feb 2017 17:39:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/9148c3a5-1e1b-4e0a-87c2-302229534991",
+          resource="https://vault.azure.net"']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "issuer": {"name": "Self"}, "x509_props": {"subject": "C=US, ST=WA, L=Redmon,
+      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60,
+      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"]}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
+      "action": {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
+      "key_props": {"kty": "RSA", "key_size": 2048, "exportable": true, "reuse_key":
+      false}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['587']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e42b9f50-f925-11e6-9a06-784f436a2ed2]
+    method: POST
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:39:49 GMT']
+      Expires: ['-1']
+      Location: ['https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=9e35499cf8b944b2817a53354cb12610']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e7aa42da-f925-11e6-ba37-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:39:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [edca5786-f925-11e6-8c08-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1417']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f47a16a8-f925-11e6-8470-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1329']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f859c9be-f925-11e6-a4a6-784f436a2ed2]
+    method: GET
+    uri: https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/b739214d38774c8aa564d3b20d159e0f","managed":true,"attributes":{"enabled":false,"nbf":1487784587,"exp":1645551587,"created":1487785188,"updated":1487785188}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5","managed":true,"attributes":{"enabled":true,"nbf":1487784605,"exp":1645551605,"created":1487785205,"updated":1487785205}}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['550']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa69ac92-f925-11e6-b32d-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets","name":"cli_test_vmss_create_linux_secrets","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['258']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [raw.githubusercontent.com]
+      User-Agent: [Python-urllib/3.5]
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\":{},\n
+        \ \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"metadata\":{\n
+        \       \"description\":\"This list of aliases is used by Azure XPLAT CLI,
+        Azure Powershell, and Azure Portal as shorthands for commonly used VM images.
+        If you change this file, please verify that this doesn't break VMSS creation
+        from Portal :).\"\n      },\n      \"type\":\"object\",\n      \"value\":{\n\n
+        \       \"Linux\":{\n          \"CentOS\":{\n            \"publisher\":\"OpenLogic\",\n
+        \           \"offer\":\"CentOS\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"CoreOS\":{\n            \"publisher\":\"CoreOS\",\n
+        \           \"offer\":\"CoreOS\",\n            \"sku\":\"Stable\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Debian\":{\n            \"publisher\":\"credativ\",\n
+        \           \"offer\":\"Debian\",\n            \"sku\":\"8\",\n            \"version\":\"latest\"\n
+        \         },\n          \"openSUSE\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"openSUSE\",\n            \"sku\":\"13.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"RHEL\":{\n            \"publisher\":\"RedHat\",\n
+        \           \"offer\":\"RHEL\",\n            \"sku\":\"7.2\",\n            \"version\":\"latest\"\n
+        \         },\n          \"SLES\":{\n            \"publisher\":\"SUSE\",\n
+        \           \"offer\":\"SLES\",\n            \"sku\":\"12-SP1\",\n            \"version\":\"latest\"\n
+        \         },\n          \"UbuntuLTS\":{\n            \"publisher\":\"Canonical\",\n
+        \           \"offer\":\"UbuntuServer\",\n            \"sku\":\"14.04.4-LTS\",\n
+        \           \"version\":\"latest\"\n          }\n        },\n\n        \"Windows\":{\n
+        \         \"Win2016Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2016-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2012R2Datacenter\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2012-R2-Datacenter\",\n            \"version\":\"latest\"\n
+        \         },\n          \"Win2012Datacenter\":{\n            \"publisher\":\"MicrosoftWindowsServer\",\n
+        \           \"offer\":\"WindowsServer\",\n            \"sku\":\"2012-Datacenter\",\n
+        \           \"version\":\"latest\"\n          },\n          \"Win2008R2SP1\":{\n
+        \           \"publisher\":\"MicrosoftWindowsServer\",\n            \"offer\":\"WindowsServer\",\n
+        \           \"sku\":\"2008-R2-SP1\",\n            \"version\":\"latest\"\n
+        \         }\n        }\n      }\n    }\n  }\n}\n"}
+    headers:
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2497']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
+      Expires: ['Wed, 22 Feb 2017 17:45:20 GMT']
+      Source-Age: ['0']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [MISS]
+      X-Cache-Hits: ['0']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [75de489281e018cd159c958bd7263cb1a9b3e81e]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['2984:6242:17F3047:18D2070:58ADCD04']
+      X-Served-By: [cache-den6026-DEN]
+      X-Timer: ['S1487785220.742797,VS0,VE60']
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fab97bb6-f925-11e6-b2e1-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"mode": "Incremental", "parameters": {}, "template": {"$schema":
+      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(''Microsoft.Compute/virtualMachineScaleSets'',
+      ''vmss1-name''),providers(''Microsoft.Compute'', ''virtualMachineScaleSets'').apiVersions[0])]"}},
+      "parameters": {}, "variables": {"vhdContainers": ["[concat(''https://'', variables(''storageAccountNames'')[0],
+      ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[1],
+      ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[2],
+      ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[3],
+      ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[4],
+      ''.blob.core.windows.net/vhds'')]"], "storageAccountNames": ["vmss14a2h0", "vmss14a2h1",
+      "vmss14a2h2", "vmss14a2h3", "vmss14a2h4"]}, "resources": [{"location": "westus",
+      "dependsOn": [], "apiVersion": "2015-06-15", "type": "Microsoft.Network/virtualNetworks",
+      "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets":
+      [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vmss1-nameSubnet"}]},
+      "name": "vmss1-nameVNET", "tags": {}}, {"location": "westus", "dependsOn": [],
+      "apiVersion": "2015-06-15", "type": "Microsoft.Network/publicIPAddresses", "properties":
+      {"publicIPAllocationMethod": "dynamic"}, "name": "vmss1-nameLBPublicIP", "tags":
+      {}}, {"location": "westus", "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP"],
+      "apiVersion": "2015-06-15", "type": "Microsoft.Network/loadBalancers", "properties":
+      {"inboundNatPools": [{"properties": {"frontendIPConfiguration": {"id": "[concat(resourceId(''Microsoft.Network/loadBalancers'',
+      ''vmss1-nameLB''), ''/frontendIPConfigurations/'', ''loadBalancerFrontEnd'')]"},
+      "frontendPortRangeStart": "50000", "protocol": "tcp", "frontendPortRangeEnd":
+      "50119", "backendPort": 22}, "name": "vmss1-nameLBNatPool"}], "backendAddressPools":
+      [{"name": "vmss1-nameLBBEPool"}], "frontendIPConfigurations": [{"properties":
+      {"publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}]}, "name": "vmss1-nameLB", "tags": {}}, {"location":
+      "westus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1-nameVNET",
+      "Microsoft.Network/loadBalancers/vmss1-nameLB"], "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/virtualMachineScaleSets", "tags": {}, "sku": {"tier":
+      "Standard", "capacity": 2, "name": "Standard_D1_v2"}, "name": "vmss1-name",
+      "properties": {"singlePlacementGroup": true, "overprovision": true, "upgradePolicy":
+      {"mode": "Manual"}, "virtualMachineProfile": {"osProfile": {"adminUsername":
+      "deploy", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003"},
+      "vaultCertificates": [{"certificateUrl": "https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5"}]}],
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\n", "path": "/home/deploy/.ssh/authorized_keys"}]}}, "computerNamePrefix":
+      "vmss14a2h"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
+      {"primary": "true", "ipConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool"}],
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}]},
+      "name": "vmss14a2hIPConfig"}]}, "name": "vmss14a2hNic"}]}, "storageProfile":
+      {"osDisk": {"caching": "ReadOnly", "createOption": "FromImage", "managedDisk":
+      {"storageAccountType": "Standard_LRS"}}, "imageReference": {"version": "latest",
+      "sku": "8", "publisher": "credativ", "offer": "Debian"}}}}}], "contentVersion":
+      "1.0.0.0"}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['5368']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","name":"vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","properties":{"templateHash":"12339123050858757016","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-22T17:40:22.1818239Z","duration":"PT0.611763S","correlationId":"4bc32cd5-d185-4296-872b-ffd5a8c37ee0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y/operationStatuses/08587138216639076007?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2207']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:40:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:41:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:41:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:42:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:42:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","name":"vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","properties":{"templateHash":"12339123050858757016","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-22T17:42:35.7727917Z","duration":"PT2M14.2027308S","correlationId":"4bc32cd5-d185-4296-872b-ffd5a8c37ee0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss14a2h","adminUsername":"deploy","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/deploy/.ssh/authorized_keys","keyData":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+        test@example.com\n"}]}},"secrets":[{"sourceVault":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003"},"vaultCertificates":[{"certificateUrl":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5"}]}]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadOnly","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss14a2hNic","properties":{"primary":true,"ipConfigurations":[{"name":"vmss14a2hIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"},"loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2"}}},"outputResources":[{"id":"Microsoft.Compute/virtualMachineScaleSets/vmss1-name"},{"id":"Microsoft.Network/loadBalancers/vmss1-nameLB"},{"id":"Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"},{"id":"Microsoft.Network/virtualNetworks/vmss1-nameVNET"}]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:42:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['5095']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [620fd4ca-f926-11e6-a392-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\"\r\n    },\r\n
+        \   \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\":
+        \"vmss14a2h\",\r\n        \"adminUsername\": \"deploy\",\r\n        \"linuxConfiguration\":
+        {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\":
+        {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\":
+        \"/home/deploy/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+        test@example.com\\n\"\r\n              }\r\n            ]\r\n          }\r\n
+        \       },\r\n        \"secrets\": [\r\n          {\r\n            \"sourceVault\":
+        {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003\"\r\n
+        \           },\r\n            \"vaultCertificates\": [\r\n              {\r\n
+        \               \"certificateUrl\": \"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5\"\r\n
+        \             }\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\":
+        \"FromImage\",\r\n          \"caching\": \"ReadOnly\",\r\n          \"managedDisk\":
+        {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n
+        \       },\r\n        \"imageReference\": {\r\n          \"publisher\": \"credativ\",\r\n
+        \         \"offer\": \"Debian\",\r\n          \"sku\": \"8\",\r\n          \"version\":
+        \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss14a2hNic\",\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss14a2hIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet\"},\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool\"}]}}]}}]}\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
+        true,\r\n    \"uniqueId\": \"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name\",\r\n
+        \ \"name\": \"vmss1-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:43:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['3617']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [68c8e638-f926-11e6-8911-784f436a2ed2]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
+        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
+        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\"\r\n    },\r\n
+        \   \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\":
+        \"vmss14a2h\",\r\n        \"adminUsername\": \"deploy\",\r\n        \"linuxConfiguration\":
+        {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\":
+        {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\":
+        \"/home/deploy/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+        test@example.com\\n\"\r\n              }\r\n            ]\r\n          }\r\n
+        \       },\r\n        \"secrets\": [\r\n          {\r\n            \"sourceVault\":
+        {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003\"\r\n
+        \           },\r\n            \"vaultCertificates\": [\r\n              {\r\n
+        \               \"certificateUrl\": \"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5\"\r\n
+        \             }\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\":
+        \"FromImage\",\r\n          \"caching\": \"ReadOnly\",\r\n          \"managedDisk\":
+        {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n
+        \       },\r\n        \"imageReference\": {\r\n          \"publisher\": \"credativ\",\r\n
+        \         \"offer\": \"Debian\",\r\n          \"sku\": \"8\",\r\n          \"version\":
+        \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss14a2hNic\",\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss14a2hIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet\"},\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool\"}]}}]}}]}\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
+        true,\r\n    \"uniqueId\": \"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
+        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name\",\r\n
+        \ \"name\": \"vmss1-name\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 17:43:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['3617']
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_create_linux_secrets.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_create_linux_secrets.yaml
@@ -9,7 +9,7 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e12e1dda-f925-11e6-a96b-784f436a2ed2]
+      x-ms-client-request-id: [d3bc8d08-f945-11e6-a08f-24f49a5003ca]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
@@ -21,25 +21,26 @@ interactions:
       Content-Length: ['1377']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 22 Feb 2017 17:39:38 GMT']
-      Duration: ['537925']
+      Date: ['Wed, 22 Feb 2017 21:28:17 GMT']
+      Duration: ['2159969']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [QOMoo8NjwimYpHGkqNG/c0nG4ec9dCHmWvHZLVnyejI=]
-      ocp-aad-session-key: [rb61AQAWR9lMXYjwFYQgQ4SKvPFjM-Y0WXMUi434ENFqiKpl1IaarOBNTGS-jWoOehWVYyrBMQmPvj7zLFz23QbNIvmXJ4fzfkACHtqEmKRrtfgUab5_wavrMUSRKcAB.Bm9oVI_p6nm6QcunrLaqxV7iQzLRYsAUVMemlMZrGFU]
-      request-id: [70053ca3-9b05-4fda-92a7-f7f65399e6ea]
+      ocp-aad-diagnostics-server-name: [C6wUGxPx6EyCvip7rXtseehyCnwl+vm9NBkEKCUjowE=]
+      ocp-aad-session-key: [Lf9Ph82sUNsQTy58xLTOsBkE-sLXXaTBRKw36zYJ-b8Qv5J3-EXlIjSCX8iPNwdn129MCZklWkndrypeD9q2LhGTXS1-ROEtvG4dYVuqiA_KMc0VbqTaNM9b51JFC6sk.U1snpTun9g2BEM7mjlvJ9yxBdfNNtCk0m1WGtf-U8zU]
+      request-id: [d132735a-1b34-4a3d-afb7-46ba1a8c9058]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"enabledForDeployment": true, "accessPolicies":
-      [{"permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}, "objectId":
-      "882b503c-c281-4fe9-a85c-d9e0cd66d376", "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}],
-      "enabledForTemplateDeployment": true, "sku": {"family": "A", "name": "standard"},
-      "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
+    body: '{"location": "westus", "properties": {"enabledForTemplateDeployment": true,
+      "accessPolicies": [{"objectId": "882b503c-c281-4fe9-a85c-d9e0cd66d376", "permissions":
+      {"keys": ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["all"]}, "tenantId": "9148c3a5-1e1b-4e0a-87c2-302229534991"}],
+      "enabledForDeployment": true, "sku": {"family": "A", "name": "standard"}, "tenantId":
+      "9148c3a5-1e1b-4e0a-87c2-302229534991"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -48,17 +49,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e159eb4a-f925-11e6-8cf7-784f436a2ed2]
+      x-ms-client-request-id: [d40189c6-f945-11e6-81c5-24f49a5003ca]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003?api-version=2015-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003","name":"vmcreatelinuxsecret003","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret003.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333","name":"vmcreatelinuxsecret3333","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret3333.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:39:39 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -68,19 +69,18 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['755']
+      content-length: ['758']
       x-ms-keyvault-service-version: [1.0.0.151]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
-      true}, "issuer": {"name": "Self"}, "x509_props": {"subject": "C=US, ST=WA, L=Redmon,
-      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60,
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
-      "action": {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
-      "key_props": {"kty": "RSA", "key_size": 2048, "exportable": true, "reuse_key":
-      false}}}'
+      true}, "secret_props": {"contentType": "application/x-pkcs12"}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}], "issuer": {"name": "Self"}, "x509_props": {"validity_months": 60, "key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -90,15 +90,15 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e42b9f50-f925-11e6-9a06-784f436a2ed2]
+      x-ms-client-request-id: [d5e30d9c-f945-11e6-8dc3-24f49a5003ca]
     method: POST
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 17:39:49 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -113,13 +113,12 @@ interactions:
     status: {code: 401, message: Unauthorized}
 - request:
     body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
-      true}, "issuer": {"name": "Self"}, "x509_props": {"subject": "C=US, ST=WA, L=Redmon,
-      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60,
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"]}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90},
-      "action": {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
-      "key_props": {"kty": "RSA", "key_size": 2048, "exportable": true, "reuse_key":
-      false}}}'
+      true}, "secret_props": {"contentType": "application/x-pkcs12"}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "lifetime_actions":
+      [{"action": {"action_type": "AutoRenew"}, "trigger": {"lifetime_percentage":
+      90}}], "issuer": {"name": "Self"}, "x509_props": {"validity_months": 60, "key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -129,20 +128,20 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e42b9f50-f925-11e6-9a06-784f436a2ed2]
+      x-ms-client-request-id: [d5e30d9c-f945-11e6-8dc3-24f49a5003ca]
     method: POST
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPP9yOej/UusL1eGRK3eoOjQ0vpuUzSlNr7QWxvI9U95s713tfFAD5XWozb0VMeQKC5WprSNGgGmV8BbcCyxFjOp3xQPh1H/IlcR76su9z6MoC4n7hCkfOHEufGCIQvyLbAnecvF24nvbWrkX17SUrEyPI5UU+TAOxAajgVEgrHYInSlBGXCQxlVGXf8tLv1LwpEDcLhd2hV8MJ/y+4fVYUU3qwh0Vr8cCu/F0eQFKj4HsI5ATxvZhk/jN0SX2gf5t6wpiGZa5IcE082K+Ot6g6fsC6NRipiyqTlP1I3aFb9y6xChBQPg5C663mAfx7Ti2w1iz+yD65dlsyxDy95OuUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB2x/Eqo95Q2eNQL/KuXdM3SdsOwWRD3j0dLXE2EEiXch2tlpLB0XmljaRN+wtqIfeoCYaDfsdz+dpGrlpYYCY+K63G/f0TW2yiPEWQ27WePWUkyxd01xUuRmF2YEWzLGvTsb+bCSksYPypFpFzMBXGJNAyX6AY4kJ6Ot5rTx4UJBqNDOE3S0SUKsamnLDnBmNsVzone29RdknBeCqjOKpfwtCmcw43NH1ZW5iDgq82vi1WalQ6To1AY+4A/40Fsy5iu6KB/o343kuOb8oT6nS77XlzX9QaXsx+LNFu3zaIf3KJQSSXv5v0gUynFanFcTV4M40idnP2tBED+fLLvJfW","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+        time based on the issuer provider. Please check again later.","request_id":"7f70f1426a3445cb9c0096c23c411489"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:39:49 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:23 GMT']
       Expires: ['-1']
-      Location: ['https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=9e35499cf8b944b2817a53354cb12610']
+      Location: ['https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=7f70f1426a3445cb9c0096c23c411489']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -162,18 +161,18 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e7aa42da-f925-11e6-ba37-784f436a2ed2]
+      x-ms-client-request-id: [d6a62234-f945-11e6-9065-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPP9yOej/UusL1eGRK3eoOjQ0vpuUzSlNr7QWxvI9U95s713tfFAD5XWozb0VMeQKC5WprSNGgGmV8BbcCyxFjOp3xQPh1H/IlcR76su9z6MoC4n7hCkfOHEufGCIQvyLbAnecvF24nvbWrkX17SUrEyPI5UU+TAOxAajgVEgrHYInSlBGXCQxlVGXf8tLv1LwpEDcLhd2hV8MJ/y+4fVYUU3qwh0Vr8cCu/F0eQFKj4HsI5ATxvZhk/jN0SX2gf5t6wpiGZa5IcE082K+Ot6g6fsC6NRipiyqTlP1I3aFb9y6xChBQPg5C663mAfx7Ti2w1iz+yD65dlsyxDy95OuUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB2x/Eqo95Q2eNQL/KuXdM3SdsOwWRD3j0dLXE2EEiXch2tlpLB0XmljaRN+wtqIfeoCYaDfsdz+dpGrlpYYCY+K63G/f0TW2yiPEWQ27WePWUkyxd01xUuRmF2YEWzLGvTsb+bCSksYPypFpFzMBXGJNAyX6AY4kJ6Ot5rTx4UJBqNDOE3S0SUKsamnLDnBmNsVzone29RdknBeCqjOKpfwtCmcw43NH1ZW5iDgq82vi1WalQ6To1AY+4A/40Fsy5iu6KB/o343kuOb8oT6nS77XlzX9QaXsx+LNFu3zaIf3KJQSSXv5v0gUynFanFcTV4M40idnP2tBED+fLLvJfW","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+        time based on the issuer provider. Please check again later.","request_id":"7f70f1426a3445cb9c0096c23c411489"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:39:50 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -194,18 +193,18 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [edca5786-f925-11e6-8c08-784f436a2ed2]
+      x-ms-client-request-id: [dcb30b88-f945-11e6-b4bd-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPP9yOej/UusL1eGRK3eoOjQ0vpuUzSlNr7QWxvI9U95s713tfFAD5XWozb0VMeQKC5WprSNGgGmV8BbcCyxFjOp3xQPh1H/IlcR76su9z6MoC4n7hCkfOHEufGCIQvyLbAnecvF24nvbWrkX17SUrEyPI5UU+TAOxAajgVEgrHYInSlBGXCQxlVGXf8tLv1LwpEDcLhd2hV8MJ/y+4fVYUU3qwh0Vr8cCu/F0eQFKj4HsI5ATxvZhk/jN0SX2gf5t6wpiGZa5IcE082K+Ot6g6fsC6NRipiyqTlP1I3aFb9y6xChBQPg5C663mAfx7Ti2w1iz+yD65dlsyxDy95OuUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB2x/Eqo95Q2eNQL/KuXdM3SdsOwWRD3j0dLXE2EEiXch2tlpLB0XmljaRN+wtqIfeoCYaDfsdz+dpGrlpYYCY+K63G/f0TW2yiPEWQ27WePWUkyxd01xUuRmF2YEWzLGvTsb+bCSksYPypFpFzMBXGJNAyX6AY4kJ6Ot5rTx4UJBqNDOE3S0SUKsamnLDnBmNsVzone29RdknBeCqjOKpfwtCmcw43NH1ZW5iDgq82vi1WalQ6To1AY+4A/40Fsy5iu6KB/o343kuOb8oT6nS77XlzX9QaXsx+LNFu3zaIf3KJQSSXv5v0gUynFanFcTV4M40idnP2tBED+fLLvJfW","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+        time based on the issuer provider. Please check again later.","request_id":"7f70f1426a3445cb9c0096c23c411489"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1417']
+      Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:01 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -226,16 +225,16 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f47a16a8-f925-11e6-8470-784f436a2ed2]
+      x-ms-client-request-id: [e2c754de-f945-11e6-9a3e-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALabExHz9nXRBV5D2uAmXBHVFpn6BV/3lfMWJj6gIguqWyez5npiobXt52nJ+khARvHj77j4kOKBoNnhaurtWxkfT3sg8G9b3RXFG/fSxaQRyLwQOdJzYBa+ftcei83em9GVzWUWaoEtMBsywlb2hFObvI3Ebvjy7TfVe6c/d04jLREASOjPKU6XJ2d/2Jui0tnRazQzUKnKpY4GNzjuZM7oG8lF0duvKhY67JT/KL+hskaNc5WhehNNd8UC0NXo31aUpcqPyxFiOTqB9NWWWolxEhUy3EgqdFT3w5eZpZOCs7bXXTpf5ois9cFlHa7Q6iTXWBkkaohsYPkZ/IG1GCUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRMsy4gbpvR5VyJ/pHylbzU/IJ0U75S3IGfAXZ77RcQvsySBnNufvs8VsHHAFVVtutVrWMSxTIaSJ4PJmR5XQ50ivxs4ZP9OB4lzaRzpQh6bATUZZZGDG6GZ/7yOeC4HepO+BYLiGlynYOslnPD+L/w6hICggBGlXe+7DiE9rA5QonH0Q2Xi3mYW0ChJIAjnEMoAQMsK0rrtYhzSpfrFgf76DBZeI7WBuUha5jOw4fHj2vBtEeDQFKKKUjMEcTVgzl2DskNSPLud0WxAKHQBi3G7GknWWZ24XIsZfRaAb5xzPy2Bef0ei38dbjwaiFfJvUMgfiQbEE7ef52RshB2TI","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret003.vault.azure.net/certificates/cert1","request_id":"9e35499cf8b944b2817a53354cb12610"}'}
+    body: {string: '{"id":"https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPP9yOej/UusL1eGRK3eoOjQ0vpuUzSlNr7QWxvI9U95s713tfFAD5XWozb0VMeQKC5WprSNGgGmV8BbcCyxFjOp3xQPh1H/IlcR76su9z6MoC4n7hCkfOHEufGCIQvyLbAnecvF24nvbWrkX17SUrEyPI5UU+TAOxAajgVEgrHYInSlBGXCQxlVGXf8tLv1LwpEDcLhd2hV8MJ/y+4fVYUU3qwh0Vr8cCu/F0eQFKj4HsI5ATxvZhk/jN0SX2gf5t6wpiGZa5IcE082K+Ot6g6fsC6NRipiyqTlP1I3aFb9y6xChBQPg5C663mAfx7Ti2w1iz+yD65dlsyxDy95OuUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB2x/Eqo95Q2eNQL/KuXdM3SdsOwWRD3j0dLXE2EEiXch2tlpLB0XmljaRN+wtqIfeoCYaDfsdz+dpGrlpYYCY+K63G/f0TW2yiPEWQ27WePWUkyxd01xUuRmF2YEWzLGvTsb+bCSksYPypFpFzMBXGJNAyX6AY4kJ6Ot5rTx4UJBqNDOE3S0SUKsamnLDnBmNsVzone29RdknBeCqjOKpfwtCmcw43NH1ZW5iDgq82vi1WalQ6To1AY+4A/40Fsy5iu6KB/o343kuOb8oT6nS77XlzX9QaXsx+LNFu3zaIf3KJQSSXv5v0gUynFanFcTV4M40idnP2tBED+fLLvJfW","cancellation_requested":false,"status":"completed","target":"https://vmcreatelinuxsecret3333.vault.azure.net/certificates/cert1","request_id":"7f70f1426a3445cb9c0096c23c411489"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['1329']
+      Content-Length: ['1331']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:11 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -256,16 +255,16 @@ interactions:
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f859c9be-f925-11e6-a4a6-784f436a2ed2]
+      x-ms-client-request-id: [e39e833e-f945-11e6-b360-24f49a5003ca]
     method: GET
-    uri: https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
+    uri: https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/b739214d38774c8aa564d3b20d159e0f","managed":true,"attributes":{"enabled":false,"nbf":1487784587,"exp":1645551587,"created":1487785188,"updated":1487785188}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5","managed":true,"attributes":{"enabled":true,"nbf":1487784605,"exp":1645551605,"created":1487785205,"updated":1487785205}}],"nextLink":null}'}
+    body: {string: '{"value":[{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/52bc666854c044c996a82ce6482a1cd1","managed":true,"attributes":{"enabled":false,"nbf":1487798303,"exp":1645565303,"created":1487798904,"updated":1487798904}},{"contentType":"application/x-pkcs12","id":"https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/8ce387980c8d4d1e9b8d8980dff93f92","managed":true,"attributes":{"enabled":true,"nbf":1487798316,"exp":1645565316,"created":1487798917,"updated":1487798917}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['550']
+      Content-Length: ['552']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:15 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -275,6 +274,64 @@ interactions:
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
       x-ms-keyvault-service-version: [1.0.0.800]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e49566fe-f945-11e6-9a5d-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333","name":"vmcreatelinuxsecret3333","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:28:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['286']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e4be6750-f945-11e6-a718-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333","name":"vmcreatelinuxsecret3333","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","accessPolicies":[{"tenantId":"9148c3a5-1e1b-4e0a-87c2-302229534991","objectId":"882b503c-c281-4fe9-a85c-d9e0cd66d376","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://vmcreatelinuxsecret3333.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:28:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['759']
+      x-ms-keyvault-service-version: [1.0.0.151]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -285,9 +342,9 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa69ac92-f925-11e6-b32d-784f436a2ed2]
+      x-ms-client-request-id: [e5a3a612-f945-11e6-a5e9-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets?api-version=2016-09-01
   response:
@@ -295,7 +352,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -352,9 +409,9 @@ interactions:
       Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:52 GMT']
       ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
-      Expires: ['Wed, 22 Feb 2017 17:45:20 GMT']
+      Expires: ['Wed, 22 Feb 2017 21:33:52 GMT']
       Source-Age: ['0']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
@@ -362,12 +419,12 @@ interactions:
       X-Cache: [MISS]
       X-Cache-Hits: ['0']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [75de489281e018cd159c958bd7263cb1a9b3e81e]
+      X-Fastly-Request-ID: [5ba540b25e853b445e53391f70797e0ac46096ff]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['2984:6242:17F3047:18D2070:58ADCD04']
-      X-Served-By: [cache-den6026-DEN]
-      X-Timer: ['S1487785220.742797,VS0,VE60']
+      X-GitHub-Request-Id: ['C54C:6244:422D0D3:4464169:58AE0294']
+      X-Served-By: [cache-sjc3135-SJC]
+      X-Timer: ['S1487798932.396475,VS0,VE91']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -378,9 +435,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fab97bb6-f925-11e6-b2e1-784f436a2ed2]
+      x-ms-client-request-id: [e834fd0c-f945-11e6-84ac-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
@@ -388,7 +445,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:20 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -396,73 +453,72 @@ interactions:
       content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"mode": "Incremental", "parameters": {}, "template": {"$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(''Microsoft.Compute/virtualMachineScaleSets'',
-      ''vmss1-name''),providers(''Microsoft.Compute'', ''virtualMachineScaleSets'').apiVersions[0])]"}},
-      "parameters": {}, "variables": {"vhdContainers": ["[concat(''https://'', variables(''storageAccountNames'')[0],
+    body: '{"properties": {"mode": "Incremental", "template": {"contentVersion": "1.0.0.0",
+      "variables": {"vhdContainers": ["[concat(''https://'', variables(''storageAccountNames'')[0],
       ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[1],
       ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[2],
       ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[3],
       ''.blob.core.windows.net/vhds'')]", "[concat(''https://'', variables(''storageAccountNames'')[4],
-      ''.blob.core.windows.net/vhds'')]"], "storageAccountNames": ["vmss14a2h0", "vmss14a2h1",
-      "vmss14a2h2", "vmss14a2h3", "vmss14a2h4"]}, "resources": [{"location": "westus",
-      "dependsOn": [], "apiVersion": "2015-06-15", "type": "Microsoft.Network/virtualNetworks",
-      "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets":
-      [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vmss1-nameSubnet"}]},
-      "name": "vmss1-nameVNET", "tags": {}}, {"location": "westus", "dependsOn": [],
-      "apiVersion": "2015-06-15", "type": "Microsoft.Network/publicIPAddresses", "properties":
-      {"publicIPAllocationMethod": "dynamic"}, "name": "vmss1-nameLBPublicIP", "tags":
-      {}}, {"location": "westus", "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP"],
-      "apiVersion": "2015-06-15", "type": "Microsoft.Network/loadBalancers", "properties":
-      {"inboundNatPools": [{"properties": {"frontendIPConfiguration": {"id": "[concat(resourceId(''Microsoft.Network/loadBalancers'',
-      ''vmss1-nameLB''), ''/frontendIPConfigurations/'', ''loadBalancerFrontEnd'')]"},
-      "frontendPortRangeStart": "50000", "protocol": "tcp", "frontendPortRangeEnd":
-      "50119", "backendPort": 22}, "name": "vmss1-nameLBNatPool"}], "backendAddressPools":
-      [{"name": "vmss1-nameLBBEPool"}], "frontendIPConfigurations": [{"properties":
-      {"publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}]}, "name": "vmss1-nameLB", "tags": {}}, {"location":
-      "westus", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1-nameVNET",
-      "Microsoft.Network/loadBalancers/vmss1-nameLB"], "apiVersion": "2016-04-30-preview",
-      "type": "Microsoft.Compute/virtualMachineScaleSets", "tags": {}, "sku": {"tier":
-      "Standard", "capacity": 2, "name": "Standard_D1_v2"}, "name": "vmss1-name",
-      "properties": {"singlePlacementGroup": true, "overprovision": true, "upgradePolicy":
-      {"mode": "Manual"}, "virtualMachineProfile": {"osProfile": {"adminUsername":
-      "deploy", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003"},
-      "vaultCertificates": [{"certificateUrl": "https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5"}]}],
-      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
-      [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\n", "path": "/home/deploy/.ssh/authorized_keys"}]}}, "computerNamePrefix":
-      "vmss14a2h"}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"primary": "true", "ipConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"},
+      ''.blob.core.windows.net/vhds'')]"], "storageAccountNames": ["vmss1hiti0", "vmss1hiti1",
+      "vmss1hiti2", "vmss1hiti3", "vmss1hiti4"]}, "outputs": {"VMSS": {"value": "[reference(resourceId(''Microsoft.Compute/virtualMachineScaleSets'',
+      ''vmss1-name''),providers(''Microsoft.Compute'', ''virtualMachineScaleSets'').apiVersions[0])]",
+      "type": "object"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "properties": {"subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "vmss1-nameSubnet"}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "type": "Microsoft.Network/virtualNetworks", "location":
+      "westus", "apiVersion": "2015-06-15", "dependsOn": [], "name": "vmss1-nameVNET"},
+      {"tags": {}, "properties": {"publicIPAllocationMethod": "dynamic"}, "type":
+      "Microsoft.Network/publicIPAddresses", "location": "westus", "apiVersion": "2015-06-15",
+      "dependsOn": [], "name": "vmss1-nameLBPublicIP"}, {"tags": {}, "properties":
+      {"backendAddressPools": [{"name": "vmss1-nameLBBEPool"}], "frontendIPConfigurations":
+      [{"properties": {"publicIPAddress": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendIPConfiguration":
+      {"id": "[concat(resourceId(''Microsoft.Network/loadBalancers'', ''vmss1-nameLB''),
+      ''/frontendIPConfigurations/'', ''loadBalancerFrontEnd'')]"}, "frontendPortRangeStart":
+      "50000", "protocol": "tcp", "frontendPortRangeEnd": "50119", "backendPort":
+      22}, "name": "vmss1-nameLBNatPool"}]}, "type": "Microsoft.Network/loadBalancers",
+      "location": "westus", "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP"],
+      "name": "vmss1-nameLB"}, {"tags": {}, "apiVersion": "2016-04-30-preview", "properties":
+      {"virtualMachineProfile": {"storageProfile": {"osDisk": {"managedDisk": {"storageAccountType":
+      "Standard_LRS"}, "createOption": "FromImage", "caching": "ReadOnly"}, "imageReference":
+      {"offer": "Debian", "publisher": "credativ", "version": "latest", "sku": "8"}},
+      "osProfile": {"computerNamePrefix": "vmss1hiti", "linuxConfiguration": {"ssh":
+      {"publicKeys": [{"path": "/home/deploy/.ssh/authorized_keys", "keyData": "ssh-rsa
+      AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\n"}]}, "disablePasswordAuthentication": true}, "adminUsername":
+      "deploy", "secrets": [{"sourceVault": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333"},
+      "vaultCertificates": [{"certificateUrl": "https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/8ce387980c8d4d1e9b8d8980dff93f92"}]}]},
+      "networkProfile": {"networkInterfaceConfigurations": [{"properties": {"ipConfigurations":
+      [{"properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}]},
-      "name": "vmss14a2hIPConfig"}]}, "name": "vmss14a2hNic"}]}, "storageProfile":
-      {"osDisk": {"caching": "ReadOnly", "createOption": "FromImage", "managedDisk":
-      {"storageAccountType": "Standard_LRS"}}, "imageReference": {"version": "latest",
-      "sku": "8", "publisher": "credativ", "offer": "Debian"}}}}}], "contentVersion":
-      "1.0.0.0"}}}'
+      "subnet": {"id": "/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"}},
+      "name": "vmss1hitiIPConfig"}], "primary": "true"}, "name": "vmss1hitiNic"}]}},
+      "upgradePolicy": {"mode": "Manual"}, "overprovision": true, "singlePlacementGroup":
+      true}, "sku": {"tier": "Standard", "capacity": 2, "name": "Standard_D1_v2"},
+      "location": "westus", "type": "Microsoft.Compute/virtualMachineScaleSets", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/vmss1-nameVNET", "Microsoft.Network/loadBalancers/vmss1-nameLB"],
+      "name": "vmss1-name"}], "parameters": {}}, "parameters": {}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['5368']
+      Content-Length: ['5370']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","name":"vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","properties":{"templateHash":"12339123050858757016","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-22T17:40:22.1818239Z","duration":"PT0.611763S","correlationId":"4bc32cd5-d185-4296-872b-ffd5a8c37ee0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_q82NLt1eBtnwcVOuRX2zpP5ScjvWC3uC","name":"vmss_deploy_q82NLt1eBtnwcVOuRX2zpP5ScjvWC3uC","properties":{"templateHash":"7126384745149127503","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-02-22T21:28:54.5653668Z","duration":"PT0.8120888S","correlationId":"674d52b5-a14d-4ab2-b449-3bb8a7548aaf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y/operationStatuses/08587138216639076007?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/cbbdaed0-fea9-4693-bf0c-d446ac93c030/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_q82NLt1eBtnwcVOuRX2zpP5ScjvWC3uC/operationStatuses/08587138079517243681?api-version=2016-09-01']
       Cache-Control: [no-cache]
       Content-Length: ['2207']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:21 GMT']
+      Date: ['Wed, 22 Feb 2017 21:28:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -477,17 +533,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:40:53 GMT']
+      Date: ['Wed, 22 Feb 2017 21:29:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -503,17 +559,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:41:23 GMT']
+      Date: ['Wed, 22 Feb 2017 21:29:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -529,17 +585,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:41:54 GMT']
+      Date: ['Wed, 22 Feb 2017 21:30:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -555,17 +611,17 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:42:25 GMT']
+      Date: ['Wed, 22 Feb 2017 21:30:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -581,17 +637,43 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138216639076007?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 22 Feb 2017 21:31:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587138079517243681?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:42:56 GMT']
+      Date: ['Wed, 22 Feb 2017 21:32:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -607,19 +689,19 @@ interactions:
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.1b3+dev]
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fad8d048-f925-11e6-966c-784f436a2ed2]
+      x-ms-client-request-id: [e85bc024-f945-11e6-bb4d-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","name":"vmss_deploy_2WOHVlteZFHvVr9lDKQ9Mfj4dsTpn51Y","properties":{"templateHash":"12339123050858757016","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-22T17:42:35.7727917Z","duration":"PT2M14.2027308S","correlationId":"4bc32cd5-d185-4296-872b-ffd5a8c37ee0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss14a2h","adminUsername":"deploy","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/deploy/.ssh/authorized_keys","keyData":"ssh-rsa
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Resources/deployments/vmss_deploy_q82NLt1eBtnwcVOuRX2zpP5ScjvWC3uC","name":"vmss_deploy_q82NLt1eBtnwcVOuRX2zpP5ScjvWC3uC","properties":{"templateHash":"7126384745149127503","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-02-22T21:31:57.3428123Z","duration":"PT3M3.5895343S","correlationId":"674d52b5-a14d-4ab2-b449-3bb8a7548aaf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/publicIpAddresses/vmss1-nameLBPublicIP","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"vmss1-nameLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1-nameVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1-nameLB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1-name"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1hiti","adminUsername":"deploy","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/deploy/.ssh/authorized_keys","keyData":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-        test@example.com\n"}]}},"secrets":[{"sourceVault":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003"},"vaultCertificates":[{"certificateUrl":"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5"}]}]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadOnly","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss14a2hNic","properties":{"primary":true,"ipConfigurations":[{"name":"vmss14a2hIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"},"loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2"}}},"outputResources":[{"id":"Microsoft.Compute/virtualMachineScaleSets/vmss1-name"},{"id":"Microsoft.Network/loadBalancers/vmss1-nameLB"},{"id":"Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"},{"id":"Microsoft.Network/virtualNetworks/vmss1-nameVNET"}]}}'}
+        test@example.com\n"}]}},"secrets":[{"sourceVault":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333"},"vaultCertificates":[{"certificateUrl":"https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/8ce387980c8d4d1e9b8d8980dff93f92"}]}]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadOnly","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1hitiNic","properties":{"primary":true,"ipConfigurations":[{"name":"vmss1hitiIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet"},"loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"309e3e48-c75f-4340-ad49-399cb831e444"}}},"outputResources":[{"id":"Microsoft.Compute/virtualMachineScaleSets/vmss1-name"},{"id":"Microsoft.Network/loadBalancers/vmss1-nameLB"},{"id":"Microsoft.Network/publicIPAddresses/vmss1-nameLBPublicIP"},{"id":"Microsoft.Network/virtualNetworks/vmss1-nameVNET"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:42:55 GMT']
+      Date: ['Wed, 22 Feb 2017 21:32:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -634,9 +716,10 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.2rc1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [620fd4ca-f926-11e6-a392-784f436a2ed2]
+      x-ms-client-request-id: [59308d34-f946-11e6-ad6f-24f49a5003ca]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name?api-version=2016-04-30-preview
   response:
@@ -644,90 +727,38 @@ interactions:
         \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
         true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\"\r\n    },\r\n
         \   \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\":
-        \"vmss14a2h\",\r\n        \"adminUsername\": \"deploy\",\r\n        \"linuxConfiguration\":
+        \"vmss1hiti\",\r\n        \"adminUsername\": \"deploy\",\r\n        \"linuxConfiguration\":
         {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\":
         {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\":
         \"/home/deploy/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
         test@example.com\\n\"\r\n              }\r\n            ]\r\n          }\r\n
         \       },\r\n        \"secrets\": [\r\n          {\r\n            \"sourceVault\":
-        {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003\"\r\n
+        {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret3333\"\r\n
         \           },\r\n            \"vaultCertificates\": [\r\n              {\r\n
-        \               \"certificateUrl\": \"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5\"\r\n
+        \               \"certificateUrl\": \"https://vmcreatelinuxsecret3333.vault.azure.net/secrets/cert1/8ce387980c8d4d1e9b8d8980dff93f92\"\r\n
         \             }\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n
         \     \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadOnly\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n
         \       },\r\n        \"imageReference\": {\r\n          \"publisher\": \"credativ\",\r\n
         \         \"offer\": \"Debian\",\r\n          \"sku\": \"8\",\r\n          \"version\":
-        \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss14a2hNic\",\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss14a2hIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet\"},\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool\"}]}}]}}]}\r\n
+        \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1hitiNic\",\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1hitiIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet\"},\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool\"}]}}]}}]}\r\n
         \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
-        true,\r\n    \"uniqueId\": \"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2\"\r\n  },\r\n
+        true,\r\n    \"uniqueId\": \"309e3e48-c75f-4340-ad49-399cb831e444\"\r\n  },\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name\",\r\n
         \ \"name\": \"vmss1-name\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:43:13 GMT']
+      Date: ['Wed, 22 Feb 2017 21:32:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3617']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Darwin-16.4.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68c8e638-f926-11e6-8911-784f436a2ed2]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n    \"tier\":
-        \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
-        true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Manual\"\r\n    },\r\n
-        \   \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\":
-        \"vmss14a2h\",\r\n        \"adminUsername\": \"deploy\",\r\n        \"linuxConfiguration\":
-        {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\":
-        {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\":
-        \"/home/deploy/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-        test@example.com\\n\"\r\n              }\r\n            ]\r\n          }\r\n
-        \       },\r\n        \"secrets\": [\r\n          {\r\n            \"sourceVault\":
-        {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.KeyVault/vaults/vmcreatelinuxsecret003\"\r\n
-        \           },\r\n            \"vaultCertificates\": [\r\n              {\r\n
-        \               \"certificateUrl\": \"https://vmcreatelinuxsecret003.vault.azure.net/secrets/cert1/bfd09708636a45b9b9b2d623e0c5bbf5\"\r\n
-        \             }\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n
-        \     \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\":
-        \"FromImage\",\r\n          \"caching\": \"ReadOnly\",\r\n          \"managedDisk\":
-        {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n
-        \       },\r\n        \"imageReference\": {\r\n          \"publisher\": \"credativ\",\r\n
-        \         \"offer\": \"Debian\",\r\n          \"sku\": \"8\",\r\n          \"version\":
-        \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss14a2hNic\",\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss14a2hIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/virtualNetworks/vmss1-nameVNET/subnets/vmss1-nameSubnet\"},\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/backendAddressPools/vmss1-nameLBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Network/loadBalancers/vmss1-nameLB/inboundNatPools/vmss1-nameLBNatPool\"}]}}]}}]}\r\n
-        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\":
-        true,\r\n    \"uniqueId\": \"ecac4d14-6e5e-4eb6-9eac-bb50cd1c8ec2\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
-        \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_linux_secrets/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1-name\",\r\n
-        \ \"name\": \"vmss1-name\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 17:43:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['3617']
+      content-length: ['3619']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1266,8 +1266,8 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
         self.cmd('keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(
             self.vault_name,
             policy_path))
-        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('vm format-secret -s \'{0}\''.format(json.dumps(secret_out)))
+        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1 --query "[?attributes.enabled].id" -o tsv'.format(self.vault_name))
+        vm_format = self.cmd('vm format-secret -s {0}'.format(secret_out))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --authentication-type {auth_type} --image {image} --ssh-key-value \'{ssh_key}\' -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1283,7 +1283,7 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
         self.cmd('vm show -g {rg} -n {vm_name}'.format(rg=self.resource_group, vm_name=self.vm_name), checks=[
             JMESPathCheck('provisioningState', 'Succeeded'),
             JMESPathCheck('osProfile.secrets[0].sourceVault.id', vault_out['id']),
-            JMESPathCheck('osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out['id'])
+            JMESPathCheck('osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out)
         ])
 
 
@@ -1331,8 +1331,8 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             self.vault_name,
             policy_path))
 
-        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('vm format-secret -s \'{0}\' --certificate-store "My"'.format(json.dumps(secret_out)))
+        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1 --query "[?attributes.enabled].id" -o tsv'.format(self.vault_name))
+        vm_format = self.cmd('vm format-secret -s {0} --certificate-store "My"'.format(secret_out))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1346,7 +1346,7 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
         self.cmd('vm show -g {rg} -n {vm_name}'.format(rg=self.resource_group, vm_name=self.vm_name), checks=[
             JMESPathCheck('provisioningState', 'Succeeded'),
             JMESPathCheck('osProfile.secrets[0].sourceVault.id', vault_out['id']),
-            JMESPathCheck('osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out['id']),
+            JMESPathCheck('osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out),
             JMESPathCheck('osProfile.secrets[0].vaultCertificates[0].certificateStore', 'My')
         ])
 
@@ -1569,8 +1569,8 @@ class VMSSCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             self.vault_name,
             policy_path))
 
-        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('vm format-secret -s \'{0}\''.format(json.dumps(secret_out)))
+        secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1 --query "[?attributes.enabled].id" -o tsv'.format(self.vault_name))
+        vm_format = self.cmd('vm format-secret -s {0}'.format(secret_out))
 
         self.cmd('vmss create -n {name} -g {rg} --image Debian --admin-username deploy --ssh-key-value \'{ssh}\' --secrets \'{secrets}\''.format(
             name=self.vmss_name,
@@ -1581,7 +1581,7 @@ class VMSSCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
         self.cmd('vmss show -n {} -g {}'.format(self.vmss_name, self.resource_group), checks=[
             JMESPathCheck('provisioningState', 'Succeeded'),
             JMESPathCheck('virtualMachineProfile.osProfile.secrets[0].sourceVault.id', vault_out['id']),
-            JMESPathCheck('virtualMachineProfile.osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out['id'])
+            JMESPathCheck('virtualMachineProfile.osProfile.secrets[0].vaultCertificates[0].certificateUrl', secret_out)
         ])
 
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1233,7 +1233,7 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
         self.vm_name = 'vm-name'
         self.secrets = None
         self.bad_secrets = json.dumps([{'sourceVault': {'id': 'id'}, 'vaultCertificates': []}])
-        self.vault_name = 'vmcreatelinuxsecret007'
+        self.vault_name = 'vmcreatelinuxsecret7777'
         self.secret_name = 'mysecret'
 
     def test_vm_create_linux_secrets(self):
@@ -1266,13 +1266,8 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
         self.cmd('keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(
             self.vault_name,
             policy_path))
-
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-
-        self.secrets = [{
-            'sourceVault': {'id': vault_out['id']},
-            'vaultCertificates': [{'certificateUrl': secret_out['id']}]
-        }]
+        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\''.format(json.dumps(secret_out)))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --authentication-type {auth_type} --image {image} --ssh-key-value \'{ssh_key}\' -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1282,7 +1277,7 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
             auth_type=self.auth_type,
             ssh_key=TEST_SSH_KEY_PUB,
             location=self.location,
-            secrets=json.dumps(self.secrets)
+            secrets=json.dumps(vm_format)
         ))
 
         self.cmd('vm show -g {rg} -n {vm_name}'.format(rg=self.resource_group, vm_name=self.vm_name), checks=[
@@ -1301,9 +1296,8 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
         self.location = 'westus'
         self.vm_image = 'Win2012R2Datacenter'
         self.vm_name = 'vm-name'
-        self.secrets = None
         self.bad_secrets = json.dumps([{'sourceVault': {'id': 'id'}, 'vaultCertificates': [{'certificateUrl': 'certurl'}]}])
-        self.vault_name = 'vmcreatewinsecret005'
+        self.vault_name = 'vmcreatewinsecret7777'
         self.secret_name = 'mysecret'
 
     def test_vm_create_windows_secrets(self):
@@ -1338,11 +1332,7 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             policy_path))
 
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-
-        self.secrets = [{
-            'sourceVault': {'id': vault_out['id']},
-            'vaultCertificates': [{'certificateUrl': secret_out['id'], 'certificateStore': 'My'}]
-        }]
+        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\' --certificate-store "My"'.format(json.dumps(secret_out)))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1350,7 +1340,7 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             image=self.vm_image,
             vm_name=self.vm_name,
             location=self.location,
-            secrets=json.dumps(self.secrets)
+            secrets=json.dumps(vm_format)
         ))
 
         self.cmd('vm show -g {rg} -n {vm_name}'.format(rg=self.resource_group, vm_name=self.vm_name), checks=[
@@ -1557,9 +1547,8 @@ class VMSSCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
     def __init__(self, test_method):
         super(VMSSCreateLinuxSecretsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_vmss_create_linux_secrets')
         self.vmss_name = 'vmss1-name'
-        self.secrets = None
         self.bad_secrets = json.dumps([{'sourceVault': {'id': 'id'}, 'vaultCertificates': []}])
-        self.vault_name = 'vmcreatelinuxsecret003'
+        self.vault_name = 'vmcreatelinuxsecret3333'
         self.secret_name = 'mysecret'
 
     def test_vmss_create_linux_secrets(self):
@@ -1581,17 +1570,13 @@ class VMSSCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             policy_path))
 
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-
-        self.secrets = [{
-            'sourceVault': {'id': vault_out['id']},
-            'vaultCertificates': [{'certificateUrl': secret_out['id']}]
-        }]
+        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\''.format(json.dumps(secret_out)))
 
         self.cmd('vmss create -n {name} -g {rg} --image Debian --admin-username deploy --ssh-key-value \'{ssh}\' --secrets \'{secrets}\''.format(
             name=self.vmss_name,
             rg=self.resource_group,
             ssh=TEST_SSH_KEY_PUB,
-            secrets=json.dumps(self.secrets)))
+            secrets=json.dumps(vm_format)))
 
         self.cmd('vmss show -n {} -g {}'.format(self.vmss_name, self.resource_group), checks=[
             JMESPathCheck('provisioningState', 'Succeeded'),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1267,7 +1267,7 @@ class VMCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: dis
             self.vault_name,
             policy_path))
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\''.format(json.dumps(secret_out)))
+        vm_format = self.cmd('vm format-secret -s \'{0}\''.format(json.dumps(secret_out)))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --authentication-type {auth_type} --image {image} --ssh-key-value \'{ssh_key}\' -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1332,7 +1332,7 @@ class VMCreateWindowsSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             policy_path))
 
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\' --certificate-store "My"'.format(json.dumps(secret_out)))
+        vm_format = self.cmd('vm format-secret -s \'{0}\' --certificate-store "My"'.format(json.dumps(secret_out)))
 
         self.cmd('vm create -g {rg} -n {vm_name} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {location} --secrets \'{secrets}\''.format(
             rg=self.resource_group,
@@ -1570,7 +1570,7 @@ class VMSSCreateLinuxSecretsScenarioTest(ResourceGroupVCRTestBase):  # pylint: d
             policy_path))
 
         secret_out = self.cmd('keyvault secret list-versions --vault-name {} -n cert1'.format(self.vault_name))[-1]
-        vm_format = self.cmd('keyvault secret vm-format -s \'{0}\''.format(json.dumps(secret_out)))
+        vm_format = self.cmd('vm format-secret -s \'{0}\''.format(json.dumps(secret_out)))
 
         self.cmd('vmss create -n {name} -g {rg} --image Debian --admin-username deploy --ssh-key-value \'{ssh}\' --secrets \'{secrets}\''.format(
             name=self.vmss_name,

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -26,6 +26,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-mgmt-compute==0.33.1rc1',
+    'azure-mgmt-keyvault==0.30.0',
     'azure-keyvault==0.1.0',
     'azure-mgmt-network==0.30.0',
     'azure-mgmt-resource==0.30.2',


### PR DESCRIPTION
- add --secrets for VM and VMSS so that it takes a file or string content in the shape of ARM vm secrets
- add `az keyvault certificate get-default-policy`
- add `az vm format-secret` 
- add tests for VM and VMSS
- add transformer for x509 certificates so that base64 thumbprint is also shown as hex as it is named in the file system when provisioned for Linux VM and VMSS. 


## Usage of: `az keyvault certificate get-default-policy`
```
$ az keyvault certificate get-default-policy -h

Command
    az keyvault certificate get-default-policy: Get a default policy for a self-signed certificate.
        This default policy can be used in conjunction with `az keyvault create` to create a self-
        signed certificate. The policy can also be used as a base to manipulate to create other
        permutations of Key Vault certificates.

Arguments

Global Arguments
    --debug    : Increase logging verbosity to show all debug logs.
    --help -h  : Show this help message and exit.
    --output -o: Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
    --query    : JMESPath query string. See http://jmespath.org/ for more information and examples.
    --verbose  : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Create a self-signed certificate with a the default policy
        az keyvault create -g group-name -n vaultname -l westus --enabled-for-deployment true \
          --enabled-for-template-deployment true

        az keyvault certificate create --vault-name vaultname -n cert1 \
          -p "$(az keyvault certificate get-default-policy)"
``` 

## Usage of `az vm format-secret`
```
$ az vm format-secret -h

Command
    az vm format-secret: Format secrets to be used in `az vm create --secrets`.
        Transform secrets into a form consumed by VMs and VMSS create via --secrets.

Arguments
    --secrets -s [Required]: JSON encoded secrets as an array of secrets [], or a single secret {}.
                             Use @{file} to load from a file.
    --certificate-store    : Certificate store the secret will be applied (Windows only).

Global Arguments
    --debug                : Increase logging verbosity to show all debug logs.
    --help -h              : Show this help message and exit.
    --output -o            : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                             json.
    --query                : JMESPath query string. See http://jmespath.org/ for more information
                             and examples.
    --verbose              : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Create a self-signed certificate with a the default policy and add to a virtual machine
        az keyvault certificate create --vault-name vaultname -n cert1 \
          -p "$(az keyvault certificate get-default-policy)"

        secrets=$(az keyvault secret list-versions --vault-name vaultname \
          -n cert1 --query "[?attributes.enabled]")

        vm_secrets=$(az vm format-secret -s "$secrets")

        az vm create -g group-name -n vm-name --admin-username deploy  \
          --image debian --secrets "$vm_secrets"
```