### PR TITLE
--admin-enabled no longer requires a input value

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+# pylint: disable=line-too-long
+
 from azure.cli.core.commands import register_cli_argument
 from azure.cli.core.commands.parameters import (
     resource_group_name_type,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -20,30 +20,18 @@ from ._validators import (
     validate_registry_name
 )
 
-register_cli_argument('acr', 'registry_name',
-                      options_list=('--name', '-n'),
-                      help='The name of the container registry',
-                      completer=get_resource_name_completion_list(ACR_RESOURCE_TYPE))
-register_cli_argument('acr', 'storage_account_name',
-                      help='The name of an existing storage account',
-                      completer=get_resource_name_completion_list(STORAGE_RESOURCE_TYPE))
+register_cli_argument('acr', 'registry_name', options_list=('--name', '-n'), help='The name of the container registry', completer=get_resource_name_completion_list(ACR_RESOURCE_TYPE))
+register_cli_argument('acr', 'storage_account_name', help='The name of an existing storage account', completer=get_resource_name_completion_list(STORAGE_RESOURCE_TYPE))
 
 register_cli_argument('acr', 'resource_group_name', resource_group_name_type)
 register_cli_argument('acr', 'location', location_type)
 register_cli_argument('acr', 'tags', tags_type)
-register_cli_argument('acr', 'admin_enabled',
-                      help='Indicates whether the admin user is enabled',
-                      choices=['true', 'false'])
+register_cli_argument('acr create', 'admin_enabled', nargs='?', required=False, const='true', default=None, help='Indicates whether the admin user is enabled', choices=['true', 'false'])
+register_cli_argument('acr update', 'admin_enabled', nargs=1, help='Indicates whether the admin user is enabled', choices=['true', 'false'])
 
-register_cli_argument('acr', 'username',
-                      options_list=('--username', '-u'),
-                      help='The username used to log into a container registry')
-register_cli_argument('acr', 'password',
-                      options_list=('--password', '-p'),
-                      help='The password used to log into a container registry')
+register_cli_argument('acr', 'username', options_list=('--username', '-u'), help='The username used to log into a container registry')
+register_cli_argument('acr', 'password', options_list=('--password', '-p'), help='The password used to log into a container registry')
 
-register_cli_argument('acr create', 'registry_name', completer=None,
-                      validator=validate_registry_name)
-register_cli_argument('acr create', 'resource_group_name',
-                      validator=validate_resource_group_name)
+register_cli_argument('acr create', 'registry_name', completer=None, validator=validate_registry_name)
+register_cli_argument('acr create', 'resource_group_name', validator=validate_resource_group_name)
 register_cli_argument('acr check-name', 'registry_name', completer=None)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -134,7 +134,7 @@ def acr_update_custom(instance,
                       storage_account_name=None,
                       tags=None):
     if admin_enabled is not None:
-        instance.admin_user_enabled = admin_enabled == 'true'
+        instance.admin_user_enabled = admin_enabled == ['true']
 
     if tags is not None:
         instance.tags = tags


### PR DESCRIPTION
Fixing

https://github.com/Azure/azure-cli/issues/1897