### PR TITLE
On scale, clear the service principal profile

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -696,6 +696,11 @@ def _mkdir_p(path):
 def update_acs(client, resource_group_name, container_service_name, new_agent_count):
     instance = client.get(resource_group_name, container_service_name)
     instance.agent_pool_profiles[0].count = new_agent_count  # pylint: disable=no-member
+
+    # null out the service principal because otherwise validation complains
+    if instance.orchestrator_profile.orchestrator_type == ContainerServiceOchestratorTypes.kubernetes:
+        instance.service_principal_profile = None
+
     return client.create_or_update(resource_group_name, container_service_name, instance)
 
 


### PR DESCRIPTION
The value is incorrect from the GET since we hide the secret, so clear it all, we don't want to update it anyway...

