### PR TITLE
vm: fix test issues in live test run

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_diagnostics_extension_install.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_diagnostics_extension_install.yaml
@@ -7,9 +7,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d87e732e-e75c-11e6-afb1-64510658e3b3]
+      x-ms-client-request-id: [11fbb5b4-fd3f-11e6-a27e-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -17,7 +17,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdngy5\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
         ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -27,20 +27,20 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdngy5Nic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdngy5IPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"c096eec7-4a82-4065-8a27-316c264c5d52\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:43 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -57,9 +57,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8bfd480-e75c-11e6-a354-64510658e3b3]
+      x-ms-client-request-id: [121ead12-fd3f-11e6-85e3-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -67,7 +67,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdngy5\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
         ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -77,20 +77,20 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdngy5Nic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdngy5IPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"c096eec7-4a82-4065-8a27-316c264c5d52\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:43 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -100,92 +100,92 @@ interactions:
       content-length: ['2232']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "sku": {"capacity": 2, "tier": "Standard", "name":
-      "Standard_D1_v2"}, "properties": {"overprovision": true, "singlePlacementGroup":
-      true, "upgradePolicy": {"mode": "Manual"}, "virtualMachineProfile": {"extensionProfile":
-      {"extensions": [{"properties": {"settings": {"storageAccount": "diagextensionsa",
-      "ladCfg": {"diagnosticMonitorConfiguration": {"metrics": {"metricAggregation":
-      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}],
-      "resourceId": "[variables(''ladMetricsResourceId'')]"}, "performanceCounters":
-      {"performanceCounterConfiguration": [{"counterSpecifier": "AvailableMemory",
-      "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PercentAvailableMemory", "namespace": "root/scx", "class": "Memory", "table":
-      "LinuxMemory"}, {"counterSpecifier": "UsedMemory", "namespace": "root/scx",
-      "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier": "PercentUsedMemory",
-      "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PercentUsedByCache", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "PagesPerSec", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PagesReadPerSec", "namespace":
-      "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PagesWrittenPerSec", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "AvailableSwap", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PercentAvailableSwap", "namespace":
-      "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "UsedSwap", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "PercentUsedSwap", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PercentIdleTime", "namespace":
-      "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentUserTime", "namespace": "root/scx", "class": "Processor", "table": "LinuxProcessor"},
-      {"counterSpecifier": "PercentNiceTime", "namespace": "root/scx", "class": "Processor",
-      "table": "LinuxProcessor"}, {"counterSpecifier": "PercentPrivilegedTime", "namespace":
-      "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentInterruptTime", "namespace": "root/scx", "class": "Processor", "table":
-      "LinuxProcessor"}, {"counterSpecifier": "PercentDPCTime", "namespace": "root/scx",
-      "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier": "PercentProcessorTime",
-      "namespace": "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentIOWaitTime", "namespace": "root/scx", "class": "Processor", "table":
-      "LinuxProcessor"}, {"counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "ReadBytesPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "WriteBytesPerSecond", "namespace":
-      "root/scx", "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "TransfersPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "ReadsPerSecond", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "WritesPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "AverageReadTime", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "AverageWriteTime", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "AverageTransferTime", "namespace":
-      "root/scx", "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "AverageDiskQueueLength", "namespace": "root/scx", "class": "PhysicalDisk",
-      "table": "LinuxPhysicalDisk"}, {"counterSpecifier": "BytesTransmitted", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "BytesReceived", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "PacketsTransmitted",
-      "namespace": "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "PacketsReceived", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "BytesTotal", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "TotalTxErrors", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "TotalCollisions", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}]}}}}, "publisher": "Microsoft.OSTCExtensions",
-      "autoUpgradeMinorVersion": true, "protectedSettings": {"storageAccountEndPoint":
-      "https://diagextensionsa.blob.core.windows.net/", "storageAccountName": "diagextensionsa",
-      "storageAccountKey": "123"}, "type": "LinuxDiagnostic", "typeHandlerVersion":
-      "2.3"}, "name": "LinuxDiagnostic"}]}, "storageProfile": {"osDisk": {"caching":
-      "ReadOnly", "managedDisk": {"storageAccountType": "Standard_LRS"}, "createOption":
-      "fromImage"}, "imageReference": {"version": "latest", "sku": "14.04.4-LTS",
-      "publisher": "Canonical", "offer": "UbuntuServer"}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"properties": {"ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
+    body: '{"tags": {}, "location": "westus", "properties": {"virtualMachineProfile":
+      {"extensionProfile": {"extensions": [{"name": "LinuxDiagnostic", "properties":
+      {"settings": {"storageAccount": "clitestdiagextsa20170227", "ladCfg": {"diagnosticMonitorConfiguration":
+      {"metrics": {"resourceId": "[variables(''ladMetricsResourceId'')]", "metricAggregation":
+      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}]},
+      "performanceCounters": {"performanceCounterConfiguration": [{"class": "Memory",
+      "counterSpecifier": "AvailableMemory", "namespace": "root/scx", "table": "LinuxMemory"},
+      {"class": "Memory", "counterSpecifier": "PercentAvailableMemory", "namespace":
+      "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "UsedMemory", "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory",
+      "counterSpecifier": "PercentUsedMemory", "namespace": "root/scx", "table": "LinuxMemory"},
+      {"class": "Memory", "counterSpecifier": "PercentUsedByCache", "namespace": "root/scx",
+      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PagesPerSec",
+      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "PagesReadPerSec", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
+      "Memory", "counterSpecifier": "PagesWrittenPerSec", "namespace": "root/scx",
+      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "AvailableSwap",
+      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "PercentAvailableSwap", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
+      "Memory", "counterSpecifier": "UsedSwap", "namespace": "root/scx", "table":
+      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentUsedSwap", "namespace":
+      "root/scx", "table": "LinuxMemory"}, {"class": "Processor", "counterSpecifier":
+      "PercentIdleTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
+      "Processor", "counterSpecifier": "PercentUserTime", "namespace": "root/scx",
+      "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentNiceTime",
+      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
+      "counterSpecifier": "PercentPrivilegedTime", "namespace": "root/scx", "table":
+      "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentInterruptTime",
+      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
+      "counterSpecifier": "PercentDPCTime", "namespace": "root/scx", "table": "LinuxProcessor"},
+      {"class": "Processor", "counterSpecifier": "PercentProcessorTime", "namespace":
+      "root/scx", "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier":
+      "PercentIOWaitTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
+      "PhysicalDisk", "counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
+      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "ReadBytesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "TransfersPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "ReadsPerSecond", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "WritesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"}, {"class":
+      "PhysicalDisk", "counterSpecifier": "AverageReadTime", "namespace": "root/scx",
+      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "AverageWriteTime", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "AverageTransferTime", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "AverageDiskQueueLength", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "NetworkInterface", "counterSpecifier": "BytesTransmitted", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "BytesReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "PacketsTransmitted", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "PacketsReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "BytesTotal", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "TotalTxErrors", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "TotalCollisions", "namespace": "root/scx", "table": "LinuxNetworkInterface"}]}}}},
+      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170227", "storageAccountKey":
+      "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/"},
+      "type": "LinuxDiagnostic", "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion":
+      true, "typeHandlerVersion": "2.3"}}]}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"properties": {"primary": true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
       [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool"}],
       "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet"},
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool"}]},
-      "name": "testdngy5IPConfig"}], "primary": true}, "name": "testdngy5Nic"}]},
-      "osProfile": {"computerNamePrefix": "testdngy5", "linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "secrets": [], "adminUsername": "yugangw"}}}, "tags": {}}'
+      "name": "testdjcfiIPConfig"}]}, "name": "testdjcfiNic"}]}, "storageProfile":
+      {"osDisk": {"createOption": "fromImage", "managedDisk": {"storageAccountType":
+      "Standard_LRS"}, "caching": "ReadOnly"}, "imageReference": {"offer": "UbuntuServer",
+      "publisher": "Canonical", "sku": "14.04.4-LTS", "version": "latest"}}, "osProfile":
+      {"adminUsername": "yugangw", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      false}, "computerNamePrefix": "testdjcfi"}}, "overprovision": true, "upgradePolicy":
+      {"mode": "Manual"}, "singlePlacementGroup": true}, "sku": {"tier": "Standard",
+      "name": "Standard_D1_v2", "capacity": 2}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['6768']
+      Content-Length: ['6795']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8e94352-e75c-11e6-87c1-64510658e3b3]
+      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -193,7 +193,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdngy5\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
         ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -203,8 +203,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdngy5Nic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdngy5IPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -212,91 +212,92 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"diagextensionsa\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"counterSpecifier\":\"AvailableMemory\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"\
-        },{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\":\"\
-        UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n\
-        \            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n         \
-        \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"c096eec7-4a82-4065-8a27-316c264c5d52\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
+        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
+        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
+        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
+        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
+        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
+        \      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"overprovision\"\
+        : true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\r\n\
+        \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
+        location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9d2e5737-1af4-4c86-bde2-042e4f86a0fb?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/7387dc89-9d96-477d-853f-d8645aa2f8a5?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:44 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7129']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      content-length: ['7138']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -306,19 +307,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8e94352-e75c-11e6-87c1-64510658e3b3]
+      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9d2e5737-1af4-4c86-bde2-042e4f86a0fb?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7387dc89-9d96-477d-853f-d8645aa2f8a5?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:27:44.3865213+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T02:27:44.5427764+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"9d2e5737-1af4-4c86-bde2-042e4f86a0fb\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:06.2604841+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:50:25.0026904+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"7387dc89-9d96-477d-853f-d8645aa2f8a5\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:14 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -335,9 +336,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8e94352-e75c-11e6-87c1-64510658e3b3]
+      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -345,7 +346,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdngy5\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
         ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -355,8 +356,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdngy5Nic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdngy5IPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -364,89 +365,90 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"diagextensionsa\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"counterSpecifier\":\"AvailableMemory\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"\
-        },{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\":\"\
-        UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n\
-        \            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n         \
-        \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"c096eec7-4a82-4065-8a27-316c264c5d52\"\
+        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
+        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
+        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
+        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
+        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
+        \      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:15 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7130']
+      content-length: ['7139']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -456,9 +458,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec307108-e75c-11e6-818c-64510658e3b3]
+      x-ms-client-request-id: [2894e7f0-fd3f-11e6-adc9-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -466,7 +468,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdngy5\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
         ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -476,8 +478,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdngy5Nic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdngy5IPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -485,89 +487,90 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"diagextensionsa\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
-        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"counterSpecifier\":\"AvailableMemory\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"\
-        },{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\":\"\
-        UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n\
-        \            },\r\n            \"name\": \"LinuxDiagnostic\"\r\n         \
-        \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"c096eec7-4a82-4065-8a27-316c264c5d52\"\
+        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
+        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
+        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
+        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
+        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
+        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
+        \      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:16 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7130']
+      content-length: ['7139']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -577,23 +580,23 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecb89b5e-e75c-11e6-8e15-64510658e3b3]
+      x-ms-client-request-id: [29c7356c-fd3f-11e6-8a5c-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"86cc85bc-1e50-47b5-aead-585d80b8b0b4\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_oSCKe4j7up\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://diagextensionsa.blob.core.windows.net/vhds/osdisk_oSCKe4j7up.vhd\"\
+        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"testdiagvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
@@ -604,14 +607,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:16 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1428']
+      content-length: ['1439']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -621,23 +624,23 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecfdbc02-e75c-11e6-92ec-64510658e3b3]
+      x-ms-client-request-id: [29e25d0a-fd3f-11e6-96aa-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"86cc85bc-1e50-47b5-aead-585d80b8b0b4\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_oSCKe4j7up\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://diagextensionsa.blob.core.windows.net/vhds/osdisk_oSCKe4j7up.vhd\"\
+        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"testdiagvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
@@ -648,173 +651,174 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:18 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1428']
+      content-length: ['1439']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"settings": {"storageAccount": "diagextensionsa",
-      "ladCfg": {"diagnosticMonitorConfiguration": {"metrics": {"metricAggregation":
-      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}],
-      "resourceId": "[variables(''ladMetricsResourceId'')]"}, "performanceCounters":
-      {"performanceCounterConfiguration": [{"counterSpecifier": "AvailableMemory",
-      "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PercentAvailableMemory", "namespace": "root/scx", "class": "Memory", "table":
-      "LinuxMemory"}, {"counterSpecifier": "UsedMemory", "namespace": "root/scx",
-      "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier": "PercentUsedMemory",
-      "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PercentUsedByCache", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "PagesPerSec", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PagesReadPerSec", "namespace":
-      "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "PagesWrittenPerSec", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "AvailableSwap", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PercentAvailableSwap", "namespace":
-      "root/scx", "class": "Memory", "table": "LinuxMemory"}, {"counterSpecifier":
-      "UsedSwap", "namespace": "root/scx", "class": "Memory", "table": "LinuxMemory"},
-      {"counterSpecifier": "PercentUsedSwap", "namespace": "root/scx", "class": "Memory",
-      "table": "LinuxMemory"}, {"counterSpecifier": "PercentIdleTime", "namespace":
-      "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentUserTime", "namespace": "root/scx", "class": "Processor", "table": "LinuxProcessor"},
-      {"counterSpecifier": "PercentNiceTime", "namespace": "root/scx", "class": "Processor",
-      "table": "LinuxProcessor"}, {"counterSpecifier": "PercentPrivilegedTime", "namespace":
-      "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentInterruptTime", "namespace": "root/scx", "class": "Processor", "table":
-      "LinuxProcessor"}, {"counterSpecifier": "PercentDPCTime", "namespace": "root/scx",
-      "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier": "PercentProcessorTime",
-      "namespace": "root/scx", "class": "Processor", "table": "LinuxProcessor"}, {"counterSpecifier":
-      "PercentIOWaitTime", "namespace": "root/scx", "class": "Processor", "table":
-      "LinuxProcessor"}, {"counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "ReadBytesPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "WriteBytesPerSecond", "namespace":
-      "root/scx", "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "TransfersPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "ReadsPerSecond", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "WritesPerSecond", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "AverageReadTime", "namespace": "root/scx",
-      "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "AverageWriteTime", "namespace": "root/scx", "class": "PhysicalDisk", "table":
-      "LinuxPhysicalDisk"}, {"counterSpecifier": "AverageTransferTime", "namespace":
-      "root/scx", "class": "PhysicalDisk", "table": "LinuxPhysicalDisk"}, {"counterSpecifier":
-      "AverageDiskQueueLength", "namespace": "root/scx", "class": "PhysicalDisk",
-      "table": "LinuxPhysicalDisk"}, {"counterSpecifier": "BytesTransmitted", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "BytesReceived", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "PacketsTransmitted",
-      "namespace": "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "PacketsReceived", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "BytesTotal", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}, {"counterSpecifier": "TotalTxErrors", "namespace":
-      "root/scx", "class": "NetworkInterface", "table": "LinuxNetworkInterface"},
-      {"counterSpecifier": "TotalCollisions", "namespace": "root/scx", "class": "NetworkInterface",
-      "table": "LinuxNetworkInterface"}]}}}}, "autoUpgradeMinorVersion": true, "protectedSettings":
-      {"storageAccountEndPoint": "https://diagextensionsa.blob.core.windows.net/",
-      "storageAccountName": "diagextensionsa", "storageAccountKey": "123"}, "type":
-      "LinuxDiagnostic", "typeHandlerVersion": "2.3", "publisher": "Microsoft.OSTCExtensions"}}'
+    body: '{"location": "westus", "properties": {"settings": {"storageAccount": "clitestdiagextsa20170227",
+      "ladCfg": {"diagnosticMonitorConfiguration": {"metrics": {"resourceId": "[variables(''ladMetricsResourceId'')]",
+      "metricAggregation": [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod":
+      "PT1M"}]}, "performanceCounters": {"performanceCounterConfiguration": [{"class":
+      "Memory", "counterSpecifier": "AvailableMemory", "namespace": "root/scx", "table":
+      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentAvailableMemory",
+      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "UsedMemory", "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory",
+      "counterSpecifier": "PercentUsedMemory", "namespace": "root/scx", "table": "LinuxMemory"},
+      {"class": "Memory", "counterSpecifier": "PercentUsedByCache", "namespace": "root/scx",
+      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PagesPerSec",
+      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "PagesReadPerSec", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
+      "Memory", "counterSpecifier": "PagesWrittenPerSec", "namespace": "root/scx",
+      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "AvailableSwap",
+      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
+      "PercentAvailableSwap", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
+      "Memory", "counterSpecifier": "UsedSwap", "namespace": "root/scx", "table":
+      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentUsedSwap", "namespace":
+      "root/scx", "table": "LinuxMemory"}, {"class": "Processor", "counterSpecifier":
+      "PercentIdleTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
+      "Processor", "counterSpecifier": "PercentUserTime", "namespace": "root/scx",
+      "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentNiceTime",
+      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
+      "counterSpecifier": "PercentPrivilegedTime", "namespace": "root/scx", "table":
+      "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentInterruptTime",
+      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
+      "counterSpecifier": "PercentDPCTime", "namespace": "root/scx", "table": "LinuxProcessor"},
+      {"class": "Processor", "counterSpecifier": "PercentProcessorTime", "namespace":
+      "root/scx", "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier":
+      "PercentIOWaitTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
+      "PhysicalDisk", "counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
+      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "ReadBytesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "TransfersPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "ReadsPerSecond", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "WritesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"}, {"class":
+      "PhysicalDisk", "counterSpecifier": "AverageReadTime", "namespace": "root/scx",
+      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "AverageWriteTime", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "PhysicalDisk", "counterSpecifier": "AverageTransferTime", "namespace":
+      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
+      "AverageDiskQueueLength", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
+      {"class": "NetworkInterface", "counterSpecifier": "BytesTransmitted", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "BytesReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "PacketsTransmitted", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "PacketsReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "BytesTotal", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
+      {"class": "NetworkInterface", "counterSpecifier": "TotalTxErrors", "namespace":
+      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
+      "counterSpecifier": "TotalCollisions", "namespace": "root/scx", "table": "LinuxNetworkInterface"}]}}}},
+      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170227", "storageAccountKey":
+      "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/"},
+      "type": "LinuxDiagnostic", "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion":
+      true, "typeHandlerVersion": "2.3"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['5162']
+      Content-Length: ['5189']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed3e4682-e75c-11e6-b837-64510658e3b3]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
         2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        storageAccount\":\"diagextensionsa\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
-        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
-        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n\
-        \    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
+        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
+        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
+        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
+        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n    \"provisioningState\"\
+        : \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/10f1d54f-32f4-4f52-a882-25368ca1ced1?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
-      Content-Length: ['5049']
+      Content-Length: ['5058']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:22 GMT']
+      Date: ['Mon, 27 Feb 2017 22:50:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -824,19 +828,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed3e4682-e75c-11e6-b837-64510658e3b3]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/10f1d54f-32f4-4f52-a882-25368ca1ced1?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:28:22.3723736+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"10f1d54f-32f4-4f52-a882-25368ca1ced1\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:53 GMT']
+      Date: ['Mon, 27 Feb 2017 22:51:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -853,19 +857,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed3e4682-e75c-11e6-b837-64510658e3b3]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/10f1d54f-32f4-4f52-a882-25368ca1ced1?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:28:22.3723736+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"10f1d54f-32f4-4f52-a882-25368ca1ced1\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:29:23 GMT']
+      Date: ['Mon, 27 Feb 2017 22:51:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -882,19 +886,106 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed3e4682-e75c-11e6-b837-64510658e3b3]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/10f1d54f-32f4-4f52-a882-25368ca1ced1?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:28:22.3723736+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T02:29:44.7510941+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"10f1d54f-32f4-4f52-a882-25368ca1ced1\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:29:53 GMT']
+      Date: ['Mon, 27 Feb 2017 22:52:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:52:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:53:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:53:28.0462382+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:53:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -911,94 +1002,95 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed3e4682-e75c-11e6-b837-64510658e3b3]
+      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
         2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        storageAccount\":\"diagextensionsa\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
-        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
-        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n\
-        \    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
+        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
+        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
+        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
+        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n    \"provisioningState\"\
+        : \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:29:53 GMT']
+      Date: ['Mon, 27 Feb 2017 22:53:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['5050']
+      content-length: ['5059']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1008,23 +1100,23 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [26b8761c-e75d-11e6-ac60-64510658e3b3]
+      x-ms-client-request-id: [9890d9e4-fd3f-11e6-8651-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"86cc85bc-1e50-47b5-aead-585d80b8b0b4\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_oSCKe4j7up\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://diagextensionsa.blob.core.windows.net/vhds/osdisk_oSCKe4j7up.vhd\"\
+        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"testdiagvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
@@ -1032,74 +1124,74 @@ interactions:
         : [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n        \"type\": \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\"\
         : \"2.3\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
-        : {\"storageAccount\":\"diagextensionsa\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
-        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
-        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedMemory\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedMemory\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"\
-        table\":\"LinuxMemory\"},{\"counterSpecifier\":\"PagesPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PagesWrittenPerSec\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"AvailableSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\"\
-        :\"LinuxMemory\"},{\"counterSpecifier\":\"PercentAvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"UsedSwap\",\"namespace\":\"root/scx\",\"class\":\"Memory\",\"table\":\"\
-        LinuxMemory\"},{\"counterSpecifier\":\"PercentUsedSwap\",\"namespace\":\"\
-        root/scx\",\"class\":\"Memory\",\"table\":\"LinuxMemory\"},{\"counterSpecifier\"\
-        :\"PercentIdleTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentUserTime\",\"namespace\"\
-        :\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentNiceTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"class\":\"Processor\",\"\
-        table\":\"LinuxProcessor\"},{\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"Processor\",\"table\":\"LinuxProcessor\"\
-        },{\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        class\":\"Processor\",\"table\":\"LinuxProcessor\"},{\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"ReadsPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"WritesPerSecond\",\"namespace\":\"root/scx\",\"\
-        class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageReadTime\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"AverageWriteTime\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"counterSpecifier\":\"AverageTransferTime\",\"namespace\":\"root/scx\"\
-        ,\"class\":\"PhysicalDisk\",\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\"\
-        :\"AverageDiskQueueLength\",\"namespace\":\"root/scx\",\"class\":\"PhysicalDisk\"\
-        ,\"table\":\"LinuxPhysicalDisk\"},{\"counterSpecifier\":\"BytesTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesReceived\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"PacketsTransmitted\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"PacketsReceived\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"class\"\
-        :\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\"\
-        ,\"table\":\"LinuxNetworkInterface\"},{\"counterSpecifier\":\"TotalTxErrors\"\
-        ,\"namespace\":\"root/scx\",\"class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"counterSpecifier\":\"TotalCollisions\",\"namespace\":\"root/scx\",\"\
-        class\":\"NetworkInterface\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n\
-        \        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\"\
-        : \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\"\
-        : \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
+        : {\"storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
+        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
+        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
+        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
+        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
+        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
+        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
+        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
+        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
+        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
+        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
+        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
+        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
+        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n        \"provisioningState\"\
+        : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n      \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
@@ -1107,13 +1199,13 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:29:54 GMT']
+      Date: ['Mon, 27 Feb 2017 22:53:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['6560']
+      content-length: ['6580']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_boot_diagnostics.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_boot_diagnostics.yaml
@@ -7,23 +7,23 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8748603a-e75c-11e6-9137-64510658e3b3]
+      x-ms-client-request-id: [3e36473a-fd40-11e6-9a31-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
@@ -34,14 +34,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:25:26 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1370']
+      content-length: ['1385']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -51,82 +51,82 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8759c492-e75c-11e6-b57b-64510658e3b3]
+      x-ms-client-request-id: [3e60bfc2-fd40-11e6-b209-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/00ngkjvhv4ur55magntpri0","kind":"Storage","location":"westus","name":"00ngkjvhv4ur55magntpri0","properties":{"creationTime":"2017-01-20T21:55:23.4208075Z","primaryEndpoints":{"blob":"https://00ngkjvhv4ur55magntpri0.blob.core.windows.net/","file":"https://00ngkjvhv4ur55magntpri0.file.core.windows.net/","queue":"https://00ngkjvhv4ur55magntpri0.queue.core.windows.net/","table":"https://00ngkjvhv4ur55magntpri0.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/60ngkjvhv4ur55magntpri1","kind":"Storage","location":"westus","name":"60ngkjvhv4ur55magntpri1","properties":{"creationTime":"2017-01-20T21:55:23.6508271Z","primaryEndpoints":{"blob":"https://60ngkjvhv4ur55magntpri1.blob.core.windows.net/","file":"https://60ngkjvhv4ur55magntpri1.file.core.windows.net/","queue":"https://60ngkjvhv4ur55magntpri1.queue.core.windows.net/","table":"https://60ngkjvhv4ur55magntpri1.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/6nafvhzcqpliqvmssw6sewsa","kind":"Storage","location":"westus","name":"6nafvhzcqpliqvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8827839Z","primaryEndpoints":{"blob":"https://6nafvhzcqpliqvmssw6sewsa.blob.core.windows.net/","file":"https://6nafvhzcqpliqvmssw6sewsa.file.core.windows.net/","queue":"https://6nafvhzcqpliqvmssw6sewsa.queue.core.windows.net/","table":"https://6nafvhzcqpliqvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/a4be7dpmmwhnkvmssw6sewsa","kind":"Storage","location":"westus","name":"a4be7dpmmwhnkvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8527816Z","primaryEndpoints":{"blob":"https://a4be7dpmmwhnkvmssw6sewsa.blob.core.windows.net/","file":"https://a4be7dpmmwhnkvmssw6sewsa.file.core.windows.net/","queue":"https://a4be7dpmmwhnkvmssw6sewsa.queue.core.windows.net/","table":"https://a4be7dpmmwhnkvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Storage/storageAccounts/ae94nvfl1k1","kind":"Storage","location":"westus","name":"ae94nvfl1k1","properties":{"creationTime":"2017-01-31T02:22:15.5219386Z","primaryEndpoints":{"blob":"https://ae94nvfl1k1.blob.core.windows.net/","file":"https://ae94nvfl1k1.file.core.windows.net/","queue":"https://ae94nvfl1k1.queue.core.windows.net/","table":"https://ae94nvfl1k1.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/anindiaccount","kind":"Storage","location":"westindia","name":"anindiaccount","properties":{"creationTime":"2017-01-09T18:27:55.5063739Z","primaryEndpoints":{"blob":"https://anindiaccount.blob.core.windows.net/","file":"https://anindiaccount.file.core.windows.net/","queue":"https://anindiaccount.queue.core.windows.net/","table":"https://anindiaccount.table.core.windows.net/"},"primaryLocation":"westindia","provisioningState":"Succeeded","secondaryEndpoints":{"blob":"https://anindiaccount-secondary.blob.core.windows.net/","queue":"https://anindiaccount-secondary.queue.core.windows.net/","table":"https://anindiaccount-secondary.table.core.windows.net/"},"secondaryLocation":"southindia","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_RAGRS","tier":"Standard"},"tags":{"tag":"demo"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/default-applicationinsights-centralus/providers/Microsoft.Storage/storageAccounts/appinsightsstorage2016","kind":"Storage","location":"centralus","name":"appinsightsstorage2016","properties":{"creationTime":"2016-03-03T23:07:20.8376748Z","primaryEndpoints":{"blob":"https://appinsightsstorage2016.blob.core.windows.net/","file":"https://appinsightsstorage2016.file.core.windows.net/","queue":"https://appinsightsstorage2016.queue.core.windows.net/","table":"https://appinsightsstorage2016.table.core.windows.net/"},"primaryLocation":"centralus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_create_existing_n6d8_/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011","kind":"Storage","location":"westus","name":"azureclivrfstorage0011","properties":{"creationTime":"2017-01-31T02:23:23.3938528Z","primaryEndpoints":{"blob":"https://azureclivrfstorage0011.blob.core.windows.net/","file":"https://azureclivrfstorage0011.file.core.windows.net/","queue":"https://azureclivrfstorage0011.queue.core.windows.net/","table":"https://azureclivrfstorage0011.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/c0ngkjvhv4ur55magntpri2","kind":"Storage","location":"westus","name":"c0ngkjvhv4ur55magntpri2","properties":{"creationTime":"2017-01-20T21:55:23.3727770Z","primaryEndpoints":{"blob":"https://c0ngkjvhv4ur55magntpri2.blob.core.windows.net/","file":"https://c0ngkjvhv4ur55magntpri2.file.core.windows.net/","queue":"https://c0ngkjvhv4ur55magntpri2.queue.core.windows.net/","table":"https://c0ngkjvhv4ur55magntpri2.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Storage/storageAccounts/cli1097441544253702156","kind":"Storage","location":"westus","name":"cli1097441544253702156","properties":{"creationTime":"2016-07-11T10:51:20.0392107Z","primaryEndpoints":{"blob":"https://cli1097441544253702156.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Storage/storageAccounts/clisto3547828837ubuntuch","kind":"Storage","location":"westus","name":"clisto3547828837ubuntuch","properties":{"creationTime":"2016-07-11T10:53:02.7462882Z","primaryEndpoints":{"blob":"https://clisto3547828837ubuntuch.blob.core.windows.net/","file":"https://clisto3547828837ubuntuch.file.core.windows.net/","queue":"https://clisto3547828837ubuntuch.queue.core.windows.net/","table":"https://clisto3547828837ubuntuch.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/destanko-test1/providers/Microsoft.Storage/storageAccounts/destanko123","kind":"Storage","location":"westus","name":"destanko123","properties":{"creationTime":"2016-01-27T19:19:44.8251464Z","primaryEndpoints":{"blob":"https://destanko123.blob.core.windows.net/","file":"https://destanko123.file.core.windows.net/","queue":"https://destanko123.queue.core.windows.net/","table":"https://destanko123.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension_ml97_/providers/Microsoft.Storage/storageAccounts/diagextensionsa","kind":"Storage","location":"westus","name":"diagextensionsa","properties":{"creationTime":"2017-01-31T02:22:14.2020515Z","primaryEndpoints":{"blob":"https://diagextensionsa.blob.core.windows.net/","file":"https://diagextensionsa.file.core.windows.net/","queue":"https://diagextensionsa.queue.core.windows.net/","table":"https://diagextensionsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/fa4mssttyodnwvmssw6sewsa","kind":"Storage","location":"westus","name":"fa4mssttyodnwvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.9027880Z","primaryEndpoints":{"blob":"https://fa4mssttyodnwvmssw6sewsa.blob.core.windows.net/","file":"https://fa4mssttyodnwvmssw6sewsa.file.core.windows.net/","queue":"https://fa4mssttyodnwvmssw6sewsa.queue.core.windows.net/","table":"https://fa4mssttyodnwvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/i0ngkjvhv4ur55magntpri3","kind":"Storage","location":"westus","name":"i0ngkjvhv4ur55magntpri3","properties":{"creationTime":"2017-01-20T21:55:23.5727921Z","primaryEndpoints":{"blob":"https://i0ngkjvhv4ur55magntpri3.blob.core.windows.net/","file":"https://i0ngkjvhv4ur55magntpri3.file.core.windows.net/","queue":"https://i0ngkjvhv4ur55magntpri3.queue.core.windows.net/","table":"https://i0ngkjvhv4ur55magntpri3.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Storage/storageAccounts/imwgqlt26npmksaddiskvm","kind":"Storage","location":"westus","name":"imwgqlt26npmksaddiskvm","properties":{"creationTime":"2016-12-23T01:17:00.0809020Z","primaryEndpoints":{"blob":"https://imwgqlt26npmksaddiskvm.blob.core.windows.net/","file":"https://imwgqlt26npmksaddiskvm.file.core.windows.net/","queue":"https://imwgqlt26npmksaddiskvm.queue.core.windows.net/","table":"https://imwgqlt26npmksaddiskvm.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"demo":"deploy_1_33168"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/kempr3hzkgos4vmssw6sewsa","kind":"Storage","location":"westus","name":"kempr3hzkgos4vmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8987856Z","primaryEndpoints":{"blob":"https://kempr3hzkgos4vmssw6sewsa.blob.core.windows.net/","file":"https://kempr3hzkgos4vmssw6sewsa.file.core.windows.net/","queue":"https://kempr3hzkgos4vmssw6sewsa.queue.core.windows.net/","table":"https://kempr3hzkgos4vmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/mmshpb4y65j2gvmssw6sewsa","kind":"Storage","location":"westus","name":"mmshpb4y65j2gvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.9997918Z","primaryEndpoints":{"blob":"https://mmshpb4y65j2gvmssw6sewsa.blob.core.windows.net/","file":"https://mmshpb4y65j2gvmssw6sewsa.file.core.windows.net/","queue":"https://mmshpb4y65j2gvmssw6sewsa.queue.core.windows.net/","table":"https://mmshpb4y65j2gvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/ngkjvhv4ur55magntpub","kind":"Storage","location":"westus","name":"ngkjvhv4ur55magntpub","properties":{"creationTime":"2017-01-20T21:55:23.4318065Z","primaryEndpoints":{"blob":"https://ngkjvhv4ur55magntpub.blob.core.windows.net/","file":"https://ngkjvhv4ur55magntpub.file.core.windows.net/","queue":"https://ngkjvhv4ur55magntpub.queue.core.windows.net/","table":"https://ngkjvhv4ur55magntpub.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/ngkjvhv4ur55mdiag0","kind":"Storage","location":"westus","name":"ngkjvhv4ur55mdiag0","properties":{"creationTime":"2017-01-20T21:55:23.5248130Z","primaryEndpoints":{"blob":"https://ngkjvhv4ur55mdiag0.blob.core.windows.net/","file":"https://ngkjvhv4ur55mdiag0.file.core.windows.net/","queue":"https://ngkjvhv4ur55mdiag0.queue.core.windows.net/","table":"https://ngkjvhv4ur55mdiag0.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/ngkjvhv4ur55mmstr0","kind":"Storage","location":"westus","name":"ngkjvhv4ur55mmstr0","properties":{"creationTime":"2017-01-20T21:55:23.8108112Z","primaryEndpoints":{"blob":"https://ngkjvhv4ur55mmstr0.blob.core.windows.net/","file":"https://ngkjvhv4ur55mmstr0.file.core.windows.net/","queue":"https://ngkjvhv4ur55mmstr0.queue.core.windows.net/","table":"https://ngkjvhv4ur55mmstr0.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/o0ngkjvhv4ur55magntpri4","kind":"Storage","location":"westus","name":"o0ngkjvhv4ur55magntpri4","properties":{"creationTime":"2017-01-20T21:55:23.9638234Z","primaryEndpoints":{"blob":"https://o0ngkjvhv4ur55magntpri4.blob.core.windows.net/","file":"https://o0ngkjvhv4ur55magntpri4.file.core.windows.net/","queue":"https://o0ngkjvhv4ur55magntpri4.queue.core.windows.net/","table":"https://o0ngkjvhv4ur55magntpri4.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/sa23b04451870","kind":"Storage","location":"eastus","name":"sa23b04451870","properties":{"creationTime":"2017-01-10T02:14:36.3659472Z","primaryEndpoints":{"blob":"https://sa23b04451870.blob.core.windows.net/","file":"https://sa23b04451870.file.core.windows.net/","queue":"https://sa23b04451870.queue.core.windows.net/","table":"https://sa23b04451870.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc123","kind":"Storage","location":"eastus","name":"saffc123","properties":{"creationTime":"2017-01-12T19:24:50.8877257Z","primaryEndpoints":{"blob":"https://saffc123.blob.core.windows.net/","file":"https://saffc123.file.core.windows.net/","queue":"https://saffc123.queue.core.windows.net/","table":"https://saffc123.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc4451870","kind":"Storage","location":"eastus","name":"saffc4451870","properties":{"creationTime":"2017-01-10T02:14:17.6897337Z","primaryEndpoints":{"blob":"https://saffc4451870.blob.core.windows.net/","file":"https://saffc4451870.file.core.windows.net/","queue":"https://saffc4451870.queue.core.windows.net/","table":"https://saffc4451870.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{"tag":"demo"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc456","kind":"Storage","location":"eastus","name":"saffc456","properties":{"creationTime":"2017-01-12T19:45:57.3408534Z","primaryEndpoints":{"blob":"https://saffc456.blob.core.windows.net/","file":"https://saffc456.file.core.windows.net/","queue":"https://saffc456.queue.core.windows.net/","table":"https://saffc456.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryEndpoints":{"blob":"https://saffc456-secondary.blob.core.windows.net/","queue":"https://saffc456-secondary.queue.core.windows.net/","table":"https://saffc456-secondary.table.core.windows.net/"},"secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_RAGRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Storage/storageAccounts/stg01191daa0fa3d","kind":"Storage","location":"eastus","name":"stg01191daa0fa3d","properties":{"creationTime":"2017-01-13T23:07:07.5993134Z","primaryEndpoints":{"blob":"https://stg01191daa0fa3d.blob.core.windows.net/","file":"https://stg01191daa0fa3d.file.core.windows.net/","queue":"https://stg01191daa0fa3d.queue.core.windows.net/","table":"https://stg01191daa0fa3d.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv8963671476/providers/Microsoft.Storage/storageAccounts/stg085882cdba618","kind":"Storage","location":"eastus","name":"stg085882cdba618","properties":{"creationTime":"2017-01-05T02:35:01.6264643Z","primaryEndpoints":{"blob":"https://stg085882cdba618.blob.core.windows.net/","file":"https://stg085882cdba618.file.core.windows.net/","queue":"https://stg085882cdba618.queue.core.windows.net/","table":"https://stg085882cdba618.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv2704547300/providers/Microsoft.Storage/storageAccounts/stg206254db0fdf9","kind":"Storage","location":"eastus","name":"stg206254db0fdf9","properties":{"creationTime":"2017-01-25T08:55:58.4907357Z","primaryEndpoints":{"blob":"https://stg206254db0fdf9.blob.core.windows.net/","file":"https://stg206254db0fdf9.file.core.windows.net/","queue":"https://stg206254db0fdf9.queue.core.windows.net/","table":"https://stg206254db0fdf9.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Storage/storageAccounts/stg2170159aa305b","kind":"Storage","location":"eastus","name":"stg2170159aa305b","properties":{"creationTime":"2017-01-10T21:41:13.9625312Z","primaryEndpoints":{"blob":"https://stg2170159aa305b.blob.core.windows.net/","file":"https://stg2170159aa305b.file.core.windows.net/","queue":"https://stg2170159aa305b.queue.core.windows.net/","table":"https://stg2170159aa305b.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvef97261861/providers/Microsoft.Storage/storageAccounts/stg764130801f21a","kind":"Storage","location":"eastus","name":"stg764130801f21a","properties":{"creationTime":"2017-01-17T23:54:37.1219032Z","primaryEndpoints":{"blob":"https://stg764130801f21a.blob.core.windows.net/","file":"https://stg764130801f21a.file.core.windows.net/","queue":"https://stg764130801f21a.queue.core.windows.net/","table":"https://stg764130801f21a.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvc857134170/providers/Microsoft.Storage/storageAccounts/stg8663736ea67a4","kind":"Storage","location":"eastus","name":"stg8663736ea67a4","properties":{"creationTime":"2017-01-05T22:59:03.3110696Z","primaryEndpoints":{"blob":"https://stg8663736ea67a4.blob.core.windows.net/","file":"https://stg8663736ea67a4.file.core.windows.net/","queue":"https://stg8663736ea67a4.queue.core.windows.net/","table":"https://stg8663736ea67a4.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomve3e3280593/providers/Microsoft.Storage/storageAccounts/stg88193bbcca4ae","kind":"Storage","location":"eastus","name":"stg88193bbcca4ae","properties":{"creationTime":"2016-11-04T18:14:48.0926881Z","primaryEndpoints":{"blob":"https://stg88193bbcca4ae.blob.core.windows.net/","file":"https://stg88193bbcca4ae.file.core.windows.net/","queue":"https://stg88193bbcca4ae.queue.core.windows.net/","table":"https://stg88193bbcca4ae.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv29c1708752/providers/Microsoft.Storage/storageAccounts/stg91425c08ed693","kind":"Storage","location":"eastus","name":"stg91425c08ed693","properties":{"creationTime":"2016-12-29T22:48:46.0214806Z","primaryEndpoints":{"blob":"https://stg91425c08ed693.blob.core.windows.net/","file":"https://stg91425c08ed693.file.core.windows.net/","queue":"https://stg91425c08ed693.queue.core.windows.net/","table":"https://stg91425c08ed693.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3394686067/providers/Microsoft.Storage/storageAccounts/stg93298f66658e1","kind":"Storage","location":"eastus","name":"stg93298f66658e1","properties":{"creationTime":"2017-01-25T08:58:24.1284991Z","primaryEndpoints":{"blob":"https://stg93298f66658e1.blob.core.windows.net/","file":"https://stg93298f66658e1.file.core.windows.net/","queue":"https://stg93298f66658e1.queue.core.windows.net/","table":"https://stg93298f66658e1.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Storage/storageAccounts/stg9912444a8a603","kind":"Storage","location":"eastus","name":"stg9912444a8a603","properties":{"creationTime":"2017-01-13T23:07:07.0612657Z","primaryEndpoints":{"blob":"https://stg9912444a8a603.blob.core.windows.net/","file":"https://stg9912444a8a603.file.core.windows.net/","queue":"https://stg9912444a8a603.queue.core.windows.net/","table":"https://stg9912444a8a603.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Storage/storageAccounts/stgd5937897f8","kind":"Storage","location":"eastus","name":"stgd5937897f8","properties":{"creationTime":"2017-01-18T01:09:19.0104106Z","primaryEndpoints":{"blob":"https://stgd5937897f8.blob.core.windows.net/","file":"https://stgd5937897f8.file.core.windows.net/","queue":"https://stgd5937897f8.queue.core.windows.net/","table":"https://stgd5937897f8.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Storage/storageAccounts/stgjavavma8d4715986a","kind":"Storage","location":"southcentralus","name":"stgjavavma8d4715986a","properties":{"creationTime":"2017-01-18T00:40:01.4303906Z","primaryEndpoints":{"blob":"https://stgjavavma8d4715986a.blob.core.windows.net/","file":"https://stgjavavma8d4715986a.file.core.windows.net/","queue":"https://stgjavavma8d4715986a.queue.core.windows.net/","table":"https://stgjavavma8d4715986a.table.core.windows.net/"},"primaryLocation":"southcentralus","provisioningState":"Succeeded","secondaryLocation":"northcentralus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Storage/storageAccounts/storagedemo33168","kind":"Storage","location":"westus","name":"storagedemo33168","properties":{"creationTime":"2016-12-23T01:12:33.4626770Z","primaryEndpoints":{"blob":"https://storagedemo33168.blob.core.windows.net/","file":"https://storagedemo33168.file.core.windows.net/","queue":"https://storagedemo33168.queue.core.windows.net/","table":"https://storagedemo33168.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/testac8745","kind":"Storage","location":"westus","name":"testac8745","properties":{"creationTime":"2017-01-18T04:08:09.5308783Z","primaryEndpoints":{"blob":"https://testac8745.blob.core.windows.net/","file":"https://testac8745.file.core.windows.net/","queue":"https://testac8745.queue.core.windows.net/","table":"https://testac8745.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-sa/providers/Microsoft.Storage/storageAccounts/tjptestsa","kind":"Storage","location":"westus","name":"tjptestsa","properties":{"creationTime":"2017-01-20T19:48:21.4060144Z","primaryEndpoints":{"blob":"https://tjptestsa.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-sa/providers/Microsoft.Storage/storageAccounts/tjptestsa2","kind":"Storage","location":"westus","name":"tjptestsa2","properties":{"creationTime":"2017-01-26T22:49:55.8547936Z","primaryEndpoints":{"blob":"https://tjptestsa2.blob.core.windows.net/","file":"https://tjptestsa2.file.core.windows.net/","queue":"https://tjptestsa2.queue.core.windows.net/","table":"https://tjptestsa2.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/vhd14849519938968","kind":"Storage","location":"westus","name":"vhd14849519938968","properties":{"creationTime":"2017-01-20T22:40:04.2954807Z","primaryEndpoints":{"blob":"https://vhd14849519938968.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/vhd14849521329131","kind":"Storage","location":"westus","name":"vhd14849521329131","properties":{"creationTime":"2017-01-20T22:42:20.6194199Z","primaryEndpoints":{"blob":"https://vhd14849521329131.blob.core.windows.net/","file":"https://vhd14849521329131.file.core.windows.net/","queue":"https://vhd14849521329131.queue.core.windows.net/","table":"https://vhd14849521329131.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group_jat2_/providers/Microsoft.Storage/storageAccounts/vhdstorage1s00b0c3tbf2o3","kind":"Storage","location":"westus","name":"vhdstorage1s00b0c3tbf2o3","properties":{"creationTime":"2017-01-31T02:22:26.9523682Z","primaryEndpoints":{"blob":"https://vhdstorage1s00b0c3tbf2o3.blob.core.windows.net/","file":"https://vhdstorage1s00b0c3tbf2o3.file.core.windows.net/","queue":"https://vhdstorage1s00b0c3tbf2o3.queue.core.windows.net/","table":"https://vhdstorage1s00b0c3tbf2o3.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_create_vm_ubuntu_5ybs_/providers/Microsoft.Storage/storageAccounts/vhdstoragedxwggxmzrykwyi","kind":"Storage","location":"westus","name":"vhdstoragedxwggxmzrykwyi","properties":{"creationTime":"2017-01-31T02:22:20.6929111Z","primaryEndpoints":{"blob":"https://vhdstoragedxwggxmzrykwyi.blob.core.windows.net/","file":"https://vhdstoragedxwggxmzrykwyi.file.core.windows.net/","queue":"https://vhdstoragedxwggxmzrykwyi.queue.core.windows.net/","table":"https://vhdstoragedxwggxmzrykwyi.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Storage/storageAccounts/vhdstorageie7phr2igs7yww","kind":"Storage","location":"westus","name":"vhdstorageie7phr2igs7yww","properties":{"creationTime":"2017-01-20T22:26:17.5683423Z","primaryEndpoints":{"blob":"https://vhdstorageie7phr2igs7yww.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_custom_ip_t654_/providers/Microsoft.Storage/storageAccounts/vhdstorageo9ah7qu4584fvf","kind":"Storage","location":"westus","name":"vhdstorageo9ah7qu4584fvf","properties":{"creationTime":"2017-01-31T02:22:20.0258789Z","primaryEndpoints":{"blob":"https://vhdstorageo9ah7qu4584fvf.blob.core.windows.net/","file":"https://vhdstorageo9ah7qu4584fvf.file.core.windows.net/","queue":"https://vhdstorageo9ah7qu4584fvf.queue.core.windows.net/","table":"https://vhdstorageo9ah7qu4584fvf.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/vhdstorageyxn6viycfkhk4","kind":"Storage","location":"westus","name":"vhdstorageyxn6viycfkhk4","properties":{"creationTime":"2016-07-31T17:40:53.5600137Z","primaryEndpoints":{"blob":"https://vhdstorageyxn6viycfkhk4.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_zi3j_/providers/Microsoft.Storage/storageAccounts/vrfvmi7w30","kind":"Storage","location":"westus","name":"vrfvmi7w30","properties":{"creationTime":"2017-01-31T02:24:50.5418192Z","primaryEndpoints":{"blob":"https://vrfvmi7w30.blob.core.windows.net/","file":"https://vrfvmi7w30.file.core.windows.net/","queue":"https://vrfvmi7w30.queue.core.windows.net/","table":"https://vrfvmi7w30.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_zi3j_/providers/Microsoft.Storage/storageAccounts/vrfvmi7w31","kind":"Storage","location":"westus","name":"vrfvmi7w31","properties":{"creationTime":"2017-01-31T02:24:50.4888144Z","primaryEndpoints":{"blob":"https://vrfvmi7w31.blob.core.windows.net/","file":"https://vrfvmi7w31.file.core.windows.net/","queue":"https://vrfvmi7w31.queue.core.windows.net/","table":"https://vrfvmi7w31.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_zi3j_/providers/Microsoft.Storage/storageAccounts/vrfvmi7w32","kind":"Storage","location":"westus","name":"vrfvmi7w32","properties":{"creationTime":"2017-01-31T02:24:50.4918144Z","primaryEndpoints":{"blob":"https://vrfvmi7w32.blob.core.windows.net/","file":"https://vrfvmi7w32.file.core.windows.net/","queue":"https://vrfvmi7w32.queue.core.windows.net/","table":"https://vrfvmi7w32.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_zi3j_/providers/Microsoft.Storage/storageAccounts/vrfvmi7w33","kind":"Storage","location":"westus","name":"vrfvmi7w33","properties":{"creationTime":"2017-01-31T02:24:50.4468100Z","primaryEndpoints":{"blob":"https://vrfvmi7w33.blob.core.windows.net/","file":"https://vrfvmi7w33.file.core.windows.net/","queue":"https://vrfvmi7w33.queue.core.windows.net/","table":"https://vrfvmi7w33.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_zi3j_/providers/Microsoft.Storage/storageAccounts/vrfvmi7w34","kind":"Storage","location":"westus","name":"vrfvmi7w34","properties":{"creationTime":"2017-01-31T02:24:50.5058177Z","primaryEndpoints":{"blob":"https://vrfvmi7w34.blob.core.windows.net/","file":"https://vrfvmi7w34.file.core.windows.net/","queue":"https://vrfvmi7w34.queue.core.windows.net/","table":"https://vrfvmi7w34.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/yugangwdiag989","kind":"Storage","location":"westus","name":"yugangwdiag989","properties":{"creationTime":"2017-01-19T18:35:12.5904967Z","primaryEndpoints":{"blob":"https://yugangwdiag989.blob.core.windows.net/","file":"https://yugangwdiag989.file.core.windows.net/","queue":"https://yugangwdiag989.queue.core.windows.net/","table":"https://yugangwdiag989.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/yugangwdisks988","kind":"Storage","location":"westus","name":"yugangwdisks988","properties":{"creationTime":"2017-01-19T18:35:12.6254972Z","primaryEndpoints":{"blob":"https://yugangwdisks988.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Storage/storageAccounts/yugangwstorage","kind":"Storage","location":"westus","name":"yugangwstorage","properties":{"creationTime":"2016-04-23T21:39:21.1078503Z","primaryEndpoints":{"blob":"https://yugangwstorage.blob.core.windows.net/","file":"https://yugangwstorage.file.core.windows.net/","queue":"https://yugangwstorage.queue.core.windows.net/","table":"https://yugangwstorage.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"tag":"demo"},"type":"Microsoft.Storage/storageAccounts"}]}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/6nafvhzcqpliqvmssw6sewsa","kind":"Storage","location":"westus","name":"6nafvhzcqpliqvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8827839Z","primaryEndpoints":{"blob":"https://6nafvhzcqpliqvmssw6sewsa.blob.core.windows.net/","file":"https://6nafvhzcqpliqvmssw6sewsa.file.core.windows.net/","queue":"https://6nafvhzcqpliqvmssw6sewsa.queue.core.windows.net/","table":"https://6nafvhzcqpliqvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/a4be7dpmmwhnkvmssw6sewsa","kind":"Storage","location":"westus","name":"a4be7dpmmwhnkvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8527816Z","primaryEndpoints":{"blob":"https://a4be7dpmmwhnkvmssw6sewsa.blob.core.windows.net/","file":"https://a4be7dpmmwhnkvmssw6sewsa.file.core.windows.net/","queue":"https://a4be7dpmmwhnkvmssw6sewsa.queue.core.windows.net/","table":"https://a4be7dpmmwhnkvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/default-applicationinsights-centralus/providers/Microsoft.Storage/storageAccounts/appinsightsstorage2016","kind":"Storage","location":"centralus","name":"appinsightsstorage2016","properties":{"creationTime":"2016-03-03T23:07:20.8376748Z","primaryEndpoints":{"blob":"https://appinsightsstorage2016.blob.core.windows.net/","file":"https://appinsightsstorage2016.file.core.windows.net/","queue":"https://appinsightsstorage2016.queue.core.windows.net/","table":"https://appinsightsstorage2016.table.core.windows.net/"},"primaryLocation":"centralus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/forcory/providers/Microsoft.Storage/storageAccounts/appservicelinuxdoc035203","kind":"Storage","location":"westus","name":"appservicelinuxdoc035203","properties":{"creationTime":"2017-02-23T03:52:08.3228286Z","encryption":{"keySource":"Microsoft.Storage","services":{"blob":{"enabled":true,"lastEnabledTime":"2017-02-23T03:52:08.3228286Z"}}},"primaryEndpoints":{"blob":"https://appservicelinuxdoc035203.blob.core.windows.net/","file":"https://appservicelinuxdoc035203.file.core.windows.net/","queue":"https://appservicelinuxdoc035203.queue.core.windows.net/","table":"https://appservicelinuxdoc035203.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"containerregistry":"AppServiceLinuxDocker1"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Storage/storageAccounts/cli1097441544253702156","kind":"Storage","location":"westus","name":"cli1097441544253702156","properties":{"creationTime":"2016-07-11T10:51:20.0392107Z","primaryEndpoints":{"blob":"https://cli1097441544253702156.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Storage/storageAccounts/clisto3547828837ubuntuch","kind":"Storage","location":"westus","name":"clisto3547828837ubuntuch","properties":{"creationTime":"2016-07-11T10:53:02.7462882Z","primaryEndpoints":{"blob":"https://clisto3547828837ubuntuch.blob.core.windows.net/","file":"https://clisto3547828837ubuntuch.file.core.windows.net/","queue":"https://clisto3547828837ubuntuch.queue.core.windows.net/","table":"https://clisto3547828837ubuntuch.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Storage/storageAccounts/clitestbootdiag20170227","kind":"Storage","location":"westus","name":"clitestbootdiag20170227","properties":{"creationTime":"2017-02-27T22:55:59.8231113Z","primaryEndpoints":{"blob":"https://clitestbootdiag20170227.blob.core.windows.net/","file":"https://clitestbootdiag20170227.file.core.windows.net/","queue":"https://clitestbootdiag20170227.queue.core.windows.net/","table":"https://clitestbootdiag20170227.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/destanko-test1/providers/Microsoft.Storage/storageAccounts/destanko123","kind":"Storage","location":"westus","name":"destanko123","properties":{"creationTime":"2016-01-27T19:19:44.8251464Z","primaryEndpoints":{"blob":"https://destanko123.blob.core.windows.net/","file":"https://destanko123.file.core.windows.net/","queue":"https://destanko123.queue.core.windows.net/","table":"https://destanko123.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/fa4mssttyodnwvmssw6sewsa","kind":"Storage","location":"westus","name":"fa4mssttyodnwvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.9027880Z","primaryEndpoints":{"blob":"https://fa4mssttyodnwvmssw6sewsa.blob.core.windows.net/","file":"https://fa4mssttyodnwvmssw6sewsa.file.core.windows.net/","queue":"https://fa4mssttyodnwvmssw6sewsa.queue.core.windows.net/","table":"https://fa4mssttyodnwvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Storage/storageAccounts/imwgqlt26npmksaddiskvm","kind":"Storage","location":"westus","name":"imwgqlt26npmksaddiskvm","properties":{"creationTime":"2016-12-23T01:17:00.0809020Z","primaryEndpoints":{"blob":"https://imwgqlt26npmksaddiskvm.blob.core.windows.net/","file":"https://imwgqlt26npmksaddiskvm.file.core.windows.net/","queue":"https://imwgqlt26npmksaddiskvm.queue.core.windows.net/","table":"https://imwgqlt26npmksaddiskvm.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"demo":"deploy_1_33168"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/kempr3hzkgos4vmssw6sewsa","kind":"Storage","location":"westus","name":"kempr3hzkgos4vmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.8987856Z","primaryEndpoints":{"blob":"https://kempr3hzkgos4vmssw6sewsa.blob.core.windows.net/","file":"https://kempr3hzkgos4vmssw6sewsa.file.core.windows.net/","queue":"https://kempr3hzkgos4vmssw6sewsa.queue.core.windows.net/","table":"https://kempr3hzkgos4vmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/mmshpb4y65j2gvmssw6sewsa","kind":"Storage","location":"westus","name":"mmshpb4y65j2gvmssw6sewsa","properties":{"creationTime":"2016-11-03T21:20:49.9997918Z","primaryEndpoints":{"blob":"https://mmshpb4y65j2gvmssw6sewsa.blob.core.windows.net/","file":"https://mmshpb4y65j2gvmssw6sewsa.file.core.windows.net/","queue":"https://mmshpb4y65j2gvmssw6sewsa.queue.core.windows.net/","table":"https://mmshpb4y65j2gvmssw6sewsa.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/mystoragedsfsdaf","kind":"Storage","location":"westus","name":"mystoragedsfsdaf","properties":{"creationTime":"2017-02-03T00:53:05.6391827Z","primaryEndpoints":{"blob":"https://mystoragedsfsdaf.blob.core.windows.net/","file":"https://mystoragedsfsdaf.file.core.windows.net/","queue":"https://mystoragedsfsdaf.queue.core.windows.net/","table":"https://mystoragedsfsdaf.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/oldapiversionstoert","kind":"Storage","location":"westus","name":"oldapiversionstoert","properties":{"creationTime":"2017-02-15T18:52:13.3130661Z","primaryEndpoints":{"blob":"https://oldapiversionstoert.blob.core.windows.net/","file":"https://oldapiversionstoert.file.core.windows.net/","queue":"https://oldapiversionstoert.queue.core.windows.net/","table":"https://oldapiversionstoert.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/sa23b04451870","kind":"Storage","location":"eastus","name":"sa23b04451870","properties":{"creationTime":"2017-01-10T02:14:36.3659472Z","primaryEndpoints":{"blob":"https://sa23b04451870.blob.core.windows.net/","file":"https://sa23b04451870.file.core.windows.net/","queue":"https://sa23b04451870.queue.core.windows.net/","table":"https://sa23b04451870.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc123","kind":"Storage","location":"eastus","name":"saffc123","properties":{"creationTime":"2017-01-12T19:24:50.8877257Z","primaryEndpoints":{"blob":"https://saffc123.blob.core.windows.net/","file":"https://saffc123.file.core.windows.net/","queue":"https://saffc123.queue.core.windows.net/","table":"https://saffc123.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc4451870","kind":"Storage","location":"eastus","name":"saffc4451870","properties":{"creationTime":"2017-01-10T02:14:17.6897337Z","primaryEndpoints":{"blob":"https://saffc4451870.blob.core.windows.net/","file":"https://saffc4451870.file.core.windows.net/","queue":"https://saffc4451870.queue.core.windows.net/","table":"https://saffc4451870.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{"tag":"demo"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgstms1274451870/providers/Microsoft.Storage/storageAccounts/saffc456","kind":"Storage","location":"eastus","name":"saffc456","properties":{"creationTime":"2017-01-12T19:45:57.3408534Z","primaryEndpoints":{"blob":"https://saffc456.blob.core.windows.net/","file":"https://saffc456.file.core.windows.net/","queue":"https://saffc456.queue.core.windows.net/","table":"https://saffc456.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryEndpoints":{"blob":"https://saffc456-secondary.blob.core.windows.net/","queue":"https://saffc456-secondary.queue.core.windows.net/","table":"https://saffc456-secondary.table.core.windows.net/"},"secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_RAGRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Storage/storageAccounts/stg01191daa0fa3d","kind":"Storage","location":"eastus","name":"stg01191daa0fa3d","properties":{"creationTime":"2017-01-13T23:07:07.5993134Z","primaryEndpoints":{"blob":"https://stg01191daa0fa3d.blob.core.windows.net/","file":"https://stg01191daa0fa3d.file.core.windows.net/","queue":"https://stg01191daa0fa3d.queue.core.windows.net/","table":"https://stg01191daa0fa3d.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv8963671476/providers/Microsoft.Storage/storageAccounts/stg085882cdba618","kind":"Storage","location":"eastus","name":"stg085882cdba618","properties":{"creationTime":"2017-01-05T02:35:01.6264643Z","primaryEndpoints":{"blob":"https://stg085882cdba618.blob.core.windows.net/","file":"https://stg085882cdba618.file.core.windows.net/","queue":"https://stg085882cdba618.queue.core.windows.net/","table":"https://stg085882cdba618.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv2704547300/providers/Microsoft.Storage/storageAccounts/stg206254db0fdf9","kind":"Storage","location":"eastus","name":"stg206254db0fdf9","properties":{"creationTime":"2017-01-25T08:55:58.4907357Z","primaryEndpoints":{"blob":"https://stg206254db0fdf9.blob.core.windows.net/","file":"https://stg206254db0fdf9.file.core.windows.net/","queue":"https://stg206254db0fdf9.queue.core.windows.net/","table":"https://stg206254db0fdf9.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Storage/storageAccounts/stg2170159aa305b","kind":"Storage","location":"eastus","name":"stg2170159aa305b","properties":{"creationTime":"2017-01-10T21:41:13.9625312Z","primaryEndpoints":{"blob":"https://stg2170159aa305b.blob.core.windows.net/","file":"https://stg2170159aa305b.file.core.windows.net/","queue":"https://stg2170159aa305b.queue.core.windows.net/","table":"https://stg2170159aa305b.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvef97261861/providers/Microsoft.Storage/storageAccounts/stg764130801f21a","kind":"Storage","location":"eastus","name":"stg764130801f21a","properties":{"creationTime":"2017-01-17T23:54:37.1219032Z","primaryEndpoints":{"blob":"https://stg764130801f21a.blob.core.windows.net/","file":"https://stg764130801f21a.file.core.windows.net/","queue":"https://stg764130801f21a.queue.core.windows.net/","table":"https://stg764130801f21a.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomvc857134170/providers/Microsoft.Storage/storageAccounts/stg8663736ea67a4","kind":"Storage","location":"eastus","name":"stg8663736ea67a4","properties":{"creationTime":"2017-01-05T22:59:03.3110696Z","primaryEndpoints":{"blob":"https://stg8663736ea67a4.blob.core.windows.net/","file":"https://stg8663736ea67a4.file.core.windows.net/","queue":"https://stg8663736ea67a4.queue.core.windows.net/","table":"https://stg8663736ea67a4.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomve3e3280593/providers/Microsoft.Storage/storageAccounts/stg88193bbcca4ae","kind":"Storage","location":"eastus","name":"stg88193bbcca4ae","properties":{"creationTime":"2016-11-04T18:14:48.0926881Z","primaryEndpoints":{"blob":"https://stg88193bbcca4ae.blob.core.windows.net/","file":"https://stg88193bbcca4ae.file.core.windows.net/","queue":"https://stg88193bbcca4ae.queue.core.windows.net/","table":"https://stg88193bbcca4ae.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv29c1708752/providers/Microsoft.Storage/storageAccounts/stg91425c08ed693","kind":"Storage","location":"eastus","name":"stg91425c08ed693","properties":{"creationTime":"2016-12-29T22:48:46.0214806Z","primaryEndpoints":{"blob":"https://stg91425c08ed693.blob.core.windows.net/","file":"https://stg91425c08ed693.file.core.windows.net/","queue":"https://stg91425c08ed693.queue.core.windows.net/","table":"https://stg91425c08ed693.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgcomv3394686067/providers/Microsoft.Storage/storageAccounts/stg93298f66658e1","kind":"Storage","location":"eastus","name":"stg93298f66658e1","properties":{"creationTime":"2017-01-25T08:58:24.1284991Z","primaryEndpoints":{"blob":"https://stg93298f66658e1.blob.core.windows.net/","file":"https://stg93298f66658e1.file.core.windows.net/","queue":"https://stg93298f66658e1.queue.core.windows.net/","table":"https://stg93298f66658e1.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Storage/storageAccounts/stg9912444a8a603","kind":"Storage","location":"eastus","name":"stg9912444a8a603","properties":{"creationTime":"2017-01-13T23:07:07.0612657Z","primaryEndpoints":{"blob":"https://stg9912444a8a603.blob.core.windows.net/","file":"https://stg9912444a8a603.file.core.windows.net/","queue":"https://stg9912444a8a603.queue.core.windows.net/","table":"https://stg9912444a8a603.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Storage/storageAccounts/stgd5937897f8","kind":"Storage","location":"eastus","name":"stgd5937897f8","properties":{"creationTime":"2017-01-18T01:09:19.0104106Z","primaryEndpoints":{"blob":"https://stgd5937897f8.blob.core.windows.net/","file":"https://stgd5937897f8.file.core.windows.net/","queue":"https://stgd5937897f8.queue.core.windows.net/","table":"https://stgd5937897f8.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","secondaryLocation":"westus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Storage/storageAccounts/stgjavavma8d4715986a","kind":"Storage","location":"southcentralus","name":"stgjavavma8d4715986a","properties":{"creationTime":"2017-01-18T00:40:01.4303906Z","primaryEndpoints":{"blob":"https://stgjavavma8d4715986a.blob.core.windows.net/","file":"https://stgjavavma8d4715986a.file.core.windows.net/","queue":"https://stgjavavma8d4715986a.queue.core.windows.net/","table":"https://stgjavavma8d4715986a.table.core.windows.net/"},"primaryLocation":"southcentralus","provisioningState":"Succeeded","secondaryLocation":"northcentralus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Storage/storageAccounts/storagedemo33168","kind":"Storage","location":"westus","name":"storagedemo33168","properties":{"creationTime":"2016-12-23T01:12:33.4626770Z","primaryEndpoints":{"blob":"https://storagedemo33168.blob.core.windows.net/","file":"https://storagedemo33168.file.core.windows.net/","queue":"https://storagedemo33168.queue.core.windows.net/","table":"https://storagedemo33168.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Storage/storageAccounts/testac8745","kind":"Storage","location":"westus","name":"testac8745","properties":{"creationTime":"2017-01-18T04:08:09.5308783Z","primaryEndpoints":{"blob":"https://testac8745.blob.core.windows.net/","file":"https://testac8745.file.core.windows.net/","queue":"https://testac8745.queue.core.windows.net/","table":"https://testac8745.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-sa/providers/Microsoft.Storage/storageAccounts/tjptestsa","kind":"Storage","location":"westus","name":"tjptestsa","properties":{"creationTime":"2017-01-20T19:48:21.4060144Z","primaryEndpoints":{"blob":"https://tjptestsa.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{"noo":"doo","noodle":"doodle","wang":"beana","wee":"bee"},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-sa/providers/Microsoft.Storage/storageAccounts/tjptestsa2","kind":"Storage","location":"westus","name":"tjptestsa2","properties":{"creationTime":"2017-01-26T22:49:55.8547936Z","primaryEndpoints":{"blob":"https://tjptestsa2.blob.core.windows.net/","file":"https://tjptestsa2.file.core.windows.net/","queue":"https://tjptestsa2.queue.core.windows.net/","table":"https://tjptestsa2.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/vhd14849519938968","kind":"Storage","location":"westus","name":"vhd14849519938968","properties":{"creationTime":"2017-01-20T22:40:04.2954807Z","primaryEndpoints":{"blob":"https://vhd14849519938968.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Storage/storageAccounts/vhd14849521329131","kind":"Storage","location":"westus","name":"vhd14849521329131","properties":{"creationTime":"2017-01-20T22:42:20.6194199Z","primaryEndpoints":{"blob":"https://vhd14849521329131.blob.core.windows.net/","file":"https://vhd14849521329131.file.core.windows.net/","queue":"https://vhd14849521329131.queue.core.windows.net/","table":"https://vhd14849521329131.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-disk/providers/Microsoft.Storage/storageAccounts/vhdstorage4xan3wz004kgvi","kind":"Storage","location":"westus","name":"vhdstorage4xan3wz004kgvi","properties":{"creationTime":"2017-02-01T21:56:26.9475276Z","primaryEndpoints":{"blob":"https://vhdstorage4xan3wz004kgvi.blob.core.windows.net/","file":"https://vhdstorage4xan3wz004kgvi.file.core.windows.net/","queue":"https://vhdstorage4xan3wz004kgvi.queue.core.windows.net/","table":"https://vhdstorage4xan3wz004kgvi.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Storage/storageAccounts/vhdstoragegtrxkxg6jv0yyq","kind":"Storage","location":"westus","name":"vhdstoragegtrxkxg6jv0yyq","properties":{"creationTime":"2017-02-27T22:56:30.1611759Z","primaryEndpoints":{"blob":"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-vm-test1/providers/Microsoft.Storage/storageAccounts/vhdstoragegxu43r39nf1dy7","kind":"Storage","location":"eastus","name":"vhdstoragegxu43r39nf1dy7","properties":{"creationTime":"2017-02-03T20:55:33.9492906Z","primaryEndpoints":{"blob":"https://vhdstoragegxu43r39nf1dy7.blob.core.windows.net/","file":"https://vhdstoragegxu43r39nf1dy7.file.core.windows.net/","queue":"https://vhdstoragegxu43r39nf1dy7.queue.core.windows.net/","table":"https://vhdstoragegxu43r39nf1dy7.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Storage/storageAccounts/vhdstorageie7phr2igs7yww","kind":"Storage","location":"westus","name":"vhdstorageie7phr2igs7yww","properties":{"creationTime":"2017-01-20T22:26:17.5683423Z","primaryEndpoints":{"blob":"https://vhdstorageie7phr2igs7yww.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vm/providers/Microsoft.Storage/storageAccounts/vhdstorageu1ow25hmh6qbtm","kind":"Storage","location":"westus","name":"vhdstorageu1ow25hmh6qbtm","properties":{"creationTime":"2017-02-23T21:09:04.2598820Z","primaryEndpoints":{"blob":"https://vhdstorageu1ow25hmh6qbtm.blob.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Tue, 31 Jan 2017 02:25:27 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['41957']
+      content-length: ['30270']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"osProfile": {"adminUsername":
-      "yugangw", "linuxConfiguration": {"disablePasswordAuthentication": false}, "secrets":
-      [], "computerName": "myvm"}, "storageProfile": {"dataDisks": [], "osDisk": {"osType":
-      "Linux", "caching": "ReadWrite", "vhd": {"uri": "https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd"},
-      "createOption": "fromImage", "name": "osdisk_FEnku5efv7"}, "imageReference":
-      {"publisher": "Canonical", "offer": "UbuntuServer", "version": "latest", "sku":
-      "14.04.4-LTS"}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic"}]},
-      "hardwareProfile": {"vmSize": "Standard_DS1"}, "diagnosticsProfile": {"bootDiagnostics":
-      {"storageUri": "https://ae94nvfl1k1.blob.core.windows.net/", "enabled": true}}}}'
+    body: '{"properties": {"osProfile": {"computerName": "myvm", "adminUsername":
+      "user11", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      false}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic"}]},
+      "storageProfile": {"imageReference": {"publisher": "Canonical", "sku": "14.04.4-LTS",
+      "version": "latest", "offer": "UbuntuServer"}, "dataDisks": [], "osDisk": {"caching":
+      "ReadWrite", "createOption": "fromImage", "vhd": {"uri": "https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd"},
+      "osType": "Linux", "name": "osdisk_go63FMcUgt"}}, "diagnosticsProfile": {"bootDiagnostics":
+      {"enabled": true, "storageUri": "https://clitestbootdiag20170227.blob.core.windows.net/"}},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "tags": {}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['924']
+      Content-Length: ['951']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [87a97418-e75c-11e6-98b4-64510658e3b3]
+      x-ms-client-request-id: [3eb09906-fd40-11e6-a1f8-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": true,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": true,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
         ,\r\n  \"name\": \"myvm\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/1c159d45-1e28-447a-99f7-6cb69892b9b5?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/c21d7113-2e06-4d10-8589-113938082bf8?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:25:28 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1537']
+      content-length: ['1564']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
@@ -137,48 +137,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [87a97418-e75c-11e6-98b4-64510658e3b3]
+      x-ms-client-request-id: [3eb09906-fd40-11e6-a1f8-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1c159d45-1e28-447a-99f7-6cb69892b9b5?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c21d7113-2e06-4d10-8589-113938082bf8?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:25:28.0358811+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"1c159d45-1e28-447a-99f7-6cb69892b9b5\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:58:27.6667928+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:58:41.1058484+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"c21d7113-2e06-4d10-8589-113938082bf8\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:25:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [87a97418-e75c-11e6-98b4-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1c159d45-1e28-447a-99f7-6cb69892b9b5?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:25:28.0358811+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T02:26:03.4903641+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"1c159d45-1e28-447a-99f7-6cb69892b9b5\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:26:29 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -195,28 +166,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [87a97418-e75c-11e6-98b4-64510658e3b3]
+      x-ms-client-request-id: [3eb09906-fd40-11e6-a1f8-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": true,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": true,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
@@ -224,14 +195,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:26:29 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1538']
+      content-length: ['1565']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -241,28 +212,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [acffae6c-e75c-11e6-bdeb-64510658e3b3]
+      x-ms-client-request-id: [5200ea98-fd40-11e6-b968-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": true,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": true,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
@@ -270,14 +241,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:26:30 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1538']
+      content-length: ['1565']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -287,28 +258,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad539aa6-e75c-11e6-9012-64510658e3b3]
+      x-ms-client-request-id: [525e03b4-fd40-11e6-b06f-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": true,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": true,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
@@ -316,70 +287,70 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:26:30 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1538']
+      content-length: ['1565']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"osProfile": {"adminUsername":
-      "yugangw", "linuxConfiguration": {"disablePasswordAuthentication": false}, "secrets":
-      [], "computerName": "myvm"}, "storageProfile": {"dataDisks": [], "osDisk": {"osType":
-      "Linux", "caching": "ReadWrite", "vhd": {"uri": "https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd"},
-      "createOption": "fromImage", "name": "osdisk_FEnku5efv7"}, "imageReference":
-      {"publisher": "Canonical", "offer": "UbuntuServer", "version": "latest", "sku":
-      "14.04.4-LTS"}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic"}]},
-      "hardwareProfile": {"vmSize": "Standard_DS1"}, "diagnosticsProfile": {"bootDiagnostics":
-      {"enabled": false}}}}'
+    body: '{"properties": {"osProfile": {"computerName": "myvm", "adminUsername":
+      "user11", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      false}}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic"}]},
+      "storageProfile": {"imageReference": {"publisher": "Canonical", "sku": "14.04.4-LTS",
+      "version": "latest", "offer": "UbuntuServer"}, "dataDisks": [], "osDisk": {"caching":
+      "ReadWrite", "createOption": "fromImage", "vhd": {"uri": "https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd"},
+      "osType": "Linux", "name": "osdisk_go63FMcUgt"}}, "diagnosticsProfile": {"bootDiagnostics":
+      {"enabled": false}}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "tags":
+      {}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['865']
+      Content-Length: ['880']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad782614-e75c-11e6-8858-64510658e3b3]
+      x-ms-client-request-id: [52798ca4-fd40-11e6-8356-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": false,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": false,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
         ,\r\n  \"name\": \"myvm\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5b998c5e-aba9-4b01-a987-f5153e25f941?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/b9a215ff-319a-44bd-be75-08484aa573fc?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:26:32 GMT']
+      Date: ['Mon, 27 Feb 2017 22:58:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1538']
+      content-length: ['1565']
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -390,26 +361,26 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad782614-e75c-11e6-8858-64510658e3b3]
+      x-ms-client-request-id: [52798ca4-fd40-11e6-8356-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5b998c5e-aba9-4b01-a987-f5153e25f941?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b9a215ff-319a-44bd-be75-08484aa573fc?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:26:31.696261+00:00\",\r\n\
-        \  \"status\": \"InProgress\",\r\n  \"name\": \"5b998c5e-aba9-4b01-a987-f5153e25f941\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:59:00.5143564+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:59:20.0009772+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"b9a215ff-319a-44bd-be75-08484aa573fc\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:03 GMT']
+      Date: ['Mon, 27 Feb 2017 22:59:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['133']
+      content-length: ['184']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -419,57 +390,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad782614-e75c-11e6-8858-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5b998c5e-aba9-4b01-a987-f5153e25f941?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:26:31.696261+00:00\",\r\n\
-        \  \"endTime\": \"2017-01-31T02:27:08.6195429+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"5b998c5e-aba9-4b01-a987-f5153e25f941\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['183']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ad782614-e75c-11e6-8858-64510658e3b3]
+      x-ms-client-request-id: [52798ca4-fd40-11e6-8356-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": false,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": false,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
@@ -477,14 +419,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:34 GMT']
+      Date: ['Mon, 27 Feb 2017 22:59:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1539']
+      content-length: ['1566']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -494,28 +436,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d3db9e30-e75c-11e6-a515-64510658e3b3]
+      x-ms-client-request-id: [65cb7a8a-fd40-11e6-9670-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"7a8254c5-b1a4-4803-b00c-eae191d24120\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"486625bc-e705-4e71-939e-09ae9c097047\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_FEnku5efv7\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://ae94nvfl1k1.blob.core.windows.net/vhds/osdisk_FEnku5efv7.vhd\"\
+        \      \"name\": \"osdisk_go63FMcUgt\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragegtrxkxg6jv0yyq.blob.core.windows.net/vhds/osdisk_go63FMcUgt.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"myvm\",\r\n      \"adminUsername\": \"yugangw\",\r\n      \"linuxConfiguration\"\
+        : \"myvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n\
-        \        \"enabled\": false,\r\n        \"storageUri\": \"https://ae94nvfl1k1.blob.core.windows.net/\"\
+        \        \"enabled\": false,\r\n        \"storageUri\": \"https://clitestbootdiag20170227.blob.core.windows.net/\"\
         \r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_diagnostics/providers/Microsoft.Compute/virtualMachines/myvm\"\
@@ -523,13 +465,13 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:35 GMT']
+      Date: ['Mon, 27 Feb 2017 22:59:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1539']
+      content-length: ['1566']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_extension.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_extension.yaml
@@ -7,9 +7,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bfe0a6a4-e75c-11e6-9254-64510658e3b3]
+      x-ms-client-request-id: [60e021a2-fd38-11e6-95c2-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2016-04-30-preview
   response:
@@ -17,8 +17,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1qjow\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss151hq\"\
+        ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -27,56 +27,56 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1qjowNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1qjowIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss151hqNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss151hqIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"ad6426b6-1256-42fd-91c7-56dd895a1e2d\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"02a57772-9fad-45b5-ac15-cdf306a7d0fe\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:01 GMT']
+      Date: ['Mon, 27 Feb 2017 22:02:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2116']
+      content-length: ['2117']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"singlePlacementGroup": true, "virtualMachineProfile":
-      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"ipConfigurations":
+    body: '{"tags": {}, "properties": {"virtualMachineProfile": {"storageProfile":
+      {"osDisk": {"caching": "ReadOnly", "managedDisk": {"storageAccountType": "Standard_LRS"},
+      "createOption": "fromImage"}, "imageReference": {"sku": "14.04.4-LTS", "version":
+      "latest", "offer": "UbuntuServer", "publisher": "Canonical"}}, "osProfile":
+      {"secrets": [], "computerNamePrefix": "vmss151hq", "adminUsername": "admin123",
+      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "networkProfile":
+      {"networkInterfaceConfigurations": [{"properties": {"primary": true, "ipConfigurations":
       [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]},
-      "name": "vmss1qjowIPConfig"}], "primary": true}, "name": "vmss1qjowNic"}]},
-      "extensionProfile": {"extensions": [{"properties": {"autoUpgradeMinorVersion":
-      true, "protectedSettings": {"username": "myadmin", "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT"},
-      "type": "VMAccessForLinux", "publisher": "Microsoft.OSTCExtensions", "typeHandlerVersion":
-      "1.4"}, "name": "VMAccessForLinux"}]}, "osProfile": {"secrets": [], "adminUsername":
-      "yugangw", "computerNamePrefix": "vmss1qjow", "linuxConfiguration": {"disablePasswordAuthentication":
-      false}}, "storageProfile": {"imageReference": {"offer": "UbuntuServer", "version":
-      "latest", "publisher": "Canonical", "sku": "14.04.4-LTS"}, "osDisk": {"createOption":
-      "fromImage", "managedDisk": {"storageAccountType": "Standard_LRS"}, "caching":
-      "ReadOnly"}}}, "upgradePolicy": {"mode": "Manual"}, "overprovision": true},
-      "sku": {"capacity": 2, "name": "Standard_D1_v2", "tier": "Standard"}, "location":
-      "westus", "tags": {}}'
+      "name": "vmss151hqIPConfig"}]}, "name": "vmss151hqNic"}]}, "extensionProfile":
+      {"extensions": [{"properties": {"protectedSettings": {"ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT",
+      "username": "myadmin"}, "type": "VMAccessForLinux", "typeHandlerVersion": "1.4",
+      "autoUpgradeMinorVersion": true, "publisher": "Microsoft.OSTCExtensions"}, "name":
+      "VMAccessForLinux"}]}}, "upgradePolicy": {"mode": "Manual"}, "overprovision":
+      true, "singlePlacementGroup": true}, "sku": {"tier": "Standard", "capacity":
+      2, "name": "Standard_D1_v2"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2130']
+      Content-Length: ['2131']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bffff010-e75c-11e6-b4dc-64510658e3b3]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2016-04-30-preview
   response:
@@ -84,8 +84,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1qjow\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss151hq\"\
+        ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -94,8 +94,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1qjowNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1qjowIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss151hqNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss151hqIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
@@ -105,23 +105,23 @@ interactions:
         ,\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\"\
         : true\r\n            },\r\n            \"name\": \"VMAccessForLinux\"\r\n\
         \          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"ad6426b6-1256-42fd-91c7-56dd895a1e2d\"\
+        : \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"02a57772-9fad-45b5-ac15-cdf306a7d0fe\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/699d8167-51dc-49f1-aba8-6b0c3959c052?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/52ab6e5a-8a0a-4829-911a-4bae123a7810?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:02 GMT']
+      Date: ['Mon, 27 Feb 2017 22:02:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2491']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      content-length: ['2492']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -131,19 +131,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bffff010-e75c-11e6-b4dc-64510658e3b3]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/699d8167-51dc-49f1-aba8-6b0c3959c052?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/52ab6e5a-8a0a-4829-911a-4bae123a7810?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:27:02.4943097+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"699d8167-51dc-49f1-aba8-6b0c3959c052\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:02:09.5078006+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"52ab6e5a-8a0a-4829-911a-4bae123a7810\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:27:33 GMT']
+      Date: ['Mon, 27 Feb 2017 22:02:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -160,19 +160,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bffff010-e75c-11e6-b4dc-64510658e3b3]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/699d8167-51dc-49f1-aba8-6b0c3959c052?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/52ab6e5a-8a0a-4829-911a-4bae123a7810?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:27:02.4943097+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"699d8167-51dc-49f1-aba8-6b0c3959c052\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:02:09.5078006+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"52ab6e5a-8a0a-4829-911a-4bae123a7810\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:03 GMT']
+      Date: ['Mon, 27 Feb 2017 22:03:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -189,19 +189,48 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bffff010-e75c-11e6-b4dc-64510658e3b3]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/699d8167-51dc-49f1-aba8-6b0c3959c052?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/52ab6e5a-8a0a-4829-911a-4bae123a7810?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T02:27:02.4943097+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T02:28:32.6852498+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"699d8167-51dc-49f1-aba8-6b0c3959c052\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:02:09.5078006+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"52ab6e5a-8a0a-4829-911a-4bae123a7810\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:33 GMT']
+      Date: ['Mon, 27 Feb 2017 22:03:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/52ab6e5a-8a0a-4829-911a-4bae123a7810?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:02:09.5078006+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:04:01.1407748+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"52ab6e5a-8a0a-4829-911a-4bae123a7810\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:04:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -218,9 +247,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bffff010-e75c-11e6-b4dc-64510658e3b3]
+      x-ms-client-request-id: [613f67ac-fd38-11e6-af72-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2016-04-30-preview
   response:
@@ -228,8 +257,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1qjow\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss151hq\"\
+        ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -238,8 +267,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1qjowNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1qjowIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss151hqNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss151hqIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
@@ -249,21 +278,21 @@ interactions:
         ,\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\"\
         : true\r\n            },\r\n            \"name\": \"VMAccessForLinux\"\r\n\
         \          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"ad6426b6-1256-42fd-91c7-56dd895a1e2d\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"02a57772-9fad-45b5-ac15-cdf306a7d0fe\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:34 GMT']
+      Date: ['Mon, 27 Feb 2017 22:04:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2492']
+      content-length: ['2493']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -273,9 +302,9 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f7a5af5c-e75c-11e6-9484-64510658e3b3]
+      x-ms-client-request-id: [ac07b5fa-fd38-11e6-bd8d-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2016-04-30-preview
   response:
@@ -283,8 +312,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1qjow\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss151hq\"\
+        ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -293,8 +322,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1qjowNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1qjowIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss151hqNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss151hqIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
@@ -304,20 +333,20 @@ interactions:
         ,\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\"\
         : true\r\n            },\r\n            \"name\": \"VMAccessForLinux\"\r\n\
         \          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"ad6426b6-1256-42fd-91c7-56dd895a1e2d\"\
+        : \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"02a57772-9fad-45b5-ac15-cdf306a7d0fe\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_extension/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 02:28:35 GMT']
+      Date: ['Mon, 27 Feb 2017 22:04:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2492']
+      content-length: ['2493']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_nics.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_nics.yaml
@@ -6,21 +6,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5c85651e-e907-11e6-b9fc-f4b7e2e85440]
+      x-ms-client-request-id: [59d4f0e4-fd39-11e6-b58b-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/microsoft.Compute/virtualMachineScaleSets/vmss1/networkInterfaces?api-version=2016-03-30
   response:
-    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss1sjnvNic\"\
-        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n      \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss14x4mNic\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n      \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"resourceGuid\": \"eae3973f-16b0-4856-ad92-041d8dde68d1\",\r\
+        ,\r\n        \"resourceGuid\": \"7fd152c7-d83d-41d2-881a-3a48e9502bbe\",\r\
         \n        \"ipConfigurations\": [\r\n          {\r\n            \"name\":\
-        \ \"vmss1sjnvIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n            \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\
+        \ \"vmss14x4mIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n            \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.0.4\",\r\n\
         \              \"privateIPAllocationMethod\": \"Dynamic\",\r\n           \
@@ -33,18 +33,18 @@ interactions:
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\
         \n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\"\
-        : \"qoiqma5d3qjuzkrfn5lzmf0r0c.dx.internal.cloudapp.net\"\r\n        },\r\n\
-        \        \"macAddress\": \"00-0D-3A-30-3E-CA\",\r\n        \"enableIPForwarding\"\
+        : \"ctokemw1krzulnnuenwsvvrupd.dx.internal.cloudapp.net\"\r\n        },\r\n\
+        \        \"macAddress\": \"00-0D-3A-36-56-6A\",\r\n        \"enableIPForwarding\"\
         : false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n\
         \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
-        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss1sjnvNic\"\
-        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n      \"etag\": \"W/\\\"9673fd27-beac-4bb5-840a-58f0a37cd141\\\"\",\r\
+        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss14x4mNic\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n      \"etag\": \"W/\\\"abfdfc81-c1a0-43e9-bc3b-f1bfe0e57a39\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"resourceGuid\": \"97306185-e154-407c-a445-4961219ad5a2\",\r\
+        ,\r\n        \"resourceGuid\": \"cd19902c-96d9-4b60-bda1-f9724ee66f57\",\r\
         \n        \"ipConfigurations\": [\r\n          {\r\n            \"name\":\
-        \ \"vmss1sjnvIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n            \"etag\": \"W/\\\"9673fd27-beac-4bb5-840a-58f0a37cd141\\\"\
+        \ \"vmss14x4mIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n            \"etag\": \"W/\\\"abfdfc81-c1a0-43e9-bc3b-f1bfe0e57a39\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.0.5\",\r\n\
         \              \"privateIPAllocationMethod\": \"Dynamic\",\r\n           \
@@ -57,16 +57,16 @@ interactions:
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\
         \n          \"appliedDnsServers\": []\r\n        },\r\n        \"macAddress\"\
-        : \"00-0D-3A-30-30-69\",\r\n        \"enableIPForwarding\": false,\r\n   \
+        : \"00-0D-3A-36-5B-8E\",\r\n        \"enableIPForwarding\": false,\r\n   \
         \     \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
-        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss1sjnvNic\"\
-        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n      \"etag\": \"W/\\\"54abddd0-5007-43d4-b574-6c5be1d579d7\\\"\",\r\
+        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss14x4mNic\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n      \"etag\": \"W/\\\"4339a23a-50f2-416b-af4a-753c10aae946\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"resourceGuid\": \"fc8c19d6-4919-4f98-8d59-38b4ca74172e\",\r\
+        ,\r\n        \"resourceGuid\": \"4faeaf57-7fdb-4fb4-8545-4a653176ac44\",\r\
         \n        \"ipConfigurations\": [\r\n          {\r\n            \"name\":\
-        \ \"vmss1sjnvIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n            \"etag\": \"W/\\\"54abddd0-5007-43d4-b574-6c5be1d579d7\\\"\
+        \ \"vmss14x4mIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n            \"etag\": \"W/\\\"4339a23a-50f2-416b-af4a-753c10aae946\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.0.6\",\r\n\
         \              \"privateIPAllocationMethod\": \"Dynamic\",\r\n           \
@@ -78,17 +78,19 @@ interactions:
         : [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.2\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\
-        \n          \"appliedDnsServers\": []\r\n        },\r\n        \"macAddress\"\
-        : \"00-0D-3A-30-33-17\",\r\n        \"enableIPForwarding\": false,\r\n   \
-        \     \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2\"\
-        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss1sjnvNic\"\
-        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n      \"etag\": \"W/\\\"f60092ea-c76b-47e6-993b-29bf99abeffe\\\"\",\r\
+        \n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\"\
+        : \"ctokemw1krzulnnuenwsvvrupd.dx.internal.cloudapp.net\"\r\n        },\r\n\
+        \        \"macAddress\": \"00-0D-3A-36-51-2C\",\r\n        \"enableIPForwarding\"\
+        : false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n\
+        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2\"\
+        \r\n        }\r\n      }\r\n    },\r\n    {\r\n      \"name\": \"vmss14x4mNic\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n      \"etag\": \"W/\\\"bb43e201-7b04-446d-a3b7-1853a223196d\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"resourceGuid\": \"1d7ab722-1294-40db-91f8-fb277835b74a\",\r\
+        ,\r\n        \"resourceGuid\": \"3e23d5b3-8d92-4682-bdae-7db2ad8ce39d\",\r\
         \n        \"ipConfigurations\": [\r\n          {\r\n            \"name\":\
-        \ \"vmss1sjnvIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n            \"etag\": \"W/\\\"f60092ea-c76b-47e6-993b-29bf99abeffe\\\"\
+        \ \"vmss14x4mIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n            \"etag\": \"W/\\\"bb43e201-7b04-446d-a3b7-1853a223196d\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.0.7\",\r\n\
         \              \"privateIPAllocationMethod\": \"Dynamic\",\r\n           \
@@ -100,16 +102,14 @@ interactions:
         : [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.3\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\
-        \n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\"\
-        : \"qoiqma5d3qjuzkrfn5lzmf0r0c.dx.internal.cloudapp.net\"\r\n        },\r\n\
-        \        \"macAddress\": \"00-0D-3A-30-31-86\",\r\n        \"enableIPForwarding\"\
-        : false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n\
-        \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3\"\
+        \n          \"appliedDnsServers\": []\r\n        },\r\n        \"macAddress\"\
+        : \"00-0D-3A-36-5A-EC\",\r\n        \"enableIPForwarding\": false,\r\n   \
+        \     \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3\"\
         \r\n        }\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 02 Feb 2017 05:20:49 GMT']
+      Date: ['Mon, 27 Feb 2017 22:09:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -125,21 +125,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d16bed2-e907-11e6-9610-f4b7e2e85440]
+      x-ms-client-request-id: [5a7157c0-fd39-11e6-bcdd-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces?api-version=2016-03-30
   response:
-    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss1sjnvNic\"\
-        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n      \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss14x4mNic\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n      \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"resourceGuid\": \"eae3973f-16b0-4856-ad92-041d8dde68d1\",\r\
+        ,\r\n        \"resourceGuid\": \"7fd152c7-d83d-41d2-881a-3a48e9502bbe\",\r\
         \n        \"ipConfigurations\": [\r\n          {\r\n            \"name\":\
-        \ \"vmss1sjnvIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n            \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\
+        \ \"vmss14x4mIPConfig\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n            \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"privateIPAddress\": \"10.0.0.4\",\r\n\
         \              \"privateIPAllocationMethod\": \"Dynamic\",\r\n           \
@@ -152,15 +152,15 @@ interactions:
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
         \n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\
         \n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\"\
-        : \"qoiqma5d3qjuzkrfn5lzmf0r0c.dx.internal.cloudapp.net\"\r\n        },\r\n\
-        \        \"macAddress\": \"00-0D-3A-30-3E-CA\",\r\n        \"enableIPForwarding\"\
+        : \"ctokemw1krzulnnuenwsvvrupd.dx.internal.cloudapp.net\"\r\n        },\r\n\
+        \        \"macAddress\": \"00-0D-3A-36-56-6A\",\r\n        \"enableIPForwarding\"\
         : false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n\
         \          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
         \r\n        }\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 02 Feb 2017 05:20:51 GMT']
+      Date: ['Mon, 27 Feb 2017 22:09:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -176,20 +176,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5db1b792-e907-11e6-91a1-f4b7e2e85440]
+      x-ms-client-request-id: [5b0e6b08-fd39-11e6-81c5-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic?api-version=2016-03-30
   response:
-    body: {string: "{\r\n  \"name\": \"vmss1sjnvNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic\"\
-        ,\r\n  \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vmss14x4mNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic\"\
+        ,\r\n  \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        resourceGuid\": \"eae3973f-16b0-4856-ad92-041d8dde68d1\",\r\n    \"ipConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"vmss1sjnvIPConfig\",\r\n        \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1sjnvNic/ipConfigurations/vmss1sjnvIPConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"0bbc3f88-6f29-456e-bfe0-fc3a3026b940\\\"\"\
+        resourceGuid\": \"7fd152c7-d83d-41d2-881a-3a48e9502bbe\",\r\n    \"ipConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"vmss14x4mIPConfig\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss14x4mNic/ipConfigurations/vmss14x4mIPConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"4a7102c1-d141-444a-b2ec-a2ab85adcd6a\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
@@ -200,16 +200,16 @@ interactions:
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.0\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\"\
-        : [],\r\n      \"internalDomainNameSuffix\": \"qoiqma5d3qjuzkrfn5lzmf0r0c.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-30-3E-CA\",\r\n    \"enableIPForwarding\"\
+        : [],\r\n      \"internalDomainNameSuffix\": \"ctokemw1krzulnnuenwsvvrupd.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-56-6A\",\r\n    \"enableIPForwarding\"\
         : false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_nics/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
         \r\n    }\r\n  }\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 02 Feb 2017 05:20:52 GMT']
-      ETag: [W/"0bbc3f88-6f29-456e-bfe0-fc3a3026b940"]
+      Date: ['Mon, 27 Feb 2017 22:09:06 GMT']
+      ETag: [W/"4a7102c1-d141-444a-b2ec-a2ab85adcd6a"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_vms.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vmss_vms.yaml
@@ -7,68 +7,68 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f7769ed2-e777-11e6-bc1a-64510658e3b3]
+      x-ms-client-request-id: [ce4eefac-fd3a-11e6-b1ae-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"1\",\r\
         \n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n        \"\
         tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"\
-        latestModelApplied\": true,\r\n        \"vmId\": \"b9c019e9-a253-4fba-a297-773edd5d3d9d\"\
+        latestModelApplied\": true,\r\n        \"vmId\": \"b0e1ac2d-a3b0-4d88-a6ce-0bb90b6849ab\"\
         ,\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n\
         \            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\"\
         ,\r\n            \"sku\": \"14.04.4-LTS\",\r\n            \"version\": \"\
         14.04.201607140\"\r\n          },\r\n          \"osDisk\": {\r\n         \
-        \   \"osType\": \"Linux\",\r\n            \"name\": \"vmss1_vmss1_1_OsDisk_1_620a8bc2913448228423600c143a3364\"\
+        \   \"osType\": \"Linux\",\r\n            \"name\": \"vmss1_vmss1_1_OsDisk_1_7489f071b7784b64b362ab9c4aab2cfc\"\
         ,\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\"\
         : \"ReadOnly\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\"\
-        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_1_OsDisk_1_620a8bc2913448228423600c143a3364\"\
+        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_1_OsDisk_1_7489f071b7784b64b362ab9c4aab2cfc\"\
         \r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n     \
-        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss14fml000001\"\
-        ,\r\n          \"adminUsername\": \"yugangw\",\r\n          \"linuxConfiguration\"\
+        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss1006x000001\"\
+        ,\r\n          \"adminUsername\": \"admin123\",\r\n          \"linuxConfiguration\"\
         : {\r\n            \"disablePasswordAuthentication\": false\r\n          },\r\
         \n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"\
-        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss14fmlNic\"\
-        }]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n     \
-        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_PKGV_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
+        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1006xNic\"\
+        }]},\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"\
+        type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n\
+        \      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_6LOX_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
         ,\r\n      \"name\": \"vmss1_1\"\r\n    },\r\n    {\r\n      \"instanceId\"\
-        : \"3\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n\
+        : \"2\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n\
         \        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n\
-        \        \"latestModelApplied\": true,\r\n        \"vmId\": \"973de4cd-314d-4115-bd0a-2ea1222227d8\"\
+        \        \"latestModelApplied\": true,\r\n        \"vmId\": \"7fbc5a6b-ff80-4629-9849-c3fe6946dbb4\"\
         ,\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n\
         \            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\"\
         ,\r\n            \"sku\": \"14.04.4-LTS\",\r\n            \"version\": \"\
         14.04.201607140\"\r\n          },\r\n          \"osDisk\": {\r\n         \
-        \   \"osType\": \"Linux\",\r\n            \"name\": \"vmss1_vmss1_3_OsDisk_1_ae36fb8788534bc093e477436b1b7b5b\"\
+        \   \"osType\": \"Linux\",\r\n            \"name\": \"vmss1_vmss1_2_OsDisk_1_06b67d4614e84cf4971a2d67c7939393\"\
         ,\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\"\
         : \"ReadOnly\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\"\
-        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_3_OsDisk_1_ae36fb8788534bc093e477436b1b7b5b\"\
+        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_2_OsDisk_1_06b67d4614e84cf4971a2d67c7939393\"\
         \r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n     \
-        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss14fml000003\"\
-        ,\r\n          \"adminUsername\": \"yugangw\",\r\n          \"linuxConfiguration\"\
+        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss1006x000002\"\
+        ,\r\n          \"adminUsername\": \"admin123\",\r\n          \"linuxConfiguration\"\
         : {\r\n            \"disablePasswordAuthentication\": false\r\n          },\r\
         \n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"\
-        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss14fmlNic\"\
+        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1006xNic\"\
         }]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n     \
         \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\"\
         ,\r\n      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_PKGV_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3\"\
-        ,\r\n      \"name\": \"vmss1_3\"\r\n    }\r\n  ]\r\n}"}
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_6LOX_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2\"\
+        ,\r\n      \"name\": \"vmss1_2\"\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:41:51 GMT']
+      Date: ['Mon, 27 Feb 2017 22:19:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3888']
+      content-length: ['3889']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -78,36 +78,36 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f7f1eb54-e777-11e6-8881-64510658e3b3]
+      x-ms-client-request-id: [cedecf36-fd3a-11e6-a3e1-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"instanceId\": \"1\",\r\n  \"sku\": {\r\n    \"name\"\
         : \"Standard_D1_v2\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"latestModelApplied\": true,\r\n    \"vmId\": \"b9c019e9-a253-4fba-a297-773edd5d3d9d\"\
+        : {\r\n    \"latestModelApplied\": true,\r\n    \"vmId\": \"b0e1ac2d-a3b0-4d88-a6ce-0bb90b6849ab\"\
         ,\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"\
         publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n  \
         \      \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"14.04.201607140\"\
         \r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n\
-        \        \"name\": \"vmss1_vmss1_1_OsDisk_1_620a8bc2913448228423600c143a3364\"\
+        \        \"name\": \"vmss1_vmss1_1_OsDisk_1_7489f071b7784b64b362ab9c4aab2cfc\"\
         ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadOnly\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_1_OsDisk_1_620a8bc2913448228423600c143a3364\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_1_OsDisk_1_7489f071b7784b64b362ab9c4aab2cfc\"\
         \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"vmss14fml000001\",\r\n      \"adminUsername\"\
-        : \"yugangw\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
+        : {\r\n      \"computerName\": \"vmss1006x000001\",\r\n      \"adminUsername\"\
+        : \"admin123\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
         : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss14fmlNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1006xNic\"\
+        }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
         ,\r\n  \"name\": \"vmss1_1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:41:52 GMT']
+      Date: ['Mon, 27 Feb 2017 22:19:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -125,1005 +125,20 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f87d6754-e777-11e6-a645-64510658e3b3]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/restart?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/cde6394f-557f-4ec6-8bb7-3d648477a2c9?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 05:41:53 GMT']
+      Date: ['Mon, 27 Feb 2017 22:19:31 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/cde6394f-557f-4ec6-8bb7-3d648477a2c9?monitor=true&api-version=2016-04-30-preview']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f87d6754-e777-11e6-a645-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cde6394f-557f-4ec6-8bb7-3d648477a2c9?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:41:53.7051371+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"cde6394f-557f-4ec6-8bb7-3d648477a2c9\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:42:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f87d6754-e777-11e6-a645-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cde6394f-557f-4ec6-8bb7-3d648477a2c9?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:41:53.7051371+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"cde6394f-557f-4ec6-8bb7-3d648477a2c9\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:42:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f87d6754-e777-11e6-a645-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cde6394f-557f-4ec6-8bb7-3d648477a2c9?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:41:53.7051371+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T05:43:02.0235276+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"cde6394f-557f-4ec6-8bb7-3d648477a2c9\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['184']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2f8670d8-e778-11e6-96c7-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
-        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:43:04+00:00\"\r\n      }\r\n    ],\r\
-        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:43:01.9766459+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
-        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
-        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['821']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2ff97e5e-e778-11e6-9ebc-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
-        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:43:01+00:00\"\r\n      }\r\n    ],\r\
-        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:43:01.9766459+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
-        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
-        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['821']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3056916c-e778-11e6-ab9d-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
-        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:43:04+00:00\"\r\n      }\r\n    ],\r\
-        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:43:01.9766459+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
-        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
-        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['821']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [30b934ee-e778-11e6-af79-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
-        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:43:01+00:00\"\r\n      }\r\n    ],\r\
-        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:43:01.9766459+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
-        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
-        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['821']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/poweroff?api-version=2016-04-30-preview
-  response:
-    body: {string: ''}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 05:43:28 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?monitor=true&api-version=2016-04-30-preview']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:43:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:44:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:44:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:45:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:45:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:46:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:47:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:47:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:48:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:48:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:49:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:49:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:50:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:50:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:51:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:51:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:52:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:52:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:53:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:53:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3119e1b8-e778-11e6-8d4a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/014992f5-f338-4439-93fd-3bf38a2f60e1?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:43:28.5259014+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T05:54:04.4741359+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"014992f5-f338-4439-93fd-3bf38a2f60e1\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:54:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['184']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ae4498d0-e779-11e6-8732-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
-        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:51:44+00:00\"\r\n      }\r\n    ],\r\
-        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
-        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:54:04.4426341+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
-        : \"PowerState/stopped\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
-        : \"VM stopped\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:54:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['821']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [aedec928-e779-11e6-86d2-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\"\
-        : [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n\
-        \        \"level\": \"Warning\",\r\n        \"displayStatus\": \"Not Ready\"\
-        ,\r\n        \"message\": \"VM Agent is unresponsive.\",\r\n        \"time\"\
-        : \"2017-01-31T05:54:09+00:00\"\r\n      }\r\n    ]\r\n  },\r\n  \"statuses\"\
-        : [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n     \
-        \ \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n      \"time\": \"2017-01-31T05:43:49.8715666+00:00\"\r\n    },\r\n \
-        \   {\r\n      \"code\": \"PowerState/stopped\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"VM stopped\"\r\n    }\r\n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:54:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['758']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [af5c5cb4-e779-11e6-9953-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/start?api-version=2016-04-30-preview
-  response:
-    body: {string: ''}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/21816406-a079-4c64-a837-394036766b47?api-version=2016-04-30-preview']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 05:54:10 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/21816406-a079-4c64-a837-394036766b47?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -1137,26 +152,26 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af5c5cb4-e779-11e6-9953-64510658e3b3]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/21816406-a079-4c64-a837-394036766b47?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:54:10.0680683+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"21816406-a079-4c64-a837-394036766b47\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:54:40 GMT']
+      Date: ['Mon, 27 Feb 2017 22:20:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1166,26 +181,26 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af5c5cb4-e779-11e6-9953-64510658e3b3]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/21816406-a079-4c64-a837-394036766b47?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:54:10.0680683+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T05:54:46.3366826+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"21816406-a079-4c64-a837-394036766b47\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:55:10 GMT']
+      Date: ['Mon, 27 Feb 2017 22:20:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['184']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1195,29 +210,145 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d48b38d8-e779-11e6-ade7-64510658e3b3]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:21:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['133']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:21:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['133']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:22:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['133']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cf6acb58-fd3a-11e6-8bf8-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9e616d8b-4a1d-4dea-95ec-716045850ac4?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:19:32.537174+00:00\",\r\n\
+        \  \"endTime\": \"2017-02-27T22:22:09.9169088+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"9e616d8b-4a1d-4dea-95ec-716045850ac4\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:22:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['183']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3cca8e64-fd3b-11e6-b7fe-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
         ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
         ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:55:06+00:00\"\r\n      }\r\n    ],\r\
+        ,\r\n        \"time\": \"2017-02-27T22:22:30+00:00\"\r\n      }\r\n    ],\r\
         \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
         \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
         ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:54:46.3210649+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"2017-02-27T22:21:43.5420547+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
         : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
         : \"VM running\"\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:55:11 GMT']
+      Date: ['Mon, 27 Feb 2017 22:22:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1234,29 +365,107 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d5063450-e779-11e6-b0f7-64510658e3b3]
+      x-ms-client-request-id: [3d3ce0f0-fd3b-11e6-a0ad-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/2/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n \
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
         ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
-        ,\r\n        \"time\": \"2017-01-31T05:55:02+00:00\"\r\n      }\r\n    ],\r\
+        ,\r\n        \"time\": \"2017-02-27T22:22:25+00:00\"\r\n      }\r\n    ],\r\
         \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
         \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
         ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
-        : \"2017-01-31T05:54:30.288492+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"2017-02-27T22:19:36.802791+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
         : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
         : \"VM running\"\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:55:12 GMT']
+      Date: ['Mon, 27 Feb 2017 22:22:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['820']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3daeb90c-fd3b-11e6-b391-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:30+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:21:43.5420547+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:22:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['821']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3e14f886-fd3b-11e6-bf29-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/2/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:25+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:19:36.802791+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:22:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1274,24 +483,24 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d57634be-e779-11e6-a78b-64510658e3b3]
+      x-ms-client-request-id: [3e79b67e-fd3b-11e6-811e-64510658e3b3]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/deallocate?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/poweroff?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/583a35ae-21dc-4e70-83e8-69e4d7d3bdc1?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 05:55:14 GMT']
+      Date: ['Mon, 27 Feb 2017 22:22:36 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/583a35ae-21dc-4e70-83e8-69e4d7d3bdc1?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1301,231 +510,19 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d57634be-e779-11e6-a78b-64510658e3b3]
+      x-ms-client-request-id: [3e79b67e-fd3b-11e6-811e-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/583a35ae-21dc-4e70-83e8-69e4d7d3bdc1?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:55:13.9798043+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"07cfdd29-c8ae-4069-8102-2b6454813f6c\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:22:38.7292865+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:23:08.057232+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"583a35ae-21dc-4e70-83e8-69e4d7d3bdc1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:55:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d57634be-e779-11e6-a78b-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:55:13.9798043+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"07cfdd29-c8ae-4069-8102-2b6454813f6c\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:56:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d57634be-e779-11e6-a78b-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:55:13.9798043+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"07cfdd29-c8ae-4069-8102-2b6454813f6c\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:56:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d57634be-e779-11e6-a78b-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/07cfdd29-c8ae-4069-8102-2b6454813f6c?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:55:13.9798043+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T05:57:05.9743675+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"07cfdd29-c8ae-4069-8102-2b6454813f6c\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:57:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['184']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1f02fd6e-e77a-11e6-a63d-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-01-31T05:57:00.8958601+00:00\"\r\n\
-        \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
-        level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
-        \n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:57:16 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['454']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1f7c1dd0-e77a-11e6-8eab-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"placementGroupId\": \"11b17718-e199-486d-a2f4-b711010afb00\"\
-        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
-        \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-01-31T05:57:05.9587424+00:00\"\r\n\
-        \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
-        level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
-        \n  ]\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:57:18 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['454']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1ff02a52-e77a-11e6-a528-64510658e3b3]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A?api-version=2016-04-30-preview
-  response:
-    body: {string: ''}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/8ad1bbce-34fd-41ca-b9e9-723f34445fa8?api-version=2016-04-30-preview']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 05:57:18 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/8ad1bbce-34fd-41ca-b9e9-723f34445fa8?monitor=true&api-version=2016-04-30-preview']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1ff02a52-e77a-11e6-a528-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/8ad1bbce-34fd-41ca-b9e9-723f34445fa8?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T05:57:19.303518+00:00\",\r\n\
-        \  \"endTime\": \"2017-01-31T05:57:34.6796966+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"8ad1bbce-34fd-41ca-b9e9-723f34445fa8\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:57:49 GMT']
+      Date: ['Mon, 27 Feb 2017 22:23:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1542,9 +539,520 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [333a74a4-e77a-11e6-a3c9-64510658e3b3]
+      x-ms-client-request-id: [5302c092-fd3b-11e6-aeee-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:30+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:23:08.0259985+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/stopped\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM stopped\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:23:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['821']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [53524d38-fd3b-11e6-8bcf-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/2/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:50+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:22:59.0260523+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/stopped\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM stopped\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:23:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['821']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [53be0276-fd3b-11e6-b706-64510658e3b3]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/start?api-version=2016-04-30-preview
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5d3fd0d6-770c-4127-bd3d-5296983e67e0?api-version=2016-04-30-preview']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 27 Feb 2017 22:23:12 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5d3fd0d6-770c-4127-bd3d-5296983e67e0?monitor=true&api-version=2016-04-30-preview']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [53be0276-fd3b-11e6-b706-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5d3fd0d6-770c-4127-bd3d-5296983e67e0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:14.1822052+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:23:34.5102152+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5d3fd0d6-770c-4127-bd3d-5296983e67e0\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:23:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6678cf02-fd3b-11e6-adb7-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:30+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:23:34.4789535+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:23:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['821']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [66fd8fac-fd3b-11e6-971b-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/2/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n \
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n        \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\"\
+        ,\r\n        \"message\": \"GuestAgent is running and accepting new configurations.\"\
+        ,\r\n        \"time\": \"2017-02-27T22:22:50+00:00\"\r\n      }\r\n    ],\r\
+        \n    \"extensionHandlers\": []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n\
+        \      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\"\
+        ,\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\"\
+        : \"2017-02-27T22:23:34.4789535+00:00\"\r\n    },\r\n    {\r\n      \"code\"\
+        : \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\"\
+        : \"VM running\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:23:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['821']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/deallocate?api-version=2016-04-30-preview
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 27 Feb 2017 22:23:46 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?monitor=true&api-version=2016-04-30-preview']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:47.6820245+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de22af17-19ce-4246-a48c-de0f9c7282c0\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:24:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:47.6820245+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de22af17-19ce-4246-a48c-de0f9c7282c0\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:24:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:47.6820245+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de22af17-19ce-4246-a48c-de0f9c7282c0\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:25:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:47.6820245+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de22af17-19ce-4246-a48c-de0f9c7282c0\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:25:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6786b74c-fd3b-11e6-92e5-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/de22af17-19ce-4246-a48c-de0f9c7282c0?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:23:47.6820245+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:26:08.7161433+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"de22af17-19ce-4246-a48c-de0f9c7282c0\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:26:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c30092a8-fd3b-11e6-b7ed-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
+        \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n      \"time\": \"2017-02-27T22:26:08.6848771+00:00\"\r\n\
+        \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
+        level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
+        \n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:26:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['454']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c36a2f6e-fd3b-11e6-9365-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/2/instanceView?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"placementGroupId\": \"5e52441c-8f24-4869-b567-fe383f018aa4\"\
+        ,\r\n  \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n \
+        \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n      \"time\": \"2017-02-27T22:26:03.6224153+00:00\"\r\n\
+        \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
+        level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
+        \n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:26:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['454']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c3ca289a-fd3b-11e6-8761-64510658e3b3]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A?api-version=2016-04-30-preview
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/ffec6ada-5cb5-44b8-8d40-7057775fb9b9?api-version=2016-04-30-preview']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 27 Feb 2017 22:26:21 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/ffec6ada-5cb5-44b8-8d40-7057775fb9b9?monitor=true&api-version=2016-04-30-preview']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c3ca289a-fd3b-11e6-8761-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/ffec6ada-5cb5-44b8-8d40-7057775fb9b9?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:26:22.6848354+00:00\",\r\
+        \n  \"endTime\": \"2017-02-27T22:26:38.1378675+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"ffec6ada-5cb5-44b8-8d40-7057775fb9b9\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 27 Feb 2017 22:26:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
+          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d71dd758-fd3b-11e6-8048-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?api-version=2016-04-30-preview
   response:
@@ -1552,7 +1060,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 05:57:50 GMT']
+      Date: ['Mon, 27 Feb 2017 22:26:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -176,12 +176,10 @@ class VMImageListOffersScenarioTest(VCRTestBase):
         self.execute()
 
     def body(self):
-        self.cmd('vm image list-offers --location {} --publisher {}'.format(
-            self.location, self.publisher_name), checks=[
-                JMESPathCheck('type(@)', 'array'),
-                JMESPathCheck("length([?location == '{}']) == length(@)".format(self.location), True),
-                JMESPathCheck("length([].id.contains(@, '/Publishers/{}'))".format(self.publisher_name), 6),
-        ])
+        result = self.cmd('vm image list-offers --location {} --publisher {}'.format(
+            self.location, self.publisher_name))
+        self.assertTrue(len(result) > 0)
+        self.assertFalse([i for i in result if i['location'].lower() != self.location])
 
 
 class VMImageListPublishersScenarioTest(VCRTestBase):
@@ -748,7 +746,7 @@ class VMBootDiagnostics(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
         super(VMBootDiagnostics, self).__init__(__file__, test_method, resource_group='cli_test_vm_diagnostics')
         self.vm_name = 'myvm'
-        self.storage_name = 'ae94nvfl1k1'
+        self.storage_name = 'clitestbootdiag20170227'
 
     def test_vm_boot_diagnostics(self):
         self.execute()
@@ -781,7 +779,7 @@ class VMSSExtensionInstallTest(ResourceGroupVCRTestBase):
 
     def set_up(self):
         super(VMSSExtensionInstallTest, self).set_up()
-        self.cmd('vmss create -n {} -g {} --image UbuntuLTS --authentication-type password --admin-password TestPass1@'.format(self.vmss_name, self.resource_group))
+        self.cmd('vmss create -n {} -g {} --image UbuntuLTS --authentication-type password --admin-username admin123 --admin-password TestPass1@'.format(self.vmss_name, self.resource_group))
 
     def test_vmss_extension(self):
         self.execute()
@@ -825,7 +823,7 @@ class DiagnosticsExtensionInstallTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
         super(DiagnosticsExtensionInstallTest, self).__init__(__file__, test_method, resource_group='cli_test_vm_vmss_diagnostics_extension')
-        self.storage_account = 'diagextensionsa'
+        self.storage_account = 'clitestdiagextsa20170227'
         self.vm = 'testdiagvm'
         self.vmss = 'testdiagvmss'
 
@@ -1498,7 +1496,7 @@ class VMSSVMsScenarioTest(ResourceGroupVCRTestBase):
 
     def set_up(self):
         super(VMSSVMsScenarioTest, self).set_up()
-        self.cmd('vmss create -g {} -n {} --image UbuntuLTS --authentication-type password --admin-password TestTest12#$ --instance-count {}'.format(self.resource_group, self.ss_name, self.vm_count))
+        self.cmd('vmss create -g {} -n {} --image UbuntuLTS --authentication-type password --admin-username admin123 --admin-password TestTest12#$ --instance-count {}'.format(self.resource_group, self.ss_name, self.vm_count))
 
     def test_vmss_vms(self):
         self.execute()
@@ -1566,7 +1564,7 @@ class VMSSNicScenarioTest(ResourceGroupVCRTestBase):
 
     def set_up(self):
         super(VMSSNicScenarioTest, self).set_up()
-        self.cmd('vmss create -g {} -n {} --authentication-type password --admin-password PasswordPassword1!  --image Win2012R2Datacenter'.format(self.resource_group, self.vmss_name))
+        self.cmd('vmss create -g {} -n {} --authentication-type password --admin-username admin123 --admin-password PasswordPassword1!  --image Win2012R2Datacenter'.format(self.resource_group, self.vmss_name))
 
     def body(self):
         self.cmd('vmss nic list -g {} --vmss-name {}'.format(self.resource_group, self.vmss_name), checks=[


### PR DESCRIPTION
1. For 2 Test failures caused by storage account name being taken, the change here is to mitigate it since we are heading to non recording based test methodology.
2. Fixed failures caused by missing `--admin-user-name` on `vm create` 
3. Fixed test verification code in vm image query command. It hard coded the expected number which may change.