### PR TITLE
[Storage] Fix issue with storage account custom domain.

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -250,10 +250,9 @@ for item in ['create', 'update']:
 
 register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
 register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
-register_cli_argument('storage account create', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.', validator=validate_custom_domain)
+register_cli_argument('storage account create', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.')
 register_cli_argument('storage account update', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source. Use "" to clear existing value.', validator=validate_custom_domain)
-register_extra_cli_argument('storage account create', 'subdomain', options_list=('--use-subdomain',), help='Specify to enable indirect CNAME validation.', action='store_true')
-register_extra_cli_argument('storage account update', 'subdomain', options_list=('--use-subdomain',), help='Specify whether to use indirect CNAME validation.', default=None, **enum_choice_list(['true', 'false']))
+register_cli_argument('storage account update', 'use_subdomain', help='Specify whether to use indirect CNAME validation.', **enum_choice_list(['true', 'false']))
 
 register_cli_argument('storage account update', 'tags', tags_type, default=None)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -15,7 +15,6 @@ from azure.cli.core._util import CLIError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_key_value_pairs
 from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.storage.models import CustomDomain
 from azure.storage.sharedaccesssignature import SharedAccessSignature
 from azure.storage.blob import Include, PublicAccess
 from azure.storage.blob.baseblobservice import BaseBlobService
@@ -272,11 +271,8 @@ def get_content_setting_validator(settings_class, update):
 
 
 def validate_custom_domain(namespace):
-    if namespace.custom_domain:
-        namespace.custom_domain = CustomDomain(namespace.custom_domain, namespace.subdomain)
-    if namespace.subdomain and not namespace.custom_domain:
-        raise ValueError("must specify '--custom-domain' to use the '--use-subdomain' flag")
-    del namespace.subdomain
+    if namespace.use_subdomain and not namespace.custom_domain:
+        raise ValueError('usage error: --custom-domain DOMAIN [--use-subdomain]')
 
 
 def validate_encryption(namespace):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -57,7 +57,7 @@ cli_command(__name__, 'storage account keys renew', mgmt_path + 'regenerate_key'
 cli_command(__name__, 'storage account keys list', mgmt_path + 'list_keys', factory, transform=lambda x: x.keys)
 cli_generic_update_command(__name__, 'storage account update',
                            mgmt_path + 'get_properties',
-                           mgmt_path + 'create', factory,
+                           mgmt_path + 'update', factory,
                            custom_function_op=custom_path + 'update_storage_account')
 cli_storage_data_plane_command('storage account generate-sas', 'azure.storage.cloudstorageaccount#CloudStorageAccount.generate_shared_access_signature', cloud_storage_account_service_factory)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -103,23 +103,26 @@ def create_storage_account(resource_group_name, account_name, sku, location,
         kind=Kind(kind),
         location=location,
         tags=tags,
-        custom_domain=CustomDomain(custom_domain) if custom_domain else None,
+        custom_domain=CustomDomain(custom_domain, None) if custom_domain else None,
         encryption=encryption,
         access_tier=AccessTier(access_tier) if access_tier else None)
     return scf.storage_accounts.create(resource_group_name, account_name, params)
 
 
 def update_storage_account(instance, sku=None, tags=None, custom_domain=None,
-                           encryption=None, access_tier=None):
+                           use_subdomain=None, encryption=None, access_tier=None):
     from azure.mgmt.storage.models import \
-        (StorageAccountCreateParameters, Sku, CustomDomain, AccessTier)
+        (StorageAccountUpdateParameters, Sku, CustomDomain, AccessTier)
+    domain = instance.custom_domain
+    if custom_domain is not None:
+        domain = CustomDomain(custom_domain)
+        if use_subdomain is not None:
+            domain.name = use_subdomain == 'true'
 
-    params = StorageAccountCreateParameters(
+    params = StorageAccountUpdateParameters(
         sku=Sku(sku) if sku is not None else instance.sku,
-        kind=instance.kind,
-        location=instance.location,
         tags=tags if tags is not None else instance.tags,
-        custom_domain=CustomDomain(custom_domain) if custom_domain is not None else instance.custom_domain,  # pylint: disable=line-too-long
+        custom_domain=domain,
         encryption=encryption if encryption is not None else instance.encryption,
         access_tier=AccessTier(access_tier) if access_tier is not None else instance.access_tier
     )

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
@@ -7,10 +7,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d3fbbbf4-f3c9-11e6-ab1b-74c63bed1137]
+      x-ms-client-request-id: [9c9be3b6-fed7-11e6-8ca8-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
@@ -20,7 +20,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:03 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -37,10 +37,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d4c73850-f3c9-11e6-9371-74c63bed1137]
+      x-ms-client-request-id: [9d4cbb68-fed7-11e6-96c5-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
@@ -50,7 +50,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:04 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -60,17 +60,17 @@ interactions:
       content-length: ['23']
     status: {code: 200, message: OK}
 - request:
-    body: '{"sku": {"name": "Standard_LRS"}, "kind": "Storage", "location": "westus"}'
+    body: '{"sku": {"name": "Standard_LRS"}, "location": "westus", "kind": "Storage"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['74']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d58758a8-f3c9-11e6-93c6-74c63bed1137]
+      x-ms-client-request-id: [9dfccaee-fed7-11e6-ac56-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
@@ -78,14 +78,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 15 Feb 2017 21:58:07 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:30 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Storage/operations/9147d762-549f-4705-a5ac-dbf05b9c7a94?monitor=true&api-version=2016-12-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Storage/operations/47260cb6-ad6b-4505-abf3-db1258120ff9?monitor=true&api-version=2016-12-01']
       Pragma: [no-cache]
       Retry-After: ['17']
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -94,20 +94,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d58758a8-f3c9-11e6-93c6-74c63bed1137]
+      x-ms-client-request-id: [9dfccaee-fed7-11e6-ac56-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/9147d762-549f-4705-a5ac-dbf05b9c7a94?monitor=true&api-version=2016-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/47260cb6-ad6b-4505-abf3-db1258120ff9?monitor=true&api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:24 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -117,28 +117,28 @@ interactions:
       content-length: ['776']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "vcrstorage733641907300", "type": "Microsoft.Storage/storageAccounts"}'
+    body: '{"name": "vcrstorage000197884384", "type": "Microsoft.Storage/storageAccounts"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['79']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1bebfcc-f3c9-11e6-a3b6-74c63bed1137]
+      x-ms-client-request-id: [a9a247a6-fed7-11e6-88e9-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
-    body: {string: '{"message":"The storage account named vcrstorage733641907300 is
+    body: {string: '{"message":"The storage account named vcrstorage000197884384 is
         already taken.","nameAvailable":false,"reason":"AlreadyExists"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:26 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -154,20 +154,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e25fb3ac-f3c9-11e6-9d53-74c63bed1137]
+      x-ms-client-request-id: [aa39415a-fed7-11e6-b244-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:26 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -183,20 +183,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2e57f30-f3c9-11e6-b459-74c63bed1137]
+      x-ms-client-request-id: [aad6b914-fed7-11e6-8f5e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:27 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -212,21 +212,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3620122-f3c9-11e6-9d80-74c63bed1137]
+      x-ms-client-request-id: [ab60fc00-fed7-11e6-8a97-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/usages?api-version=2016-12-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"unit\": \"Count\",\r\n\
-        \      \"currentValue\": 41,\r\n      \"limit\": 250,\r\n      \"name\": {\r\
+        \      \"currentValue\": 43,\r\n      \"limit\": 250,\r\n      \"name\": {\r\
         \n        \"value\": \"StorageAccounts\",\r\n        \"localizedValue\": \"\
         Storage Accounts\"\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:28 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -243,20 +243,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3f246c6-f3c9-11e6-8348-74c63bed1137]
+      x-ms-client-request-id: [abff0f12-fed7-11e6-8753-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage/listKeys?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"FvHhwyIgb9w4f9IP8q8hsco9YRMQx2Cmw7/twW6Z5BDSqV7E3glSpl6XjhGd4EBoH1y3Qs7ZydIzRdzXb5RUlA=="},{"keyName":"key2","permissions":"Full","value":"bl05+mAzQpLT0w07vniIWTHZfgxJ8M9ywLnk6NmJ0EsWmpa/QBeO9zK7AObh4pOmsIBgeQq7ibjoDYpLBjLxmw=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ItLmzJCF8AnEJIgk03B+Hnp6H7farh0R/pAriD55Jfpx1/h5VM7StJbEACuMPO+1yPL4F0JolztcG1Ma4wS1Sw=="},{"keyName":"key2","permissions":"Full","value":"sVCBmSEwOpBbPiI3MNKdBMJKBdrHun8OTUkiyRIkZQWwNbgt2xcfOFn0GluHepOkQ9Mopcjld8Xjxm7MfPD91g=="}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:29 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -264,7 +264,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['289']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -274,20 +274,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e461e3c2-f3c9-11e6-a33d-74c63bed1137]
+      x-ms-client-request-id: [ac779990-fed7-11e6-b38f-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage/listKeys?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"FvHhwyIgb9w4f9IP8q8hsco9YRMQx2Cmw7/twW6Z5BDSqV7E3glSpl6XjhGd4EBoH1y3Qs7ZydIzRdzXb5RUlA=="},{"keyName":"key2","permissions":"Full","value":"bl05+mAzQpLT0w07vniIWTHZfgxJ8M9ywLnk6NmJ0EsWmpa/QBeO9zK7AObh4pOmsIBgeQq7ibjoDYpLBjLxmw=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ItLmzJCF8AnEJIgk03B+Hnp6H7farh0R/pAriD55Jfpx1/h5VM7StJbEACuMPO+1yPL4F0JolztcG1Ma4wS1Sw=="},{"keyName":"key2","permissions":"Full","value":"sVCBmSEwOpBbPiI3MNKdBMJKBdrHun8OTUkiyRIkZQWwNbgt2xcfOFn0GluHepOkQ9Mopcjld8Xjxm7MfPD91g=="}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:31 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -295,24 +295,24 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['289']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:55 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.blob.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:31 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:54 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -321,19 +321,19 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:55 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.queue.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.queue.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:32 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:57 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -344,18 +344,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:57 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.table.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.table.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:31 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:56 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -367,16 +367,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['264']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:58 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.blob.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 15 Feb 2017 21:58:32 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:57 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -385,18 +385,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.blob.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>true</Enabled><Days>1</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:32 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:58 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -405,19 +405,19 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.queue.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.queue.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:58 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -428,18 +428,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.table.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.table.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:58 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -448,18 +448,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.blob.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>true</Enabled><Days>1</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:58 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -468,18 +468,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.file.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -488,19 +488,19 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.queue.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.queue.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:34 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -511,18 +511,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:00 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.table.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.table.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:33 GMT']
+      Date: ['Wed, 01 Mar 2017 23:34:59 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -534,16 +534,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['386']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:00 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.file.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 15 Feb 2017 21:58:34 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:00 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -552,18 +552,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.blob.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>true</Enabled><Days>1</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:34 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:00 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -572,18 +572,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.file.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><HourMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>1</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>true</Enabled><Days>1</Days></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -592,19 +592,19 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.queue.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.queue.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -615,18 +615,18 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.3; Windows 10) AZURECLI/0.1.1b3+dev]
-      x-ms-client-request-id: [d1951d86-f3c9-11e6-849f-74c63bed1137]
-      x-ms-date: ['Wed, 15 Feb 2017 21:58:38 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.1; Windows 10) AZURECLI/2.0.0+dev]
+      x-ms-client-request-id: [99cd850c-fed7-11e6-bb24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.table.core.windows.net/?restype=service&comp=properties
+    uri: https://dummystorage.table.core.windows.net/?comp=properties&restype=service
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors\
         \ /></StorageServiceProperties>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 15 Feb 2017 21:58:35 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:00 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -639,20 +639,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e7dff490-f3c9-11e6-94b6-74c63bed1137]
+      x-ms-client-request-id: [b0eb465e-fed7-11e6-af56-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage/listKeys?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"FvHhwyIgb9w4f9IP8q8hsco9YRMQx2Cmw7/twW6Z5BDSqV7E3glSpl6XjhGd4EBoH1y3Qs7ZydIzRdzXb5RUlA=="},{"keyName":"key2","permissions":"Full","value":"bl05+mAzQpLT0w07vniIWTHZfgxJ8M9ywLnk6NmJ0EsWmpa/QBeO9zK7AObh4pOmsIBgeQq7ibjoDYpLBjLxmw=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ItLmzJCF8AnEJIgk03B+Hnp6H7farh0R/pAriD55Jfpx1/h5VM7StJbEACuMPO+1yPL4F0JolztcG1Ma4wS1Sw=="},{"keyName":"key2","permissions":"Full","value":"sVCBmSEwOpBbPiI3MNKdBMJKBdrHun8OTUkiyRIkZQWwNbgt2xcfOFn0GluHepOkQ9Mopcjld8Xjxm7MfPD91g=="}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:36 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -670,20 +670,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['19']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e876def8-f3c9-11e6-92c4-74c63bed1137]
+      x-ms-client-request-id: [b17d4e74-fed7-11e6-8937-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage/regenerateKey?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"l03UHMDSrRKgCV8svPY6KwOJkLebUO4Ga+hTp6OOmbfgGHErym9xC0cqiRv1EFwD1qGl4n6L2meRzgmIIvwDtw=="},{"keyName":"key2","permissions":"Full","value":"bl05+mAzQpLT0w07vniIWTHZfgxJ8M9ywLnk6NmJ0EsWmpa/QBeO9zK7AObh4pOmsIBgeQq7ibjoDYpLBjLxmw=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"u0uWulZ6Y6Ang3CrIvE/bT6y3xHip8viRr9RY88vKtv/LPSsYDZdXDOfP1SLswm3aiBzTZarZsbo4ssJqfBJ3g=="},{"keyName":"key2","permissions":"Full","value":"sVCBmSEwOpBbPiI3MNKdBMJKBdrHun8OTUkiyRIkZQWwNbgt2xcfOFn0GluHepOkQ9Mopcjld8Xjxm7MfPD91g=="}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:37 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -691,7 +691,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['289']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: '{"keyName": "key2"}'
@@ -701,20 +701,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['19']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e8fa5966-f3c9-11e6-9f40-74c63bed1137]
+      x-ms-client-request-id: [b23a6bec-fed7-11e6-a4cf-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage/regenerateKey?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"l03UHMDSrRKgCV8svPY6KwOJkLebUO4Ga+hTp6OOmbfgGHErym9xC0cqiRv1EFwD1qGl4n6L2meRzgmIIvwDtw=="},{"keyName":"key2","permissions":"Full","value":"YfbqITRrz1Rtt8HMj/hKLxQDho6ZbojNZnjevh8Di8ZmWr4NYsneWY47IdSQTxUFSqrveoyrXwpp+xjNBVDVeA=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"u0uWulZ6Y6Ang3CrIvE/bT6y3xHip8viRr9RY88vKtv/LPSsYDZdXDOfP1SLswm3aiBzTZarZsbo4ssJqfBJ3g=="},{"keyName":"key2","permissions":"Full","value":"aZHNVFhuVqvRgW4/6NW++p2F6tQfnTIi25FMnRw3tlL/l3vIzGuG9UuU3dbGsEOJyiZKMj/Zn8gIi2FZo0tUXQ=="}]}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:38 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -731,20 +731,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e971ec5a-f3c9-11e6-98df-74c63bed1137]
+      x-ms-client-request-id: [b2ef2162-fed7-11e6-9a04-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:39 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -754,28 +754,27 @@ interactions:
       content-length: ['776']
     status: {code: 200, message: OK}
 - request:
-    body: '{"sku": {"name": "Standard_LRS"}, "kind": "Storage", "tags": {"cat": "",
-      "foo": "bar"}, "location": "westus"}'
+    body: '{"sku": {"name": "Standard_LRS"}, "tags": {"foo": "bar", "cat": ""}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['109']
+      Content-Length: ['68']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9ba9bba-f3c9-11e6-ad5f-74c63bed1137]
-    method: PUT
+      x-ms-client-request-id: [b319532c-fed7-11e6-8eb2-a0b3ccf7272a]
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:39 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -783,67 +782,6 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['796']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ea9f11d8-f3c9-11e6-aff0-74c63bed1137]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
-
-        '}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['796']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"sku": {"name": "Standard_GRS"}, "kind": "Storage", "tags": {}, "location":
-      "westus"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['86']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [eae678e6-f3c9-11e6-9c30-74c63bed1137]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
-
-        '}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['837']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -853,20 +791,80 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ebb69412-f3c9-11e6-90d2-74c63bed1137]
+      x-ms-client-request-id: [b4500b98-fed7-11e6-afb5-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:42 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['796']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"sku": {"name": "Standard_GRS"}, "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['45']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b49a3afa-fed7-11e6-b7e6-a0b3ccf7272a]
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+
+        '}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Wed, 01 Mar 2017 23:35:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['837']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b5e70440-fed7-11e6-9c11-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+
+        '}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Wed, 01 Mar 2017 23:35:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -876,28 +874,27 @@ interactions:
       content-length: ['837']
     status: {code: 200, message: OK}
 - request:
-    body: '{"sku": {"name": "Standard_GRS"}, "kind": "Storage", "tags": {"test": "success"},
-      "location": "westus"}'
+    body: '{"sku": {"name": "Standard_GRS"}, "tags": {"test": "success"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['103']
+      Content-Length: ['62']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec0156a2-f3c9-11e6-accb-74c63bed1137]
-    method: PUT
+      x-ms-client-request-id: [b631db38-fed7-11e6-af1c-a0b3ccf7272a]
+    method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage733641907300","kind":"Storage","location":"westus","name":"vcrstorage733641907300","properties":{"creationTime":"2017-02-15T21:58:07.7815453Z","primaryEndpoints":{"blob":"https://vcrstorage733641907300.blob.core.windows.net/","file":"https://vcrstorage733641907300.file.core.windows.net/","queue":"https://vcrstorage733641907300.queue.core.windows.net/","table":"https://vcrstorage733641907300.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{"test":"success"},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/vcrstorage000197884384","kind":"Storage","location":"westus","name":"vcrstorage000197884384","properties":{"creationTime":"2017-03-01T23:34:31.1193082Z","primaryEndpoints":{"blob":"https://vcrstorage000197884384.blob.core.windows.net/","file":"https://vcrstorage000197884384.file.core.windows.net/","queue":"https://vcrstorage000197884384.queue.core.windows.net/","table":"https://vcrstorage000197884384.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{"test":"success"},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:43 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -905,7 +902,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['853']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -915,10 +912,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec90ffe8-f3c9-11e6-8acd-74c63bed1137]
+      x-ms-client-request-id: [b785f78c-fed7-11e6-96c7-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage?api-version=2016-12-01
   response:
@@ -926,25 +923,25 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 15 Feb 2017 21:58:45 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "vcrstorage733641907300", "type": "Microsoft.Storage/storageAccounts"}'
+    body: '{"name": "vcrstorage000197884384", "type": "Microsoft.Storage/storageAccounts"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['79']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed84472e-f3c9-11e6-b3f4-74c63bed1137]
+      x-ms-client-request-id: [b88a3394-fed7-11e6-b3ef-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
@@ -954,7 +951,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:46 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -971,10 +968,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ee15b978-f3c9-11e6-9fe3-74c63bed1137]
+      x-ms-client-request-id: [b8fa7600-fed7-11e6-8db2-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
@@ -984,7 +981,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 15 Feb 2017 21:58:47 GMT']
+      Date: ['Wed, 01 Mar 2017 23:35:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]


### PR DESCRIPTION
Fixes #2341, which prevented setting a custom domain on a storage account.

Additionally:
- **BC**: removed `--use-subdomain` from the storage account create command, as the SDK documentation (and testing) confirm that this parameter can only be set on update. This is technically a breaking change. While any existing scripts that used this didn't do what was intended, its omission will break any existing scripts that use `--use-subdomain` in create calls. 
- altered the storage account update command to use the SDK's update method instead of create.
