### PR TITLE
Fix KeyError: 'environmentName' on 'az account list'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -11,6 +11,7 @@ import json
 import os.path
 from pprint import pformat
 from enum import Enum
+from copy import deepcopy
 
 import adal
 import azure.cli.core.azlogging as azlogging
@@ -137,7 +138,8 @@ class Profile(object):
                                                      subscriptions,
                                                      is_service_principal)
         self._set_subscriptions(consolidated)
-        return consolidated
+        # use deepcopy as we don't want to persist these changes to file.
+        return deepcopy(consolidated)
 
     @staticmethod
     def _normalize_properties(user, subscriptions, is_service_principal):
@@ -224,8 +226,10 @@ class Profile(object):
     def load_cached_subscriptions(self, all_clouds=False):
         subscriptions = self._storage.get(_SUBSCRIPTIONS) or []
         active_cloud = get_active_cloud()
-        return [sub for sub in subscriptions
+        cached_subscriptions = [sub for sub in subscriptions
                 if all_clouds or sub[_ENVIRONMENT_NAME] == active_cloud.name]
+        # use deepcopy as we don't want to persist these changes to file.
+        return deepcopy(cached_subscriptions)
 
     def get_current_account_user(self):
         try:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -10,8 +10,8 @@ import errno
 import json
 import os.path
 from pprint import pformat
-from enum import Enum
 from copy import deepcopy
+from enum import Enum
 
 import adal
 import azure.cli.core.azlogging as azlogging
@@ -227,7 +227,7 @@ class Profile(object):
         subscriptions = self._storage.get(_SUBSCRIPTIONS) or []
         active_cloud = get_active_cloud()
         cached_subscriptions = [sub for sub in subscriptions
-                if all_clouds or sub[_ENVIRONMENT_NAME] == active_cloud.name]
+                                if all_clouds or sub[_ENVIRONMENT_NAME] == active_cloud.name]
         # use deepcopy as we don't want to persist these changes to file.
         return deepcopy(cached_subscriptions)
 
@@ -286,7 +286,6 @@ class Profile(object):
             result[_ENVIRONMENT_NAME] = CLOUD.name
             result['subscriptionName'] = account[_SUBSCRIPTION_NAME]
         else:  # has logged in through cli
-            from copy import deepcopy
             result = deepcopy(account)
             user_type = account[_USER_ENTITY].get(_USER_TYPE)
             if user_type == _SERVICE_PRINCIPAL:

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -157,13 +157,11 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                                                      False)
         profile._set_subscriptions(consolidated)
 
-        subscription1 = storage_mock['subscriptions'][0]
-        subscription2 = storage_mock['subscriptions'][1]
-        self.assertTrue(subscription2['isDefault'])
+        self.assertTrue(storage_mock['subscriptions'][1]['isDefault'])
 
-        profile.set_active_subscription(subscription1['id'])
-        self.assertFalse(subscription2['isDefault'])
-        self.assertTrue(subscription1['isDefault'])
+        profile.set_active_subscription(storage_mock['subscriptions'][0]['id'])
+        self.assertFalse(storage_mock['subscriptions'][1]['isDefault'])
+        self.assertTrue(storage_mock['subscriptions'][0]['isDefault'])
 
     def test_get_subscription(self):
         storage_mock = {'subscriptions': None}

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from copy import deepcopy
 import requests
 from adal.adal_error import AdalError
 from azure.cli.core.prompting import prompt_pass, NoTTYException
@@ -85,8 +84,7 @@ def login(username=None, password=None, service_principal=None, tenant=None):
         raise CLIError(err)
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
-    # use deepcopy as we don't want to persist these changes to file.
-    all_subscriptions = deepcopy(subscriptions)
+    all_subscriptions = list(subscriptions)
     for sub in all_subscriptions:
         sub['cloudName'] = sub.pop('environmentName', None)
     return all_subscriptions


### PR DESCRIPTION
When CLI telemetry attempts to get installation id, it would modify the user `~/.azure/azureProfile.json` saving incorrect data into it.

We fix this by returning deep copies of subscriptions to prevent later modification (e.g. by telemetry).

https://github.com/Azure/azure-cli/issues/2031