### PR TITLE
Fix resource_id parsing to accept 'resourcegroups'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -20,10 +20,11 @@ from azure.cli.core._util import CLIError, todict
 
 logger = azlogging.get_az_logger(__name__)
 
-regex = re.compile('/subscriptions/(?P<subscription>[^/]*)/resourceGroups/(?P<resource_group>[^/]*)'
-                   '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)'
-                   '(/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
-                   '(/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
+regex = re.compile(
+    '/subscriptions/(?P<subscription>[^/]*)/resource[gG]roups/(?P<resource_group>[^/]*)'
+    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)'
+    '(/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
+    '(/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
 
 
 def resource_id(**kwargs):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_api_check.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_api_check.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from azure.cli.core._util import CLIError
 # pylint: disable=line-too-long
-from azure.cli.command_modules.resource.custom  import _ResourceUtils, _validate_resource_inputs
+from azure.cli.command_modules.resource.custom  import _ResourceUtils, _validate_resource_inputs, parse_resource_id
 
 class TestApiCheck(unittest.TestCase):
 
@@ -28,6 +28,15 @@ class TestApiCheck(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+
+    def test_parse_resource(self):
+        parts = parse_resource_id('/subscriptions/00000/resourcegroups/bocconitestlabrg138089/providers/microsoft.devtestlab/labs/bocconitestlab/virtualmachines/tasktest1')
+        self.assertIsNotNone(parts.get('type'))
+
+    def test_parse_resource_capital(self):
+        parts = parse_resource_id('/subscriptions/00000/resourceGroups/bocconitestlabrg138089/providers/microsoft.devtestlab/labs/bocconitestlab/virtualmachines/tasktest1')
+        self.assertIsNotNone(parts.get('type'))
 
     def test_validate_resource_inputs(self):
         self.assertRaises(CLIError, _validate_resource_inputs, None, None, None, None)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/2248