### PR TITLE
appservice: fix slot related bugs

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -70,6 +70,7 @@ register_cli_argument('appservice web deployment slot', 'webapp', arg_type=name_
 register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to auto swap', default='production')
 register_cli_argument('appservice web deployment slot', 'disable', help='disable auto swap', action='store_true')
 register_cli_argument('appservice web deployment slot', 'target_slot', help="target slot to swap, default to 'production'")
+register_cli_argument('appservice web deployment slot create', 'configuration_source', help="source slot to clone configurations from. Use webapp's name to refer to the product slot")
 
 
 two_states_switch = ['true', 'false']
@@ -85,6 +86,7 @@ register_cli_argument('appservice web log tail', 'provider', help="scope the liv
 register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', type=file_type, completer=FilesCompleter(), help='the downloaded zipped log file path')
 
 register_cli_argument('appservice web config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
+register_cli_argument('appservice web config appsettings', 'slot_specific_settings', nargs='+', help="space separated slot specific app settings in a format of <name>=<value>")
 register_cli_argument('appservice web config appsettings', 'setting_names', nargs='+', help="space separated app setting names")
 
 register_cli_argument('appservice web config container', 'docker_registry_server_url', options_list=('--docker-registry-server-url', '-r'), help='the container registry server url')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -70,7 +70,7 @@ register_cli_argument('appservice web deployment slot', 'webapp', arg_type=name_
 register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to auto swap', default='production')
 register_cli_argument('appservice web deployment slot', 'disable', help='disable auto swap', action='store_true')
 register_cli_argument('appservice web deployment slot', 'target_slot', help="target slot to swap, default to 'production'")
-register_cli_argument('appservice web deployment slot create', 'configuration_source', help="source slot to clone configurations from. Use webapp's name to refer to the product slot")
+register_cli_argument('appservice web deployment slot create', 'configuration_source', help="source slot to clone configurations from. Use webapp's name to refer to the production slot")
 
 
 two_states_switch = ['true', 'false']

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -55,7 +55,7 @@ register_cli_argument('appservice plan update', 'allow_pending_state', ignore_ty
 register_cli_argument('appservice plan', 'number_of_workers', help='Number of workers to be allocated.', type=int, default=1)
 register_cli_argument('appservice plan', 'admin_site_name', help='The name of the admin web app.')
 
-register_cli_argument('appservice web', 'slot', help="the name of the slot. Default to the productions slot if not specified")
+register_cli_argument('appservice web', 'slot', options_list=('--slot', '-s'), help="the name of the slot. Default to the productions slot if not specified")
 register_cli_argument('appservice web', 'name', arg_type=name_arg_type, completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name', help='name of the web')
 register_cli_argument('appservice web create', 'name', options_list=('--name', '-n'), help='name of the new webapp')
 register_cli_argument('appservice web create', 'plan', options_list=('--plan', '-p'), completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -86,7 +86,7 @@ register_cli_argument('appservice web log tail', 'provider', help="scope the liv
 register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', type=file_type, completer=FilesCompleter(), help='the downloaded zipped log file path')
 
 register_cli_argument('appservice web config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
-register_cli_argument('appservice web config appsettings', 'slot_specific_settings', nargs='+', help="space separated slot specific app settings in a format of <name>=<value>")
+register_cli_argument('appservice web config appsettings', 'slot_settings', nargs='+', help="space separated slot app settings in a format of <name>=<value>")
 register_cli_argument('appservice web config appsettings', 'setting_names', nargs='+', help="space separated app setting names")
 
 register_cli_argument('appservice web config container', 'docker_registry_server_url', options_list=('--docker-registry-server-url', '-r'), help='the container registry server url')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -10,6 +10,9 @@ from azure.cli.core._util import empty_on_404
 
 from ._client_factory import web_client_factory
 
+def output_slots_In_table(slots):
+    return [{'name': s['name'], 'status': s['state'], 'app service plan': s['appServicePlan']} for s in slots]
+
 cli_command(__name__, 'appservice web create', 'azure.cli.command_modules.appservice.custom#create_webapp')
 cli_command(__name__, 'appservice web list', 'azure.cli.command_modules.appservice.custom#list_webapp')
 cli_command(__name__, 'appservice web show', 'azure.cli.command_modules.appservice.custom#show_webapp', exception_handler=empty_on_404)
@@ -50,17 +53,17 @@ cli_command(__name__, 'appservice web source-control show', 'azure.cli.command_m
 cli_command(__name__, 'appservice web source-control delete', 'azure.cli.command_modules.appservice.custom#delete_source_control')
 cli_command(__name__, 'appservice web source-control update-token', 'azure.cli.command_modules.appservice.custom#update_git_token')
 
-
 cli_command(__name__, 'appservice web log tail', 'azure.cli.command_modules.appservice.custom#get_streaming_log')
 cli_command(__name__, 'appservice web log download', 'azure.cli.command_modules.appservice.custom#download_historical_logs')
 cli_command(__name__, 'appservice web log config', 'azure.cli.command_modules.appservice.custom#config_diagnostics')
 cli_command(__name__, 'appservice web browse', 'azure.cli.command_modules.appservice.custom#view_in_browser')
 
-cli_command(__name__, 'appservice web deployment slot list', 'azure.mgmt.web.operations.web_apps_operations#WebAppsOperations.list_slots', factory)
+cli_command(__name__, 'appservice web deployment slot list', 'azure.cli.command_modules.appservice.custom#list_slots', table_transformer=output_slots_In_table)
 cli_command(__name__, 'appservice web deployment slot delete', 'azure.cli.command_modules.appservice.custom#delete_slot')
 cli_command(__name__, 'appservice web deployment slot auto-swap', 'azure.cli.command_modules.appservice.custom#config_slot_auto_swap')
 cli_command(__name__, 'appservice web deployment slot swap', 'azure.cli.command_modules.appservice.custom#swap_slot')
 cli_command(__name__, 'appservice web deployment slot create', 'azure.cli.command_modules.appservice.custom#create_webapp_slot')
+
 cli_command(__name__, 'appservice web deployment user set', 'azure.cli.command_modules.appservice.custom#set_deployment_user')
 cli_command(__name__, 'appservice web deployment list-site-credentials',
             'azure.mgmt.web.operations.web_apps_operations#WebAppsOperations.list_publishing_credentials', factory)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -10,8 +10,8 @@ from azure.cli.core._util import empty_on_404
 
 from ._client_factory import web_client_factory
 
-def output_slots_In_table(slots):
-    return [{'name': s['name'], 'status': s['state'], 'app service plan': s['appServicePlan']} for s in slots]
+def output_slots_in_table(slots):
+    return [{'name': s['name'], 'status': s['state'], 'plan': s['appServicePlan']} for s in slots]
 
 cli_command(__name__, 'appservice web create', 'azure.cli.command_modules.appservice.custom#create_webapp')
 cli_command(__name__, 'appservice web list', 'azure.cli.command_modules.appservice.custom#list_webapp')
@@ -58,7 +58,7 @@ cli_command(__name__, 'appservice web log download', 'azure.cli.command_modules.
 cli_command(__name__, 'appservice web log config', 'azure.cli.command_modules.appservice.custom#config_diagnostics')
 cli_command(__name__, 'appservice web browse', 'azure.cli.command_modules.appservice.custom#view_in_browser')
 
-cli_command(__name__, 'appservice web deployment slot list', 'azure.cli.command_modules.appservice.custom#list_slots', table_transformer=output_slots_In_table)
+cli_command(__name__, 'appservice web deployment slot list', 'azure.cli.command_modules.appservice.custom#list_slots', table_transformer=output_slots_in_table)
 cli_command(__name__, 'appservice web deployment slot delete', 'azure.cli.command_modules.appservice.custom#delete_slot')
 cli_command(__name__, 'appservice web deployment slot auto-swap', 'azure.cli.command_modules.appservice.custom#config_slot_auto_swap')
 cli_command(__name__, 'appservice web deployment slot swap', 'azure.cli.command_modules.appservice.custom#swap_slot')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -245,6 +245,8 @@ def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=N
         clone_from_prod = configuration_source.lower() == webapp.lower()
         slot_def.site_config = get_site_configs(
             resource_group_name, webapp, None if clone_from_prod else configuration_source)
+    else:
+        slot_def.site_config = SiteConfig(location)
 
     poller = client.web_apps.create_or_update_slot(resource_group_name, webapp, slot_def, slot)
     result = AppServiceLongRunningOperation()(poller)
@@ -270,7 +272,7 @@ def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=N
                                 slot, app_settings)
         _generic_site_operation(resource_group_name, webapp, 'update_connection_strings',
                                 slot, connection_strings)
-
+    result.name = result.name.split('/')[-1]
     return result
 
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -31,7 +31,7 @@ from ._params import web_client_factory, _generic_site_operation
 
 logger = azlogging.get_az_logger(__name__)
 
-#pylint:disable=no-member
+#pylint:disable=no-member,superfluous-parens
 
 #workaround that app service's error doesn't comform to LRO spec
 class AppServiceLongRunningOperation(LongRunningOperation): #pylint: disable=too-few-public-methods
@@ -199,7 +199,8 @@ def update_container_settings(resource_group_name, name, docker_registry_server_
         settings.append('DOCKER_REGISTRY_SERVER_PASSWORD=' + docker_registry_server_password)
     if docker_custom_image_name is not None:
         settings.append('DOCKER_CUSTOM_IMAGE_NAME=' + docker_custom_image_name)
-    settings = update_app_settings(resource_group_name, name, settings, slot)
+    update_app_settings(resource_group_name, name, settings, slot)
+    settings = get_app_settings(resource_group_name, name, slot)
     return _filter_for_container_settings(settings)
 
 def delete_container_settings(resource_group_name, name, slot=None):
@@ -545,7 +546,7 @@ def _get_local_git_url(client, resource_group_name, name, slot=None):
 def _get_scm_url(resource_group_name, name, slot=None):
     from azure.mgmt.web.models import HostType
     webapp = show_webapp(resource_group_name, name, slot=slot)
-    for host in webapp.host_name_ssl_states or []:
+    for host in (webapp.host_name_ssl_states or []):
         if host.host_type == HostType.repository:
             return "https://{}".format(host.name)
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_linux_webapp.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_linux_webapp.yaml
@@ -6,10 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [03819702-ee88-11e6-a1f6-64510658e3b3]
+      x-ms-client-request-id: [aacbd106-014f-11e7-a43a-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-webapp-linux2?api-version=2016-09-01
   response:
@@ -17,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Feb 2017 05:24:21 GMT']
+      Date: ['Sun, 05 Mar 2017 02:58:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -25,29 +26,28 @@ interactions:
       content-length: ['224']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"perSiteScaling": false, "name":
-      "webapp-linux-plan", "reserved": true}, "sku": {"name": "S1", "capacity": 1,
-      "tier": "STANDARD"}}'
+    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1, "tier": "STANDARD"},
+      "properties": {"perSiteScaling": false, "reserved": true, "name": "webapp-linux-plan"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['168']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [03a4ffde-ee88-11e6-a526-64510658e3b3]
+      x-ms-client-request-id: [aae97c4c-014f-11e7-ac67-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","name":"webapp-linux-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","name":"webapp-linux-plan","type":"Microsoft.Web/serverfarms","kind":"linux","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-linux-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-linux2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-linux2","reserved":true,"mdmId":"waws-prod-bay-063_1489","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"linux","resourceGroup":"cli-webapp-linux2","reserved":true,"mdmId":"waws-prod-bay-063_1912","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:37 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -56,8 +56,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1171']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['1175']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -66,20 +66,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d69d252-ee88-11e6-ad51-64510658e3b3]
+      x-ms-client-request-id: [b3beb030-014f-11e7-a54d-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","name":"webapp-linux-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","name":"webapp-linux-plan","type":"Microsoft.Web/serverfarms","kind":"linux","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-linux-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-linux2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-linux2","reserved":true,"mdmId":"waws-prod-bay-063_1489","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"linux","resourceGroup":"cli-webapp-linux2","reserved":true,"mdmId":"waws-prod-bay-063_1912","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:39 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -88,30 +88,31 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1171']
+      content-length: ['1175']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "serverFarmId":
-      "webapp-linux-plan", "reserved": false, "scmSiteAlsoStopped": false}}'
+    body: '{"location": "West US", "properties": {"scmSiteAlsoStopped": false, "reserved":
+      false, "serverFarmId": "webapp-linux-plan", "microService": "false"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['149']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e013e58-ee88-11e6-a5ed-64510658e3b3]
+      x-ms-client-request-id: [b433dac8-014f-11e7-9f88-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1","name":"webapp-linux1","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-linux1","state":"Running","hostNames":["webapp-linux1.azurewebsites.net"],"webSpace":"cli-webapp-linux2-WestUSwebspace","selfLink":"https://waws-prod-bay-063.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-linux2-WestUSwebspace/sites/webapp-linux1","repositorySiteName":"webapp-linux1","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-linux1.azurewebsites.net","webapp-linux1.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-linux1.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-linux1.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","reserved":true,"lastModifiedTimeUtc":"2017-02-09T05:24:42.1","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-linux1","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.220.109,40.118.249.44,104.42.108.136,40.112.255.56,13.93.230.131","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-063","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-linux2","defaultHostName":"webapp-linux1.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"webapp-linux1","state":"Running","hostNames":["webapp-linux1.azurewebsites.net"],"webSpace":"cli-webapp-linux2-WestUSwebspace","selfLink":"https://waws-prod-bay-063.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-linux2-WestUSwebspace/sites/webapp-linux1","repositorySiteName":"webapp-linux1","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-linux1.azurewebsites.net","webapp-linux1.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-linux1.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-linux1.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/serverfarms/webapp-linux-plan","reserved":true,"lastModifiedTimeUtc":"2017-03-05T02:59:09.9833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-linux1","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.220.109,13.64.108.119,13.64.198.87,13.64.192.142,13.64.109.132","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-063","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-linux2","defaultHostName":"webapp-linux1.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:45 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:21 GMT']
+      ETag: ['"1D2955C7657E28B"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -120,8 +121,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2653']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['2657']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -130,19 +131,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [11c719d0-ee88-11e6-8c6e-64510658e3b3]
+      x-ms-client-request-id: [bc6364a4-014f-11e7-8824-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/web","name":"webapp-linux1","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-linux1","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-linux1","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:46 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -151,38 +152,40 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2354']
+      content-length: ['2329']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "webapp-linux1", "properties": {"managedPipelineMode": "Integrated",
-      "scmType": "None", "experiments": {"rampUpRules": []}, "publishingUsername":
-      "$webapp-linux1", "linuxFxVersion": "", "virtualApplications": [{"virtualPath":
-      "/", "preloadEnabled": false, "physicalPath": "site\\wwwroot"}], "appCommandLine":
-      "process.json", "defaultDocuments": ["Default.htm", "Default.html", "Default.asp",
-      "index.htm", "index.html", "iisstart.htm", "default.aspx", "index.php", "hostingstart.html"],
-      "localMySqlEnabled": false, "requestTracingEnabled": false, "loadBalancing":
-      "LeastRequests", "logsDirectorySizeLimit": 35, "numberOfWorkers": 1, "vnetName":
-      "", "httpLoggingEnabled": false, "detailedErrorLoggingEnabled": false}, "location":
-      "West US", "type": "Microsoft.Web/sites/config"}'
+    body: '{"type": "Microsoft.Web/sites/config", "location": "West US", "name": "webapp-linux1",
+      "properties": {"remoteDebuggingEnabled": false, "publishingUsername": "$webapp-linux1",
+      "virtualApplications": [{"virtualPath": "/", "physicalPath": "site\\wwwroot",
+      "preloadEnabled": false}], "autoHealEnabled": false, "httpLoggingEnabled": false,
+      "logsDirectorySizeLimit": 35, "localMySqlEnabled": false, "managedPipelineMode":
+      "Integrated", "alwaysOn": false, "experiments": {"rampUpRules": []}, "detailedErrorLoggingEnabled":
+      false, "requestTracingEnabled": false, "numberOfWorkers": 1, "loadBalancing":
+      "LeastRequests", "linuxFxVersion": "", "use32BitWorkerProcess": false, "appCommandLine":
+      "process.json", "webSocketsEnabled": false, "vnetName": "", "scmType": "None",
+      "defaultDocuments": ["Default.htm", "Default.html", "Default.asp", "index.htm",
+      "index.html", "iisstart.htm", "default.aspx", "index.php", "hostingstart.html"]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['785']
+      Content-Length: ['923']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [12306a0c-ee88-11e6-8cca-64510658e3b3]
+      x-ms-client-request-id: [bcbef9d8-014f-11e7-bc28-f4b7e2e85440]
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1","name":"webapp-linux1","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-linux1","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"process.json","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-linux1","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"process.json","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:47 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:24 GMT']
+      ETag: ['"1D2955C7E46D46B"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -191,8 +194,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2376']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-length: ['2356']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -202,10 +205,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [137fba0c-ee88-11e6-bb43-64510658e3b3]
+      x-ms-client-request-id: [bded3a06-014f-11e7-8873-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings/list?api-version=2016-08-01
   response:
@@ -214,7 +217,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:49 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -224,32 +227,33 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['306']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11979']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "appsettings", "properties": {"DOCKER_REGISTRY_SERVER_USERNAME":
-      "foo-user", "DOCKER_CUSTOM_IMAGE_NAME": "foo-image", "DOCKER_REGISTRY_SERVER_URL":
-      "foo-url", "DOCKER_REGISTRY_SERVER_PASSWORD": "foo-password", "WEBSITE_NODE_DEFAULT_VERSION":
-      "6.9.1"}, "location": "West US", "type": "Microsoft.Web/sites/config"}'
+    body: '{"location": "West US", "type": "Microsoft.Web/sites/config", "name": "appsettings",
+      "properties": {"DOCKER_REGISTRY_SERVER_PASSWORD": "foo-password", "DOCKER_CUSTOM_IMAGE_NAME":
+      "foo-image", "DOCKER_REGISTRY_SERVER_URL": "foo-url", "WEBSITE_NODE_DEFAULT_VERSION":
+      "6.9.1", "DOCKER_REGISTRY_SERVER_USERNAME": "foo-user"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['321']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [13df6d1e-ee88-11e6-a715-64510658e3b3]
+      x-ms-client-request-id: [be4d6646-014f-11e7-ba37-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_USERNAME":"foo-user","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
+        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","DOCKER_REGISTRY_SERVER_USERNAME":"foo-user"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:50 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:27 GMT']
+      ETag: ['"1D2955C7FEC7B20"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -269,19 +273,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [14c74a74-ee88-11e6-9ca2-64510658e3b3]
+      x-ms-client-request-id: [bf3a299a-014f-11e7-8f2c-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_USERNAME":"foo-user","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
+        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","DOCKER_REGISTRY_SERVER_USERNAME":"foo-user"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:51 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -291,7 +295,37 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['478']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11970']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bf8ffbfa-014f-11e7-9aab-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-linux1","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 02:59:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['163']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -301,19 +335,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [154fda86-ee88-11e6-863d-64510658e3b3]
+      x-ms-client-request-id: [c0673a9a-014f-11e7-a825-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_USERNAME":"foo-user","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
+        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","DOCKER_REGISTRY_SERVER_USERNAME":"foo-user"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:52 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -323,21 +357,113 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['478']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11968']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "appsettings", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
-      "6.9.1"}, "location": "West US", "type": "Microsoft.Web/sites/config"}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c0a517d4-014f-11e7-a090-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-linux1","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 02:59:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['163']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c13e57b6-014f-11e7-816d-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"DOCKER_REGISTRY_SERVER_PASSWORD":"foo-password","DOCKER_CUSTOM_IMAGE_NAME":"foo-image","DOCKER_REGISTRY_SERVER_URL":"foo-url","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","DOCKER_REGISTRY_SERVER_USERNAME":"foo-user"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 02:59:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['478']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c177a6e4-014f-11e7-8f71-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-linux1","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 02:59:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['163']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "West US", "type": "Microsoft.Web/sites/config", "name": "appsettings",
+      "properties": {"WEBSITE_NODE_DEFAULT_VERSION": "6.9.1"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [15911714-ee88-11e6-a1db-64510658e3b3]
+      x-ms-client-request-id: [c1aba1d8-014f-11e7-9845-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings?api-version=2016-08-01
   response:
@@ -346,7 +472,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:52 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:32 GMT']
+      ETag: ['"1D2955C832EA0CB"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -356,7 +483,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['306']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -366,10 +493,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [16591674-ee88-11e6-a081-64510658e3b3]
+      x-ms-client-request-id: [c2d0bdf0-014f-11e7-912a-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/appsettings/list?api-version=2016-08-01
   response:
@@ -378,7 +505,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 05:24:53 GMT']
+      Date: ['Sun, 05 Mar 2017 02:59:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -388,6 +515,36 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['306']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11976']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c306deb0-014f-11e7-8dcf-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-linux2/providers/Microsoft.Web/sites/webapp-linux1/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-linux1","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 02:59:34 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['163']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_config.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_config.yaml
@@ -6,19 +6,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [46471400-ef07-11e6-a18b-64510658e3b3]
+      x-ms-client-request-id: [b7bb8834-0140-11e7-a4a6-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web","name":"webapp-config-test","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:19 GMT']
+      Date: ['Sun, 05 Mar 2017 01:11:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -27,7 +27,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2377']
+      content-length: ['2352']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -36,19 +36,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [46dd19d4-ef07-11e6-b312-64510658e3b3]
+      x-ms-client-request-id: [b8849338-0140-11e7-9d30-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web","name":"webapp-config-test","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:21 GMT']
+      Date: ['Sun, 05 Mar 2017 01:11:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -57,40 +57,41 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2377']
+      content-length: ['2352']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Web/sites/config", "location": "West US", "name": "webapp-config-test",
-      "properties": {"requestTracingEnabled": false, "netFrameworkVersion": "v3.5",
-      "pythonVersion": "3.4", "linuxFxVersion": "", "use32BitWorkerProcess": false,
-      "httpLoggingEnabled": false, "experiments": {"rampUpRules": []}, "defaultDocuments":
+    body: '{"properties": {"netFrameworkVersion": "v3.5", "pythonVersion": "3.4",
+      "phpVersion": "7.0", "requestTracingEnabled": false, "webSocketsEnabled": true,
+      "virtualApplications": [{"virtualPath": "/", "physicalPath": "site\\wwwroot",
+      "preloadEnabled": false}], "publishingUsername": "$webapp-config-test", "alwaysOn":
+      true, "logsDirectorySizeLimit": 35, "numberOfWorkers": 1, "httpLoggingEnabled":
+      false, "localMySqlEnabled": false, "detailedErrorLoggingEnabled": false, "remoteDebuggingEnabled":
+      false, "use32BitWorkerProcess": false, "scmType": "None", "vnetName": "", "autoHealEnabled":
+      true, "managedPipelineMode": "Integrated", "loadBalancing": "LeastRequests",
+      "linuxFxVersion": "", "experiments": {"rampUpRules": []}, "defaultDocuments":
       ["Default.htm", "Default.html", "Default.asp", "index.htm", "index.html", "iisstart.htm",
-      "default.aspx", "index.php", "hostingstart.html"], "localMySqlEnabled": false,
-      "loadBalancing": "LeastRequests", "alwaysOn": true, "remoteDebuggingEnabled":
-      false, "autoHealEnabled": true, "detailedErrorLoggingEnabled": false, "managedPipelineMode":
-      "Integrated", "webSocketsEnabled": true, "virtualApplications": [{"physicalPath":
-      "site\\wwwroot", "preloadEnabled": false, "virtualPath": "/"}], "numberOfWorkers":
-      1, "vnetName": "", "logsDirectorySizeLimit": 35, "phpVersion": "7.0", "publishingUsername":
-      "$webapp-config-test", "scmType": "None"}}'
+      "default.aspx", "index.php", "hostingstart.html"]}, "type": "Microsoft.Web/sites/config",
+      "location": "West US", "name": "webapp-config-test"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['972']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [473fcc36-ef07-11e6-9d7f-64510658e3b3]
+      x-ms-client-request-id: [b8d5aba2-0140-11e7-95ec-f4b7e2e85440]
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test","name":"webapp-config-test","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v3.0","phpVersion":"7.0","pythonVersion":"3.4","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":true,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":true,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":true,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v3.0","phpVersion":"7.0","pythonVersion":"3.4","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":true,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":true,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":true,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:23 GMT']
+      Date: ['Sun, 05 Mar 2017 01:11:56 GMT']
+      ETag: ['"1D2954D7C0DDF30"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -99,7 +100,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2363']
+      content-length: ['2338']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -109,19 +110,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [489d3142-ef07-11e6-8231-64510658e3b3]
+      x-ms-client-request-id: [ba6b6118-0140-11e7-81d0-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web","name":"webapp-config-test","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v3.0","phpVersion":"7.0","pythonVersion":"3.4","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":true,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":true,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":true,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v3.0","phpVersion":"7.0","pythonVersion":"3.4","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-config-test","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":false,"webSocketsEnabled":true,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":true,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":true,"autoHealRules":null,"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:25 GMT']
+      Date: ['Sun, 05 Mar 2017 01:11:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -130,7 +131,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2381']
+      content-length: ['2356']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -140,10 +141,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [49d6dd1a-ef07-11e6-ba24-64510658e3b3]
+      x-ms-client-request-id: [bb79d610-0140-11e7-a799-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
   response:
@@ -152,7 +153,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:26 GMT']
+      Date: ['Sun, 05 Mar 2017 01:11:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -162,31 +163,32 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['316']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Web/sites/config", "location": "West US", "name": "appsettings",
-      "properties": {"WEBSITE_NODE_DEFAULT_VERSION": "6.9.1", "s3": "bar2", "s2":
-      "bar", "s1": "foo"}}'
+    body: '{"properties": {"WEBSITE_NODE_DEFAULT_VERSION": "6.9.1", "s2": "bar", "s1":
+      "foo", "s3": "bar2"}, "type": "Microsoft.Web/sites/config", "location": "West
+      US", "name": "appsettings"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['181']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a24664c-ef07-11e6-9747-64510658e3b3]
+      x-ms-client-request-id: [bbccef6e-0140-11e7-8815-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2","s2":"bar","s1":"foo"}}'}
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s2":"bar","s1":"foo","s3":"bar2"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:28 GMT']
+      Date: ['Sun, 05 Mar 2017 01:12:01 GMT']
+      ETag: ['"1D2954D7F253150"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -196,6 +198,164 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['350']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd54b600-0140-11e7-9220-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s2":"bar","s1":"foo","s3":"bar2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 01:12:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['350']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd89fd90-0140-11e7-bcc2-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-config-test","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 01:12:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['168']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [be3034d2-0140-11e7-8aff-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s2":"bar","s1":"foo","s3":"bar2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 01:12:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['350']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [be863d82-0140-11e7-a81e-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"webapp-config-test","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 01:12:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['168']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"WEBSITE_NODE_DEFAULT_VERSION": "6.9.1", "s3": "bar2"},
+      "type": "Microsoft.Web/sites/config", "location": "West US", "name": "appsettings"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['155']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [beee393a-0140-11e7-9b68-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sun, 05 Mar 2017 01:12:06 GMT']
+      ETag: ['"1D2954D81B9E5F0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['328']
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -206,84 +366,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4b2a9e0c-ef07-11e6-af16-64510658e3b3]
+      x-ms-client-request-id: [c042dd14-0140-11e7-bd62-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2","s2":"bar","s1":"foo"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['350']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4bc1d5c2-ef07-11e6-9b1e-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2","s2":"bar","s1":"foo"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['350']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"type": "Microsoft.Web/sites/config", "location": "West US", "name": "appsettings",
-      "properties": {"WEBSITE_NODE_DEFAULT_VERSION": "6.9.1", "s3": "bar2"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['155']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4c28af82-ef07-11e6-84b7-64510658e3b3]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
         US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:31 GMT']
+      Date: ['Sun, 05 Mar 2017 01:12:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -293,7 +388,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -301,21 +396,20 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4d0e3e6e-ef07-11e6-8561-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2016-08-01
+      x-ms-client-request-id: [c0b6a0b4-0140-11e7-ba6b-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/slotConfigNames?api-version=2016-08-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s3":"bar2"}}'}
+    body: {string: '{"id":null,"name":"webapp-config-test","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:34 GMT']
+      Date: ['Sun, 05 Mar 2017 01:12:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -324,8 +418,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-length: ['168']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -334,10 +427,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4f5aa702-ef07-11e6-b13d-64510658e3b3]
+      x-ms-client-request-id: [c15b5d8c-0140-11e7-aece-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/hostNameBindings?api-version=2016-08-01
   response:
@@ -346,8 +439,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Thu, 09 Feb 2017 20:35:35 GMT']
-      ETag: ['"1D283140F93E160"']
+      Date: ['Sun, 05 Mar 2017 01:12:09 GMT']
+      ETag: ['"1D2954D81B9E5F0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
@@ -6,10 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3b13fd8-f946-11e6-a774-64510658e3b3]
+      x-ms-client-request-id: [2ae55cda-00a0-11e7-906c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-webapp-slot2?api-version=2016-09-01
   response:
@@ -17,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 21:35:54 GMT']
+      Date: ['Sat, 04 Mar 2017 06:02:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -25,29 +26,28 @@ interactions:
       content-length: ['222']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"perSiteScaling": false, "name":
-      "webapp-slot-test2-plan"}, "sku": {"tier": "STANDARD", "capacity": 1, "name":
-      "S1"}}'
+    body: '{"sku": {"capacity": 1, "tier": "STANDARD", "name": "S1"}, "location":
+      "westus", "properties": {"perSiteScaling": false, "name": "webapp-slot-test2-plan"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3c51602-f946-11e6-9ba2-64510658e3b3]
+      x-ms-client-request-id: [2b020d1e-00a0-11e7-8480-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","name":"webapp-slot-test2-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-slot-test2-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-slot2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-029_18212","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-027_17401","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:10 GMT']
+      Date: ['Sat, 04 Mar 2017 06:02:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -57,7 +57,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['1185']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -66,20 +66,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ee26137a-f946-11e6-8e03-64510658e3b3]
+      x-ms-client-request-id: [31f24e30-00a0-11e7-a2be-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","name":"webapp-slot-test2-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-slot-test2-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-slot2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-029_18212","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-027_17401","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:11 GMT']
+      Date: ['Sat, 04 Mar 2017 06:02:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -91,28 +91,28 @@ interactions:
       content-length: ['1185']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"reserved": false, "scmSiteAlsoStopped":
-      false, "serverFarmId": "webapp-slot-test2-plan", "microService": "false"}}'
+    body: '{"location": "West US", "properties": {"microService": "false", "reserved":
+      false, "scmSiteAlsoStopped": false, "serverFarmId": "webapp-slot-test2-plan"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ee92799a-f946-11e6-9822-64510658e3b3]
+      x-ms-client-request-id: [325b88fa-00a0-11e7-982b-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:16.74","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:53.633","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:17 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:02:52 GMT']
+      ETag: ['"1D294ACF671BAE0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -130,21 +130,21 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
+      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f1c37f42-f946-11e6-919b-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
+      x-ms-client-request-id: [350eb870-00a0-11e7-bae8-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings/list?api-version=2016-08-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:16.977","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:18 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:02:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -153,32 +153,32 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2657']
+      content-length: ['306']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"reserved": false, "scmSiteAlsoStopped":
-      false, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan",
-      "microService": "false"}}'
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
+      "6.9.1", "s1": "v1", "s2": "v2"}, "location": "West US", "name": "appsettings"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['280']
+      Content-Length: ['165']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f24feb50-f946-11e6-8d08-64510658e3b3]
+      x-ms-client-request-id: [3579a5e2-00a0-11e7-bbc1-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings?api-version=2016-08-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:23.1","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__2820","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":null}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:29 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:02:56 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -187,7 +187,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2746']
+      content-length: ['326']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -197,20 +197,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9b9f928-f946-11e6-8833-64510658e3b3]
+      x-ms-client-request-id: [36a4759a-00a0-11e7-8009-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:16.977","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:31 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:02:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -219,21 +218,150 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2657']
+      content-length: ['164']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"branch": "staging", "isMercurial":
-      false, "repoUrl": "https://github.com/yugangw-msft/azure-site-test"}}'
+    body: '{"type": "Microsoft.Web/sites", "name": "web-slot-test2", "location": "West
+      US", "properties": {"connectionStringNames": [], "appSettingNames": ["s2", "s2"]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['158']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [36f00668-00a0-11e7-a923-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:02:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['169']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [37e0f802-00a0-11e7-8efc-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:57.87","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:02:59 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2655']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "West US", "properties": {"microService": "false", "reserved":
+      false, "scmSiteAlsoStopped": false, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['280']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [383d63b4-00a0-11e7-a6be-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:03:04.307","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:03:04 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2747']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3cc8f4f8-00a0-11e7-934c-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:57.87","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:03:06 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2655']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "West US", "properties": {"repoUrl": "https://github.com/yugangw-msft/azure-site-test",
+      "isMercurial": false, "branch": "staging"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['144']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9ec2ac8-f946-11e6-93d4-64510658e3b3]
+      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
@@ -243,15 +371,15 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['486']
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:36:38 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:03:17 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -260,22 +388,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9ec2ac8-f946-11e6-93d4-64510658e3b3]
+      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web","name":"web-slot-test2","type":"Microsoft.Web/sites/sourcecontrols","location":"West
-        US","tags":null,"properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test","branch":"staging","isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-02-22T21:37:07.7735749
-        https://web-slot-test2-staging.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-02-22_21-36-45Z"}}'}
+        US","tags":null,"properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test","branch":"staging","isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-03-04T06:03:46.6832772
+        https://web-slot-test2-staging.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-03-04_06-03-28Z"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['656']
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:37:09 GMT']
-      ETag: ['"1D28D53C0D2AD00"']
+      Date: ['Sat, 04 Mar 2017 06:03:48 GMT']
+      ETag: ['"1D294AD060F1330"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -290,10 +418,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9ec2ac8-f946-11e6-93d4-64510658e3b3]
+      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
@@ -302,8 +430,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:37:40 GMT']
-      ETag: ['"1D28D53C0D2AD00"']
+      Date: ['Sat, 04 Mar 2017 06:04:19 GMT']
+      ETag: ['"1D294AD060F1330"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -313,72 +441,6 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['485']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [23e5936c-f947-11e6-bf9a-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:16.977","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:37:42 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['2657']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "West US", "properties": {"reserved": false, "scmSiteAlsoStopped":
-      false, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan",
-      "microService": "false"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['280']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [244cc382-f947-11e6-a29b-64510658e3b3]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev?api-version=2016-08-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:37:47.073","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__7e1e","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":null}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:37:55 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['2712']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -393,10 +455,10 @@ interactions:
     body: {string: 'Staging2: Hello world from linux 4'}
     headers:
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 21:38:28 GMT']
-      ETag: [W/"22-08QfZ0Mt9RwnXj/cUIdxPw"]
+      Date: ['Sat, 04 Mar 2017 06:04:54 GMT']
+      ETag: [W/"22-fTRHXGSB8NabOgGwQJfnmcJGQr4"]
       Server: [Microsoft-IIS/8.0]
-      Set-Cookie: [ARRAffinity=29840e26e0965d3f9bbc8f7dde3a18300476208a27573047f2be1ab04a5a81a2;Path=/;Domain=web-slot-test2-staging.azurewebsites.net]
+      Set-Cookie: [ARRAffinity=01b0ab1e0f567e843581409d708dae8af3846f37dd30b0f0c0d4786d27a81d8a;Path=/;Domain=web-slot-test2-staging.azurewebsites.net]
       Vary: [Accept-Encoding]
       X-Powered-By: [Express, ASP.NET]
       content-length: ['34']
@@ -409,10 +471,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40f36694-f947-11e6-8622-64510658e3b3]
+      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slotsswap?api-version=2016-08-01
   response:
@@ -420,17 +482,17 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:38:32 GMT']
-      ETag: ['"1D28D53B2DC9C10"']
+      Date: ['Sat, 04 Mar 2017 06:04:56 GMT']
+      ETag: ['"1D294ACF8EC7EE0"']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -439,20 +501,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40f36694-f947-11e6-8622-64510658e3b3]
+      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:38:47 GMT']
+      Date: ['Sat, 04 Mar 2017 06:05:11 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -467,20 +529,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40f36694-f947-11e6-8622-64510658e3b3]
+      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:39:03 GMT']
+      Date: ['Sat, 04 Mar 2017 06:05:27 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -495,20 +557,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40f36694-f947-11e6-8622-64510658e3b3]
+      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:39:19 GMT']
+      Date: ['Sat, 04 Mar 2017 06:05:42 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -523,20 +585,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40f36694-f947-11e6-8622-64510658e3b3]
+      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/14d4245e-5cb9-4523-a09a-d03b18a82df8?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:36:40.4","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__2820","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-02-22T21:39:24.222Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:04:58.013","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:05:46.818Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:39:35 GMT']
-      ETag: ['"1D28D53C0D2AD00"']
+      Date: ['Sat, 04 Mar 2017 06:05:59 GMT']
+      ETag: ['"1D294AD4088DCD0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -545,7 +607,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2762']
+      content-length: ['2763']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -560,13 +622,538 @@ interactions:
     body: {string: 'Staging2: Hello world from linux 4'}
     headers:
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Wed, 22 Feb 2017 21:40:05 GMT']
-      ETag: [W/"22-08QfZ0Mt9RwnXj/cUIdxPw"]
+      Date: ['Sat, 04 Mar 2017 06:06:30 GMT']
+      ETag: [W/"22-fTRHXGSB8NabOgGwQJfnmcJGQr4"]
       Server: [Microsoft-IIS/8.0]
-      Set-Cookie: [ARRAffinity=29840e26e0965d3f9bbc8f7dde3a18300476208a27573047f2be1ab04a5a81a2;Path=/;Domain=web-slot-test2.azurewebsites.net]
+      Set-Cookie: [ARRAffinity=01b0ab1e0f567e843581409d708dae8af3846f37dd30b0f0c0d4786d27a81d8a;Path=/;Domain=web-slot-test2.azurewebsites.net]
       Vary: [Accept-Encoding]
       X-Powered-By: [Express, ASP.NET]
       content-length: ['34']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b6444c92-00a0-11e7-8675-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b6a3288c-00a0-11e7-86c0-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['169']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b760bcc0-00a0-11e7-8a04-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:04:58.013","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:05:46.818Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:32 GMT']
+      ETag: ['"1D294AD4088DCD0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2763']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b80f54d4-00a0-11e7-a8b3-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/web?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/web","name":"web-slot-test2","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$web-slot-test2","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2366']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "West US", "properties": {"microService": "false", "scmSiteAlsoStopped":
+      false, "reserved": false, "siteConfig": {"type": "Microsoft.Web/sites/config",
+      "name": "web-slot-test2", "location": "West US", "properties": {"defaultDocuments":
+      ["Default.htm", "Default.html", "Default.asp", "index.htm", "index.html", "iisstart.htm",
+      "default.aspx", "index.php", "hostingstart.html"], "phpVersion": "5.6", "scmType":
+      "None", "experiments": {"rampUpRules": []}, "loadBalancing": "LeastRequests",
+      "alwaysOn": false, "publishingUsername": "$web-slot-test2", "httpLoggingEnabled":
+      false, "remoteDebuggingVersion": "VS2012", "pythonVersion": "", "linuxFxVersion":
+      "", "netFrameworkVersion": "v4.0", "appCommandLine": "", "remoteDebuggingEnabled":
+      false, "use32BitWorkerProcess": true, "numberOfWorkers": 1, "autoHealRules":
+      {}, "webSocketsEnabled": false, "virtualApplications": [{"physicalPath": "site\\wwwroot",
+      "preloadEnabled": false, "virtualPath": "/"}], "nodeVersion": "", "vnetName":
+      "", "localMySqlEnabled": false, "requestTracingEnabled": false, "detailedErrorLoggingEnabled":
+      false, "logsDirectorySizeLimit": 35, "autoHealEnabled": false, "managedPipelineMode":
+      "Integrated"}}, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1357']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b862508c-00a0-11e7-8121-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:06:38.947","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:38 GMT']
+      ETag: ['"1D294AD4088DCD0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2711']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bb5e2cfa-00a0-11e7-98a1-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['169']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bbc4d658-00a0-11e7-bc4d-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['326']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc3859ca-00a0-11e7-9a79-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/connectionstrings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/connectionstrings","name":"connectionstrings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['280']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
+      "6.9.1", "s1": "v1"}, "location": "West US", "name": "appsettings"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['153']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc726db6-00a0-11e7-9be3-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:42 GMT']
+      ETag: ['"1D294AD4088DCD0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['326']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {}, "location": "West
+      US", "name": "connectionstrings"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['108']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bdc84bb8-00a0-11e7-a995-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/connectionstrings?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/connectionstrings","name":"connectionstrings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:43 GMT']
+      ETag: ['"1D294AD4088DCD0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['290']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bf28181e-00a0-11e7-99fd-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['326']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bf8f0038-00a0-11e7-9517-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['169']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c0120898-00a0-11e7-aab3-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['326']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
+      "6.9.1", "s1": "v1", "s3": "v3", "s4": "v4"}, "location": "West US", "name":
+      "appsettings"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['177']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c06cc5ae-00a0-11e7-859d-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s3":"v3","s4":"v4"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:49 GMT']
+      ETag: ['"1D294AD4088DCD0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['346']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c173d788-00a0-11e7-a3f1-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['169']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Web/sites", "name": "web-slot-test2", "location": "West
+      US", "properties": {"connectionStringNames": [], "appSettingNames": ["s2", "s2",
+      "s4"]}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['164']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c1a1027a-00a0-11e7-a6bf-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:06:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['174']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: '{"preserveVnet": true, "targetSlot": "dev"}'
@@ -576,10 +1163,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['43']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a602b88-f947-11e6-aeff-64510658e3b3]
+      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/slotsswap?api-version=2016-08-01
   response:
@@ -587,17 +1174,17 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:40:07 GMT']
-      ETag: ['"1D28D53C0D2AD00"']
+      Date: ['Sat, 04 Mar 2017 06:06:53 GMT']
+      ETag: ['"1D294AD4088DCD0"']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -606,20 +1193,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a602b88-f947-11e6-aeff-64510658e3b3]
+      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:40:24 GMT']
+      Date: ['Sat, 04 Mar 2017 06:07:09 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -634,20 +1221,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a602b88-f947-11e6-aeff-64510658e3b3]
+      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:40:39 GMT']
+      Date: ['Sat, 04 Mar 2017 06:07:24 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -662,20 +1249,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a602b88-f947-11e6-aeff-64510658e3b3]
+      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:40:55 GMT']
+      Date: ['Sat, 04 Mar 2017 06:07:39 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -690,20 +1277,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a602b88-f947-11e6-aeff-64510658e3b3]
+      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/06d4d6c0-ad84-4f15-947e-99c5490ba5be?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:41:02.147","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__7e1e","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-02-22T21:41:00.871Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:07:42.67","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:41:11 GMT']
-      ETag: ['"1D28D545CD61930"']
+      Date: ['Sat, 04 Mar 2017 06:07:55 GMT']
+      ETag: ['"1D294ADA2AD86E0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -712,7 +1299,39 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2842']
+      content-length: ['2840']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e9d32d92-00a0-11e7-9ded-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s4":"v4"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:07:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['336']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -721,20 +1340,112 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a15ff658-f947-11e6-94eb-64510658e3b3]
+      x-ms-client-request-id: [ea134318-00a0-11e7-9c19-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:07:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['174']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [eac38fc6-00a0-11e7-851c-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings/list?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s3":"v3","s2":"v2"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:07:59 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['350']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [eb1ada90-00a0-11e7-94c7-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 06:07:59 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['174']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ebba1eb4-00a0-11e7-ab9b-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots?api-version=2016-08-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:41:02.147","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__7e1e","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-02-22T21:41:00.871Z","sourceSlotName":"staging","destinationSlotName":"dev"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-029.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-02-22T21:40:09.943","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.52.104,191.239.49.193,191.239.53.140,191.239.50.228","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-029","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-02-22T21:41:00.871Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}],"nextLink":null,"id":null}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:06:55.03","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:07:42.67","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 22 Feb 2017 21:41:12 GMT']
+      Date: ['Sat, 04 Mar 2017 06:08:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -743,7 +1454,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['5681']
+      content-length: ['5677']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -753,10 +1464,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc1+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1f2fad4-f947-11e6-b039-64510658e3b3]
+      x-ms-client-request-id: [ec650554-00a0-11e7-b303-f4b7e2e85440]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging?api-version=2016-08-01
   response:
@@ -764,14 +1475,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 22 Feb 2017 21:41:20 GMT']
-      ETag: ['"1D28D53C0D2AD00"']
+      Date: ['Sat, 04 Mar 2017 06:08:06 GMT']
+      ETag: ['"1D294AD4088DCD0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
@@ -10,7 +10,7 @@ interactions:
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2ae55cda-00a0-11e7-906c-f4b7e2e85440]
+      x-ms-client-request-id: [0469aa9e-010a-11e7-92fe-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-webapp-slot2?api-version=2016-09-01
   response:
@@ -18,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 04 Mar 2017 06:02:37 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -26,8 +26,8 @@ interactions:
       content-length: ['222']
     status: {code: 200, message: OK}
 - request:
-    body: '{"sku": {"capacity": 1, "tier": "STANDARD", "name": "S1"}, "location":
-      "westus", "properties": {"perSiteScaling": false, "name": "webapp-slot-test2-plan"}}'
+    body: '{"sku": {"tier": "STANDARD", "capacity": 1, "name": "S1"}, "properties":
+      {"perSiteScaling": false, "name": "webapp-slot-test2-plan"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -37,17 +37,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b020d1e-00a0-11e7-8480-f4b7e2e85440]
+      x-ms-client-request-id: [04868580-010a-11e7-9b6a-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","name":"webapp-slot-test2-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-slot-test2-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-slot2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-027_17401","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-051_14503","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:46 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -69,17 +69,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [31f24e30-00a0-11e7-a2be-f4b7e2e85440]
+      x-ms-client-request-id: [0addde2e-010a-11e7-8a1b-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","name":"webapp-slot-test2-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-slot-test2-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli-webapp-slot2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-027_17401","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":false,"mdmId":"waws-prod-bay-051_14503","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:48 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -91,8 +91,8 @@ interactions:
       content-length: ['1185']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "reserved":
-      false, "scmSiteAlsoStopped": false, "serverFarmId": "webapp-slot-test2-plan"}}'
+    body: '{"properties": {"scmSiteAlsoStopped": false, "serverFarmId": "webapp-slot-test2-plan",
+      "microService": "false", "reserved": false}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -102,17 +102,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [325b88fa-00a0-11e7-982b-f4b7e2e85440]
+      x-ms-client-request-id: [0b3970c0-010a-11e7-9ab0-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:53.633","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:40:32.083","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:52 GMT']
-      ETag: ['"1D294ACF671BAE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:35 GMT']
+      ETag: ['"1D29516CDC8BE30"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -121,8 +121,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2656']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['2648']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -135,7 +135,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [350eb870-00a0-11e7-bae8-f4b7e2e85440]
+      x-ms-client-request-id: [0f20ffe8-010a-11e7-8739-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings/list?api-version=2016-08-01
   response:
@@ -144,7 +144,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:54 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -157,8 +157,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
-      "6.9.1", "s1": "v1", "s2": "v2"}, "location": "West US", "name": "appsettings"}'
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {"s1": "v1", "s2":
+      "v2", "WEBSITE_NODE_DEFAULT_VERSION": "6.9.1"}, "location": "West US", "name":
+      "appsettings"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -168,17 +169,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3579a5e2-00a0-11e7-bbc1-f4b7e2e85440]
+      x-ms-client-request-id: [0f826a0c-010a-11e7-98a9-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
+        US","tags":null,"properties":{"s1":"v1","s2":"v2","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:56 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:38 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -200,16 +201,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [36a4759a-00a0-11e7-8009-f4b7e2e85440]
+      x-ms-client-request-id: [1045165c-010a-11e7-b79c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":null,"appSettingNames":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:56 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -221,27 +222,27 @@ interactions:
       content-length: ['164']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Web/sites", "name": "web-slot-test2", "location": "West
-      US", "properties": {"connectionStringNames": [], "appSettingNames": ["s2", "s2"]}}'
+    body: '{"name": "web-slot-test2", "properties": {"appSettingNames": ["s2"]}, "location":
+      "West US", "type": "Microsoft.Web/sites"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['158']
+      Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [36f00668-00a0-11e7-a923-f4b7e2e85440]
+      x-ms-client-request-id: [10af842e-010a-11e7-b159-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:57 GMT']
+      Date: ['Sat, 04 Mar 2017 18:40:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -250,8 +251,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['169']
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      content-length: ['164']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -263,17 +264,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [37e0f802-00a0-11e7-8efc-f4b7e2e85440]
+      x-ms-client-request-id: [1175b164-010a-11e7-ae0a-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:57.87","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:40:38.18","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:02:59 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:40 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -282,31 +283,33 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2655']
+      content-length: ['2647']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "reserved":
-      false, "scmSiteAlsoStopped": false, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan"}}'
+    body: '{"properties": {"scmSiteAlsoStopped": false, "siteConfig": {"properties":
+      {"localMySqlEnabled": false, "netFrameworkVersion": "v4.6"}, "location": "West
+      US"}, "microService": "false", "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan",
+      "reserved": false}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['280']
+      Content-Length: ['394']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [383d63b4-00a0-11e7-a6be-f4b7e2e85440]
+      x-ms-client-request-id: [11be9c5e-010a-11e7-851b-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:03:04.307","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:40:44.647","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__231a","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:03:04 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:45 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -315,8 +318,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2747']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-length: ['2739']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -328,17 +331,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3cc8f4f8-00a0-11e7-934c-f4b7e2e85440]
+      x-ms-client-request-id: [1519dac6-010a-11e7-82a8-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:02:57.87","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:40:38.18","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:03:06 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:46 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -347,11 +350,11 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2655']
+      content-length: ['2647']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"repoUrl": "https://github.com/yugangw-msft/azure-site-test",
-      "isMercurial": false, "branch": "staging"}}'
+    body: '{"properties": {"branch": "staging", "isMercurial": false, "repoUrl": "https://github.com/yugangw-msft/azure-site-test"},
+      "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -361,7 +364,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
+      x-ms-client-request-id: [155e0e64-010a-11e7-bba7-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
@@ -371,15 +374,15 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['486']
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:03:17 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:40:55 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -391,19 +394,19 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
+      x-ms-client-request-id: [155e0e64-010a-11e7-bba7-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web","name":"web-slot-test2","type":"Microsoft.Web/sites/sourcecontrols","location":"West
-        US","tags":null,"properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test","branch":"staging","isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-03-04T06:03:46.6832772
-        https://web-slot-test2-staging.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-03-04_06-03-28Z"}}'}
+        US","tags":null,"properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test","branch":"staging","isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress","provisioningDetails":"2017-03-04T18:41:27.2188666
+        https://web-slot-test2-staging.scm.azurewebsites.net/api/deployments/latest?deployer=GitHub&time=2017-03-04_18-41-06Z"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['656']
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:03:48 GMT']
-      ETag: ['"1D294AD060F1330"']
+      Date: ['Sat, 04 Mar 2017 18:41:26 GMT']
+      ETag: ['"1D29516DB6FEBD0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -421,7 +424,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3d310c52-00a0-11e7-ad59-f4b7e2e85440]
+      x-ms-client-request-id: [155e0e64-010a-11e7-bba7-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/sourcecontrols/web?api-version=2016-08-01
   response:
@@ -430,8 +433,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:04:19 GMT']
-      ETag: ['"1D294AD060F1330"']
+      Date: ['Sat, 04 Mar 2017 18:41:57 GMT']
+      ETag: ['"1D29516DB6FEBD0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -455,10 +458,10 @@ interactions:
     body: {string: 'Staging2: Hello world from linux 4'}
     headers:
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Sat, 04 Mar 2017 06:04:54 GMT']
+      Date: ['Sat, 04 Mar 2017 18:42:32 GMT']
       ETag: [W/"22-fTRHXGSB8NabOgGwQJfnmcJGQr4"]
       Server: [Microsoft-IIS/8.0]
-      Set-Cookie: [ARRAffinity=01b0ab1e0f567e843581409d708dae8af3846f37dd30b0f0c0d4786d27a81d8a;Path=/;Domain=web-slot-test2-staging.azurewebsites.net]
+      Set-Cookie: [ARRAffinity=76943f10210a2d5f2884e586646a79d504a2dc9e5cdcb7d1dfe40e81b70a6aa4;Path=/;Domain=web-slot-test2-staging.azurewebsites.net]
       Vary: [Accept-Encoding]
       X-Powered-By: [Express, ASP.NET]
       content-length: ['34']
@@ -474,7 +477,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
+      x-ms-client-request-id: [5499afac-010a-11e7-9722-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slotsswap?api-version=2016-08-01
   response:
@@ -482,17 +485,17 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:04:56 GMT']
-      ETag: ['"1D294ACF8EC7EE0"']
+      Date: ['Sat, 04 Mar 2017 18:42:34 GMT']
+      ETag: ['"1D29516D1614E40"']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -504,17 +507,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
+      x-ms-client-request-id: [5499afac-010a-11e7-9722-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:05:11 GMT']
+      Date: ['Sat, 04 Mar 2017 18:42:50 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -532,17 +535,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
+      x-ms-client-request-id: [5499afac-010a-11e7-9722-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:05:27 GMT']
+      Date: ['Sat, 04 Mar 2017 18:43:06 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -560,17 +563,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
+      x-ms-client-request-id: [5499afac-010a-11e7-9722-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:05:42 GMT']
+      Date: ['Sat, 04 Mar 2017 18:43:21 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -588,17 +591,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2af774-00a0-11e7-adba-f4b7e2e85440]
+      x-ms-client-request-id: [5499afac-010a-11e7-9722-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/fca3a4fd-e642-4a88-be37-eecbd41be2fd?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/operationresults/610e4fac-7546-414e-8626-4188614c2610?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:04:58.013","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:05:46.818Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:42:33.777","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__231a","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T18:43:23.896Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:05:59 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:43:37 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -607,7 +610,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2763']
+      content-length: ['2755']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -622,10 +625,10 @@ interactions:
     body: {string: 'Staging2: Hello world from linux 4'}
     headers:
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Sat, 04 Mar 2017 06:06:30 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:07 GMT']
       ETag: [W/"22-fTRHXGSB8NabOgGwQJfnmcJGQr4"]
       Server: [Microsoft-IIS/8.0]
-      Set-Cookie: [ARRAffinity=01b0ab1e0f567e843581409d708dae8af3846f37dd30b0f0c0d4786d27a81d8a;Path=/;Domain=web-slot-test2.azurewebsites.net]
+      Set-Cookie: [ARRAffinity=76943f10210a2d5f2884e586646a79d504a2dc9e5cdcb7d1dfe40e81b70a6aa4;Path=/;Domain=web-slot-test2.azurewebsites.net]
       Vary: [Accept-Encoding]
       X-Powered-By: [Express, ASP.NET]
       content-length: ['34']
@@ -641,16 +644,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b6444c92-00a0-11e7-8675-f4b7e2e85440]
+      x-ms-client-request-id: [8da38594-010a-11e7-8cc7-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
+        US","tags":null,"properties":{"s1":"v1","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:31 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -659,7 +662,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['340']
+      content-length: ['330']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
@@ -672,16 +675,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b6a3288c-00a0-11e7-86c0-f4b7e2e85440]
+      x-ms-client-request-id: [8e462792-010a-11e7-9766-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:31 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -690,7 +693,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['169']
+      content-length: ['164']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -702,17 +705,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b760bcc0-00a0-11e7-8a04-f4b7e2e85440]
+      x-ms-client-request-id: [8ef6c5c8-010a-11e7-96c0-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2","name":"web-slot-test2","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:04:58.013","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__fdb3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:05:46.818Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2","state":"Running","hostNames":["web-slot-test2.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2.azurewebsites.net","web-slot-test2.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:42:33.777","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__231a","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T18:43:23.896Z","sourceSlotName":"staging","destinationSlotName":"Production"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:32 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:11 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -721,7 +724,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2763']
+      content-length: ['2755']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -733,16 +736,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b80f54d4-00a0-11e7-a8b3-f4b7e2e85440]
+      x-ms-client-request-id: [8f378f0c-010a-11e7-a29b-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/web?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/web","name":"web-slot-test2","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":"VS2012","httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$web-slot-test2","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","linuxFxVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$web-slot-test2","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"None","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":"Integrated","virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":"LeastRequests","routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:33 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -751,44 +754,44 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2366']
+      content-length: ['2362']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "scmSiteAlsoStopped":
-      false, "reserved": false, "siteConfig": {"type": "Microsoft.Web/sites/config",
-      "name": "web-slot-test2", "location": "West US", "properties": {"defaultDocuments":
-      ["Default.htm", "Default.html", "Default.asp", "index.htm", "index.html", "iisstart.htm",
-      "default.aspx", "index.php", "hostingstart.html"], "phpVersion": "5.6", "scmType":
-      "None", "experiments": {"rampUpRules": []}, "loadBalancing": "LeastRequests",
-      "alwaysOn": false, "publishingUsername": "$web-slot-test2", "httpLoggingEnabled":
-      false, "remoteDebuggingVersion": "VS2012", "pythonVersion": "", "linuxFxVersion":
-      "", "netFrameworkVersion": "v4.0", "appCommandLine": "", "remoteDebuggingEnabled":
-      false, "use32BitWorkerProcess": true, "numberOfWorkers": 1, "autoHealRules":
-      {}, "webSocketsEnabled": false, "virtualApplications": [{"physicalPath": "site\\wwwroot",
-      "preloadEnabled": false, "virtualPath": "/"}], "nodeVersion": "", "vnetName":
-      "", "localMySqlEnabled": false, "requestTracingEnabled": false, "detailedErrorLoggingEnabled":
-      false, "logsDirectorySizeLimit": 35, "autoHealEnabled": false, "managedPipelineMode":
-      "Integrated"}}, "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan"}}'
+    body: '{"properties": {"scmSiteAlsoStopped": false, "siteConfig": {"location":
+      "West US", "properties": {"defaultDocuments": ["Default.htm", "Default.html",
+      "Default.asp", "index.htm", "index.html", "iisstart.htm", "default.aspx", "index.php",
+      "hostingstart.html"], "vnetName": "", "logsDirectorySizeLimit": 35, "virtualApplications":
+      [{"physicalPath": "site\\wwwroot", "preloadEnabled": false, "virtualPath": "/"}],
+      "alwaysOn": false, "localMySqlEnabled": false, "use32BitWorkerProcess": true,
+      "managedPipelineMode": "Integrated", "autoHealEnabled": false, "autoHealRules":
+      {}, "publishingUsername": "$web-slot-test2", "numberOfWorkers": 1, "experiments":
+      {"rampUpRules": []}, "loadBalancing": "LeastRequests", "requestTracingEnabled":
+      false, "pythonVersion": "", "linuxFxVersion": "", "nodeVersion": "", "scmType":
+      "None", "remoteDebuggingEnabled": false, "webSocketsEnabled": false, "httpLoggingEnabled":
+      false, "phpVersion": "5.6", "netFrameworkVersion": "v4.0", "appCommandLine":
+      "", "detailedErrorLoggingEnabled": false}, "type": "Microsoft.Web/sites/config",
+      "name": "web-slot-test2"}, "microService": "false", "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan",
+      "reserved": false}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1357']
+      Content-Length: ['1321']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b862508c-00a0-11e7-8121-f4b7e2e85440]
+      x-ms-client-request-id: [8fc26cee-010a-11e7-b4d9-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:06:38.947","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":null}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:44:14.293","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__3192","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:38 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:20 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -797,8 +800,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2711']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['2703']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -810,16 +813,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb5e2cfa-00a0-11e7-98a1-f4b7e2e85440]
+      x-ms-client-request-id: [95207a06-010a-11e7-b66c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:39 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -828,7 +831,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['169']
+      content-length: ['164']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -841,16 +844,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bbc4d658-00a0-11e7-bc4d-f4b7e2e85440]
+      x-ms-client-request-id: [954d13c0-010a-11e7-ad64-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s2":"v2"}}'}
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s2":"v2"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:40 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -859,7 +862,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['326']
+      content-length: ['316']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
@@ -873,7 +876,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bc3859ca-00a0-11e7-9a79-f4b7e2e85440]
+      x-ms-client-request-id: [957f4f1c-010a-11e7-8495-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/connectionstrings/list?api-version=2016-08-01
   response:
@@ -882,7 +885,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:41 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -896,27 +899,27 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
-      "6.9.1", "s1": "v1"}, "location": "West US", "name": "appsettings"}'
+      "6.9.1"}, "location": "West US", "name": "appsettings"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['153']
+      Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bc726db6-00a0-11e7-9be3-f4b7e2e85440]
+      x-ms-client-request-id: [95b61366-010a-11e7-be33-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:42 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:23 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -925,8 +928,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['326']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      content-length: ['316']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "Microsoft.Web/sites/config", "properties": {}, "location": "West
@@ -940,7 +943,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bdc84bb8-00a0-11e7-a995-f4b7e2e85440]
+      x-ms-client-request-id: [96401bde-010a-11e7-adbb-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/connectionstrings?api-version=2016-08-01
   response:
@@ -949,8 +952,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:43 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:25 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -960,7 +963,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['290']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -973,16 +976,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bf28181e-00a0-11e7-99fd-f4b7e2e85440]
+      x-ms-client-request-id: [97ee48e4-010a-11e7-b373-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:46 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -991,8 +994,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['326']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-length: ['316']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1004,16 +1007,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bf8f0038-00a0-11e7-9517-f4b7e2e85440]
+      x-ms-client-request-id: [98264cd0-010a-11e7-8d95-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:46 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1022,7 +1025,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['169']
+      content-length: ['164']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1035,16 +1038,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c0120898-00a0-11e7-aab3-f4b7e2e85440]
+      x-ms-client-request-id: [98a5e00c-010a-11e7-ad65-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1"}}'}
+        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:47 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1053,33 +1056,32 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['326']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-length: ['316']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Web/sites/config", "properties": {"WEBSITE_NODE_DEFAULT_VERSION":
-      "6.9.1", "s1": "v1", "s3": "v3", "s4": "v4"}, "location": "West US", "name":
-      "appsettings"}'
+    body: '{"type": "Microsoft.Web/sites/config", "properties": {"s3": "v3", "WEBSITE_NODE_DEFAULT_VERSION":
+      "6.9.1", "s4": "v4"}, "location": "West US", "name": "appsettings"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['177']
+      Content-Length: ['165']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c06cc5ae-00a0-11e7-859d-f4b7e2e85440]
+      x-ms-client-request-id: [99014124-010a-11e7-a3f4-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s3":"v3","s4":"v4"}}'}
+        US","tags":null,"properties":{"s3":"v3","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s4":"v4"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:49 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:28 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1088,7 +1090,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['346']
+      content-length: ['336']
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -1101,16 +1103,48 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c173d788-00a0-11e7-a3f1-f4b7e2e85440]
+      x-ms-client-request-id: [999127c2-010a-11e7-b393-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:49 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['164']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"name": "web-slot-test2", "properties": {"appSettingNames": ["s2", "s4"],
+      "connectionStringNames": []}, "location": "West US", "type": "Microsoft.Web/sites"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['158']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [99c70b78-010a-11e7-bdd5-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
+  response:
+    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s4"]}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Sat, 04 Mar 2017 18:44:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1120,40 +1154,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       content-length: ['169']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"type": "Microsoft.Web/sites", "name": "web-slot-test2", "location": "West
-      US", "properties": {"connectionStringNames": [], "appSettingNames": ["s2", "s2",
-      "s4"]}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['164']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c1a1027a-00a0-11e7-a6bf-f4b7e2e85440]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
-  response:
-    body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:06:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['174']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: '{"preserveVnet": true, "targetSlot": "dev"}'
@@ -1166,7 +1167,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
+      x-ms-client-request-id: [9aa455ee-010a-11e7-aefa-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/slotsswap?api-version=2016-08-01
   response:
@@ -1174,10 +1175,10 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:06:53 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:44:32 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -1196,17 +1197,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
+      x-ms-client-request-id: [9aa455ee-010a-11e7-aefa-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:07:09 GMT']
+      Date: ['Sat, 04 Mar 2017 18:44:47 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -1224,17 +1225,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
+      x-ms-client-request-id: [9aa455ee-010a-11e7-aefa-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:07:24 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:02 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -1252,17 +1253,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
+      x-ms-client-request-id: [9aa455ee-010a-11e7-aefa-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:07:39 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:18 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
@@ -1280,17 +1281,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c2adcb92-00a0-11e7-9711-f4b7e2e85440]
+      x-ms-client-request-id: [9aa455ee-010a-11e7-aefa-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/e748490f-7432-4164-963c-0fd16f791beb?api-version=2016-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/operationresults/aa9237d8-b521-49bc-81d8-06ea3b2eaa05?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:07:42.67","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}'}
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:45:18.883","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__3192","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T18:45:19.716Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:07:55 GMT']
-      ETag: ['"1D294ADA2AD86E0"']
+      Date: ['Sat, 04 Mar 2017 18:45:33 GMT']
+      ETag: ['"1D2951778B12F30"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1299,7 +1300,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2840']
+      content-length: ['2833']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1312,16 +1313,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9d32d92-00a0-11e7-9ded-f4b7e2e85440]
+      x-ms-client-request-id: [c09c4286-010a-11e7-a9a2-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s4":"v4"}}'}
+        US","tags":null,"properties":{"s1":"v1","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s4":"v4"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:07:57 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1343,16 +1344,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea134318-00a0-11e7-9c19-f4b7e2e85440]
+      x-ms-client-request-id: [c107fab6-010a-11e7-b2f3-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s4"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:07:57 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1361,7 +1362,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['174']
+      content-length: ['169']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1374,16 +1375,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eac38fc6-00a0-11e7-851c-f4b7e2e85440]
+      x-ms-client-request-id: [c1abcf9c-010a-11e7-9dd7-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings/list?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","tags":null,"properties":{"WEBSITE_NODE_DEFAULT_VERSION":"6.9.1","s1":"v1","s3":"v3","s2":"v2"}}'}
+        US","tags":null,"properties":{"s3":"v3","WEBSITE_NODE_DEFAULT_VERSION":"6.9.1"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:07:59 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1392,8 +1393,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['350']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-length: ['330']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1405,16 +1406,16 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb1ada90-00a0-11e7-94c7-f4b7e2e85440]
+      x-ms-client-request-id: [c212fab6-010a-11e7-a79c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/config/slotConfigNames?api-version=2016-08-01
   response:
     body: {string: '{"id":null,"name":"web-slot-test2","type":"Microsoft.Web/sites","location":"West
-        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s2","s4"]}}'}
+        US","tags":null,"properties":{"connectionStringNames":[],"appSettingNames":["s2","s4"]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:07:59 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1423,7 +1424,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['174']
+      content-length: ['169']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1435,17 +1436,17 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ebba1eb4-00a0-11e7-ab9b-f4b7e2e85440]
+      x-ms-client-request-id: [c2accdd0-010a-11e7-be6c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots?api-version=2016-08-01
   response:
     body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/dev","name":"web-slot-test2/dev","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:06:55.03","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-027.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T06:07:42.67","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__c581","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"191.239.57.218,191.239.58.113,191.239.58.48,191.239.60.207","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-027","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T06:07:41.024Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}],"nextLink":null,"id":null}'}
+        US","tags":null,"properties":{"name":"web-slot-test2(dev)","state":"Running","hostNames":["web-slot-test2-dev.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-dev.azurewebsites.net","web-slot-test2-dev.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-dev.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-dev.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:44:31.207","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-dev.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T18:45:19.716Z","sourceSlotName":"staging","destinationSlotName":"dev"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging","name":"web-slot-test2/staging","type":"Microsoft.Web/sites/slots","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"web-slot-test2(staging)","state":"Running","hostNames":["web-slot-test2-staging.azurewebsites.net"],"webSpace":"cli-webapp-slot2-WestUSwebspace","selfLink":"https://waws-prod-bay-051.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli-webapp-slot2-WestUSwebspace/sites/web-slot-test2","repositorySiteName":"web-slot-test2","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-slot-test2-staging.azurewebsites.net","web-slot-test2-staging.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-slot-test2-staging.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-slot-test2-staging.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-test2-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-04T18:45:18.883","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-slot-test2__3192","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"40.78.17.157,40.78.21.191,40.78.22.38,40.78.21.180","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-051","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli-webapp-slot2","defaultHostName":"web-slot-test2-staging.azurewebsites.net","slotSwapStatus":{"timestampUtc":"2017-03-04T18:45:19.716Z","sourceSlotName":"staging","destinationSlotName":"dev"}}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Sat, 04 Mar 2017 06:08:00 GMT']
+      Date: ['Sat, 04 Mar 2017 18:45:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1454,7 +1455,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['5677']
+      content-length: ['5663']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1467,7 +1468,7 @@ interactions:
       User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
           msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec650554-00a0-11e7-b303-f4b7e2e85440]
+      x-ms-client-request-id: [c3695570-010a-11e7-a379-f4b7e2e85440]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test2/slots/staging?api-version=2016-08-01
   response:
@@ -1475,14 +1476,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Sat, 04 Mar 2017 06:08:06 GMT']
-      ETag: ['"1D294AD4088DCD0"']
+      Date: ['Sat, 04 Mar 2017 18:45:53 GMT']
+      ETag: ['"1D2951716480210"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
Fix #1895: so people can specify that an appsetting shouldn't participate in a swap
Fix #1870: Add a short name alias for the slot parameter
Fix #1868: Help text for creating a deployment slot isn't completely clear
Fix #1867: Deployment slot list doesn't provide the actual "raw" slot name