### PR TITLE
VM/VMSS: reuse existing extension instance name on update

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_diagnostics_extension_install.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_diagnostics_extension_install.yaml
@@ -6,10 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [11fbb5b4-fd3f-11e6-a27e-64510658e3b3]
+      x-ms-client-request-id: [cc6d0738-022f-11e7-b866-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -17,8 +18,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdubtb\"\
+        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -27,27 +28,27 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdubtbNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdubtbIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"c84f6301-20b4-4221-95af-b338a7129cbd\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:00 GMT']
+      Date: ['Mon, 06 Mar 2017 05:43:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2232']
+      content-length: ['2231']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -56,10 +57,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [121ead12-fd3f-11e6-85e3-64510658e3b3]
+      x-ms-client-request-id: [ccbfa154-022f-11e7-8ac7-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -67,8 +69,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdubtb\"\
+        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -77,115 +79,115 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdubtbNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdubtbIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"c84f6301-20b4-4221-95af-b338a7129cbd\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:04 GMT']
+      Date: ['Mon, 06 Mar 2017 05:43:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2232']
+      content-length: ['2231']
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {}, "location": "westus", "properties": {"virtualMachineProfile":
-      {"extensionProfile": {"extensions": [{"name": "LinuxDiagnostic", "properties":
-      {"settings": {"storageAccount": "clitestdiagextsa20170227", "ladCfg": {"diagnosticMonitorConfiguration":
-      {"metrics": {"resourceId": "[variables(''ladMetricsResourceId'')]", "metricAggregation":
-      [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod": "PT1M"}]},
-      "performanceCounters": {"performanceCounterConfiguration": [{"class": "Memory",
-      "counterSpecifier": "AvailableMemory", "namespace": "root/scx", "table": "LinuxMemory"},
-      {"class": "Memory", "counterSpecifier": "PercentAvailableMemory", "namespace":
-      "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "UsedMemory", "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory",
-      "counterSpecifier": "PercentUsedMemory", "namespace": "root/scx", "table": "LinuxMemory"},
-      {"class": "Memory", "counterSpecifier": "PercentUsedByCache", "namespace": "root/scx",
-      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PagesPerSec",
-      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "PagesReadPerSec", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
-      "Memory", "counterSpecifier": "PagesWrittenPerSec", "namespace": "root/scx",
-      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "AvailableSwap",
-      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "PercentAvailableSwap", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
-      "Memory", "counterSpecifier": "UsedSwap", "namespace": "root/scx", "table":
-      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentUsedSwap", "namespace":
-      "root/scx", "table": "LinuxMemory"}, {"class": "Processor", "counterSpecifier":
-      "PercentIdleTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
-      "Processor", "counterSpecifier": "PercentUserTime", "namespace": "root/scx",
-      "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentNiceTime",
-      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
-      "counterSpecifier": "PercentPrivilegedTime", "namespace": "root/scx", "table":
-      "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentInterruptTime",
-      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
-      "counterSpecifier": "PercentDPCTime", "namespace": "root/scx", "table": "LinuxProcessor"},
-      {"class": "Processor", "counterSpecifier": "PercentProcessorTime", "namespace":
-      "root/scx", "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier":
-      "PercentIOWaitTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
-      "PhysicalDisk", "counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
-      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "ReadBytesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "TransfersPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "ReadsPerSecond", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "WritesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"}, {"class":
-      "PhysicalDisk", "counterSpecifier": "AverageReadTime", "namespace": "root/scx",
-      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "AverageWriteTime", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "AverageTransferTime", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "AverageDiskQueueLength", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "NetworkInterface", "counterSpecifier": "BytesTransmitted", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "BytesReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "PacketsTransmitted", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "PacketsReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "BytesTotal", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "TotalTxErrors", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "TotalCollisions", "namespace": "root/scx", "table": "LinuxNetworkInterface"}]}}}},
-      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170227", "storageAccountKey":
-      "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/"},
-      "type": "LinuxDiagnostic", "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion":
-      true, "typeHandlerVersion": "2.3"}}]}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"properties": {"primary": true, "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool"}],
-      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet"},
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool"}]},
-      "name": "testdjcfiIPConfig"}]}, "name": "testdjcfiNic"}]}, "storageProfile":
-      {"osDisk": {"createOption": "fromImage", "managedDisk": {"storageAccountType":
-      "Standard_LRS"}, "caching": "ReadOnly"}, "imageReference": {"offer": "UbuntuServer",
-      "publisher": "Canonical", "sku": "14.04.4-LTS", "version": "latest"}}, "osProfile":
-      {"adminUsername": "yugangw", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "computerNamePrefix": "testdjcfi"}}, "overprovision": true, "upgradePolicy":
-      {"mode": "Manual"}, "singlePlacementGroup": true}, "sku": {"tier": "Standard",
-      "name": "Standard_D1_v2", "capacity": 2}}'
+    body: '{"location": "westus", "tags": {}, "sku": {"capacity": 2, "tier": "Standard",
+      "name": "Standard_D1_v2"}, "properties": {"singlePlacementGroup": true, "upgradePolicy":
+      {"mode": "Manual"}, "overprovision": true, "virtualMachineProfile": {"storageProfile":
+      {"imageReference": {"version": "latest", "publisher": "Canonical", "sku": "14.04.4-LTS",
+      "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadOnly", "createOption":
+      "fromImage", "managedDisk": {"storageAccountType": "Standard_LRS"}}}, "extensionProfile":
+      {"extensions": [{"name": "LinuxDiagnostic", "properties": {"settings": {"ladCfg":
+      {"diagnosticMonitorConfiguration": {"metrics": {"metricAggregation": [{"scheduledTransferPeriod":
+      "PT1H"}, {"scheduledTransferPeriod": "PT1M"}], "resourceId": "[variables(''ladMetricsResourceId'')]"},
+      "performanceCounters": {"performanceCounterConfiguration": [{"namespace": "root/scx",
+      "table": "LinuxMemory", "counterSpecifier": "AvailableMemory", "class": "Memory"},
+      {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier": "PercentAvailableMemory",
+      "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "UsedMemory", "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory",
+      "counterSpecifier": "PercentUsedMemory", "class": "Memory"}, {"namespace": "root/scx",
+      "table": "LinuxMemory", "counterSpecifier": "PercentUsedByCache", "class": "Memory"},
+      {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier": "PagesPerSec",
+      "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "PagesReadPerSec", "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory",
+      "counterSpecifier": "PagesWrittenPerSec", "class": "Memory"}, {"namespace":
+      "root/scx", "table": "LinuxMemory", "counterSpecifier": "AvailableSwap", "class":
+      "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "PercentAvailableSwap", "class": "Memory"}, {"namespace": "root/scx", "table":
+      "LinuxMemory", "counterSpecifier": "UsedSwap", "class": "Memory"}, {"namespace":
+      "root/scx", "table": "LinuxMemory", "counterSpecifier": "PercentUsedSwap", "class":
+      "Memory"}, {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier":
+      "PercentIdleTime", "class": "Processor"}, {"namespace": "root/scx", "table":
+      "LinuxProcessor", "counterSpecifier": "PercentUserTime", "class": "Processor"},
+      {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier": "PercentNiceTime",
+      "class": "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor",
+      "counterSpecifier": "PercentPrivilegedTime", "class": "Processor"}, {"namespace":
+      "root/scx", "table": "LinuxProcessor", "counterSpecifier": "PercentInterruptTime",
+      "class": "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor",
+      "counterSpecifier": "PercentDPCTime", "class": "Processor"}, {"namespace": "root/scx",
+      "table": "LinuxProcessor", "counterSpecifier": "PercentProcessorTime", "class":
+      "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier":
+      "PercentIOWaitTime", "class": "Processor"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "BytesPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "ReadBytesPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "TransfersPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "ReadsPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "WritesPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "AverageReadTime", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "AverageWriteTime", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "AverageTransferTime", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "AverageDiskQueueLength", "class": "PhysicalDisk"}, {"namespace": "root/scx",
+      "table": "LinuxNetworkInterface", "counterSpecifier": "BytesTransmitted", "class":
+      "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "BytesReceived", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "PacketsTransmitted",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "PacketsReceived", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "BytesTotal",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "TotalRxErrors", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "TotalTxErrors",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "TotalCollisions", "class": "NetworkInterface"}]}}}, "storageAccount":
+      "clitestdiagextsa20170227"}, "typeHandlerVersion": "2.3", "protectedSettings":
+      {"storageAccountKey": "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/",
+      "storageAccountName": "clitestdiagextsa20170227"}, "type": "LinuxDiagnostic",
+      "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion": true}}]},
+      "osProfile": {"adminUsername": "user11", "linuxConfiguration": {"disablePasswordAuthentication":
+      false}, "computerNamePrefix": "testdubtb", "secrets": []}, "networkProfile":
+      {"networkInterfaceConfigurations": [{"name": "testdubtbNic", "properties": {"primary":
+      true, "ipConfigurations": [{"name": "testdubtbIPConfig", "properties": {"subnet":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool"}],
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool"}]}}]}}]}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['6795']
+      Content-Length: ['6794']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
+      x-ms-client-request-id: [cd075cfe-022f-11e7-bf1b-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -193,8 +195,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdubtb\"\
+        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -203,8 +205,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdubtbNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdubtbIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -212,92 +214,91 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
-        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
-        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
-        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
-        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
-        \      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"overprovision\"\
-        : true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\r\n\
+        : true,\r\n              \"settings\": {\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
+        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
+        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\"\
+        ,\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        ,\"counterSpecifier\":\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"\
+        UsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\",\"counterSpecifier\":\"PercentUsedMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedByCache\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesReadPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesWrittenPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"AvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentAvailableSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"UsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedSwap\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentIdleTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentUserTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"BytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"TransfersPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadsPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageWriteTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTransmitted\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\",\"class\"\
+        :\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTotal\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalRxErrors\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalCollisions\",\"class\":\"NetworkInterface\"}]}}},\"\
+        storageAccount\":\"clitestdiagextsa20170227\"}\r\n            },\r\n     \
+        \       \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n    \
+        \  }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"overprovision\"\
+        : true,\r\n    \"uniqueId\": \"c84f6301-20b4-4221-95af-b338a7129cbd\"\r\n\
         \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
         location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/7387dc89-9d96-477d-853f-d8645aa2f8a5?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/15a6a78d-dbfe-4b6e-a152-73cbf52835f3?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:05 GMT']
+      Date: ['Mon, 06 Mar 2017 05:43:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7138']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['7137']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -306,20 +307,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
+      x-ms-client-request-id: [cd075cfe-022f-11e7-bf1b-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7387dc89-9d96-477d-853f-d8645aa2f8a5?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/15a6a78d-dbfe-4b6e-a152-73cbf52835f3?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:06.2604841+00:00\",\r\
-        \n  \"endTime\": \"2017-02-27T22:50:25.0026904+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"7387dc89-9d96-477d-853f-d8645aa2f8a5\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:43:19.1369784+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:43:19.3558239+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"15a6a78d-dbfe-4b6e-a152-73cbf52835f3\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:35 GMT']
+      Date: ['Mon, 06 Mar 2017 05:43:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -335,10 +337,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [140e849a-fd3f-11e6-854a-64510658e3b3]
+      x-ms-client-request-id: [cd075cfe-022f-11e7-bf1b-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -346,8 +349,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdubtb\"\
+        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -356,8 +359,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdubtbNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdubtbIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -365,90 +368,89 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
-        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
-        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
-        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
-        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
-        \      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
+        : true,\r\n              \"settings\": {\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
+        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
+        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\"\
+        ,\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        ,\"counterSpecifier\":\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"\
+        UsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\",\"counterSpecifier\":\"PercentUsedMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedByCache\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesReadPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesWrittenPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"AvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentAvailableSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"UsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedSwap\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentIdleTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentUserTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"BytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"TransfersPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadsPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageWriteTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTransmitted\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\",\"class\"\
+        :\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTotal\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalRxErrors\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalCollisions\",\"class\":\"NetworkInterface\"}]}}},\"\
+        storageAccount\":\"clitestdiagextsa20170227\"}\r\n            },\r\n     \
+        \       \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n    \
+        \  }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\"\
+        : true,\r\n    \"uniqueId\": \"c84f6301-20b4-4221-95af-b338a7129cbd\"\r\n\
+        \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
+        location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:37 GMT']
+      Date: ['Mon, 06 Mar 2017 05:43:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7139']
+      content-length: ['7138']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -457,10 +459,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2894e7f0-fd3f-11e6-adc9-64510658e3b3]
+      x-ms-client-request-id: [e94e1d3e-022f-11e7-b96f-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss?api-version=2016-04-30-preview
   response:
@@ -468,8 +471,8 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdjcfi\"\
-        ,\r\n        \"adminUsername\": \"yugangw\",\r\n        \"linuxConfiguration\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"testdubtb\"\
+        ,\r\n        \"adminUsername\": \"user11\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
         \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
@@ -478,8 +481,8 @@ interactions:
         \    },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
         ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"14.04.4-LTS\"\
         ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
-        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdjcfiNic\"\
-        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdjcfiIPConfig\"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"testdubtbNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"testdubtbIPConfig\"\
         ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/virtualNetworks/testdiagvmssVNET/subnets/testdiagvmssSubnet\"\
         },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/backendAddressPools/testdiagvmssLBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/loadBalancers/testdiagvmssLB/inboundNatPools/testdiagvmssLBNatPool\"\
@@ -487,90 +490,89 @@ interactions:
         \n          {\r\n            \"properties\": {\r\n              \"publisher\"\
         : \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"LinuxDiagnostic\"\
         ,\r\n              \"typeHandlerVersion\": \"2.3\",\r\n              \"autoUpgradeMinorVersion\"\
-        : true,\r\n              \"settings\": {\"storageAccount\":\"clitestdiagextsa20170227\"\
-        ,\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"resourceId\"\
-        :\"[variables('ladMetricsResourceId')]\",\"metricAggregation\":[{\"scheduledTransferPeriod\"\
-        :\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"}]},\"performanceCounters\"\
-        :{\"performanceCounterConfiguration\":[{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"AvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableMemory\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedMemory\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedMemory\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PagesWrittenPerSec\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"AvailableSwap\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentAvailableSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\"\
-        ,\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"root/scx\",\"table\":\"\
-        LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedSwap\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIdleTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentUserTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentNiceTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentInterruptTime\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}}\r\n            },\r\
-        \n            \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n\
-        \      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"e04e1a99-34b6-4647-8680-fbc2c026171a\"\
-        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
-        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
+        : true,\r\n              \"settings\": {\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
+        :{\"metrics\":{\"metricAggregation\":[{\"scheduledTransferPeriod\":\"PT1H\"\
+        },{\"scheduledTransferPeriod\":\"PT1M\"}],\"resourceId\":\"[variables('ladMetricsResourceId')]\"\
+        },\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\"\
+        ,\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
+        ,\"counterSpecifier\":\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\":\"\
+        UsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxMemory\",\"counterSpecifier\":\"PercentUsedMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedByCache\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesReadPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PagesWrittenPerSec\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"AvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentAvailableSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"UsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedSwap\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentIdleTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentUserTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentNiceTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentPrivilegedTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentInterruptTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentDPCTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentProcessorTime\",\"\
+        class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"BytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"TransfersPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"ReadsPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageWriteTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTransmitted\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\",\"class\"\
+        :\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"BytesTotal\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalRxErrors\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalCollisions\",\"class\":\"NetworkInterface\"}]}}},\"\
+        storageAccount\":\"clitestdiagextsa20170227\"}\r\n            },\r\n     \
+        \       \"name\": \"LinuxDiagnostic\"\r\n          }\r\n        ]\r\n    \
+        \  }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\"\
+        : true,\r\n    \"uniqueId\": \"c84f6301-20b4-4221-95af-b338a7129cbd\"\r\n\
+        \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
+        location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachineScaleSets/testdiagvmss\"\
         ,\r\n  \"name\": \"testdiagvmss\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:39 GMT']
+      Date: ['Mon, 06 Mar 2017 05:44:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['7139']
+      content-length: ['7138']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -579,21 +581,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [29c7356c-fd3f-11e6-8a5c-64510658e3b3]
+      x-ms-client-request-id: [f53d8d38-022f-11e7-953a-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"e3067ac4-60fd-4699-b5cb-be79cc4d7c44\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
+        \      \"name\": \"osdisk_t0wjqLONjR\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage0iz8fu5demy7pm.blob.core.windows.net/vhds/osdisk_t0wjqLONjR.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
@@ -607,7 +610,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:40 GMT']
+      Date: ['Mon, 06 Mar 2017 05:44:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -623,197 +626,215 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [29e25d0a-fd3f-11e6-96aa-64510658e3b3]
+      x-ms-client-request-id: [f5858708-022f-11e7-b703-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview&$expand=instanceView
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"e3067ac4-60fd-4699-b5cb-be79cc4d7c44\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
+        \      \"name\": \"osdisk_t0wjqLONjR\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage0iz8fu5demy7pm.blob.core.windows.net/vhds/osdisk_t0wjqLONjR.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
         : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Network/networkInterfaces/testdiagvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
-        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:44:23+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_t0wjqLONjR\"\
+        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
+        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
+        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
+        \       \"time\": \"2017-03-06T05:40:50.3653769+00:00\"\r\n            }\r\
+        \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
+        \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
+        \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2017-03-06T05:42:14.7026345+00:00\"\r\n       \
+        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
+        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
+        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
         ,\r\n  \"name\": \"testdiagvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:40 GMT']
+      Date: ['Mon, 06 Mar 2017 05:44:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1439']
+      content-length: ['2630']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"settings": {"storageAccount": "clitestdiagextsa20170227",
-      "ladCfg": {"diagnosticMonitorConfiguration": {"metrics": {"resourceId": "[variables(''ladMetricsResourceId'')]",
-      "metricAggregation": [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod":
-      "PT1M"}]}, "performanceCounters": {"performanceCounterConfiguration": [{"class":
-      "Memory", "counterSpecifier": "AvailableMemory", "namespace": "root/scx", "table":
-      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentAvailableMemory",
-      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "UsedMemory", "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory",
-      "counterSpecifier": "PercentUsedMemory", "namespace": "root/scx", "table": "LinuxMemory"},
-      {"class": "Memory", "counterSpecifier": "PercentUsedByCache", "namespace": "root/scx",
-      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PagesPerSec",
-      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "PagesReadPerSec", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
-      "Memory", "counterSpecifier": "PagesWrittenPerSec", "namespace": "root/scx",
-      "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "AvailableSwap",
-      "namespace": "root/scx", "table": "LinuxMemory"}, {"class": "Memory", "counterSpecifier":
-      "PercentAvailableSwap", "namespace": "root/scx", "table": "LinuxMemory"}, {"class":
-      "Memory", "counterSpecifier": "UsedSwap", "namespace": "root/scx", "table":
-      "LinuxMemory"}, {"class": "Memory", "counterSpecifier": "PercentUsedSwap", "namespace":
-      "root/scx", "table": "LinuxMemory"}, {"class": "Processor", "counterSpecifier":
-      "PercentIdleTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
-      "Processor", "counterSpecifier": "PercentUserTime", "namespace": "root/scx",
-      "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentNiceTime",
-      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
-      "counterSpecifier": "PercentPrivilegedTime", "namespace": "root/scx", "table":
-      "LinuxProcessor"}, {"class": "Processor", "counterSpecifier": "PercentInterruptTime",
-      "namespace": "root/scx", "table": "LinuxProcessor"}, {"class": "Processor",
-      "counterSpecifier": "PercentDPCTime", "namespace": "root/scx", "table": "LinuxProcessor"},
-      {"class": "Processor", "counterSpecifier": "PercentProcessorTime", "namespace":
-      "root/scx", "table": "LinuxProcessor"}, {"class": "Processor", "counterSpecifier":
-      "PercentIOWaitTime", "namespace": "root/scx", "table": "LinuxProcessor"}, {"class":
-      "PhysicalDisk", "counterSpecifier": "BytesPerSecond", "namespace": "root/scx",
-      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "ReadBytesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "TransfersPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "ReadsPerSecond", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "WritesPerSecond", "namespace": "root/scx", "table": "LinuxPhysicalDisk"}, {"class":
-      "PhysicalDisk", "counterSpecifier": "AverageReadTime", "namespace": "root/scx",
-      "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "AverageWriteTime", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "PhysicalDisk", "counterSpecifier": "AverageTransferTime", "namespace":
-      "root/scx", "table": "LinuxPhysicalDisk"}, {"class": "PhysicalDisk", "counterSpecifier":
-      "AverageDiskQueueLength", "namespace": "root/scx", "table": "LinuxPhysicalDisk"},
-      {"class": "NetworkInterface", "counterSpecifier": "BytesTransmitted", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "BytesReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "PacketsTransmitted", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "PacketsReceived", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "BytesTotal", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "TotalRxErrors", "namespace": "root/scx", "table": "LinuxNetworkInterface"},
-      {"class": "NetworkInterface", "counterSpecifier": "TotalTxErrors", "namespace":
-      "root/scx", "table": "LinuxNetworkInterface"}, {"class": "NetworkInterface",
-      "counterSpecifier": "TotalCollisions", "namespace": "root/scx", "table": "LinuxNetworkInterface"}]}}}},
-      "protectedSettings": {"storageAccountName": "clitestdiagextsa20170227", "storageAccountKey":
-      "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/"},
-      "type": "LinuxDiagnostic", "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion":
-      true, "typeHandlerVersion": "2.3"}}'
+    body: '{"location": "westus", "properties": {"settings": {"ladCfg": {"diagnosticMonitorConfiguration":
+      {"metrics": {"metricAggregation": [{"scheduledTransferPeriod": "PT1H"}, {"scheduledTransferPeriod":
+      "PT1M"}], "resourceId": "[variables(''ladMetricsResourceId'')]"}, "performanceCounters":
+      {"performanceCounterConfiguration": [{"namespace": "root/scx", "table": "LinuxMemory",
+      "counterSpecifier": "AvailableMemory", "class": "Memory"}, {"namespace": "root/scx",
+      "table": "LinuxMemory", "counterSpecifier": "PercentAvailableMemory", "class":
+      "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "UsedMemory", "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory",
+      "counterSpecifier": "PercentUsedMemory", "class": "Memory"}, {"namespace": "root/scx",
+      "table": "LinuxMemory", "counterSpecifier": "PercentUsedByCache", "class": "Memory"},
+      {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier": "PagesPerSec",
+      "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "PagesReadPerSec", "class": "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory",
+      "counterSpecifier": "PagesWrittenPerSec", "class": "Memory"}, {"namespace":
+      "root/scx", "table": "LinuxMemory", "counterSpecifier": "AvailableSwap", "class":
+      "Memory"}, {"namespace": "root/scx", "table": "LinuxMemory", "counterSpecifier":
+      "PercentAvailableSwap", "class": "Memory"}, {"namespace": "root/scx", "table":
+      "LinuxMemory", "counterSpecifier": "UsedSwap", "class": "Memory"}, {"namespace":
+      "root/scx", "table": "LinuxMemory", "counterSpecifier": "PercentUsedSwap", "class":
+      "Memory"}, {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier":
+      "PercentIdleTime", "class": "Processor"}, {"namespace": "root/scx", "table":
+      "LinuxProcessor", "counterSpecifier": "PercentUserTime", "class": "Processor"},
+      {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier": "PercentNiceTime",
+      "class": "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor",
+      "counterSpecifier": "PercentPrivilegedTime", "class": "Processor"}, {"namespace":
+      "root/scx", "table": "LinuxProcessor", "counterSpecifier": "PercentInterruptTime",
+      "class": "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor",
+      "counterSpecifier": "PercentDPCTime", "class": "Processor"}, {"namespace": "root/scx",
+      "table": "LinuxProcessor", "counterSpecifier": "PercentProcessorTime", "class":
+      "Processor"}, {"namespace": "root/scx", "table": "LinuxProcessor", "counterSpecifier":
+      "PercentIOWaitTime", "class": "Processor"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "BytesPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "ReadBytesPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "WriteBytesPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "TransfersPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "ReadsPerSecond", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "WritesPerSecond", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "AverageReadTime", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "AverageWriteTime", "class": "PhysicalDisk"}, {"namespace": "root/scx", "table":
+      "LinuxPhysicalDisk", "counterSpecifier": "AverageTransferTime", "class": "PhysicalDisk"},
+      {"namespace": "root/scx", "table": "LinuxPhysicalDisk", "counterSpecifier":
+      "AverageDiskQueueLength", "class": "PhysicalDisk"}, {"namespace": "root/scx",
+      "table": "LinuxNetworkInterface", "counterSpecifier": "BytesTransmitted", "class":
+      "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "BytesReceived", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "PacketsTransmitted",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "PacketsReceived", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "BytesTotal",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "TotalRxErrors", "class": "NetworkInterface"}, {"namespace":
+      "root/scx", "table": "LinuxNetworkInterface", "counterSpecifier": "TotalTxErrors",
+      "class": "NetworkInterface"}, {"namespace": "root/scx", "table": "LinuxNetworkInterface",
+      "counterSpecifier": "TotalCollisions", "class": "NetworkInterface"}]}}}, "storageAccount":
+      "clitestdiagextsa20170227"}, "typeHandlerVersion": "2.3", "protectedSettings":
+      {"storageAccountKey": "123", "storageAccountEndPoint": "https://clitestdiagextsa20170227.blob.core.windows.net/",
+      "storageAccountName": "clitestdiagextsa20170227"}, "type": "LinuxDiagnostic",
+      "publisher": "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['5189']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+      x-ms-client-request-id: [f5d695fe-022f-11e7-a534-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
         2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
         :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
-        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
-        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
-        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
-        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n    \"provisioningState\"\
-        : \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedMemory\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedByCache\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PagesReadPerSec\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableSwap\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIdleTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentUserTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentNiceTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentPrivilegedTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentInterruptTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentDPCTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentProcessorTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIOWaitTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"BytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"TransfersPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadsPerSecond\",\"\
+        class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WritesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageWriteTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageTransferTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTransmitted\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsTransmitted\",\"class\":\"NetworkInterface\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTotal\",\"\
+        class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalRxErrors\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"TotalTxErrors\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalCollisions\"\
+        ,\"class\":\"NetworkInterface\"}]}}},\"storageAccount\":\"clitestdiagextsa20170227\"\
+        },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/b594186f-9a4b-4819-8db1-d4c5f8ee5707?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['5058']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:50:41 GMT']
+      Date: ['Mon, 06 Mar 2017 05:44:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -827,20 +848,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+      x-ms-client-request-id: [f5d695fe-022f-11e7-a534-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b594186f-9a4b-4819-8db1-d4c5f8ee5707?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:44:27.7228817+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"b594186f-9a4b-4819-8db1-d4c5f8ee5707\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:51:11 GMT']
+      Date: ['Mon, 06 Mar 2017 05:44:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -856,20 +878,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+      x-ms-client-request-id: [f5d695fe-022f-11e7-a534-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b594186f-9a4b-4819-8db1-d4c5f8ee5707?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:44:27.7228817+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"b594186f-9a4b-4819-8db1-d4c5f8ee5707\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:51:42 GMT']
+      Date: ['Mon, 06 Mar 2017 05:45:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -885,107 +908,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+      x-ms-client-request-id: [f5d695fe-022f-11e7-a534-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b594186f-9a4b-4819-8db1-d4c5f8ee5707?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:44:27.7228817+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:45:31.0472264+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"b594186f-9a4b-4819-8db1-d4c5f8ee5707\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:52:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:52:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:53:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f2f7760f-e869-4a94-b7ca-e7ee26e933d2?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-02-27T22:50:43.1925558+00:00\",\r\
-        \n  \"endTime\": \"2017-02-27T22:53:28.0462382+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"f2f7760f-e869-4a94-b7ca-e7ee26e933d2\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:53:44 GMT']
+      Date: ['Mon, 06 Mar 2017 05:45:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1001,89 +938,89 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2a023518-fd3f-11e6-b201-64510658e3b3]
+      x-ms-client-request-id: [f5d695fe-022f-11e7-a534-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n    \"type\": \"LinuxDiagnostic\",\r\n    \"typeHandlerVersion\": \"\
         2.3\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"settings\": {\"\
-        storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
         :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
-        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
-        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
-        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
-        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n    \"provisioningState\"\
-        : \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
+        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedMemory\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedByCache\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PagesReadPerSec\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableSwap\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIdleTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentUserTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentNiceTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentPrivilegedTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentInterruptTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentDPCTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentProcessorTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIOWaitTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"BytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"TransfersPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadsPerSecond\",\"\
+        class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WritesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageWriteTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageTransferTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTransmitted\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsTransmitted\",\"class\":\"NetworkInterface\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTotal\",\"\
+        class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalRxErrors\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"TotalTxErrors\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalCollisions\"\
+        ,\"class\":\"NetworkInterface\"}]}}},\"storageAccount\":\"clitestdiagextsa20170227\"\
+        },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n  \"name\": \"LinuxDiagnostic\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:53:45 GMT']
+      Date: ['Mon, 06 Mar 2017 05:45:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1099,21 +1036,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9890d9e4-fd3f-11e6-8651-64510658e3b3]
+      x-ms-client-request-id: [38f08010-0230-11e7-8ccc-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"817440e4-4f00-42f5-85a7-e2851176fc71\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"e3067ac4-60fd-4699-b5cb-be79cc4d7c44\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_SxD5EOvXjp\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstoragewso4cqc55pmaph.blob.core.windows.net/vhds/osdisk_SxD5EOvXjp.vhd\"\
+        \      \"name\": \"osdisk_t0wjqLONjR\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhdstorage0iz8fu5demy7pm.blob.core.windows.net/vhds/osdisk_t0wjqLONjR.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"testdiagvm\",\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
@@ -1124,74 +1062,74 @@ interactions:
         : [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
         ,\r\n        \"type\": \"LinuxDiagnostic\",\r\n        \"typeHandlerVersion\"\
         : \"2.3\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"settings\"\
-        : {\"storageAccount\":\"clitestdiagextsa20170227\",\"ladCfg\":{\"diagnosticMonitorConfiguration\"\
-        :{\"metrics\":{\"resourceId\":\"[variables('ladMetricsResourceId')]\",\"metricAggregation\"\
+        : {\"ladCfg\":{\"diagnosticMonitorConfiguration\":{\"metrics\":{\"metricAggregation\"\
         :[{\"scheduledTransferPeriod\":\"PT1H\"},{\"scheduledTransferPeriod\":\"PT1M\"\
-        }]},\"performanceCounters\":{\"performanceCounterConfiguration\":[{\"class\"\
-        :\"Memory\",\"counterSpecifier\":\"AvailableMemory\",\"namespace\":\"root/scx\"\
-        ,\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\":\"\
-        PercentAvailableMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedMemory\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedMemory\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"PercentUsedByCache\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"},{\"\
-        class\":\"Memory\",\"counterSpecifier\":\"PagesReadPerSec\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PagesWrittenPerSec\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"AvailableSwap\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentAvailableSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Memory\",\"counterSpecifier\":\"UsedSwap\",\"namespace\":\"\
-        root/scx\",\"table\":\"LinuxMemory\"},{\"class\":\"Memory\",\"counterSpecifier\"\
-        :\"PercentUsedSwap\",\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentIdleTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentUserTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentNiceTime\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\"\
-        :\"PercentPrivilegedTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
-        },{\"class\":\"Processor\",\"counterSpecifier\":\"PercentInterruptTime\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentDPCTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxProcessor\"},{\"class\":\"Processor\",\"counterSpecifier\":\"PercentProcessorTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"},{\"class\":\"Processor\"\
-        ,\"counterSpecifier\":\"PercentIOWaitTime\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxProcessor\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"BytesPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"WriteBytesPerSecond\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"TransfersPerSecond\",\"namespace\":\"root/scx\",\"\
-        table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\"\
-        :\"ReadsPerSecond\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"WritesPerSecond\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\"\
-        ,\"counterSpecifier\":\"AverageReadTime\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxPhysicalDisk\"},{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"\
-        AverageWriteTime\",\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
-        },{\"class\":\"PhysicalDisk\",\"counterSpecifier\":\"AverageTransferTime\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"\
-        PhysicalDisk\",\"counterSpecifier\":\"AverageDiskQueueLength\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTransmitted\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"BytesReceived\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"PacketsTransmitted\"\
-        ,\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\"\
-        :\"NetworkInterface\",\"counterSpecifier\":\"PacketsReceived\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\"\
-        ,\"counterSpecifier\":\"BytesTotal\",\"namespace\":\"root/scx\",\"table\"\
-        :\"LinuxNetworkInterface\"},{\"class\":\"NetworkInterface\",\"counterSpecifier\"\
-        :\"TotalRxErrors\",\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
-        },{\"class\":\"NetworkInterface\",\"counterSpecifier\":\"TotalTxErrors\",\"\
-        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"},{\"class\":\"\
-        NetworkInterface\",\"counterSpecifier\":\"TotalCollisions\",\"namespace\"\
-        :\"root/scx\",\"table\":\"LinuxNetworkInterface\"}]}}}},\r\n        \"provisioningState\"\
-        : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
+        }],\"resourceId\":\"[variables('ladMetricsResourceId')]\"},\"performanceCounters\"\
+        :{\"performanceCounterConfiguration\":[{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"AvailableMemory\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedMemory\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedMemory\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxMemory\",\"counterSpecifier\":\"PercentUsedByCache\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"table\"\
+        :\"LinuxMemory\",\"counterSpecifier\":\"PagesReadPerSec\",\"class\":\"Memory\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PagesWrittenPerSec\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"AvailableSwap\",\"class\"\
+        :\"Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentAvailableSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxMemory\",\"counterSpecifier\":\"UsedSwap\",\"class\":\"\
+        Memory\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxMemory\",\"counterSpecifier\"\
+        :\"PercentUsedSwap\",\"class\":\"Memory\"},{\"namespace\":\"root/scx\",\"\
+        table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIdleTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentUserTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentNiceTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\"\
+        ,\"counterSpecifier\":\"PercentPrivilegedTime\",\"class\":\"Processor\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\"\
+        :\"PercentInterruptTime\",\"class\":\"Processor\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentDPCTime\",\"class\"\
+        :\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxProcessor\",\"\
+        counterSpecifier\":\"PercentProcessorTime\",\"class\":\"Processor\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxProcessor\",\"counterSpecifier\":\"PercentIOWaitTime\"\
+        ,\"class\":\"Processor\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"BytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\"\
+        :\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadBytesPerSecond\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WriteBytesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"TransfersPerSecond\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"ReadsPerSecond\",\"\
+        class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"WritesPerSecond\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageReadTime\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\":\"AverageWriteTime\"\
+        ,\"class\":\"PhysicalDisk\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\"\
+        ,\"counterSpecifier\":\"AverageTransferTime\",\"class\":\"PhysicalDisk\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxPhysicalDisk\",\"counterSpecifier\"\
+        :\"AverageDiskQueueLength\",\"class\":\"PhysicalDisk\"},{\"namespace\":\"\
+        root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTransmitted\"\
+        ,\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"\
+        LinuxNetworkInterface\",\"counterSpecifier\":\"BytesReceived\",\"class\":\"\
+        NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"PacketsTransmitted\",\"class\":\"NetworkInterface\"\
+        },{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"PacketsReceived\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"BytesTotal\",\"\
+        class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\"\
+        ,\"counterSpecifier\":\"TotalRxErrors\",\"class\":\"NetworkInterface\"},{\"\
+        namespace\":\"root/scx\",\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\"\
+        :\"TotalTxErrors\",\"class\":\"NetworkInterface\"},{\"namespace\":\"root/scx\"\
+        ,\"table\":\"LinuxNetworkInterface\",\"counterSpecifier\":\"TotalCollisions\"\
+        ,\"class\":\"NetworkInterface\"}]}}},\"storageAccount\":\"clitestdiagextsa20170227\"\
+        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"\
+        type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\"\
+        : \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm/extensions/LinuxDiagnostic\"\
         ,\r\n      \"name\": \"LinuxDiagnostic\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_vmss_diagnostics_extension/providers/Microsoft.Compute/virtualMachines/testdiagvm\"\
@@ -1199,7 +1137,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 27 Feb 2017 22:53:45 GMT']
+      Date: ['Mon, 06 Mar 2017 05:46:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
@@ -6,10 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4034b930-fec0-11e6-8fd5-64510658e3b3]
+      x-ms-client-request-id: [f067bcda-022b-11e7-ae7c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines?api-version=2016-04-30-preview
   response:
@@ -17,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:14 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -80,9 +81,9 @@ interactions:
       Content-Length: ['2497']
       Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
       Content-Type: [text/plain; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:15 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:40 GMT']
       ETag: ['"176c0a6aa96be3f7c227ab95161b3f5317b72a64"']
-      Expires: ['Wed, 01 Mar 2017 20:52:15 GMT']
+      Expires: ['Mon, 06 Mar 2017 05:20:40 GMT']
       Source-Age: ['0']
       Strict-Transport-Security: [max-age=31536000]
       Vary: ['Authorization,Accept-Encoding']
@@ -90,12 +91,12 @@ interactions:
       X-Cache: [MISS]
       X-Cache-Hits: ['0']
       X-Content-Type-Options: [nosniff]
-      X-Fastly-Request-ID: [8d4b0356080d896bddd6d33bd4a8097ffb4e02db]
+      X-Fastly-Request-ID: [e74212eef2e34a6e0e1dc045a0855078a83e57b7]
       X-Frame-Options: [deny]
       X-Geo-Block-List: ['']
-      X-GitHub-Request-Id: ['4E90:768E:2635A39:27A4002:58B73352']
-      X-Served-By: [cache-sea1027-SEA]
-      X-Timer: ['S1488401235.173486,VS0,VE107']
+      X-GitHub-Request-Id: ['F756:06E0:954F94:9AEB8C:58BCF07C']
+      X-Served-By: [cache-sjc3130-SJC]
+      X-Timer: ['S1488777340.849385,VS0,VE90']
       X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -105,10 +106,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40a8bf80-fec0-11e6-baea-64510658e3b3]
+      x-ms-client-request-id: [f119149a-022b-11e7-be38-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage?api-version=2016-09-01
   response:
@@ -132,7 +134,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:14 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -146,10 +148,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40bc9f2e-fec0-11e6-9ed6-64510658e3b3]
+      x-ms-client-request-id: [f1380e4a-022b-11e7-91bb-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301?api-version=2016-12-01
   response:
@@ -159,7 +162,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['188']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:15 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -172,10 +175,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [414f2d50-fec0-11e6-85a5-64510658e3b3]
+      x-ms-client-request-id: [f16b0580-022b-11e7-bdcb-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2016-09-01
   response:
@@ -259,7 +263,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:16 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -273,10 +277,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [416af3e6-fec0-11e6-a9c7-64510658e3b3]
+      x-ms-client-request-id: [f1909990-022b-11e7-a0d7-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-12-01
   response:
@@ -286,7 +291,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:16 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -299,10 +304,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [41b69d98-fec0-11e6-a5ce-64510658e3b3]
+      x-ms-client-request-id: [f1c732ee-022b-11e7-825d-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2016-09-01
   response:
@@ -386,7 +392,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:16 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -400,10 +406,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [41d0adbe-fec0-11e6-ab66-64510658e3b3]
+      x-ms-client-request-id: [f1ec46fe-022b-11e7-90c8-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip?api-version=2016-12-01
   response:
@@ -413,75 +420,76 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:17 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-failure-cause: [gateway]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "contentVersion": "1.0.0.0", "outputs": {}, "resources": [{"dependsOn":
-      [], "name": "clitestvmcreate20170301", "apiVersion": "2015-06-15", "properties":
-      {"accountType": "Premium_LRS"}, "tags": {"secondtag": "2", "thirdtag": "", "firsttag":
-      "1"}, "type": "Microsoft.Storage/storageAccounts", "location": "eastus"}, {"dependsOn":
-      [], "name": "myvnet", "apiVersion": "2015-06-15", "properties": {"subnets":
-      [{"name": "vm-state-modSubnet", "properties": {"addressPrefix": "10.0.0.0/24"}}],
-      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "tags": {"secondtag":
-      "2", "thirdtag": "", "firsttag": "1"}, "type": "Microsoft.Network/virtualNetworks",
-      "location": "eastus"}, {"dependsOn": [], "name": "mynsg", "apiVersion": "2015-06-15",
-      "properties": {"securityRules": [{"name": "default-allow-ssh", "properties":
-      {"destinationAddressPrefix": "*", "sourcePortRange": "*", "sourceAddressPrefix":
-      "*", "direction": "Inbound", "priority": 1000, "destinationPortRange": "22",
-      "protocol": "Tcp", "access": "Allow"}}]}, "tags": {"secondtag": "2", "thirdtag":
-      "", "firsttag": "1"}, "type": "Microsoft.Network/networkSecurityGroups", "location":
-      "eastus"}, {"dependsOn": [], "name": "mypubip", "apiVersion": "2015-06-15",
-      "properties": {"publicIPAllocationMethod": "dynamic"}, "tags": {"secondtag":
-      "2", "thirdtag": "", "firsttag": "1"}, "type": "Microsoft.Network/publicIPAddresses",
-      "location": "eastus"}, {"dependsOn": ["Microsoft.Network/virtualNetworks/myvnet",
-      "Microsoft.Network/networkSecurityGroups/mynsg", "Microsoft.Network/publicIpAddresses/mypubip"],
-      "name": "vm-state-modVMNic", "apiVersion": "2015-06-15", "properties": {"networkSecurityGroup":
+    body: '{"properties": {"template": {"resources": [{"apiVersion": "2015-06-15",
+      "tags": {"thirdtag": "", "secondtag": "2", "firsttag": "1"}, "location": "eastus",
+      "type": "Microsoft.Storage/storageAccounts", "name": "clitestvmcreate20170301",
+      "dependsOn": [], "properties": {"accountType": "Premium_LRS"}}, {"apiVersion":
+      "2015-06-15", "tags": {"thirdtag": "", "secondtag": "2", "firsttag": "1"}, "location":
+      "eastus", "type": "Microsoft.Network/virtualNetworks", "name": "myvnet", "dependsOn":
+      [], "properties": {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
+      "name": "vm-state-modSubnet"}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}},
+      {"apiVersion": "2015-06-15", "tags": {"thirdtag": "", "secondtag": "2", "firsttag":
+      "1"}, "location": "eastus", "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "mynsg", "dependsOn": [], "properties": {"securityRules": [{"properties":
+      {"protocol": "Tcp", "priority": 1000, "destinationAddressPrefix": "*", "sourceAddressPrefix":
+      "*", "access": "Allow", "sourcePortRange": "*", "direction": "Inbound", "destinationPortRange":
+      "22"}, "name": "default-allow-ssh"}]}}, {"apiVersion": "2015-06-15", "tags":
+      {"thirdtag": "", "secondtag": "2", "firsttag": "1"}, "location": "eastus", "type":
+      "Microsoft.Network/publicIPAddresses", "name": "mypubip", "dependsOn": [], "properties":
+      {"publicIPAllocationMethod": "dynamic"}}, {"apiVersion": "2015-06-15", "tags":
+      {"thirdtag": "", "secondtag": "2", "firsttag": "1"}, "location": "eastus", "type":
+      "Microsoft.Network/networkInterfaces", "name": "vm-state-modVMNic", "dependsOn":
+      ["Microsoft.Network/virtualNetworks/myvnet", "Microsoft.Network/networkSecurityGroups/mynsg",
+      "Microsoft.Network/publicIpAddresses/mypubip"], "properties": {"networkSecurityGroup":
       {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
-      "ipConfigurations": [{"name": "ipconfigvm-state-mod", "properties": {"subnet":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/vm-state-modSubnet"},
-      "privateIPAllocationMethod": "Dynamic", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip"}}}]},
-      "tags": {"secondtag": "2", "thirdtag": "", "firsttag": "1"}, "type": "Microsoft.Network/networkInterfaces",
-      "location": "eastus"}, {"dependsOn": ["Microsoft.Storage/storageAccounts/clitestvmcreate20170301",
-      "Microsoft.Network/networkInterfaces/vm-state-modVMNic"], "name": "vm-state-mod",
-      "apiVersion": "2016-04-30-preview", "properties": {"hardwareProfile": {"vmSize":
-      "Standard_DS1_v2"}, "storageProfile": {"osDisk": {"name": "osdisk_2axcDgcYFD",
-      "createOption": "fromImage", "vhd": {"uri": "https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd"},
-      "caching": "ReadWrite"}, "imageReference": {"version": "latest", "sku": "14.04.4-LTS",
-      "publisher": "Canonical", "offer": "UbuntuServer"}}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]},
-      "osProfile": {"computerName": "vm-state-mod", "adminPassword": "testPassword0",
-      "adminUsername": "ubuntu"}}, "tags": {"secondtag": "2", "thirdtag": "", "firsttag":
-      "1"}, "type": "Microsoft.Compute/virtualMachines", "location": "eastus"}], "parameters":
-      {}}, "parameters": {}, "mode": "Incremental"}}'
+      "ipConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/vm-state-modSubnet"},
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm-state-mod"}]}},
+      {"apiVersion": "2016-04-30-preview", "tags": {"thirdtag": "", "secondtag": "2",
+      "firsttag": "1"}, "location": "eastus", "type": "Microsoft.Compute/virtualMachines",
+      "name": "vm-state-mod", "dependsOn": ["Microsoft.Storage/storageAccounts/clitestvmcreate20170301",
+      "Microsoft.Network/networkInterfaces/vm-state-modVMNic"], "properties": {"osProfile":
+      {"adminUsername": "ubuntu", "adminPassword": "testPassword0", "computerName":
+      "vm-state-mod"}, "storageProfile": {"imageReference": {"sku": "14.04.4-LTS",
+      "publisher": "Canonical", "offer": "UbuntuServer", "version": "latest"}, "osDisk":
+      {"vhd": {"uri": "https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd"},
+      "name": "osdisk_UXxYivdlP6", "caching": "ReadWrite", "createOption": "fromImage"}},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces":
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]}}}],
+      "outputs": {}, "contentVersion": "1.0.0.0", "parameters": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}}, "mode": "Incremental", "parameters": {}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3666']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_MmMgPTeUQQq12x7YwXtG1zwm00WYx1ST","name":"vm_deploy_MmMgPTeUQQq12x7YwXtG1zwm00WYx1ST","properties":{"templateHash":"15307526802642439873","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-03-01T20:47:20.878212Z","duration":"PT1.49512S","correlationId":"863cd62b-a085-40c1-aa04-24e452f5ad50","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myvnet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"mynsg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIpAddresses/mypubip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"mypubip"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"clitestvmcreate20170301"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-state-mod"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_bmreA21rjzcKqYTlDuUQaRJ3Pvu0HP3h","name":"vm_deploy_bmreA21rjzcKqYTlDuUQaRJ3Pvu0HP3h","properties":{"templateHash":"2536255309130517667","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-03-06T05:15:44.9997732Z","duration":"PT1.2458133S","correlationId":"00d3f6db-27cb-46e3-b5f2-9716509fcb30","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myvnet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"mynsg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIpAddresses/mypubip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"mypubip"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"clitestvmcreate20170301"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-state-mod"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_MmMgPTeUQQq12x7YwXtG1zwm00WYx1ST/operationStatuses/08587132056460946052?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_bmreA21rjzcKqYTlDuUQaRJ3Pvu0HP3h/operationStatuses/08587128295417236770?api-version=2016-09-01']
       Cache-Control: [no-cache]
-      Content-Length: ['2779']
+      Content-Length: ['2781']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:21 GMT']
+      Date: ['Mon, 06 Mar 2017 05:15:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -490,18 +498,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587132056460946052?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:47:51 GMT']
+      Date: ['Mon, 06 Mar 2017 05:16:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -515,18 +524,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587132056460946052?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:48:24 GMT']
+      Date: ['Mon, 06 Mar 2017 05:16:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -540,18 +550,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587132056460946052?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:48:56 GMT']
+      Date: ['Mon, 06 Mar 2017 05:17:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -565,18 +576,253 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587132056460946052?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:17:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:18:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:18:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:19:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:19:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:20:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:20:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:21:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:21:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587128295417236770?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:27 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -590,23 +836,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42203b6e-fec0-11e6-b52c-64510658e3b3]
+      x-ms-client-request-id: [f21e019e-022b-11e7-881a-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_MmMgPTeUQQq12x7YwXtG1zwm00WYx1ST","name":"vm_deploy_MmMgPTeUQQq12x7YwXtG1zwm00WYx1ST","properties":{"templateHash":"15307526802642439873","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-03-01T20:49:16.9803409Z","duration":"PT1M57.5972489S","correlationId":"863cd62b-a085-40c1-aa04-24e452f5ad50","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myvnet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"mynsg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIpAddresses/mypubip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"mypubip"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"clitestvmcreate20170301"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-state-mod"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-state-mod"},{"id":"Microsoft.Network/networkInterfaces/vm-state-modVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/mynsg"},{"id":"Microsoft.Network/publicIPAddresses/mypubip"},{"id":"Microsoft.Network/virtualNetworks/myvnet"},{"id":"Microsoft.Storage/storageAccounts/clitestvmcreate20170301"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Resources/deployments/vm_deploy_bmreA21rjzcKqYTlDuUQaRJ3Pvu0HP3h","name":"vm_deploy_bmreA21rjzcKqYTlDuUQaRJ3Pvu0HP3h","properties":{"templateHash":"2536255309130517667","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-03-06T05:21:55.2097437Z","duration":"PT6M11.4557838S","correlationId":"00d3f6db-27cb-46e3-b5f2-9716509fcb30","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myvnet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"mynsg"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIpAddresses/mypubip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"mypubip"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"clitestvmcreate20170301"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm-state-modVMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm-state-mod"}],"outputs":{},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-state-mod"},{"id":"Microsoft.Network/networkInterfaces/vm-state-modVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/mynsg"},{"id":"Microsoft.Network/publicIPAddresses/mypubip"},{"id":"Microsoft.Network/virtualNetworks/myvnet"},{"id":"Microsoft.Storage/storageAccounts/clitestvmcreate20170301"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:27 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['3163']
+      content-length: ['3162']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -615,21 +862,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [903d499a-fec0-11e6-803f-64510658e3b3]
+      x-ms-client-request-id: [e1d9b28c-022c-11e7-99fe-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -641,28 +889,28 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:49:06+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:22:17+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-03-01T20:47:51.9984163+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-03-06T05:16:16.5084601+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:49:09.8577303+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:17:42.0407992+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"\
-        2\",\r\n    \"thirdtag\": \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
+        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\"\
+        ,\r\n    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:30 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -678,22 +926,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [91b1e59a-fec0-11e6-9670-64510658e3b3]
+      x-ms-client-request-id: [e2192350-022c-11e7-bab0-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"vm-state-modVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"08b8a4b0-7bca-440f-8707-158d3099ce3d\\\"\",\r\n \
-        \ \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"2\",\r\
-        \n    \"thirdtag\": \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\"\
+        ,\r\n  \"etag\": \"W/\\\"5eb9e5ab-6b64-4dc5-ac4c-7a7f0b01948c\\\"\",\r\n \
+        \ \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\",\r\n\
+        \    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"84bd8a21-77e0-4c6c-8086-e46eaa2477c6\",\r\n    \"ipConfigurations\": [\r\
+        \ \"384e8dd6-efe5-431f-a0f2-b9f9a977e168\",\r\n    \"ipConfigurations\": [\r\
         \n      {\r\n        \"name\": \"ipconfigvm-state-mod\",\r\n        \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
-        ,\r\n        \"etag\": \"W/\\\"08b8a4b0-7bca-440f-8707-158d3099ce3d\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"5eb9e5ab-6b64-4dc5-ac4c-7a7f0b01948c\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -702,8 +950,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"uynwyq0vfwsehj0sut4otgp3kg.bx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-19-1C-1F\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"pvs0h325vmaera2wuduuwxmy5h.bx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-12-1B-77\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -713,8 +961,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:31 GMT']
-      ETag: [W/"08b8a4b0-7bca-440f-8707-158d3099ce3d"]
+      Date: ['Mon, 06 Mar 2017 05:22:25 GMT']
+      ETag: [W/"5eb9e5ab-6b64-4dc5-ac4c-7a7f0b01948c"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -730,35 +978,36 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [91d9fb9c-fec0-11e6-93c7-64510658e3b3]
+      x-ms-client-request-id: [e24da708-022c-11e7-ae08-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"mypubip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip\"\
-        ,\r\n  \"etag\": \"W/\\\"7a986d18-0fed-44a0-8865-a0cbfbb377a0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"\
-        eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\"\
-        : \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\": {\r\n    \"\
-        provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f66198bc-5d50-4b09-8214-7830676a5e26\"\
-        ,\r\n    \"ipAddress\": \"40.71.200.177\",\r\n    \"publicIPAddressVersion\"\
-        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
-        : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
-        \r\n    }\r\n  }\r\n}"}
+        ,\r\n  \"etag\": \"W/\\\"81774715-74e0-4727-a3ba-5fab6fb7cc4d\\\"\",\r\n \
+        \ \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\",\r\n\
+        \    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"e04f3375-5f5b-4191-9f39-217f07db89d6\",\r\n    \"ipAddress\": \"52.168.168.137\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\"\
+        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\
+        \n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:31 GMT']
-      ETag: [W/"7a986d18-0fed-44a0-8865-a0cbfbb377a0"]
+      Date: ['Mon, 06 Mar 2017 05:22:25 GMT']
+      ETag: [W/"81774715-74e0-4727-a3ba-5fab6fb7cc4d"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['922']
+      content-length: ['923']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -767,23 +1016,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9259f4f4-fec0-11e6-8873-64510658e3b3]
+      x-ms-client-request-id: [e2ed53be-022c-11e7-ac1d-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n  \
-        \      \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\",\r\n        \"hardwareProfile\"\
+        \      \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\",\r\n        \"hardwareProfile\"\
         : {\r\n          \"vmSize\": \"Standard_DS1_v2\"\r\n        },\r\n       \
         \ \"storageProfile\": {\r\n          \"imageReference\": {\r\n           \
         \ \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\"\
         ,\r\n            \"sku\": \"14.04.4-LTS\",\r\n            \"version\": \"\
         latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\"\
-        : \"Linux\",\r\n            \"name\": \"osdisk_2axcDgcYFD\",\r\n         \
+        : \"Linux\",\r\n            \"name\": \"osdisk_UXxYivdlP6\",\r\n         \
         \   \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n       \
-        \       \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \       \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n            },\r\n            \"caching\": \"ReadWrite\"\r\n         \
         \ },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\"\
         : {\r\n          \"computerName\": \"vm-state-mod\",\r\n          \"adminUsername\"\
@@ -792,14 +1042,14 @@ interactions:
         \     \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
         }]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n     \
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\":\
-        \ \"eastus\",\r\n      \"tags\": {\r\n        \"secondtag\": \"2\",\r\n  \
-        \      \"thirdtag\": \"\",\r\n        \"firsttag\": \"1\"\r\n      },\r\n\
+        \ \"eastus\",\r\n      \"tags\": {\r\n        \"thirdtag\": \"\",\r\n    \
+        \    \"secondtag\": \"2\",\r\n        \"firsttag\": \"1\"\r\n      },\r\n\
         \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n      \"name\": \"vm-state-mod\"\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:31 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -815,21 +1065,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [92bb4254-fec0-11e6-9c65-64510658e3b3]
+      x-ms-client-request-id: [e37e509c-022c-11e7-97d6-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -838,13 +1089,13 @@ interactions:
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:32 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -860,21 +1111,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [931850b8-fec0-11e6-8cb1-64510658e3b3]
+      x-ms-client-request-id: [e40e3a70-022c-11e7-8cf5-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -886,28 +1138,28 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:49:32+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:22:17+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-03-01T20:47:51.9984163+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-03-06T05:16:16.5084601+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:49:09.8577303+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:17:42.0407992+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"\
-        2\",\r\n    \"thirdtag\": \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
+        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\"\
+        ,\r\n    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:33 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -923,21 +1175,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [937902ee-fec0-11e6-b821-64510658e3b3]
+      x-ms-client-request-id: [e4a1a2c0-022c-11e7-9fca-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -949,28 +1202,28 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:49:32+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:22:17+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\"\
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-03-01T20:47:51.9984163+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-03-06T05:16:16.5084601+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:49:09.8577303+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:17:42.0407992+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"\
-        2\",\r\n    \"thirdtag\": \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
+        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\"\
+        ,\r\n    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:34 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -980,82 +1233,20 @@ interactions:
       content-length: ['2672']
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [939d7670-fec0-11e6-8a54-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
-        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
-        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
-        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:49:32+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\"\
-        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
-        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
-        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-03-01T20:47:51.9984163+00:00\"\r\n            }\r\
-        \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
-        \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
-        \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:49:09.8577303+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"\
-        2\",\r\n    \"thirdtag\": \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
-        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['2672']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"protectedSettings": {"username": "foouser1", "password":
-      "Foo12345"}, "publisher": "Microsoft.OSTCExtensions", "type": "VMAccessForLinux",
-      "typeHandlerVersion": "1.4", "settings": {}}, "location": "eastus"}'
+    body: '{"location": "eastus", "properties": {"type": "VMAccessForLinux", "publisher":
+      "Microsoft.OSTCExtensions", "protectedSettings": {"password": "Foo12345", "username":
+      "foouser1"}, "settings": {}, "typeHandlerVersion": "1.4"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['223']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93bbbe9a-fec0-11e6-bd75-64510658e3b3]
+      x-ms-client-request-id: [e4da69ee-022c-11e7-84b1-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess?api-version=2016-04-30-preview
   response:
@@ -1066,16 +1257,16 @@ interactions:
         ,\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n  \"name\": \"enablevmaccess\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/5005efb3-0c68-4085-9f1b-de90387ad2db?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/7ee9c750-68d0-40da-b814-16a440b60d09?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['541']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:49:36 GMT']
+      Date: ['Mon, 06 Mar 2017 05:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1084,20 +1275,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93bbbe9a-fec0-11e6-bd75-64510658e3b3]
+      x-ms-client-request-id: [e4da69ee-022c-11e7-84b1-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/5005efb3-0c68-4085-9f1b-de90387ad2db?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/7ee9c750-68d0-40da-b814-16a440b60d09?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:49:36.2956453+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5005efb3-0c68-4085-9f1b-de90387ad2db\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:22:31.9137489+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"7ee9c750-68d0-40da-b814-16a440b60d09\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:50:06 GMT']
+      Date: ['Mon, 06 Mar 2017 05:23:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1113,49 +1305,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93bbbe9a-fec0-11e6-bd75-64510658e3b3]
+      x-ms-client-request-id: [e4da69ee-022c-11e7-84b1-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/5005efb3-0c68-4085-9f1b-de90387ad2db?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/7ee9c750-68d0-40da-b814-16a440b60d09?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:49:36.2956453+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"5005efb3-0c68-4085-9f1b-de90387ad2db\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:22:31.9137489+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:23:18.7879913+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"7ee9c750-68d0-40da-b814-16a440b60d09\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:50:37 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [93bbbe9a-fec0-11e6-bd75-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/5005efb3-0c68-4085-9f1b-de90387ad2db?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:49:36.2956453+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:50:39.0921727+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"5005efb3-0c68-4085-9f1b-de90387ad2db\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:07 GMT']
+      Date: ['Mon, 06 Mar 2017 05:23:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1171,10 +1335,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93bbbe9a-fec0-11e6-bd75-64510658e3b3]
+      x-ms-client-request-id: [e4da69ee-022c-11e7-84b1-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess?api-version=2016-04-30-preview
   response:
@@ -1187,7 +1352,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:08 GMT']
+      Date: ['Mon, 06 Mar 2017 05:23:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1203,21 +1368,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cc948794-fec0-11e6-beb2-64510658e3b3]
+      x-ms-client-request-id: [0b59a1ba-022d-11e7-8138-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -1229,17 +1395,17 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:50:58+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:23:17+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
         ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
+        : [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\",\r\n       \
         \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:49:36.4674939+00:00\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-06T05:22:32.1168486+00:00\"\
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
         : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
         type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
@@ -1250,7 +1416,7 @@ interactions:
         \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
         \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
         level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:50:39.0765949+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:23:18.7723992+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
@@ -1262,13 +1428,13 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:09 GMT']
+      Date: ['Mon, 06 Mar 2017 05:23:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1278,100 +1444,20 @@ interactions:
       content-length: ['4068']
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ccccbe4c-fec0-11e6-a071-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
-        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
-        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
-        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:50:58+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
-        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
-        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
-        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
-        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
-        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:49:36.4674939+00:00\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
-        : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
-        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
-        : \"1.4.6.0\",\r\n          \"statuses\": [\r\n            {\r\n         \
-        \     \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
-        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n              \"message\": \"Enable succeeded.\"\r\n            }\r\n\
-        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
-        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
-        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:50:39.0765949+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
-        \      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n        \"type\": \"VMAccessForLinux\",\r\n        \"typeHandlerVersion\"\
-        : \"1.4\",\r\n        \"autoUpgradeMinorVersion\": false,\r\n        \"settings\"\
-        : {},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n    \
-        \  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"\
-        location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
-        ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
-        firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
-        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['4068']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"protectedSettings": {"remove_user": "foouser1"}, "publisher":
-      "Microsoft.OSTCExtensions", "type": "VMAccessForLinux", "typeHandlerVersion":
-      "1.4", "settings": {}}, "location": "eastus"}'
+    body: '{"location": "eastus", "properties": {"type": "VMAccessForLinux", "publisher":
+      "Microsoft.OSTCExtensions", "protectedSettings": {"remove_user": "foouser1"},
+      "settings": {}, "typeHandlerVersion": "1.4"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['202']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd0c64c2-fec0-11e6-bfc9-64510658e3b3]
+      x-ms-client-request-id: [0b8d56cc-022d-11e7-ac52-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess?api-version=2016-04-30-preview
   response:
@@ -1382,10 +1468,10 @@ interactions:
         ,\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n  \"name\": \"enablevmaccess\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/b34f43e4-213e-4b51-921d-92a02a5c6e3c?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/1b98da80-f41d-4ef0-b9ac-045a5ecc82a9?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:10 GMT']
+      Date: ['Mon, 06 Mar 2017 05:23:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1402,27 +1488,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd0c64c2-fec0-11e6-bfc9-64510658e3b3]
+      x-ms-client-request-id: [0b8d56cc-022d-11e7-ac52-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/b34f43e4-213e-4b51-921d-92a02a5c6e3c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1b98da80-f41d-4ef0-b9ac-045a5ecc82a9?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:51:11.2169872+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"b34f43e4-213e-4b51-921d-92a02a5c6e3c\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:23:35.807844+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"1b98da80-f41d-4ef0-b9ac-045a5ecc82a9\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:51:40 GMT']
+      Date: ['Mon, 06 Mar 2017 05:24:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1431,27 +1518,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd0c64c2-fec0-11e6-bfc9-64510658e3b3]
+      x-ms-client-request-id: [0b8d56cc-022d-11e7-ac52-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/b34f43e4-213e-4b51-921d-92a02a5c6e3c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1b98da80-f41d-4ef0-b9ac-045a5ecc82a9?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:51:11.2169872+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"b34f43e4-213e-4b51-921d-92a02a5c6e3c\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:23:35.807844+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"1b98da80-f41d-4ef0-b9ac-045a5ecc82a9\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:11 GMT']
+      Date: ['Mon, 06 Mar 2017 05:24:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1460,27 +1548,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd0c64c2-fec0-11e6-bfc9-64510658e3b3]
+      x-ms-client-request-id: [0b8d56cc-022d-11e7-ac52-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/b34f43e4-213e-4b51-921d-92a02a5c6e3c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/1b98da80-f41d-4ef0-b9ac-045a5ecc82a9?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:51:11.2169872+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:52:25.5916142+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"b34f43e4-213e-4b51-921d-92a02a5c6e3c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:23:35.807844+00:00\",\r\n\
+        \  \"endTime\": \"2017-03-06T05:24:44.0409967+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"1b98da80-f41d-4ef0-b9ac-045a5ecc82a9\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:42 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['184']
+      content-length: ['183']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1489,10 +1578,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd0c64c2-fec0-11e6-bfc9-64510658e3b3]
+      x-ms-client-request-id: [0b8d56cc-022d-11e7-ac52-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess?api-version=2016-04-30-preview
   response:
@@ -1505,7 +1595,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:42 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1521,22 +1611,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [04c336c2-fec1-11e6-b1ee-64510658e3b3]
+      x-ms-client-request-id: [4366241a-022d-11e7-9012-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"mynsg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg\"\
-        ,\r\n  \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
-        : \"eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\"\
-        : \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\": {\r\n    \"\
-        provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7c219bc1-86aa-4d7c-af40-da0842541306\"\
+        : \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\"\
+        : \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\": {\r\n   \
+        \ \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"32b2bcf5-3388-40fb-977b-82ddf9fbb94e\"\
         ,\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"default-allow-ssh\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/securityRules/default-allow-ssh\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"\
         *\",\r\n          \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\"\
@@ -1545,7 +1635,7 @@ interactions:
         : \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
         : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/AllowVnetInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1555,7 +1645,7 @@ interactions:
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1564,7 +1654,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/DenyAllInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
         \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
@@ -1573,7 +1663,7 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/AllowVnetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
         \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
@@ -1582,7 +1672,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
         \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/AllowInternetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1591,7 +1681,7 @@ interactions:
         \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
         \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
         \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkSecurityGroups/mynsg/defaultSecurityRules/DenyAllOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"3aa4f60e-8163-4206-b756-2d1dc2f46302\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"3c48211c-f444-4f75-a19b-41a2f856b778\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
         \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
@@ -1604,8 +1694,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:44 GMT']
-      ETag: [W/"3aa4f60e-8163-4206-b756-2d1dc2f46302"]
+      Date: ['Mon, 06 Mar 2017 05:25:08 GMT']
+      ETag: [W/"3c48211c-f444-4f75-a19b-41a2f856b778"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1621,35 +1711,36 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [054747de-fec1-11e6-9c54-64510658e3b3]
+      x-ms-client-request-id: [44145198-022d-11e7-bc18-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"mypubip\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/publicIPAddresses/mypubip\"\
-        ,\r\n  \"etag\": \"W/\\\"64437d1b-b901-4b94-aa51-01756c1e6ed2\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"\
-        eastus\",\r\n  \"tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\"\
-        : \"\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\": {\r\n    \"\
-        provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f66198bc-5d50-4b09-8214-7830676a5e26\"\
-        ,\r\n    \"ipAddress\": \"40.71.200.177\",\r\n    \"publicIPAddressVersion\"\
-        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
-        : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
-        \r\n    }\r\n  }\r\n}"}
+        ,\r\n  \"etag\": \"W/\\\"5e1e942b-7110-40aa-b9eb-c2908f98b02b\\\"\",\r\n \
+        \ \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"thirdtag\": \"\",\r\n\
+        \    \"secondtag\": \"2\",\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"e04f3375-5f5b-4191-9f39-217f07db89d6\",\r\n    \"ipAddress\": \"52.168.168.137\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipConfiguration\"\
+        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\
+        \n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:45 GMT']
-      ETag: [W/"64437d1b-b901-4b94-aa51-01756c1e6ed2"]
+      Date: ['Mon, 06 Mar 2017 05:25:09 GMT']
+      ETag: [W/"5e1e942b-7110-40aa-b9eb-c2908f98b02b"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['922']
+      content-length: ['923']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1658,23 +1749,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [05cd1aa6-fec1-11e6-96ff-64510658e3b3]
+      x-ms-client-request-id: [44c62412-022d-11e7-aa7c-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"myvnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet\"\
-        ,\r\n  \"etag\": \"W/\\\"cb4e93a8-2298-4379-abc5-f3013d076580\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"c4ac410c-3b51-4141-b33f-12f7c4d6f112\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
-        ,\r\n  \"tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\"\
+        ,\r\n  \"tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\"\
         ,\r\n    \"firsttag\": \"1\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"436c1ba6-2d55-43a4-a752-a4fce999fd56\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"f7a3657d-ab9f-4800-8396-a0e94b5d98ff\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n  \
         \      \"name\": \"vm-state-modSubnet\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/vm-state-modSubnet\"\
-        ,\r\n        \"etag\": \"W/\\\"cb4e93a8-2298-4379-abc5-f3013d076580\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"c4ac410c-3b51-4141-b33f-12f7c4d6f112\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"ipConfigurations\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic/ipConfigurations/ipconfigvm-state-mod\"\
@@ -1683,8 +1774,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:52:45 GMT']
-      ETag: [W/"cb4e93a8-2298-4379-abc5-f3013d076580"]
+      Date: ['Mon, 06 Mar 2017 05:25:10 GMT']
+      ETag: [W/"c4ac410c-3b51-4141-b33f-12f7c4d6f112"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1700,20 +1791,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [06581e18-fec1-11e6-8b20-64510658e3b3]
+      x-ms-client-request-id: [4570e6d2-022d-11e7-b555-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301?api-version=2016-12-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","kind":"Storage","location":"eastus","name":"clitestvmcreate20170301","properties":{"creationTime":"2017-03-01T20:47:24.7033054Z","primaryEndpoints":{"blob":"https://clitestvmcreate20170301.blob.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{"firsttag":"1","secondtag":"2","thirdtag":""},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Storage/storageAccounts/clitestvmcreate20170301","kind":"Storage","location":"eastus","name":"clitestvmcreate20170301","properties":{"creationTime":"2017-03-06T05:15:48.2291311Z","primaryEndpoints":{"blob":"https://clitestvmcreate20170301.blob.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{"firsttag":"1","secondtag":"2","thirdtag":""},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Wed, 01 Mar 2017 20:52:47 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -1730,21 +1821,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [06e4056c-fec1-11e6-9227-64510658e3b3]
+      x-ms-client-request-id: [461daf24-022d-11e7-9513-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/powerOff?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/c73ae5f2-9a6d-4ea1-89d9-257fe491912d?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/45fd66ca-4e98-4500-8750-83e0955699b0?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 01 Mar 2017 20:52:47 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:13 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/c73ae5f2-9a6d-4ea1-89d9-257fe491912d?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/45fd66ca-4e98-4500-8750-83e0955699b0?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -1757,27 +1849,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [06e4056c-fec1-11e6-9227-64510658e3b3]
+      x-ms-client-request-id: [461daf24-022d-11e7-9513-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/c73ae5f2-9a6d-4ea1-89d9-257fe491912d?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/45fd66ca-4e98-4500-8750-83e0955699b0?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:52:47.966498+00:00\",\r\n\
-        \  \"endTime\": \"2017-03-01T20:52:55.1226756+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"c73ae5f2-9a6d-4ea1-89d9-257fe491912d\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:25:13.7122971+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:25:27.7923865+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"45fd66ca-4e98-4500-8750-83e0955699b0\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:53:18 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['183']
+      content-length: ['184']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1786,21 +1879,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1a3897a8-fec1-11e6-8415-64510658e3b3]
+      x-ms-client-request-id: [58fd426c-022d-11e7-bd86-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -1812,17 +1906,17 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:52:44+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:25:04+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
         ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
+        : [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\",\r\n       \
         \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:51:11.2794652+00:00\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-06T05:23:35.8703197+00:00\"\
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
         : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
         type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
@@ -1833,7 +1927,7 @@ interactions:
         \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
         \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
         level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:52:55.1070639+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:25:27.7767813+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/stopped\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
@@ -1845,13 +1939,13 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:53:19 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1868,21 +1962,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1a8f11a8-fec1-11e6-906c-64510658e3b3]
+      x-ms-client-request-id: [5983e952-022d-11e7-9080-f4b7e2e85440]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/start?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/4dce272a-3372-4ec0-ac09-2234bd46fc8c?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/bb3b3b55-c779-41b9-981c-d9e550e71175?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 01 Mar 2017 20:53:20 GMT']
+      Date: ['Mon, 06 Mar 2017 05:25:45 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/4dce272a-3372-4ec0-ac09-2234bd46fc8c?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/bb3b3b55-c779-41b9-981c-d9e550e71175?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -1895,354 +1990,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1a8f11a8-fec1-11e6-906c-64510658e3b3]
+      x-ms-client-request-id: [5983e952-022d-11e7-9080-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/4dce272a-3372-4ec0-ac09-2234bd46fc8c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/bb3b3b55-c779-41b9-981c-d9e550e71175?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:53:20.8725899+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:53:42.0287126+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"4dce272a-3372-4ec0-ac09-2234bd46fc8c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:25:46.229589+00:00\",\r\n\
+        \  \"endTime\": \"2017-03-06T05:26:03.2233467+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"bb3b3b55-c779-41b9-981c-d9e550e71175\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:53:51 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['184']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2d4b3ed2-fec1-11e6-b479-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
-        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
-        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
-        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:52:44+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
-        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
-        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
-        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
-        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
-        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:51:11.2794652+00:00\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
-        : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
-        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
-        : \"1.4.6.0\",\r\n          \"statuses\": [\r\n            {\r\n         \
-        \     \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
-        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n              \"message\": \"Enable succeeded.\"\r\n            }\r\n\
-        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
-        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
-        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:53:42.0130886+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
-        \      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n        \"type\": \"VMAccessForLinux\",\r\n        \"typeHandlerVersion\"\
-        : \"1.4\",\r\n        \"autoUpgradeMinorVersion\": false,\r\n        \"settings\"\
-        : {},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n    \
-        \  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"\
-        location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
-        ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
-        firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
-        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:53:51 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['4068']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2dafbec2-fec1-11e6-9b51-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/restart?api-version=2016-04-30-preview
-  response:
-    body: {string: ''}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/e57ce653-1f75-48d1-a6d6-5c5940d7f7fb?api-version=2016-04-30-preview']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Wed, 01 Mar 2017 20:53:52 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/e57ce653-1f75-48d1-a6d6-5c5940d7f7fb?monitor=true&api-version=2016-04-30-preview']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2dafbec2-fec1-11e6-9b51-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/e57ce653-1f75-48d1-a6d6-5c5940d7f7fb?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:53:52.9836762+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:53:53.1242723+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"e57ce653-1f75-48d1-a6d6-5c5940d7f7fb\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:54:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['184']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [406bfb3a-fec1-11e6-b1b7-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
-        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
-        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
-        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
-        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
-        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
-        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
-        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
-        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:53:55+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
-        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
-        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
-        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
-        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
-        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:51:11.2794652+00:00\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
-        : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
-        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
-        : \"1.4.6.0\",\r\n          \"statuses\": [\r\n            {\r\n         \
-        \     \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
-        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n              \"message\": \"Enable succeeded.\"\r\n            }\r\n\
-        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
-        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
-        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:53:53.1086326+00:00\"\r\n       \
-        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
-        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
-        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
-        \      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
-        ,\r\n        \"type\": \"VMAccessForLinux\",\r\n        \"typeHandlerVersion\"\
-        : \"1.4\",\r\n        \"autoUpgradeMinorVersion\": false,\r\n        \"settings\"\
-        : {},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n    \
-        \  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"\
-        location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
-        ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
-        firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
-        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:54:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['4068']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [40e4e17a-fec1-11e6-bb34-64510658e3b3]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/deallocate?api-version=2016-04-30-preview
-  response:
-    body: {string: ''}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/399c8197-ffbf-416d-a380-c3974156830f?api-version=2016-04-30-preview']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Wed, 01 Mar 2017 20:54:24 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/399c8197-ffbf-416d-a380-c3974156830f?monitor=true&api-version=2016-04-30-preview']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [40e4e17a-fec1-11e6-bb34-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/399c8197-ffbf-416d-a380-c3974156830f?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:54:25.389701+00:00\",\r\n\
-        \  \"status\": \"InProgress\",\r\n  \"name\": \"399c8197-ffbf-416d-a380-c3974156830f\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:54:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['133']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [40e4e17a-fec1-11e6-bb34-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/399c8197-ffbf-416d-a380-c3974156830f?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:54:25.389701+00:00\",\r\n\
-        \  \"status\": \"InProgress\",\r\n  \"name\": \"399c8197-ffbf-416d-a380-c3974156830f\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:55:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['133']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [40e4e17a-fec1-11e6-bb34-64510658e3b3]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/399c8197-ffbf-416d-a380-c3974156830f?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:54:25.389701+00:00\",\r\n\
-        \  \"endTime\": \"2017-03-01T20:55:56.3286356+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"399c8197-ffbf-416d-a380-c3974156830f\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:55:56 GMT']
+      Date: ['Mon, 06 Mar 2017 05:26:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2258,21 +2020,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7898c7f8-fec1-11e6-acd7-64510658e3b3]
+      x-ms-client-request-id: [6c61e7b8-022d-11e7-ad48-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -2284,17 +2047,17 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-01T20:53:55+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:25:04+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
         ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"osdisk_2axcDgcYFD\",\r\n       \
+        : [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\",\r\n       \
         \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
-        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-01T20:55:56.3130333+00:00\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-06T05:23:35.8703197+00:00\"\
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
         : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
         type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
@@ -2305,7 +2068,349 @@ interactions:
         \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
         \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
         level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-03-01T20:55:56.3130333+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-03-06T05:26:03.2077243+00:00\"\r\n       \
+        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
+        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
+        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
+        \      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
+        ,\r\n        \"type\": \"VMAccessForLinux\",\r\n        \"typeHandlerVersion\"\
+        : \"1.4\",\r\n        \"autoUpgradeMinorVersion\": false,\r\n        \"settings\"\
+        : {},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n    \
+        \  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"\
+        location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
+        ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
+        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
+        firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
+        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:26:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['4068']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cff50fa-022d-11e7-b61b-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/restart?api-version=2016-04-30-preview
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/e66a78a0-c19f-4449-ada3-c4aa0dc85f1f?api-version=2016-04-30-preview']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 06 Mar 2017 05:26:17 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/e66a78a0-c19f-4449-ada3-c4aa0dc85f1f?monitor=true&api-version=2016-04-30-preview']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cff50fa-022d-11e7-b61b-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/e66a78a0-c19f-4449-ada3-c4aa0dc85f1f?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:26:17.2661021+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:26:17.3910566+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"e66a78a0-c19f-4449-ada3-c4aa0dc85f1f\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:26:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7fe1570c-022d-11e7-bcfb-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
+        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
+        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
+        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:25:04+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
+        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
+        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
+        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
+        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
+        : [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\",\r\n       \
+        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-06T05:23:35.8703197+00:00\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
+        : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
+        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
+        : \"1.4.6.0\",\r\n          \"statuses\": [\r\n            {\r\n         \
+        \     \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
+        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n              \"message\": \"Enable succeeded.\"\r\n            }\r\n\
+        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
+        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
+        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2017-03-06T05:26:17.3754321+00:00\"\r\n       \
+        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
+        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
+        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\n\
+        \      \"properties\": {\r\n        \"publisher\": \"Microsoft.OSTCExtensions\"\
+        ,\r\n        \"type\": \"VMAccessForLinux\",\r\n        \"typeHandlerVersion\"\
+        : \"1.4\",\r\n        \"autoUpgradeMinorVersion\": false,\r\n        \"settings\"\
+        : {},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n    \
+        \  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"\
+        location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
+        ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
+        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
+        firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
+        ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:26:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['4068']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8089b198-022d-11e7-8bf0-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/deallocate?api-version=2016-04-30-preview
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/de149cb0-26f6-489f-934e-c4f5d9c4e896?api-version=2016-04-30-preview']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 06 Mar 2017 05:26:51 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/de149cb0-26f6-489f-934e-c4f5d9c4e896?monitor=true&api-version=2016-04-30-preview']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8089b198-022d-11e7-8bf0-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/de149cb0-26f6-489f-934e-c4f5d9c4e896?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:26:50.0846218+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de149cb0-26f6-489f-934e-c4f5d9c4e896\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:27:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8089b198-022d-11e7-8bf0-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/de149cb0-26f6-489f-934e-c4f5d9c4e896?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:26:50.0846218+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"de149cb0-26f6-489f-934e-c4f5d9c4e896\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:27:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8089b198-022d-11e7-8bf0-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/de149cb0-26f6-489f-934e-c4f5d9c4e896?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:26:50.0846218+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:28:11.0300682+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"de149cb0-26f6-489f-934e-c4f5d9c4e896\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:28:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['184']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b7d03358-022d-11e7-983e-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?$expand=instanceView&api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
+        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
+        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
+        : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:25:04+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
+        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
+        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
+        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
+        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
+        : [\r\n        {\r\n          \"name\": \"osdisk_UXxYivdlP6\",\r\n       \
+        \   \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Provisioning succeeded\",\r\n              \"time\": \"2017-03-06T05:28:10.9988177+00:00\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"extensions\"\
+        : [\r\n        {\r\n          \"name\": \"enablevmaccess\",\r\n          \"\
+        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"typeHandlerVersion\"\
+        : \"1.4.6.0\",\r\n          \"statuses\": [\r\n            {\r\n         \
+        \     \"code\": \"ProvisioningState/succeeded\",\r\n              \"level\"\
+        : \"Info\",\r\n              \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n              \"message\": \"Enable succeeded.\"\r\n            }\r\n\
+        \          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n       \
+        \ {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"\
+        level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2017-03-06T05:28:11.0144384+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/deallocated\",\r\n \
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM deallocated\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -2317,13 +2422,13 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:55:58 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2339,21 +2444,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [791b7fbe-fec1-11e6-a5ff-64510658e3b3]
+      x-ms-client-request-id: [b8667c34-022d-11e7-b66d-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -2369,13 +2475,13 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:55:59 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2385,36 +2491,37 @@ interactions:
       content-length: ['2105']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"hardwareProfile": {"vmSize": "Standard_A4"}, "storageProfile":
-      {"dataDisks": [], "osDisk": {"name": "osdisk_2axcDgcYFD", "createOption": "fromImage",
-      "vhd": {"uri": "https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd"},
-      "caching": "ReadWrite", "osType": "Linux"}, "imageReference": {"offer": "UbuntuServer",
-      "sku": "14.04.4-LTS", "publisher": "Canonical", "version": "latest"}}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]},
-      "osProfile": {"secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "computerName": "vm-state-mod", "adminUsername": "ubuntu"}}, "tags":
-      {"secondtag": "2", "thirdtag": "", "firsttag": "1"}, "location": "eastus"}'
+    body: '{"location": "eastus", "tags": {"thirdtag": "", "secondtag": "2", "firsttag":
+      "1"}, "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]},
+      "storageProfile": {"dataDisks": [], "imageReference": {"sku": "14.04.4-LTS",
+      "publisher": "Canonical", "offer": "UbuntuServer", "version": "latest"}, "osDisk":
+      {"osType": "Linux", "vhd": {"uri": "https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd"},
+      "name": "osdisk_UXxYivdlP6", "caching": "ReadWrite", "createOption": "fromImage"}},
+      "hardwareProfile": {"vmSize": "Standard_A4"}, "osProfile": {"adminUsername":
+      "ubuntu", "secrets": [], "linuxConfiguration": {"disablePasswordAuthentication":
+      false}, "computerName": "vm-state-mod"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['875']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [793d9dbe-fec1-11e6-a6e7-64510658e3b3]
+      x-ms-client-request-id: [b895f1f4-022d-11e7-869d-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A4\"\r\n \
         \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n   \
         \     \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -2430,14 +2537,14 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/54ee7ddc-ef54-4327-bce3-d2d4d3ce961b?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/3fe7c9bf-794d-4d1c-a90f-8bc5e8e13ee7?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:56:01 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2445,7 +2552,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['2100']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2454,20 +2561,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [793d9dbe-fec1-11e6-a6e7-64510658e3b3]
+      x-ms-client-request-id: [b895f1f4-022d-11e7-869d-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/54ee7ddc-ef54-4327-bce3-d2d4d3ce961b?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/3fe7c9bf-794d-4d1c-a90f-8bc5e8e13ee7?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:56:00.2973543+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:56:03.4536104+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"54ee7ddc-ef54-4327-bce3-d2d4d3ce961b\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:28:24.6667565+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:28:28.2906929+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"3fe7c9bf-794d-4d1c-a90f-8bc5e8e13ee7\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:56:31 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2483,21 +2591,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [793d9dbe-fec1-11e6-a6e7-64510658e3b3]
+      x-ms-client-request-id: [b895f1f4-022d-11e7-869d-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"cd44f146-d757-45d7-b4a7-423411d3cb0c\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"bd0d9fef-7b3b-49c2-a7dd-3ceb28c1059c\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A4\"\r\n \
         \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n   \
         \     \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_2axcDgcYFD\",\r\n        \"createOption\": \"FromImage\"\
-        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_2axcDgcYFD.vhd\"\
+        \      \"name\": \"osdisk_UXxYivdlP6\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"vhd\": {\r\n          \"uri\": \"https://clitestvmcreate20170301.blob.core.windows.net/vhds/osdisk_UXxYivdlP6.vhd\"\
         \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
         \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
         : \"vm-state-mod\",\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -2513,13 +2622,13 @@ interactions:
         location\": \"eastus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/extensions/enablevmaccess\"\
         ,\r\n      \"name\": \"enablevmaccess\"\r\n    }\r\n  ],\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n  \"\
-        tags\": {\r\n    \"secondtag\": \"2\",\r\n    \"thirdtag\": \"\",\r\n    \"\
+        tags\": {\r\n    \"thirdtag\": \"\",\r\n    \"secondtag\": \"2\",\r\n    \"\
         firsttag\": \"1\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod\"\
         ,\r\n  \"name\": \"vm-state-mod\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:56:31 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2536,21 +2645,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d2ab638-fec1-11e6-9896-64510658e3b3]
+      x-ms-client-request-id: [ccadf298-022d-11e7-8a8d-f4b7e2e85440]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/651569db-a17a-4abb-87ee-1bd5193de3c9?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/5299090d-661e-4619-805a-20fa88b215ba?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 01 Mar 2017 20:56:33 GMT']
+      Date: ['Mon, 06 Mar 2017 05:28:58 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/651569db-a17a-4abb-87ee-1bd5193de3c9?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/eastus/operations/5299090d-661e-4619-805a-20fa88b215ba?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -2563,20 +2673,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d2ab638-fec1-11e6-9896-64510658e3b3]
+      x-ms-client-request-id: [ccadf298-022d-11e7-8a8d-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/651569db-a17a-4abb-87ee-1bd5193de3c9?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus/operations/5299090d-661e-4619-805a-20fa88b215ba?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-01T20:56:33.2502866+00:00\",\r\
-        \n  \"endTime\": \"2017-03-01T20:56:43.5470974+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"651569db-a17a-4abb-87ee-1bd5193de3c9\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:28:57.8603624+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:29:08.0761567+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5299090d-661e-4619-805a-20fa88b215ba\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:57:03 GMT']
+      Date: ['Mon, 06 Mar 2017 05:29:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2592,10 +2703,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9fdeeffa-fec1-11e6-8063-64510658e3b3]
+      x-ms-client-request-id: [e01bb202-022d-11e7-a0c0-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_state_mod/providers/Microsoft.Compute/virtualMachines?api-version=2016-04-30-preview
   response:
@@ -2603,7 +2715,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 01 Mar 2017 20:57:04 GMT']
+      Date: ['Mon, 06 Mar 2017 05:29:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_extension.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_extension.yaml
@@ -6,59 +6,72 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [842e3494-e765-11e6-9e2c-64510658e3b3]
+      x-ms-client-request-id: [57fcff76-0231-11e7-89d8-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"40535184-3286-43bd-8570-09fda74f67be\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8e6af570-9500-48e8-abc6-ebbfbe474519\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_mdFgDaFXvr\",\r\n        \"createOption\": \"FromImage\"\
+        \      \"name\": \"osdisk_t1mMxjK58H\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
-        \          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\":\
-        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_mdFgDaFXvr\"\
+        \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_t1mMxjK58H\"\
         \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"yugangw\"\
+        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"user11\"\
         ,\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
         : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
         : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
-        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
-        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
-        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:54:16+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
+        \   },\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n          \"time\": \"2017-03-06T05:53:55.2041861+00:00\"\
+        \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
+        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
+        \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm\"\
         ,\r\n  \"name\": \"myvm\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:29:47 GMT']
+      Date: ['Mon, 06 Mar 2017 05:54:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1491']
+      content-length: ['2322']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"type": "VMAccessForLinux", "typeHandlerVersion": "1.2",
-      "autoUpgradeMinorVersion": true, "protectedSettings": {"ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT",
-      "username": "foouser1"}, "publisher": "Microsoft.OSTCExtensions"}, "location":
-      "westus"}'
+    body: '{"location": "westus", "properties": {"autoUpgradeMinorVersion": true,
+      "protectedSettings": {"username": "foouser1", "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT"},
+      "type": "VMAccessForLinux", "publisher": "Microsoft.OSTCExtensions", "typeHandlerVersion":
+      "1.2"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['611']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [84795ca2-e765-11e6-b204-64510658e3b3]
+      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -69,11 +82,11 @@ interactions:
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux\"\
         ,\r\n  \"name\": \"VMAccessForLinux\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/49f0bc16-8a1b-4d4b-8207-64e5ac5da6db?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['512']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:29:49 GMT']
+      Date: ['Mon, 06 Mar 2017 05:54:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -87,20 +100,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [84795ca2-e765-11e6-b204-64510658e3b3]
+      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f0bc16-8a1b-4d4b-8207-64e5ac5da6db?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T03:29:48.8686773+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"49f0bc16-8a1b-4d4b-8207-64e5ac5da6db\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:30:19 GMT']
+      Date: ['Mon, 06 Mar 2017 05:54:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -116,20 +130,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [84795ca2-e765-11e6-b204-64510658e3b3]
+      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/49f0bc16-8a1b-4d4b-8207-64e5ac5da6db?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T03:29:48.8686773+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T03:30:45.0112946+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"49f0bc16-8a1b-4d4b-8207-64e5ac5da6db\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:30:50 GMT']
+      Date: ['Mon, 06 Mar 2017 05:55:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:55:24.8715653+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:55:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -145,10 +190,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [84795ca2-e765-11e6-b204-64510658e3b3]
+      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -161,7 +207,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:30:49 GMT']
+      Date: ['Mon, 06 Mar 2017 05:55:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -177,25 +223,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aa3e879a-e765-11e6-ac15-64510658e3b3]
+      x-ms-client-request-id: [8f633e42-0231-11e7-88ac-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview&$expand=instanceView
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"40535184-3286-43bd-8570-09fda74f67be\"\
-        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
-        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
-        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8e6af570-9500-48e8-abc6-ebbfbe474519\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_mdFgDaFXvr\",\r\n        \"createOption\": \"FromImage\"\
+        \      \"name\": \"osdisk_t1mMxjK58H\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
-        \          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\":\
-        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_mdFgDaFXvr\"\
+        \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_t1mMxjK58H\"\
         \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"yugangw\"\
+        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"user11\"\
         ,\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
         : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
         : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
@@ -204,7 +251,7 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-01-31T03:30:42+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:55:42+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
         ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
@@ -220,7 +267,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\"\
         : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
         \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-01-31T03:30:45.0112946+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2017-03-06T05:55:24.8559493+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -236,14 +283,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:30:50 GMT']
+      Date: ['Mon, 06 Mar 2017 05:55:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3686']
+      content-length: ['3687']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -252,10 +299,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aabff8a4-e765-11e6-ba07-64510658e3b3]
+      x-ms-client-request-id: [8ffc677a-0231-11e7-ad99-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -268,7 +316,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:30:52 GMT']
+      Date: ['Mon, 06 Mar 2017 05:55:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -285,21 +333,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ab446a8a-e765-11e6-ae27-64510658e3b3]
+      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/7de7d61e-c51f-4cec-837a-4f15d86ca201?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Tue, 31 Jan 2017 03:30:52 GMT']
+      Date: ['Mon, 06 Mar 2017 05:55:55 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/7de7d61e-c51f-4cec-837a-4f15d86ca201?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -312,20 +361,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ab446a8a-e765-11e6-ae27-64510658e3b3]
+      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7de7d61e-c51f-4cec-837a-4f15d86ca201?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T03:30:53.4021671+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"7de7d61e-c51f-4cec-837a-4f15d86ca201\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:31:23 GMT']
+      Date: ['Mon, 06 Mar 2017 05:56:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -341,20 +391,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.7
-          computemanagementclient/0.33.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ab446a8a-e765-11e6-ae27-64510658e3b3]
+      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/7de7d61e-c51f-4cec-837a-4f15d86ca201?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-01-31T03:30:53.4021671+00:00\",\r\
-        \n  \"endTime\": \"2017-01-31T03:31:47.5949429+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"7de7d61e-c51f-4cec-837a-4f15d86ca201\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 31 Jan 2017 03:31:54 GMT']
+      Date: ['Mon, 06 Mar 2017 05:56:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
+          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
+        \n  \"endTime\": \"2017-03-06T05:57:13.6275803+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 06 Mar 2017 05:57:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]


### PR DESCRIPTION
Otherwise, vm agent might reject for more than 2 handlers
There is subtle difference on extension API between VM and VMSS, and this change handles both 