### PR TITLE
Mitigate AI SDK's problem with numeric in properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Virtual environment
 env/
 env27/
+.python-version
 
 # PTVS analysis
 .ptvs/


### PR DESCRIPTION
This is requested by VS business insights. The application insight SDK will convert numeric value in the `properties` values to string type. To allow these values types unchanged, numeric values should be saved through `measurements` argument on `track_event` method. It is a odd design, but it is what it is.