### PR TITLE
Add profile switching params and profile listing command

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -9,7 +9,6 @@ import collections
 import errno
 import json
 import os.path
-from pprint import pformat
 from copy import deepcopy
 from enum import Enum
 
@@ -65,9 +64,7 @@ _AUTH_CTX_FACTORY = _authentication_context_factory
 
 CLOUD = get_active_cloud()
 
-logger.debug("Current active cloud '%s'", CLOUD.name)
-logger.debug(pformat(vars(CLOUD.endpoints)))
-logger.debug(pformat(vars(CLOUD.suffixes)))
+logger.debug(str(CLOUD))
 
 
 def get_authority_url(tenant=None):

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -341,7 +341,7 @@ def _save_cloud(cloud, overwrite=False):
     except configparser.DuplicateSectionError:
         if not overwrite:
             raise CloudAlreadyRegisteredException(cloud.name)
-    if cloud.profile is not None:
+    if cloud.profile:
         config.set(cloud.name, 'profile', cloud.profile)
     for k, v in cloud.endpoints.__dict__.items():
         if v is not None:

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -245,6 +245,9 @@ def get_clouds():
         if c.profile is None:
             # If profile isn't set, use latest
             c.profile = 'latest'  # pylint: disable=redefined-variable-type
+        if not hasattr(c.endpoints, 'management') and hasattr(c.endpoints, 'resource_manager'):
+            # If management endpoint not set, use resource manager endpoint
+            c.endpoints.management = c.endpoints.resource_manager
         clouds.append(c)
     active_cloud_name = get_active_cloud_name()
     for c in clouds:

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -67,6 +67,13 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
         self.active_directory_resource_id = active_directory_resource_id
         self.active_directory_graph_resource_id = active_directory_graph_resource_id
 
+    def has_endpoint_set(self, endpoint_name):
+        try:
+            getattr(self, endpoint_name)
+            return True
+        except Exception:  # pylint: disable=broad-except
+            return False
+
     def __getattribute__(self, name):
         val = object.__getattribute__(self, name)
         if val is None:
@@ -245,7 +252,8 @@ def get_clouds():
         if c.profile is None:
             # If profile isn't set, use latest
             c.profile = 'latest'  # pylint: disable=redefined-variable-type
-        if not hasattr(c.endpoints, 'management') and hasattr(c.endpoints, 'resource_manager'):
+        if not c.endpoints.has_endpoint_set('management') and \
+                c.endpoints.has_endpoint_set('resource_manager'):
             # If management endpoint not set, use resource manager endpoint
             c.endpoints.management = c.endpoints.resource_manager
         clouds.append(c)

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -244,7 +244,7 @@ def get_clouds():
                 setattr(c.suffixes, option.replace('suffix_', ''), config.get(section, option))
         if c.profile is None:
             # If profile isn't set, use latest
-            c.profile = 'latest'
+            c.profile = 'latest'  # pylint: disable=redefined-variable-type
         clouds.append(c)
     active_cloud_name = get_active_cloud_name()
     for c in clouds:

--- a/src/azure-cli-core/azure/cli/core/profiles/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/__init__.py
@@ -1,0 +1,13 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.profiles._shared import AZURE_API_PROFILES
+
+# API Profiles currently supported in the CLI.
+API_PROFILES = {
+    'latest': {},
+    '2016-01-01-example': AZURE_API_PROFILES['2016-01-01-example'],
+    '2015-06-15-example': AZURE_API_PROFILES['2015-06-15-example']
+}

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -1,0 +1,11 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# TODO Move this to a package shared by CLI and SDK
+
+AZURE_API_PROFILES = {
+    '2016-01-01-example': {},
+    '2015-06-15-example': {}
+}

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -84,6 +84,41 @@ class TestCloud(unittest.TestCase):
             for c in clouds:
                 self.assertEqual(c.profile, 'latest')
 
+    def test_custom_cloud_management_endpoint_set(self):
+        ''' We have set management endpoint so don't override it '''
+        endpoint_rm = 'http://management.contoso.com'
+        endpoint_mgmt = 'http://management.core.contoso.com'
+        endpoints = CloudEndpoints(resource_manager=endpoint_rm, management=endpoint_mgmt)
+        profile = '2017-01-01-test'
+        c = Cloud('MyOwnCloud', endpoints=endpoints, profile=profile)
+        with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]):
+            add_cloud(c)
+            custom_clouds = get_custom_clouds()
+            self.assertEqual(len(custom_clouds), 1)
+            self.assertEqual(custom_clouds[0].endpoints.resource_manager,
+                             c.endpoints.resource_manager)
+            # CLI logic should keep our set management endpoint
+            self.assertEqual(custom_clouds[0].endpoints.management,
+                             c.endpoints.management)
+
+    def test_custom_cloud_no_management_endpoint_set(self):
+        ''' Use ARM 'resource manager' endpoint as 'management' (old ASM) endpoint
+            if only ARM endpoint is set '''
+        endpoint_rm = 'http://management.contoso.com'
+        endpoints = CloudEndpoints(resource_manager=endpoint_rm)
+        profile = '2017-01-01-test'
+        c = Cloud('MyOwnCloud', endpoints=endpoints, profile=profile)
+        with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]):
+            add_cloud(c)
+            custom_clouds = get_custom_clouds()
+            self.assertEqual(len(custom_clouds), 1)
+            self.assertEqual(custom_clouds[0].endpoints.resource_manager,
+                             c.endpoints.resource_manager)
+            # CLI logic should add management endpoint to equal resource_manager as we didn't set it
+            self.assertEqual(custom_clouds[0].endpoints.management,
+                             c.endpoints.resource_manager)
+
+
     def test_get_active_cloud_name_default(self):
         expected = AZURE_PUBLIC_CLOUD.name
         actual = get_active_cloud_name()

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -118,7 +118,6 @@ class TestCloud(unittest.TestCase):
             self.assertEqual(custom_clouds[0].endpoints.management,
                              c.endpoints.resource_manager)
 
-
     def test_get_active_cloud_name_default(self):
         expected = AZURE_PUBLIC_CLOUD.name
         actual = get_active_cloud_name()

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -93,6 +93,7 @@ setup(
         'azure.cli.core',
         'azure.cli.core.commands',
         'azure.cli.core.extensions',
+        'azure.cli.core.profiles',
     ],
     install_requires=DEPENDENCIES
 )

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_help.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_help.py
@@ -41,3 +41,8 @@ helps['cloud update'] = """
             type: command
             short-summary: Update the configuration for a cloud.
 """
+
+helps['cloud list-profiles'] = """
+            type: command
+            short-summary: List the profiles a given cloud supports.
+"""

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_params.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_params.py
@@ -5,11 +5,12 @@
 import json
 
 from azure.cli.core.commands import register_cli_argument
-
 from azure.cli.core.cloud import get_clouds, get_custom_clouds, get_active_cloud_name
 
+from azure.cli.core.profiles import API_PROFILES
 
 # pylint: disable=line-too-long
+
 
 def get_cloud_name_completion_list(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
     return [c.name for c in get_clouds()]
@@ -29,11 +30,19 @@ register_cli_argument('cloud show', 'cloud_name',
                       help='Name of a registered cloud.', default=active_cloud_name)
 register_cli_argument('cloud update', 'cloud_name',
                       help='Name of a registered cloud.', default=active_cloud_name)
+register_cli_argument('cloud list-profiles', 'cloud_name',
+                      help='Name of a registered cloud.', default=active_cloud_name)
+register_cli_argument('cloud list-profiles', 'show_all',
+                      help='Show all available profiles supported in the CLI.', action='store_true')
 
 register_cli_argument('cloud register', 'cloud_name', completer=None)
 
 register_cli_argument('cloud unregister', 'cloud_name',
                       completer=get_custom_cloud_name_completion_list)
+
+register_cli_argument('cloud', 'profile',
+                      help='Profile to use for this cloud',
+                      choices=list(API_PROFILES))
 
 register_cli_argument('cloud', 'cloud_config', options_list=('--cloud-config',),
                       help='JSON encoded cloud configuration. Use @{file} to load from a file.',

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/commands.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/commands.py
@@ -11,3 +11,4 @@ cli_command(__name__, 'cloud register', 'azure.cli.command_modules.cloud.custom#
 cli_command(__name__, 'cloud unregister', 'azure.cli.command_modules.cloud.custom#unregister_cloud')
 cli_command(__name__, 'cloud set', 'azure.cli.command_modules.cloud.custom#set_cloud')
 cli_command(__name__, 'cloud update', 'azure.cli.command_modules.cloud.custom#modify_cloud')
+cli_command(__name__, 'cloud list-profiles', 'azure.cli.command_modules.cloud.custom#list_profiles')

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
@@ -39,6 +39,8 @@ def _build_cloud(cloud_name, cloud_config=None, cloud_args=None):
         cloud_args = cloud_config
     c = Cloud(cloud_name)
     for arg in cloud_args:
+        if arg == 'profile' and cloud_args[arg] is not None:
+            c.profile = cloud_args[arg]
         if arg.startswith('endpoint_') and cloud_args[arg] is not None:
             setattr(c.endpoints, arg.replace('endpoint_', ''), cloud_args[arg])
         elif arg.startswith('suffix_') and cloud_args[arg] is not None:
@@ -50,6 +52,7 @@ def _build_cloud(cloud_name, cloud_config=None, cloud_args=None):
 
 def register_cloud(cloud_name,
                    cloud_config=None,
+                   profile=None,
                    endpoint_management=None,
                    endpoint_resource_manager=None,
                    endpoint_sql_management=None,
@@ -72,6 +75,7 @@ def register_cloud(cloud_name,
 
 def modify_cloud(cloud_name=None,
                  cloud_config=None,
+                 profile=None,
                  endpoint_management=None,
                  endpoint_resource_manager=None,
                  endpoint_sql_management=None,
@@ -108,3 +112,14 @@ def set_cloud(cloud_name):
         switch_active_cloud(cloud_name)
     except CloudNotRegisteredException as e:
         raise CLIError(e)
+
+
+def list_profiles(cloud_name=None, show_all=False):
+    from azure.cli.core.profiles import API_PROFILES
+    if not cloud_name:
+        cloud_name = get_active_cloud_name()
+    if show_all:
+        return list(API_PROFILES)
+    else:
+        # TODO Query cloud endpoint to get supported profiles.
+        return list(API_PROFILES)

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+# pylint: disable=unused-argument,too-many-arguments
+
 from azure.cli.core._util import CLIError, to_snake_case
 
 from azure.cli.core.cloud import (Cloud,
@@ -38,16 +40,13 @@ def _build_cloud(cloud_name, cloud_config=None, cloud_args=None):
             cloud_config[to_snake_case(key)] = cloud_config.pop(key)
         cloud_args = cloud_config
     c = Cloud(cloud_name)
+    c.profile = cloud_args.get('profile', None)
     for arg in cloud_args:
-        if arg == 'profile' and cloud_args[arg] is not None:
-            c.profile = cloud_args[arg]
         if arg.startswith('endpoint_') and cloud_args[arg] is not None:
             setattr(c.endpoints, arg.replace('endpoint_', ''), cloud_args[arg])
         elif arg.startswith('suffix_') and cloud_args[arg] is not None:
             setattr(c.suffixes, arg.replace('suffix_', ''), cloud_args[arg])
     return c
-
-    # pylint: disable=unused-argument,too-many-arguments
 
 
 def register_cloud(cloud_name,


### PR DESCRIPTION
- Modify ‘az cloud register’ and ‘az cloud update’ to include the ‘—profile’ parameter
- Add ability to view all supported API versions without querying a cloud
- Use ARM 'resource manager' endpoint if ASM 'management' endpoint not set

note: With this change, switching profile will not change anything as they are just example profiles.

FYI @lmazuel For the `_shared.py` file change. This would contain the resource type to api version map.

Closes https://github.com/Azure/azure-cli/issues/2280
Closes https://github.com/Azure/azure-cli/issues/2279
Closes https://github.com/Azure/azure-cli/issues/2265