### PR TITLE
vm/vmss: remove the length requirement of admin-username

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -531,12 +531,12 @@ def _validate_vm_create_auth(namespace):
                                      StorageProfile.SASpecializedOSDisk]:
         return
 
-    if len(namespace.admin_username) < 6 or namespace.admin_username.lower() == 'root':
+    if not namespace.admin_username or namespace.admin_username.lower() == 'root':
         # prompt for admin username if inadequate
         from azure.cli.core.prompting import prompt, NoTTYException
         try:
-            logger.warning("Cannot use admin username: %s. Admin username should be at "
-                           "least 6 characters and cannot be 'root'", namespace.admin_username)
+            logger.warning("Cannot use admin username: %s. Admin username should not be empty"
+                           "and cannot be 'root'", namespace.admin_username)
             namespace.admin_username = prompt('Admin Username: ')
         except NoTTYException:
             raise CLIError('Please specify a valid admin username in non-interactive mode.')


### PR DESCRIPTION
Reported by someone whose login name is 5 characters long, and could not create a VM.
Turned out shorter names are accepted by both portal and vm itself. And more important we do not have justification for why chose 6 characters long; hence it appears a bit random