### PR TITLE
Update pyOpenSSL version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ paramiko==2.0.2
 pip==9.0.1
 pygments==2.1.3
 pylint==1.5.4
-pyOpenSSL==16.1.0
+pyOpenSSL==16.2.0
 pyyaml==3.11
 requests==2.9.1
 setuptools==30.4.0


### PR DESCRIPTION
After a recent run of dev_setup.py I have been experiencing  the following error:
```
\keyvault\custom.py", line 12, in <module>
    from OpenSSL import crypto
  File "C:\Users\trpresco\Documents\github\azure-cli\env\lib\site-packages\OpenSSL\__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "C:\Users\trpresco\Documents\github\azure-cli\env\lib\site-packages\OpenSSL\SSL.py", line 112, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: module 'lib' has no attribute 'SSL_ST_INIT'
```

This occurs on both Python 2 and 3 (though it manifests worse in Python 2). Updating the pyOpenSSL version fixes this issue. 