### PR TITLE
[KeyVault] Command fixes

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -90,7 +90,7 @@ def get_generic_completion_list(generic_list):
     return completer
 
 
-class CaseInsenstiveList(list):  # pylint: disable=too-few-public-methods
+class CaseInsensitiveList(list):  # pylint: disable=too-few-public-methods
 
     def __contains__(self, other):
         return next((True for x in self if other.lower() == x.lower()), False)
@@ -107,8 +107,28 @@ def enum_choice_list(data):
     def _type(value):
         return next((x for x in choices if x.lower() == value.lower()), value) if value else value
     params = {
-        'choices': CaseInsenstiveList(choices),
+        'choices': CaseInsensitiveList(choices),
         'type': _type
+    }
+    return params
+
+def three_state_flag(none_default=True, use_enabled_disabled=False):
+
+    choices = ['enabled', 'disabled'] if use_enabled_disabled else ['true', 'false']
+    none_defaults_to = choices[0] if none_default else choices[1]  # default to enabled/true
+
+    class ThreeStateAction(argparse.Action):
+        def __init__(self, **kw):
+            super().__init__(**kw)    
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values.lower() if values else none_defaults_to)
+            val = getattr(namespace, self.dest, None)
+            setattr(namespace, self.dest, val in ['true', 'enabled'])
+
+    params = {
+        'choices': CaseInsensitiveList(choices),
+        'nargs': '?',
+        'action': ThreeStateAction
     }
     return params
 

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -112,14 +112,15 @@ def enum_choice_list(data):
     }
     return params
 
+
 def three_state_flag(none_default=True, use_enabled_disabled=False):
 
     choices = ['enabled', 'disabled'] if use_enabled_disabled else ['true', 'false']
     none_defaults_to = choices[0] if none_default else choices[1]  # default to enabled/true
 
+    # pylint: disable=too-few-public-methods
     class ThreeStateAction(argparse.Action):
-        def __init__(self, **kw):
-            super().__init__(**kw)    
+
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, values.lower() if values else none_defaults_to)
             val = getattr(namespace, self.dest, None)

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -113,18 +113,22 @@ def enum_choice_list(data):
     return params
 
 
-def three_state_flag(none_default=True, use_enabled_disabled=False):
-
-    choices = ['enabled', 'disabled'] if use_enabled_disabled else ['true', 'false']
-    none_defaults_to = choices[0] if none_default else choices[1]  # default to enabled/true
+def three_state_flag(positive_label='true', negative_label='false'):
+    """ Creates a flag-like argument that can also accept positive/negative values. This allows
+    consistency between create commands that typically use flags and update commands that require
+    positive/negative values without introducing breaking changes. Flag-like behavior always
+    implies the affirmative.
+    - positive_label: label for the positive value (ex: 'enabled')
+    - negative_label: label for the negative value (ex: 'disabled')
+    """
+    choices = [positive_label, negative_label]
 
     # pylint: disable=too-few-public-methods
     class ThreeStateAction(argparse.Action):
 
         def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, self.dest, values.lower() if values else none_defaults_to)
-            val = getattr(namespace, self.dest, None)
-            setattr(namespace, self.dest, val in ['true', 'enabled'])
+            values = values or positive_label
+            setattr(namespace, self.dest, values == positive_label)
 
     params = {
         'choices': CaseInsensitiveList(choices),

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -41,6 +41,15 @@ def generate_deployment_name(namespace):
             'azurecli{}{}'.format(str(time.time()), str(random.randint(1, 100000)))
 
 
+def get_default_location_from_resource_group(namespace):
+    if not namespace.location:
+        from azure.mgmt.resource.resources import ResourceManagementClient
+        from azure.cli.core.commands.client_factory import get_mgmt_service_client
+        resource_client = get_mgmt_service_client(ResourceManagementClient)
+        rg = resource_client.resource_groups.get(namespace.resource_group_name)
+        namespace.location = rg.location  # pylint: disable=no-member
+
+
 SPECIFIED_SENTINEL = '__SET__'
 
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -16,7 +16,7 @@ helps['keyvault'] = """
 helps['keyvault create'] = """
     type: command
     short-summary: Create a key vault.
-    long-summary: "Default permissions are created for the current user unless the --no-self-perms flag is specified."
+    long-summary: "Default permissions are created for the current user or service principal unless the --no-self-perms flag is specified."
 """
 
 helps['keyvault delete'] = """

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -86,7 +86,7 @@ def register_attributes_argument(scope, name, attr_class, create=False):
 
 # ARGUMENT DEFINITIONS
 
-vault_name_type = CliArgumentType(help='Name of the key vault.', options_list=('--vault-name',), completer=get_resource_name_completion_list('Microsoft.KeyVault/vaults'), id_part=None)
+vault_name_type = CliArgumentType(help='Name of the key vault.', options_list=('--vault-name',), metavar='NAME', completer=get_resource_name_completion_list('Microsoft.KeyVault/vaults'), id_part=None)
 
 # PARAMETER REGISTRATIONS
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -79,9 +79,9 @@ certificate_file_encoding_values = ['binary', 'string']
 def register_attributes_argument(scope, name, attr_class, create=False):
     register_cli_argument(scope, '{}_attributes'.format(name), ignore_type, validator=get_attribute_validator(name, attr_class, create))
     if create:
-        register_extra_cli_argument(scope, 'disabled', action='store_true', help='Create {} in disabled state.'.format(name))
+        register_extra_cli_argument(scope, 'disabled', help='Create {} in disabled state.'.format(name), **three_state_flag())
     else:
-        register_extra_cli_argument(scope, 'enabled', default=None, choices=['true', 'false'], help='Enable the {}.'.format(name))
+        register_extra_cli_argument(scope, 'enabled', help='Enable the {}.'.format(name), **three_state_flag())
     register_extra_cli_argument(scope, 'expires', default=None, help='Expiration UTC datetime  (Y-m-d\'T\'H:M:S\'Z\').', type=datetime_type)
     register_extra_cli_argument(scope, 'not_before', default=None, help='Key not usable before the provided UTC datetime  (Y-m-d\'T\'H:M:S\'Z\').', type=datetime_type)
 
@@ -179,7 +179,8 @@ register_cli_argument('keyvault certificate issuer admin', 'name', options_list=
 register_cli_argument('keyvault certificate issuer admin', 'phone', options_list=('--phone',), help='Amin phone number.')
 
 register_cli_argument('keyvault certificate issuer', 'issuer_name', help='Certificate issuer name.')
-register_cli_argument('keyvault certificate issuer', 'disabled', action='store_true', help='Set issuer to disabled state.')
+register_cli_argument('keyvault certificate issuer', 'disabled', help='Set issuer to disabled state.', **three_state_flag())
+register_cli_argument('keyvault certificate issuer', 'enabled', help='Set issuer enabled state.', **three_state_flag())
 register_cli_argument('keyvault certificate issuer', 'account_id', arg_group='Issuer Credential')
 register_cli_argument('keyvault certificate issuer', 'password', arg_group='Issuer Credential')
 register_cli_argument('keyvault certificate issuer', 'organization_id', arg_group='Organization Detail')

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -11,6 +11,7 @@ from azure.mgmt.keyvault.models.key_vault_management_client_enums import \
 from azure.cli.core.commands import \
     (register_cli_argument, register_extra_cli_argument, CliArgumentType)
 import azure.cli.core.commands.arm # pylint: disable=unused-import
+from azure.cli.core.commands.validators import get_default_location_from_resource_group
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list, resource_group_name_type,
     tags_type, ignore_type, enum_choice_list, file_type)
@@ -97,10 +98,11 @@ register_cli_argument('keyvault', 'spn', help='name of a service principal that 
 register_cli_argument('keyvault', 'upn', help='name of a user principal that will receive permissions')
 register_cli_argument('keyvault', 'tags', tags_type)
 
-register_cli_argument('keyvault create', 'resource_group_name', resource_group_name_type, completer=None, validator=None)
+register_cli_argument('keyvault create', 'resource_group_name', resource_group_name_type, required=True, completer=None, validator=None)
 register_cli_argument('keyvault create', 'vault_name', completer=None)
 register_cli_argument('keyvault create', 'sku', **enum_choice_list(SkuName))
 register_cli_argument('keyvault create', 'no_self_perms', action='store_true', help="If specified, don't add permissions for the current user in the new vault")
+register_cli_argument('keyvault create', 'location', validator=get_default_location_from_resource_group)
 
 register_cli_argument('keyvault list', 'resource_group_name', resource_group_name_type, validator=None)
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -97,15 +97,15 @@ register_cli_argument('keyvault', 'object_id', help='a GUID that identifies the 
 register_cli_argument('keyvault', 'spn', help='name of a service principal that will receive permissions')
 register_cli_argument('keyvault', 'upn', help='name of a user principal that will receive permissions')
 register_cli_argument('keyvault', 'tags', tags_type)
+register_cli_argument('keyvault', 'enabled_for_deployment', help='Allow Virtual Machines to retrieve certificates stored as secrets from the vault.', **three_state_flag())
+register_cli_argument('keyvault', 'enabled_for_disk_encryption', help='Allow Disk Encryption to retrieve secrets from the vault and unwrap keys.', **three_state_flag())
+register_cli_argument('keyvault', 'enabled_for_template_deployment', help='Allow Resource Manager to retrieve secrets from the vault.', **three_state_flag())
 
 register_cli_argument('keyvault create', 'resource_group_name', resource_group_name_type, required=True, completer=None, validator=None)
 register_cli_argument('keyvault create', 'vault_name', completer=None)
 register_cli_argument('keyvault create', 'sku', **enum_choice_list(SkuName))
 register_cli_argument('keyvault create', 'no_self_perms', help="Don't add permissions for the current user/service principal in the new vault", **three_state_flag())
 register_cli_argument('keyvault create', 'location', validator=get_default_location_from_resource_group)
-register_cli_argument('keyvault create', 'enabled_for_deployment', help='Allow Virtual Machines to retrieve certificates stored as secrets from the vault.', **three_state_flag())
-register_cli_argument('keyvault create', 'enabled_for_disk_encryption', help='Allow Disk Encryption to retrieve secrets from the vault and unwrap keys.', **three_state_flag())
-register_cli_argument('keyvault create', 'enabled_for_template_deployment', help='Allow Resource Manager to retrieve secrets from the vault.', **three_state_flag())
 
 register_cli_argument('keyvault list', 'resource_group_name', resource_group_name_type, validator=None)
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -14,7 +14,7 @@ import azure.cli.core.commands.arm # pylint: disable=unused-import
 from azure.cli.core.commands.validators import get_default_location_from_resource_group
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list, resource_group_name_type,
-    tags_type, ignore_type, enum_choice_list, file_type)
+    tags_type, ignore_type, enum_choice_list, file_type, three_state_flag)
 from azure.cli.core._profile import Profile
 from azure.cli.core._util import get_json_object
 from azure.keyvault import KeyVaultClient, KeyVaultAuthentication
@@ -101,8 +101,11 @@ register_cli_argument('keyvault', 'tags', tags_type)
 register_cli_argument('keyvault create', 'resource_group_name', resource_group_name_type, required=True, completer=None, validator=None)
 register_cli_argument('keyvault create', 'vault_name', completer=None)
 register_cli_argument('keyvault create', 'sku', **enum_choice_list(SkuName))
-register_cli_argument('keyvault create', 'no_self_perms', action='store_true', help="If specified, don't add permissions for the current user in the new vault")
+register_cli_argument('keyvault create', 'no_self_perms', help="Don't add permissions for the current user/service principal in the new vault", **three_state_flag())
 register_cli_argument('keyvault create', 'location', validator=get_default_location_from_resource_group)
+register_cli_argument('keyvault create', 'enabled_for_deployment', help='Allow Virtual Machines to retrieve certificates stored as secrets from the vault.', **three_state_flag())
+register_cli_argument('keyvault create', 'enabled_for_disk_encryption', help='Allow Disk Encryption to retrieve secrets from the vault and unwrap keys.', **three_state_flag())
+register_cli_argument('keyvault create', 'enabled_for_template_deployment', help='Allow Resource Manager to retrieve secrets from the vault.', **three_state_flag())
 
 register_cli_argument('keyvault list', 'resource_group_name', resource_group_name_type, validator=None)
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
@@ -108,7 +108,7 @@ def get_attribute_validator(name, attribute_class, create=False):
 
     def validator(ns):
         ns_dict = ns.__dict__
-        enabled = not ns_dict.pop('disabled') if create else ns_dict.pop('enabled') == 'true'
+        enabled = not ns_dict.pop('disabled') if create else ns_dict.pop('enabled')
         attributes = attribute_class(
             enabled,
             ns_dict.pop('not_before'),

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -27,19 +27,13 @@ cli_command(__name__, 'keyvault delete', mgmt_path.format('VaultsOperations.dele
 cli_command(__name__, 'keyvault set-policy', custom_path.format('set_policy'), factory)
 cli_command(__name__, 'keyvault delete-policy', custom_path.format('delete_policy'), factory)
 
-def keyvault_update_setter(client, resource_group_name, vault_name, parameters):
-    from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
-    return client.create_or_update(resource_group_name=resource_group_name,
-                                   vault_name=vault_name,
-                                   parameters=VaultCreateOrUpdateParameters(
-                                       location=parameters.location,
-                                       properties=parameters.properties))
 
 cli_generic_update_command(__name__,
                            'keyvault update',
                            mgmt_path.format('VaultsOperations.get'),
-                           'azure.cli.command_modules.keyvault.commands#keyvault_update_setter',
-                           lambda: keyvault_client_factory().vaults)
+                           custom_path.format('update_keyvault_setter'),
+                           lambda: keyvault_client_factory().vaults,
+                           custom_function_op=custom_path.format('update_keyvault'))
 
 # Data Plane Commands
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -270,6 +270,30 @@ def create_keyvault(client, resource_group_name, vault_name, location=None, #pyl
 create_keyvault.__doc__ = VaultProperties.__doc__
 
 
+def update_keyvault_setter(client, parameters, resource_group_name, vault_name):
+    from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
+    return client.create_or_update(resource_group_name=resource_group_name,
+                                   vault_name=vault_name,
+                                   parameters=VaultCreateOrUpdateParameters(
+                                       location=parameters.location,
+                                       properties=parameters.properties))
+
+
+def update_keyvault(instance, enabled_for_deployment=None, enabled_for_disk_encryption=None,
+                    enabled_for_template_deployment=None):
+
+    if enabled_for_deployment is not None:
+        instance.properties.enabled_for_deployment = enabled_for_deployment
+
+    if enabled_for_disk_encryption is not None:
+        instance.properties.enabled_for_disk_encryption = enabled_for_disk_encryption
+
+    if enabled_for_template_deployment is not None:
+        instance.properties.enabled_for_template_deployment = enabled_for_template_deployment
+
+    return instance
+
+
 def _object_id_args_helper(object_id, spn, upn):
     if not object_id:
         from azure.cli.core._profile import Profile, CLOUD

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -216,7 +216,7 @@ def get_default_policy(client, scaffold=False): #pylint: disable=unused-argument
         return _default_certificate_profile()
 
 
-def create_keyvault(client, resource_group_name, vault_name, location, #pylint:disable=too-many-arguments
+def create_keyvault(client, resource_group_name, vault_name, location=None, #pylint:disable=too-many-arguments
                     sku=SkuName.standard.value,
                     enabled_for_deployment=None,
                     enabled_for_disk_encryption=None,

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -221,7 +221,7 @@ def create_keyvault(client, resource_group_name, vault_name, location=None, #pyl
                     enabled_for_deployment=None,
                     enabled_for_disk_encryption=None,
                     enabled_for_template_deployment=None,
-                    no_self_perms=False,
+                    no_self_perms=None,
                     tags=None):
     from azure.cli.core._profile import Profile, CLOUD
     profile = Profile()

--- a/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_certificate.yaml
+++ b/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_certificate.yaml
@@ -6,10 +6,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [59858e74-051c-11e7-8cf5-a0b3ccf7272a]
+      x-ms-client-request-id: [60c24e5e-0816-11e7-812b-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
   response:
@@ -20,44 +20,44 @@ interactions:
       Content-Length: ['1344']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:01:36 GMT']
-      Duration: ['2151786']
+      Date: ['Mon, 13 Mar 2017 17:56:26 GMT']
+      Duration: ['2282489']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [TKj+s3Z/Bsgx+L73TUZt+hEO5/9inQO9TFxHs8I650s=]
-      ocp-aad-session-key: [UfnNfxyf4usQEjpfyI6yODcvUt0wU-UjjlPAkicFwxOZQJ_acfohrieEDPqbSYh0LVDd2IIWCDcDhuWWOriCSM6zLMAxYUe6J98WPdm42c8f8ywkFE_zj6Y5G5TQlTLR.V-90VesPJ8RpxgxXlgWuI82ddGTzpzLYhzbSbjY3cH0]
-      request-id: [04f4bc04-125e-451e-9f73-b761fe03ae31]
+      ocp-aad-diagnostics-server-name: [CKyOEhdhx9pArCnWTr+Cu19PN9S6oUB1geMbOgndE1o=]
+      ocp-aad-session-key: [BQbzQJ697_qPCXo3SSktfhCZMimU__fj7sUgn0BVxcIuPs6Mf-mo2TtOJr4hAC6Zd5pe86z3aoWPhstQVMZsBZgBGif8yJRSDfJ-pk83Xf9ALmp7RZEDoR9tYEb_Ewit.XK6JmM1YWySLlhAPTAeRXtKq3bFO1Moh1tZCwK9yMYk]
+      request-id: [e6fec14c-2b01-4214-9062-82d778173b8a]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "premium", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies":
-      [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}}]}}'
+    body: '{"location": "westus", "properties": {"accessPolicies": [{"permissions":
+      {"certificates": ["all"], "keys": ["get", "create", "delete", "list", "update",
+      "import", "backup", "restore"], "secrets": ["all"]}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}], "sku": {"family": "A",
+      "name": "premium"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['407']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [59c07618-051c-11e7-a6f7-a0b3ccf7272a]
+      x-ms-client-request-id: [60fd4480-0816-11e7-9f20-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:39 GMT']
+      Date: ['Mon, 13 Mar 2017 17:56:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -69,7 +69,7 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['710']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -78,10 +78,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5ba0d640-051c-11e7-80c0-a0b3ccf7272a]
+      x-ms-client-request-id: [74bcdd12-0816-11e7-952f-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -89,7 +89,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Thu, 09 Mar 2017 23:01:39 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -109,10 +109,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5ba0d640-051c-11e7-80c0-a0b3ccf7272a]
+      x-ms-client-request-id: [74bcdd12-0816-11e7-952f-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -121,7 +121,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['30']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:39 GMT']
+      Date: ['Mon, 13 Mar 2017 17:56:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -133,31 +133,30 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props": {"reuse_key":
-      false, "key_size": 2048, "kty": "RSA", "exportable": true}}, "value": "-----BEGIN
-      PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: '{"attributes": {"enabled": true}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}, "key_props": {"key_size": 2048, "reuse_key": false,
+      "exportable": true, "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3132']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5c54fd8a-051c-11e7-99c8-a0b3ccf7272a]
+      x-ms-client-request-id: [7543b892-0816-11e7-aa9d-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489100501,"updated":1489100501},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100501,"updated":1489100501}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489427822,"updated":1489427822},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427822,"updated":1489427822}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:41 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -175,19 +174,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d4a970a-051c-11e7-8f39-a0b3ccf7272a]
+      x-ms-client-request-id: [761632f8-0816-11e7-97a2-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489100501,"updated":1489100501},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100501,"updated":1489100501}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489427822,"updated":1489427822},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427822,"updated":1489427822}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:41 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -205,19 +204,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5db8b322-051c-11e7-b963-a0b3ccf7272a]
+      x-ms-client-request-id: [768b9636-0816-11e7-9ade-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489100501,"updated":1489100501},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100501,"updated":1489100501}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489427822,"updated":1489427822},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427822,"updated":1489427822}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -236,19 +235,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5e28f8d4-051c-11e7-8cf7-a0b3ccf7272a]
+      x-ms-client-request-id: [76fc3926-0816-11e7-b91a-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6353a80bca9e4a11a72da3d38b69bf21","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489100501,"updated":1489100501},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100501,"updated":1489100501}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/7fdaf0e57c8746e18ec16cf35bc7aecf","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489427822,"updated":1489427822},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427822,"updated":1489427822}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:44 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -260,36 +259,37 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"lifetime_actions": [{"trigger":
-      {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}], "attributes":
-      {"enabled": true}, "issuer": {"name": "Self"}, "key_props": {"reuse_key": false,
-      "key_size": 2048, "kty": "RSA", "exportable": true}, "secret_props": {"contentType":
-      "application/x-pkcs12"}, "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation",
-      "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months": 60, "subject":
-      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action":
+      {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
+      "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment",
+      "keyAgreement", "keyCertSign"], "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle,
+      OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60}, "issuer": {"name":
+      "Self"}, "key_props": {"key_size": 2048, "reuse_key": false, "exportable": true,
+      "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5eaea17a-051c-11e7-af7e-a0b3ccf7272a]
+      x-ms-client-request-id: [77802638-0816-11e7-954a-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOUalbV+P4flxx/bqASGb6YXRMHFOFNjhh7GT6YsR0bjT7tdKP5YNjaj+78Kba5k767IhAzhq/NkMpksa2s7DtCTE+6EOCpNou+OIEAufviJwtM/sQHqTfRCC27CoCG6hWGjau6HOQ9HfuUTI8/bM+c4AyVgBNVBJGfrK79lv7/qg/aMZv4ECzX7MjcGB3bYGx33GY2iBNWxqu81dEbNdRrWRJXdmtGsBBpfrMTiOoYpFQVZYc/lFAVnzwxWfc3ENwUzxWOhsUyk26FTAeWhZl5mOz7K/vb/vugbGngNaWOg4AjLM5Rbo9a/Zs36vCnDcNFBeiOYc2fElYER0yI+HPkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB3/2b7Hspu/3Fji41q2TywWPE5k/IplxbcSKyKSupwRkUHDYOZp/jO5NMpVTqXm3ubEBuNKoBcG8Udk+eYLbkTX+rb/T+OwZyuePfHUGCnf6nXaC6RugLHBQDmxNvBUu6Hc4+/WafU526yFBpl2THWFZhkoOTx5IsBT8gEAJFs/GfWFjy2WMbqcccTKO7EzzVJapj777Cr+oXNQfQ+r2fohFWKSGyMql363Vel70hUyKJZxYe6qaCFPL0dWKI2uqRysSUqMyDhaWXYJXNWNe/7cqCOdr5qp7b4lAcQt9WAW2anQ0+jt+muYg46MaZQokKRiundcp5px+22zdA78lIi","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL52GDVvv37p22DsOFxu6uiM3MgbmL9VPr3oxPaAq06qXAc+bOCESSLWcKJQzzH7q1323f3lURVaZ58N9reLMZ1qcVcrdSU3NAEIkQ1wK16b7BrulR4Y6LHOvkB9GAE+dFuI9vkeawKFD59sS1aIQaSGE32s2oN5WruRs3yo7zKk2UJQF8P33JJkqEBEHjLrgtPAJHJLwR+At6mOTSHTIKzTPFrKwRjVAxPYi8xozm/5CJXVRGHWCQ3DgFRlsR4nQ80XYOr6uXdKgp4/P1nYrUd0UM5S+inWuH+6MZ+TOTsdDlSwfV6uh1d9tNHnZsfUIxwZX0VBR/YSZNxzW4z+yFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAD/vSwJJPOfDFThBfExbUz/0uMOhaEFvlGy2RBssbP/1PnWzWLabHcncKbCnjaoUyg54ezz9Urt5D4/nXl8XPhU0Xsy5WId/dryLmhypHt3KoedhC6DnaGEifiyb2rwR7Te137Q4alEADIy6vBB7ULMOkdkMeafSISt+jTFpeMf0L2pZio6tcnjn4Bu7nlRBo1cf+DTZG9TffCfR1DQ41iHesxVMEW+Y//TjbgcG4GSmkl/cOd8nhxI2uyekHUpia1NdmT0TmG+NEoKnzppW956tzqTfGlmXr2IgsZLRLwhaMWRUeBQpoPm7ZRmx13mmqryoEyaSoAjK2lGabHoDtS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"2a64064160fb4bcf813485bb47fe178d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"a200ea81a2d041078551f62724befc1f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:04 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=2a64064160fb4bcf813485bb47fe178d']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=a200ea81a2d041078551f62724befc1f']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -306,21 +306,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5f993ec0-051c-11e7-b62f-a0b3ccf7272a]
+      x-ms-client-request-id: [783ec142-0816-11e7-8cc0-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOUalbV+P4flxx/bqASGb6YXRMHFOFNjhh7GT6YsR0bjT7tdKP5YNjaj+78Kba5k767IhAzhq/NkMpksa2s7DtCTE+6EOCpNou+OIEAufviJwtM/sQHqTfRCC27CoCG6hWGjau6HOQ9HfuUTI8/bM+c4AyVgBNVBJGfrK79lv7/qg/aMZv4ECzX7MjcGB3bYGx33GY2iBNWxqu81dEbNdRrWRJXdmtGsBBpfrMTiOoYpFQVZYc/lFAVnzwxWfc3ENwUzxWOhsUyk26FTAeWhZl5mOz7K/vb/vugbGngNaWOg4AjLM5Rbo9a/Zs36vCnDcNFBeiOYc2fElYER0yI+HPkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB3/2b7Hspu/3Fji41q2TywWPE5k/IplxbcSKyKSupwRkUHDYOZp/jO5NMpVTqXm3ubEBuNKoBcG8Udk+eYLbkTX+rb/T+OwZyuePfHUGCnf6nXaC6RugLHBQDmxNvBUu6Hc4+/WafU526yFBpl2THWFZhkoOTx5IsBT8gEAJFs/GfWFjy2WMbqcccTKO7EzzVJapj777Cr+oXNQfQ+r2fohFWKSGyMql363Vel70hUyKJZxYe6qaCFPL0dWKI2uqRysSUqMyDhaWXYJXNWNe/7cqCOdr5qp7b4lAcQt9WAW2anQ0+jt+muYg46MaZQokKRiundcp5px+22zdA78lIi","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL52GDVvv37p22DsOFxu6uiM3MgbmL9VPr3oxPaAq06qXAc+bOCESSLWcKJQzzH7q1323f3lURVaZ58N9reLMZ1qcVcrdSU3NAEIkQ1wK16b7BrulR4Y6LHOvkB9GAE+dFuI9vkeawKFD59sS1aIQaSGE32s2oN5WruRs3yo7zKk2UJQF8P33JJkqEBEHjLrgtPAJHJLwR+At6mOTSHTIKzTPFrKwRjVAxPYi8xozm/5CJXVRGHWCQ3DgFRlsR4nQ80XYOr6uXdKgp4/P1nYrUd0UM5S+inWuH+6MZ+TOTsdDlSwfV6uh1d9tNHnZsfUIxwZX0VBR/YSZNxzW4z+yFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAD/vSwJJPOfDFThBfExbUz/0uMOhaEFvlGy2RBssbP/1PnWzWLabHcncKbCnjaoUyg54ezz9Urt5D4/nXl8XPhU0Xsy5WId/dryLmhypHt3KoedhC6DnaGEifiyb2rwR7Te137Q4alEADIy6vBB7ULMOkdkMeafSISt+jTFpeMf0L2pZio6tcnjn4Bu7nlRBo1cf+DTZG9TffCfR1DQ41iHesxVMEW+Y//TjbgcG4GSmkl/cOd8nhxI2uyekHUpia1NdmT0TmG+NEoKnzppW956tzqTfGlmXr2IgsZLRLwhaMWRUeBQpoPm7ZRmx13mmqryoEyaSoAjK2lGabHoDtS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"2a64064160fb4bcf813485bb47fe178d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"a200ea81a2d041078551f62724befc1f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:46 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -338,21 +338,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [65ada71a-051c-11e7-9aee-a0b3ccf7272a]
+      x-ms-client-request-id: [7e609e88-0816-11e7-a520-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOUalbV+P4flxx/bqASGb6YXRMHFOFNjhh7GT6YsR0bjT7tdKP5YNjaj+78Kba5k767IhAzhq/NkMpksa2s7DtCTE+6EOCpNou+OIEAufviJwtM/sQHqTfRCC27CoCG6hWGjau6HOQ9HfuUTI8/bM+c4AyVgBNVBJGfrK79lv7/qg/aMZv4ECzX7MjcGB3bYGx33GY2iBNWxqu81dEbNdRrWRJXdmtGsBBpfrMTiOoYpFQVZYc/lFAVnzwxWfc3ENwUzxWOhsUyk26FTAeWhZl5mOz7K/vb/vugbGngNaWOg4AjLM5Rbo9a/Zs36vCnDcNFBeiOYc2fElYER0yI+HPkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB3/2b7Hspu/3Fji41q2TywWPE5k/IplxbcSKyKSupwRkUHDYOZp/jO5NMpVTqXm3ubEBuNKoBcG8Udk+eYLbkTX+rb/T+OwZyuePfHUGCnf6nXaC6RugLHBQDmxNvBUu6Hc4+/WafU526yFBpl2THWFZhkoOTx5IsBT8gEAJFs/GfWFjy2WMbqcccTKO7EzzVJapj777Cr+oXNQfQ+r2fohFWKSGyMql363Vel70hUyKJZxYe6qaCFPL0dWKI2uqRysSUqMyDhaWXYJXNWNe/7cqCOdr5qp7b4lAcQt9WAW2anQ0+jt+muYg46MaZQokKRiundcp5px+22zdA78lIi","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL52GDVvv37p22DsOFxu6uiM3MgbmL9VPr3oxPaAq06qXAc+bOCESSLWcKJQzzH7q1323f3lURVaZ58N9reLMZ1qcVcrdSU3NAEIkQ1wK16b7BrulR4Y6LHOvkB9GAE+dFuI9vkeawKFD59sS1aIQaSGE32s2oN5WruRs3yo7zKk2UJQF8P33JJkqEBEHjLrgtPAJHJLwR+At6mOTSHTIKzTPFrKwRjVAxPYi8xozm/5CJXVRGHWCQ3DgFRlsR4nQ80XYOr6uXdKgp4/P1nYrUd0UM5S+inWuH+6MZ+TOTsdDlSwfV6uh1d9tNHnZsfUIxwZX0VBR/YSZNxzW4z+yFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAD/vSwJJPOfDFThBfExbUz/0uMOhaEFvlGy2RBssbP/1PnWzWLabHcncKbCnjaoUyg54ezz9Urt5D4/nXl8XPhU0Xsy5WId/dryLmhypHt3KoedhC6DnaGEifiyb2rwR7Te137Q4alEADIy6vBB7ULMOkdkMeafSISt+jTFpeMf0L2pZio6tcnjn4Bu7nlRBo1cf+DTZG9TffCfR1DQ41iHesxVMEW+Y//TjbgcG4GSmkl/cOd8nhxI2uyekHUpia1NdmT0TmG+NEoKnzppW956tzqTfGlmXr2IgsZLRLwhaMWRUeBQpoPm7ZRmx13mmqryoEyaSoAjK2lGabHoDtS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"2a64064160fb4bcf813485bb47fe178d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"a200ea81a2d041078551f62724befc1f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1418']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:01:56 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -370,19 +370,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6bc47736-051c-11e7-89c2-a0b3ccf7272a]
+      x-ms-client-request-id: [8477a650-0816-11e7-b22a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOUalbV+P4flxx/bqASGb6YXRMHFOFNjhh7GT6YsR0bjT7tdKP5YNjaj+78Kba5k767IhAzhq/NkMpksa2s7DtCTE+6EOCpNou+OIEAufviJwtM/sQHqTfRCC27CoCG6hWGjau6HOQ9HfuUTI8/bM+c4AyVgBNVBJGfrK79lv7/qg/aMZv4ECzX7MjcGB3bYGx33GY2iBNWxqu81dEbNdRrWRJXdmtGsBBpfrMTiOoYpFQVZYc/lFAVnzwxWfc3ENwUzxWOhsUyk26FTAeWhZl5mOz7K/vb/vugbGngNaWOg4AjLM5Rbo9a/Zs36vCnDcNFBeiOYc2fElYER0yI+HPkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB3/2b7Hspu/3Fji41q2TywWPE5k/IplxbcSKyKSupwRkUHDYOZp/jO5NMpVTqXm3ubEBuNKoBcG8Udk+eYLbkTX+rb/T+OwZyuePfHUGCnf6nXaC6RugLHBQDmxNvBUu6Hc4+/WafU526yFBpl2THWFZhkoOTx5IsBT8gEAJFs/GfWFjy2WMbqcccTKO7EzzVJapj777Cr+oXNQfQ+r2fohFWKSGyMql363Vel70hUyKJZxYe6qaCFPL0dWKI2uqRysSUqMyDhaWXYJXNWNe/7cqCOdr5qp7b4lAcQt9WAW2anQ0+jt+muYg46MaZQokKRiundcp5px+22zdA78lIi","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"2a64064160fb4bcf813485bb47fe178d"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL52GDVvv37p22DsOFxu6uiM3MgbmL9VPr3oxPaAq06qXAc+bOCESSLWcKJQzzH7q1323f3lURVaZ58N9reLMZ1qcVcrdSU3NAEIkQ1wK16b7BrulR4Y6LHOvkB9GAE+dFuI9vkeawKFD59sS1aIQaSGE32s2oN5WruRs3yo7zKk2UJQF8P33JJkqEBEHjLrgtPAJHJLwR+At6mOTSHTIKzTPFrKwRjVAxPYi8xozm/5CJXVRGHWCQ3DgFRlsR4nQ80XYOr6uXdKgp4/P1nYrUd0UM5S+inWuH+6MZ+TOTsdDlSwfV6uh1d9tNHnZsfUIxwZX0VBR/YSZNxzW4z+yFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAD/vSwJJPOfDFThBfExbUz/0uMOhaEFvlGy2RBssbP/1PnWzWLabHcncKbCnjaoUyg54ezz9Urt5D4/nXl8XPhU0Xsy5WId/dryLmhypHt3KoedhC6DnaGEifiyb2rwR7Te137Q4alEADIy6vBB7ULMOkdkMeafSISt+jTFpeMf0L2pZio6tcnjn4Bu7nlRBo1cf+DTZG9TffCfR1DQ41iHesxVMEW+Y//TjbgcG4GSmkl/cOd8nhxI2uyekHUpia1NdmT0TmG+NEoKnzppW956tzqTfGlmXr2IgsZLRLwhaMWRUeBQpoPm7ZRmx13mmqryoEyaSoAjK2lGabHoDtS","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"a200ea81a2d041078551f62724befc1f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1331']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:07 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -400,19 +400,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6c325450-051c-11e7-be3a-a0b3ccf7272a]
+      x-ms-client-request-id: [84e81e78-0816-11e7-a746-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"vx6jKz8iNnHFx1rD2RgdpksrG3I","attributes":{"enabled":true,"nbf":1489099923,"exp":1646866923,"created":1489100524,"updated":1489100524}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"8rc4DbM1oshzOTcnLnfiG_0ql0c","attributes":{"enabled":true,"nbf":1489427237,"exp":1647194237,"created":1489427837,"updated":1489427837}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['245']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:07 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -424,36 +424,37 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"lifetime_actions": [{"trigger":
-      {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}], "attributes":
-      {"enabled": true}, "issuer": {"name": "Self"}, "key_props": {"reuse_key": false,
-      "key_size": 2048, "kty": "RSA", "exportable": true}, "secret_props": {"contentType":
-      "application/x-pkcs12"}, "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation",
-      "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months": 50, "subject":
-      "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com"}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action":
+      {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
+      "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment",
+      "keyAgreement", "keyCertSign"], "subject": "C=US, ST=WA, L=Redmond, O=TestO,
+      OU=TestOU, CN=www.mytestdomain.com", "validity_months": 50}, "issuer": {"name":
+      "Self"}, "key_props": {"key_size": 2048, "reuse_key": false, "exportable": true,
+      "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['578']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6ca09418-051c-11e7-862b-a0b3ccf7272a]
+      x-ms-client-request-id: [855eb9fa-0816-11e7-bc6e-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBb62vDqL/bnVSMBSPajld5PCfjsPTaLL/trz6+bt73FwwWfvuxhXefw1mbyNoy7ibS6giUhoiKApuKM3M9jF1soLOIQic2dd7ulBzZuwNBCeaYns4PodClaYu1UNEgQB8J67Jb0+iFZulXYIkiolHWm9osAldjzZBzu6GsEGl7LkVQdUDdkabJqmIedpgriT2UhIHccWRmrXt/X5xqwHd/Eap8Z77u0wOnB7kir3XTvXkCT58lzkiLiBWIVJNGo0JZHb1flWhZvhXFtPiLaj3OSREKKfLZNCzQYVihyt0963gY/Dvq5FLpgAJrY8MJ9XrxQO37OP0wP1iSyZQI/VvM","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQC++mzhAoTVvWMckp6yjXjk3Przi7D+8zmJkRu3kbQPFOn1JY9RVzNTsG69lVKyUQdC3OQAvUd/ELZO1AxpJst4C0sM3tOJAJF+VhLzxWbCEfEMImqLPfqVmEWBtlz5jKAEXjfzh7wf4VXvWTOkK1Nvel45JC/QJPOXWUiMVHRo6VqfexfMeskktk2i16VKnqlA3517+vxcq3WXb1xbKwINuTsmSRzyFjwRtATlWBQBbanTM83cWVgtUwKOqVil0rh5NlOZwWSsNpGz+3b8g1DH5TgMS8dwam9JWP50kN0sqFifMuNjvKMgNXm6OvrdJJj1MAG3cOv5IOZJ7lqtKREa","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"ef90e92aadb74df48c7728fbb0af607d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"298cf0c6fd8f4d49bd855a3539e3df90"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1406']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:09 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:27 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=ef90e92aadb74df48c7728fbb0af607d']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=298cf0c6fd8f4d49bd855a3539e3df90']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -470,21 +471,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d3e6ac2-051c-11e7-bdb4-a0b3ccf7272a]
+      x-ms-client-request-id: [85edd31e-0816-11e7-9f7f-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBb62vDqL/bnVSMBSPajld5PCfjsPTaLL/trz6+bt73FwwWfvuxhXefw1mbyNoy7ibS6giUhoiKApuKM3M9jF1soLOIQic2dd7ulBzZuwNBCeaYns4PodClaYu1UNEgQB8J67Jb0+iFZulXYIkiolHWm9osAldjzZBzu6GsEGl7LkVQdUDdkabJqmIedpgriT2UhIHccWRmrXt/X5xqwHd/Eap8Z77u0wOnB7kir3XTvXkCT58lzkiLiBWIVJNGo0JZHb1flWhZvhXFtPiLaj3OSREKKfLZNCzQYVihyt0963gY/Dvq5FLpgAJrY8MJ9XrxQO37OP0wP1iSyZQI/VvM","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQC++mzhAoTVvWMckp6yjXjk3Przi7D+8zmJkRu3kbQPFOn1JY9RVzNTsG69lVKyUQdC3OQAvUd/ELZO1AxpJst4C0sM3tOJAJF+VhLzxWbCEfEMImqLPfqVmEWBtlz5jKAEXjfzh7wf4VXvWTOkK1Nvel45JC/QJPOXWUiMVHRo6VqfexfMeskktk2i16VKnqlA3517+vxcq3WXb1xbKwINuTsmSRzyFjwRtATlWBQBbanTM83cWVgtUwKOqVil0rh5NlOZwWSsNpGz+3b8g1DH5TgMS8dwam9JWP50kN0sqFifMuNjvKMgNXm6OvrdJJj1MAG3cOv5IOZJ7lqtKREa","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"ef90e92aadb74df48c7728fbb0af607d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"298cf0c6fd8f4d49bd855a3539e3df90"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1406']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:08 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -502,19 +503,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [73522c00-051c-11e7-81c5-a0b3ccf7272a]
+      x-ms-client-request-id: [8c021106-0816-11e7-b9fe-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBb62vDqL/bnVSMBSPajld5PCfjsPTaLL/trz6+bt73FwwWfvuxhXefw1mbyNoy7ibS6giUhoiKApuKM3M9jF1soLOIQic2dd7ulBzZuwNBCeaYns4PodClaYu1UNEgQB8J67Jb0+iFZulXYIkiolHWm9osAldjzZBzu6GsEGl7LkVQdUDdkabJqmIedpgriT2UhIHccWRmrXt/X5xqwHd/Eap8Z77u0wOnB7kir3XTvXkCT58lzkiLiBWIVJNGo0JZHb1flWhZvhXFtPiLaj3OSREKKfLZNCzQYVihyt0963gY/Dvq5FLpgAJrY8MJ9XrxQO37OP0wP1iSyZQI/VvM","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"ef90e92aadb74df48c7728fbb0af607d"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQC++mzhAoTVvWMckp6yjXjk3Przi7D+8zmJkRu3kbQPFOn1JY9RVzNTsG69lVKyUQdC3OQAvUd/ELZO1AxpJst4C0sM3tOJAJF+VhLzxWbCEfEMImqLPfqVmEWBtlz5jKAEXjfzh7wf4VXvWTOkK1Nvel45JC/QJPOXWUiMVHRo6VqfexfMeskktk2i16VKnqlA3517+vxcq3WXb1xbKwINuTsmSRzyFjwRtATlWBQBbanTM83cWVgtUwKOqVil0rh5NlOZwWSsNpGz+3b8g1DH5TgMS8dwam9JWP50kN0sqFifMuNjvKMgNXm6OvrdJJj1MAG3cOv5IOZJ7lqtKREa","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"298cf0c6fd8f4d49bd855a3539e3df90"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['1406']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:57:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.802]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [96a8bcc0-0816-11e7-b8c0-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQC++mzhAoTVvWMckp6yjXjk3Przi7D+8zmJkRu3kbQPFOn1JY9RVzNTsG69lVKyUQdC3OQAvUd/ELZO1AxpJst4C0sM3tOJAJF+VhLzxWbCEfEMImqLPfqVmEWBtlz5jKAEXjfzh7wf4VXvWTOkK1Nvel45JC/QJPOXWUiMVHRo6VqfexfMeskktk2i16VKnqlA3517+vxcq3WXb1xbKwINuTsmSRzyFjwRtATlWBQBbanTM83cWVgtUwKOqVil0rh5NlOZwWSsNpGz+3b8g1DH5TgMS8dwam9JWP50kN0sqFifMuNjvKMgNXm6OvrdJJj1MAG3cOv5IOZJ7lqtKREa","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"298cf0c6fd8f4d49bd855a3539e3df90"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1319']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:19 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -532,19 +565,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [73bf465e-051c-11e7-83d9-a0b3ccf7272a]
+      x-ms-client-request-id: [971d7074-0816-11e7-a7e0-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4d41102b701a47e6bd5c91d2d806b86e","x5t":"vx6jKz8iNnHFx1rD2RgdpksrG3I","attributes":{"enabled":true,"nbf":1489099923,"exp":1646866923,"created":1489100524,"updated":1489100524}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e2b63e0c14a740febbb794c913b30811","x5t":"R6C-g9sdddM1KFe46P4w-a0tyyg","attributes":{"enabled":true,"nbf":1489099938,"exp":1620601338,"created":1489100538,"updated":1489100538}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b50c859185a04f28828e6423a4940133","x5t":"1W6GnjhcTEn9QhcRyMb47k4jkWI","attributes":{"enabled":true,"nbf":1489427269,"exp":1620928669,"created":1489427869,"updated":1489427869}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e01d9fc880d845619675cb8e38e787f3","x5t":"8rc4DbM1oshzOTcnLnfiG_0ql0c","attributes":{"enabled":true,"nbf":1489427237,"exp":1647194237,"created":1489427837,"updated":1489427837}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['529']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:20 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -562,20 +595,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7423bd62-051c-11e7-a176-a0b3ccf7272a]
+      x-ms-client-request-id: [97970500-0816-11e7-a519-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e2b63e0c14a740febbb794c913b30811","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/e2b63e0c14a740febbb794c913b30811","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/e2b63e0c14a740febbb794c913b30811","x5t":"R6C-g9sdddM1KFe46P4w-a0tyyg","cer":"MIID3jCCAsagAwIBAgIQCvjPAND9T224LNcqszjIXTANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMwOTIyNTIxOFoXDTIxMDUwOTIzMDIxOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFIkLmX3E+YY4f0ENvpLWkujOrmVpMB0GA1UdDgQWBBSJC5l9xPmGOH9BDb6S1pLozq5laTANBgkqhkiG9w0BAQsFAAOCAQEAenMkzlerbTy/P9FkDsxQALcjiOjf9aUceUa+ceMTHMU0FNVxtUONQALE1l67FzbLwhSe+k30LMPgIf99psZRCdCNvMwrdQOE+91clk5aB1qCvOUzID8ybK8W8jaHJjHCpL/w95WE83U+J0iqEjWndxNK44W+5tDz++ADE6cOv8lIs3slj3Cyo9kLAIc5CDUOe9TW8cqLgAIlfT7RP/a9ni55RvzWC5nf455/hRB+1URFMel+EQux8zeK9w1GuIiZvlLKjKsTeZlsqAShW8QGpiX/pCqZbAq3Gn8n32GNfUokuNLFw//qI+TWTizneKntVKr5SawhDEmbJEHSStcFww==","attributes":{"enabled":true,"nbf":1489099938,"exp":1620601338,"created":1489100538,"updated":1489100538},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100505,"updated":1489100529}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b50c859185a04f28828e6423a4940133","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b50c859185a04f28828e6423a4940133","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b50c859185a04f28828e6423a4940133","x5t":"1W6GnjhcTEn9QhcRyMb47k4jkWI","cer":"MIID3jCCAsagAwIBAgIQaqcBJQkiS2mIRlSvbJqXPDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMxMzE3NDc0OVoXDTIxMDUxMzE3NTc0OVowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCiW0m3ad5jpa2aNyRmiJ0/CSc/ZMB0GA1UdDgQWBBQoltJt2neY6WtmjckZoidPwknP2TANBgkqhkiG9w0BAQsFAAOCAQEAd1cVR6+I3kCGy0vMpg7PajFMMsyYdKEwDw5zmDTrAQFE02ceLT2QK9rhdXmsTlOw5xrlIXZh0ddSgXPpn4sIXRNcP7anFGiia9MYr5WSt8cFUmcghp5TBIL7evMBfsyVnkJ92qwOO59qBzIXmdRMbfFeaoGHLXGF9syit4dOf2DIvn5Z4juRQeag4e7toaLT34eXPZBvxJl2EHgAlIQlpOMgkwnxfk621y90k9FFkOuWsFU5eu9debvPz+9B2h4s49AO9GUGPfjQlzSd5Xh6zVEFhdzQV0UaSig13GEP6OsEsC3PUbz+KsXAMnUSZJpwAdKaANTBkA4tQckptth8Jw==","attributes":{"enabled":true,"nbf":1489427269,"exp":1620928669,"created":1489427869,"updated":1489427869},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427825,"updated":1489427847}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2597']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:20 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -593,19 +626,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7491f7d2-051c-11e7-937b-a0b3ccf7272a]
+      x-ms-client-request-id: [980fbf58-0816-11e7-9344-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4d41102b701a47e6bd5c91d2d806b86e?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e01d9fc880d845619675cb8e38e787f3?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/4d41102b701a47e6bd5c91d2d806b86e","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/4d41102b701a47e6bd5c91d2d806b86e","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/4d41102b701a47e6bd5c91d2d806b86e","x5t":"vx6jKz8iNnHFx1rD2RgdpksrG3I","cer":"MIID8DCCAtigAwIBAgIQJS4fBzSbQ6yUpdwlbhQwDDANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMwOTIyNTIwM1oXDTIyMDMwOTIzMDIwM1owdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOUalbV+P4flxx/bqASGb6YXRMHFOFNjhh7GT6YsR0bjT7tdKP5YNjaj+78Kba5k767IhAzhq/NkMpksa2s7DtCTE+6EOCpNou+OIEAufviJwtM/sQHqTfRCC27CoCG6hWGjau6HOQ9HfuUTI8/bM+c4AyVgBNVBJGfrK79lv7/qg/aMZv4ECzX7MjcGB3bYGx33GY2iBNWxqu81dEbNdRrWRJXdmtGsBBpfrMTiOoYpFQVZYc/lFAVnzwxWfc3ENwUzxWOhsUyk26FTAeWhZl5mOz7K/vb/vugbGngNaWOg4AjLM5Rbo9a/Zs36vCnDcNFBeiOYc2fElYER0yI+HPkCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFL9jZlO4h2Ym+nNVOoP1tuxnJMlNMB0GA1UdDgQWBBS/Y2ZTuIdmJvpzVTqD9bbsZyTJTTANBgkqhkiG9w0BAQsFAAOCAQEABBWw6FHhY/bs/zQ8Eo/A/WOfXGigGWKM+5tW6BkpL0skXw2TwWBlb5X3JQKUm54zDArSHMDlBfQ0EURqiZTYeblNxhrxlMrEgWv4ZPSVukTTtOB8gTtqViJ0JUJOG4mcXUKEpi1wf7RxwnkqObv6dQf6tbUi5iFao+KuNeTgfWJvPkRhoIgZdmDZkM9p72ZEiwsyeFkkqPkXdmRWys8PfH70yYzuwXTWadXZLAXSAfg43lA5O3chDbWHvJkHm+uFoXbJXpBBVjjcUS9sy+3I3RZ1dvosY4eE3qZo+Oe31KNNHKdjVgVKF6pIcqGw7tk/WNSloGi34WCA4C/cQ0uDBQ==","attributes":{"enabled":true,"nbf":1489099923,"exp":1646866923,"created":1489100524,"updated":1489100524}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e01d9fc880d845619675cb8e38e787f3","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/e01d9fc880d845619675cb8e38e787f3","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/e01d9fc880d845619675cb8e38e787f3","x5t":"8rc4DbM1oshzOTcnLnfiG_0ql0c","cer":"MIID8DCCAtigAwIBAgIQT3I2oq0QRtm6QgMd8ECi/TANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMxMzE3NDcxN1oXDTIyMDMxMzE3NTcxN1owdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL52GDVvv37p22DsOFxu6uiM3MgbmL9VPr3oxPaAq06qXAc+bOCESSLWcKJQzzH7q1323f3lURVaZ58N9reLMZ1qcVcrdSU3NAEIkQ1wK16b7BrulR4Y6LHOvkB9GAE+dFuI9vkeawKFD59sS1aIQaSGE32s2oN5WruRs3yo7zKk2UJQF8P33JJkqEBEHjLrgtPAJHJLwR+At6mOTSHTIKzTPFrKwRjVAxPYi8xozm/5CJXVRGHWCQ3DgFRlsR4nQ80XYOr6uXdKgp4/P1nYrUd0UM5S+inWuH+6MZ+TOTsdDlSwfV6uh1d9tNHnZsfUIxwZX0VBR/YSZNxzW4z+yFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFIxsG94Hs6xp9DUkC+0/P5eShWdtMB0GA1UdDgQWBBSMbBveB7OsafQ1JAvtPz+XkoVnbTANBgkqhkiG9w0BAQsFAAOCAQEARfHmOjgHNlF3XTPQMD1RwiaTHXRBWPdA5Z+cNbUlvCjS1HAXMs8Wb4SqiRpVTFh8W4EeEMPTABEmxjb6C88cyre34/WqNVX0JhC0R9ynHyFuxtm6x9bDaDxAicz5M3QkgTjhnYcw/jiqGQRnz9OxJ+JqIP2cNsS59gkYvZOolpZNVcLuxdhnj5mURdRygHCf/Do4CsohGN7PgpsfGIJJomjoqumfmIz+sSemTNJQDIpZKHIsLzaNYUxEHsy71onVxD9kOytC2cTtbJ4zeyyZvr8Thz1GQVQ28tFnDzsbsQpqoXEJQEIe/0SgRNnC2Ae8MZCk05Ki5L6SHi9R409beQ==","attributes":{"enabled":true,"nbf":1489427237,"exp":1647194237,"created":1489427837,"updated":1489427837}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1814']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:21 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -617,33 +650,34 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": false}, "policy": {"lifetime_actions": [{"trigger":
-      {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}], "attributes":
-      {"enabled": true}, "issuer": {"name": "Self"}, "key_props": {"reuse_key": false,
-      "key_size": 2048, "kty": "RSA", "exportable": true}, "secret_props": {"contentType":
-      "application/x-pkcs12"}, "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation",
-      "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months": 60, "subject":
-      "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com"}}}'
+    body: '{"attributes": {"enabled": false}, "policy": {"attributes": {"enabled":
+      true}, "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action":
+      {"action_type": "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"},
+      "x509_props": {"key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment",
+      "keyAgreement", "keyCertSign"], "subject": "C=US, ST=WA, L=Redmon, O=Test Noodle,
+      OU=TestNugget, CN=www.mytestdomain.com", "validity_months": 60}, "issuer": {"name":
+      "Self"}, "key_props": {"key_size": 2048, "reuse_key": false, "exportable": true,
+      "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['588']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75031dee-051c-11e7-adac-a0b3ccf7272a]
+      x-ms-client-request-id: [987eda14-0816-11e7-98ec-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e2b63e0c14a740febbb794c913b30811","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/e2b63e0c14a740febbb794c913b30811","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/e2b63e0c14a740febbb794c913b30811","x5t":"R6C-g9sdddM1KFe46P4w-a0tyyg","cer":"MIID3jCCAsagAwIBAgIQCvjPAND9T224LNcqszjIXTANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMwOTIyNTIxOFoXDTIxMDUwOTIzMDIxOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFIkLmX3E+YY4f0ENvpLWkujOrmVpMB0GA1UdDgQWBBSJC5l9xPmGOH9BDb6S1pLozq5laTANBgkqhkiG9w0BAQsFAAOCAQEAenMkzlerbTy/P9FkDsxQALcjiOjf9aUceUa+ceMTHMU0FNVxtUONQALE1l67FzbLwhSe+k30LMPgIf99psZRCdCNvMwrdQOE+91clk5aB1qCvOUzID8ybK8W8jaHJjHCpL/w95WE83U+J0iqEjWndxNK44W+5tDz++ADE6cOv8lIs3slj3Cyo9kLAIc5CDUOe9TW8cqLgAIlfT7RP/a9ni55RvzWC5nf455/hRB+1URFMel+EQux8zeK9w1GuIiZvlLKjKsTeZlsqAShW8QGpiX/pCqZbAq3Gn8n32GNfUokuNLFw//qI+TWTizneKntVKr5SawhDEmbJEHSStcFww==","attributes":{"enabled":false,"nbf":1489099938,"exp":1620601338,"created":1489100538,"updated":1489100542},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100505,"updated":1489100542}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b50c859185a04f28828e6423a4940133","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b50c859185a04f28828e6423a4940133","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b50c859185a04f28828e6423a4940133","x5t":"1W6GnjhcTEn9QhcRyMb47k4jkWI","cer":"MIID3jCCAsagAwIBAgIQaqcBJQkiS2mIRlSvbJqXPDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMxMzE3NDc0OVoXDTIxMDUxMzE3NTc0OVowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCiW0m3ad5jpa2aNyRmiJ0/CSc/ZMB0GA1UdDgQWBBQoltJt2neY6WtmjckZoidPwknP2TANBgkqhkiG9w0BAQsFAAOCAQEAd1cVR6+I3kCGy0vMpg7PajFMMsyYdKEwDw5zmDTrAQFE02ceLT2QK9rhdXmsTlOw5xrlIXZh0ddSgXPpn4sIXRNcP7anFGiia9MYr5WSt8cFUmcghp5TBIL7evMBfsyVnkJ92qwOO59qBzIXmdRMbfFeaoGHLXGF9syit4dOf2DIvn5Z4juRQeag4e7toaLT34eXPZBvxJl2EHgAlIQlpOMgkwnxfk621y90k9FFkOuWsFU5eu9debvPz+9B2h4s49AO9GUGPfjQlzSd5Xh6zVEFhdzQV0UaSig13GEP6OsEsC3PUbz+KsXAMnUSZJpwAdKaANTBkA4tQckptth8Jw==","attributes":{"enabled":false,"nbf":1489427269,"exp":1620928669,"created":1489427869,"updated":1489427878},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427825,"updated":1489427878}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2607']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:23 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -661,10 +695,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75c79f3e-051c-11e7-9733-a0b3ccf7272a]
+      x-ms-client-request-id: [996abd86-0816-11e7-ad9b-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -673,7 +707,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['68']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:23 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -685,17 +719,18 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"contacts": [{"phone": "123-456-7890", "name": "John Doe", "email": "admin@contoso.com"}]}'
+    body: '{"contacts": [{"email": "admin@contoso.com", "phone": "123-456-7890", "name":
+      "John Doe"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['91']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75e2805e-051c-11e7-8048-a0b3ccf7272a]
+      x-ms-client-request-id: [99866b1c-0816-11e7-a404-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -705,7 +740,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['162']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:23 GMT']
+      Date: ['Mon, 13 Mar 2017 17:57:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -723,10 +758,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7659d5e6-051c-11e7-afa3-a0b3ccf7272a]
+      x-ms-client-request-id: [9a4dcd10-0816-11e7-bf05-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -736,7 +771,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['162']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:23 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -748,18 +783,18 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"contacts": [{"phone": "123-456-7890", "name": "John Doe", "email": "admin@contoso.com"},
-      {"email": "other@contoso.com"}]}'
+    body: '{"contacts": [{"email": "admin@contoso.com", "phone": "123-456-7890", "name":
+      "John Doe"}, {"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76753f88-051c-11e7-9918-a0b3ccf7272a]
+      x-ms-client-request-id: [9a6f26b0-0816-11e7-a9d0-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -769,7 +804,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:25 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -787,10 +822,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76e48128-051c-11e7-854c-a0b3ccf7272a]
+      x-ms-client-request-id: [9ae5fc62-0816-11e7-abfb-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -800,7 +835,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:24 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -818,10 +853,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [775093a6-051c-11e7-9558-a0b3ccf7272a]
+      x-ms-client-request-id: [9b550190-0816-11e7-9ae5-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -831,7 +866,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['192']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:26 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -850,10 +885,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['46']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [776ae66e-051c-11e7-8560-a0b3ccf7272a]
+      x-ms-client-request-id: [9b6f51ba-0816-11e7-bcc5-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -862,7 +897,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['121']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -880,10 +915,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77d2aaa2-051c-11e7-a6df-a0b3ccf7272a]
+      x-ms-client-request-id: [9bea2f3e-0816-11e7-8374-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
@@ -892,7 +927,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['121']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:26 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -904,58 +939,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [783fff0a-051c-11e7-90a3-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
-  response:
-    body: {string: '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
-        not found"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['75']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.802]
-    status: {code: 404, message: Not Found}
-- request:
-    body: '{"credentials": {}, "attributes": {"enabled": true}, "org_details": {"admin_details":
-      []}, "provider": "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"admin_details":
+      []}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7858a794-051c-11e7-9f54-a0b3ccf7272a]
+      x-ms-client-request-id: [9c698f30-0816-11e7-8e45-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100548}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427885}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:28 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -973,19 +977,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [78c98186-051c-11e7-97b4-a0b3ccf7272a]
+      x-ms-client-request-id: [9ce4fa7e-0816-11e7-b4e3-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100548}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427885}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:28 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1003,19 +1007,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [793028f6-051c-11e7-baae-a0b3ccf7272a]
+      x-ms-client-request-id: [9d5caa5a-0816-11e7-a236-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100548}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427885}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['235']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:28 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1027,57 +1031,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [79df7c02-051c-11e7-844b-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
-  response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100548}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['235']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.802]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"credentials": {"account_id": "test_account"}, "attributes": {"enabled":
-      true}, "org_details": {"admin_details": [], "id": "TestOrg"}, "provider": "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"id":
+      "TestOrg", "admin_details": []}, "credentials": {"account_id": "test_account"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79fd7568-051c-11e7-b44f-a0b3ccf7272a]
+      x-ms-client-request-id: [9d81a424-0816-11e7-9891-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100550}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427887}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:29 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1095,10 +1069,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a797a22-051c-11e7-a133-a0b3ccf7272a]
+      x-ms-client-request-id: [9dfaf9e8-0816-11e7-b262-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
   response:
@@ -1108,7 +1082,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['75']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:31 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1126,19 +1100,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7af04cf4-051c-11e7-92f7-a0b3ccf7272a]
+      x-ms-client-request-id: [9e6c2610-0816-11e7-ae37-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100550}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427887}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:32 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1150,27 +1124,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"credentials": {}, "attributes": {"enabled": true}, "org_details": {"admin_details":
-      [], "id": "TestOrg"}, "provider": "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"id":
+      "TestOrg", "admin_details": []}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b0ab2f4-051c-11e7-8e1c-a0b3ccf7272a]
+      x-ms-client-request-id: [9e8949e6-0816-11e7-8e37-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100552}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427890}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['250']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:32 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1188,10 +1162,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b79ef5c-051c-11e7-88da-a0b3ccf7272a]
+      x-ms-client-request-id: [9f05d93a-0816-11e7-997d-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
@@ -1200,7 +1174,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:33 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1218,19 +1192,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7bf10de4-051c-11e7-bb67-a0b3ccf7272a]
+      x-ms-client-request-id: [9f8eec5a-0816-11e7-be02-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100552}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427890}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['250']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:33 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1242,28 +1216,28 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"credentials": {}, "attributes": {"enabled": true}, "org_details": {"admin_details":
-      [{"first_name": "Test", "last_name": "Admin", "phone": "123-456-7890", "email":
-      "test@test.com"}], "id": "TestOrg"}, "provider": "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"id":
+      "TestOrg", "admin_details": [{"last_name": "Admin", "email": "test@test.com",
+      "phone": "123-456-7890", "first_name": "Test"}]}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c0b2a28-051c-11e7-8483-a0b3ccf7272a]
+      x-ms-client-request-id: [9fab3e12-0816-11e7-88da-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100554}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427891}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:34 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1281,19 +1255,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c97039a-051c-11e7-846c-a0b3ccf7272a]
+      x-ms-client-request-id: [a02ff26e-0816-11e7-b2cf-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100554}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427891}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:35 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1311,19 +1285,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d0d59d0-051c-11e7-9f68-a0b3ccf7272a]
+      x-ms-client-request-id: [a099da00-0816-11e7-9bb3-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100554}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427891}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['338']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:37 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1335,29 +1309,29 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"credentials": {}, "attributes": {"enabled": true}, "org_details": {"admin_details":
-      [{"first_name": "Test", "last_name": "Admin", "phone": "123-456-7890", "email":
-      "test@test.com"}, {"email": "test2@test.com"}], "id": "TestOrg"}, "provider":
-      "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"id":
+      "TestOrg", "admin_details": [{"last_name": "Admin", "email": "test@test.com",
+      "phone": "123-456-7890", "first_name": "Test"}, {"email": "test2@test.com"}]},
+      "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2ac29c-051c-11e7-9a6f-a0b3ccf7272a]
+      x-ms-client-request-id: [a0bb6f52-0816-11e7-ac48-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427892}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:36 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1375,19 +1349,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7da13b10-051c-11e7-a5b7-a0b3ccf7272a]
+      x-ms-client-request-id: [a1360958-0816-11e7-9840-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427892}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:36 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1405,19 +1379,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e137c7e-051c-11e7-ae8e-a0b3ccf7272a]
+      x-ms-client-request-id: [a1aef858-0816-11e7-a29d-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427892}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['365']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:38 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1429,27 +1403,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"credentials": {}, "attributes": {"enabled": true}, "org_details": {"admin_details":
-      [{"email": "test2@test.com"}], "id": "TestOrg"}, "provider": "Test"}'
+    body: '{"attributes": {"enabled": true}, "provider": "Test", "org_details": {"id":
+      "TestOrg", "admin_details": [{"email": "test2@test.com"}]}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e2edc38-051c-11e7-a515-a0b3ccf7272a]
+      x-ms-client-request-id: [a1cb7a40-0816-11e7-9b39-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427894}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:37 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1467,19 +1441,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7eaa3508-051c-11e7-9f08-a0b3ccf7272a]
+      x-ms-client-request-id: [a2434b1a-0816-11e7-be7e-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427894}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:38 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1498,19 +1472,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7f136424-051c-11e7-b7de-a0b3ccf7272a]
+      x-ms-client-request-id: [a2b675dc-0816-11e7-8ff3-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489100548,"updated":1489100557}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1489427885,"updated":1489427894}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:41 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1528,10 +1502,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [8080535a-051c-11e7-ba75-a0b3ccf7272a]
+      x-ms-client-request-id: [a3424a3e-0816-11e7-ba59-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
@@ -1540,7 +1514,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:42 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1552,34 +1526,34 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"x509_props": {"key_usage":
-      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
-      "validity_months": 50, "subject": "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU,
-      CN=www.mytestdomain.com"}, "secret_props": {"contentType": "application/x-pkcs12"},
-      "attributes": {"enabled": true}, "issuer": {"name": "Unknown"}, "key_props":
-      {"reuse_key": false, "key_size": 2048, "kty": "RSA", "exportable": true}}}'
+    body: '{"attributes": {"enabled": true}, "policy": {"attributes": {"enabled":
+      true}, "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props":
+      {"key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"], "subject": "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com",
+      "validity_months": 50}, "issuer": {"name": "Unknown"}, "key_props": {"key_size":
+      2048, "reuse_key": false, "exportable": true, "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [80f47138-051c-11e7-8e8d-a0b3ccf7272a]
+      x-ms-client-request-id: [a3c33b98-0816-11e7-aa3f-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI5Sa/NMqETgvri2qBB+I+bLSc/tD+NDcKyk4Shalh2s1exynKWrCrPx3p46iY7RcC4egwE+WRRnyVV0IiDjASXp8Gyw85AFOcljlpKw1j7qqqUVhzUWhxaGCHhGnJokX+4XDLobTRjDhzD+zJ9qMBWZmnIRQtyJXZgBYne6s4Cs8JZhXppifOw5Vr9TU05C6U7VScGjddk+TGhvROhzCyYCGwdCkjsfJNl3RgY28Y788L2FFmbN+fdcRf2FIrUUy/evlahL+h8YzEy/0uvjtvvPDGEiPCMMy2cI2s2LLgE5leZlBh4vRXs2tymhxUN3ewjA/lA+oxpEOx3ff2kNSFsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQADh6uFJqUVbN6t2IBIfjnqMb8Lkj/mmxMse5EmEP8kSnPFbp7+0xZ9owufp1BAh3BLJpJL5zwnT5NJ8oCR+Dx4tAUcunDp4yWO77P+5tdNS0WtRmKtaZLUT9JKFxaZ7Ze5p5fP7J9iKc1WmJAy6T0Q4GhYC9gHayCokuVnOvRcoCno+DHTulvHIpH+R4AcnR6yccyK6a1aOOATU0DuhLKDyjVMfTU0LMnQYfbH1AATjtXFHEY2za6+Fhu9efB/o+JDLAlqe0CI1gm0JCwCWWBDdVCK5J4+7JzOUOBJTNDu0TAi44AygxlogecJtZ5ZHG2BsmVuVz1dEWX1EHVsS8AS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"672ed76a6e404543b509187f28187e69"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQubLQsqENEEQ121AVYornYPgUL7ksbDs4qIseqgtmwJW24OpnnS9BZU7ugVmZtNhEInuvStZUHEz4cuQ7drk5o18Mb/K/SlqVYI+wrjtGLEIOpTHUpWVag/f2cyM9nX57VZr2tCx/YdFHOG4BhyOnUDR2TkFu109GZNVtJOmNfBuGUF1Gp1TbgaKpix2bBcMvG0H4nPOXkHMNTX6gXjJVv1FuovcR0ThrmY+IAONJjpG27Tm79gY4E8hPeMK99B8C1Cy8gSdFjm6tfiv4Ry2hPUoqge5TJErdikElw1TLMHslxUuQTXYH0o9qQalWyGsLJojQ80vFL79GU4z5vkNUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAdLH9JBkJz7+UFicTz1wIU04Kw8Ho0mt5DzTVBtxakvtTFb4tIp05QrOYBG1IprIbW3K1pCi3uyCh3uEd7phT0l6frFHDVH5cyTicYpK7Dd5UTDSqlbAupdSaJ7wQQRFL/3zLA7NM+ELdFZdiEjhLUbdYJtEjvw8ZTPHRIGj3JzRXow3q+mlJNGDjisclKuVrOfeqmrR4WCFSGvhschOyDg7PTKM90GLh6SR1suMTAp4uxBl5FNMckldLqc/oxPxDJHU2QyKKsB2KVtPTmM7ZfeppmPWUxiqFo5ldhjBx44WR/be9rrmnm6zeQBtAXRAZBTAGSYBmZBoRr/+IwpW7E","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"59e9ebca172f483395e079a19837943e"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:44 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:19 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=672ed76a6e404543b509187f28187e69']
+      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=59e9ebca172f483395e079a19837943e']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -1596,20 +1570,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [81d19a3e-051c-11e7-b5b9-a0b3ccf7272a]
+      x-ms-client-request-id: [a4a983e6-0816-11e7-9cf0-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI5Sa/NMqETgvri2qBB+I+bLSc/tD+NDcKyk4Shalh2s1exynKWrCrPx3p46iY7RcC4egwE+WRRnyVV0IiDjASXp8Gyw85AFOcljlpKw1j7qqqUVhzUWhxaGCHhGnJokX+4XDLobTRjDhzD+zJ9qMBWZmnIRQtyJXZgBYne6s4Cs8JZhXppifOw5Vr9TU05C6U7VScGjddk+TGhvROhzCyYCGwdCkjsfJNl3RgY28Y788L2FFmbN+fdcRf2FIrUUy/evlahL+h8YzEy/0uvjtvvPDGEiPCMMy2cI2s2LLgE5leZlBh4vRXs2tymhxUN3ewjA/lA+oxpEOx3ff2kNSFsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQADh6uFJqUVbN6t2IBIfjnqMb8Lkj/mmxMse5EmEP8kSnPFbp7+0xZ9owufp1BAh3BLJpJL5zwnT5NJ8oCR+Dx4tAUcunDp4yWO77P+5tdNS0WtRmKtaZLUT9JKFxaZ7Ze5p5fP7J9iKc1WmJAy6T0Q4GhYC9gHayCokuVnOvRcoCno+DHTulvHIpH+R4AcnR6yccyK6a1aOOATU0DuhLKDyjVMfTU0LMnQYfbH1AATjtXFHEY2za6+Fhu9efB/o+JDLAlqe0CI1gm0JCwCWWBDdVCK5J4+7JzOUOBJTNDu0TAi44AygxlogecJtZ5ZHG2BsmVuVz1dEWX1EHVsS8AS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"672ed76a6e404543b509187f28187e69"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQubLQsqENEEQ121AVYornYPgUL7ksbDs4qIseqgtmwJW24OpnnS9BZU7ugVmZtNhEInuvStZUHEz4cuQ7drk5o18Mb/K/SlqVYI+wrjtGLEIOpTHUpWVag/f2cyM9nX57VZr2tCx/YdFHOG4BhyOnUDR2TkFu109GZNVtJOmNfBuGUF1Gp1TbgaKpix2bBcMvG0H4nPOXkHMNTX6gXjJVv1FuovcR0ThrmY+IAONJjpG27Tm79gY4E8hPeMK99B8C1Cy8gSdFjm6tfiv4Ry2hPUoqge5TJErdikElw1TLMHslxUuQTXYH0o9qQalWyGsLJojQ80vFL79GU4z5vkNUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAdLH9JBkJz7+UFicTz1wIU04Kw8Ho0mt5DzTVBtxakvtTFb4tIp05QrOYBG1IprIbW3K1pCi3uyCh3uEd7phT0l6frFHDVH5cyTicYpK7Dd5UTDSqlbAupdSaJ7wQQRFL/3zLA7NM+ELdFZdiEjhLUbdYJtEjvw8ZTPHRIGj3JzRXow3q+mlJNGDjisclKuVrOfeqmrR4WCFSGvhschOyDg7PTKM90GLh6SR1suMTAp4uxBl5FNMckldLqc/oxPxDJHU2QyKKsB2KVtPTmM7ZfeppmPWUxiqFo5ldhjBx44WR/be9rrmnm6zeQBtAXRAZBTAGSYBmZBoRr/+IwpW7E","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"59e9ebca172f483395e079a19837943e"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:43 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1627,20 +1601,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [82422358-051c-11e7-bfc1-a0b3ccf7272a]
+      x-ms-client-request-id: [a5236546-0816-11e7-9796-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI5Sa/NMqETgvri2qBB+I+bLSc/tD+NDcKyk4Shalh2s1exynKWrCrPx3p46iY7RcC4egwE+WRRnyVV0IiDjASXp8Gyw85AFOcljlpKw1j7qqqUVhzUWhxaGCHhGnJokX+4XDLobTRjDhzD+zJ9qMBWZmnIRQtyJXZgBYne6s4Cs8JZhXppifOw5Vr9TU05C6U7VScGjddk+TGhvROhzCyYCGwdCkjsfJNl3RgY28Y788L2FFmbN+fdcRf2FIrUUy/evlahL+h8YzEy/0uvjtvvPDGEiPCMMy2cI2s2LLgE5leZlBh4vRXs2tymhxUN3ewjA/lA+oxpEOx3ff2kNSFsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQADh6uFJqUVbN6t2IBIfjnqMb8Lkj/mmxMse5EmEP8kSnPFbp7+0xZ9owufp1BAh3BLJpJL5zwnT5NJ8oCR+Dx4tAUcunDp4yWO77P+5tdNS0WtRmKtaZLUT9JKFxaZ7Ze5p5fP7J9iKc1WmJAy6T0Q4GhYC9gHayCokuVnOvRcoCno+DHTulvHIpH+R4AcnR6yccyK6a1aOOATU0DuhLKDyjVMfTU0LMnQYfbH1AATjtXFHEY2za6+Fhu9efB/o+JDLAlqe0CI1gm0JCwCWWBDdVCK5J4+7JzOUOBJTNDu0TAi44AygxlogecJtZ5ZHG2BsmVuVz1dEWX1EHVsS8AS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"672ed76a6e404543b509187f28187e69"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQubLQsqENEEQ121AVYornYPgUL7ksbDs4qIseqgtmwJW24OpnnS9BZU7ugVmZtNhEInuvStZUHEz4cuQ7drk5o18Mb/K/SlqVYI+wrjtGLEIOpTHUpWVag/f2cyM9nX57VZr2tCx/YdFHOG4BhyOnUDR2TkFu109GZNVtJOmNfBuGUF1Gp1TbgaKpix2bBcMvG0H4nPOXkHMNTX6gXjJVv1FuovcR0ThrmY+IAONJjpG27Tm79gY4E8hPeMK99B8C1Cy8gSdFjm6tfiv4Ry2hPUoqge5TJErdikElw1TLMHslxUuQTXYH0o9qQalWyGsLJojQ80vFL79GU4z5vkNUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAdLH9JBkJz7+UFicTz1wIU04Kw8Ho0mt5DzTVBtxakvtTFb4tIp05QrOYBG1IprIbW3K1pCi3uyCh3uEd7phT0l6frFHDVH5cyTicYpK7Dd5UTDSqlbAupdSaJ7wQQRFL/3zLA7NM+ELdFZdiEjhLUbdYJtEjvw8ZTPHRIGj3JzRXow3q+mlJNGDjisclKuVrOfeqmrR4WCFSGvhschOyDg7PTKM90GLh6SR1suMTAp4uxBl5FNMckldLqc/oxPxDJHU2QyKKsB2KVtPTmM7ZfeppmPWUxiqFo5ldhjBx44WR/be9rrmnm6zeQBtAXRAZBTAGSYBmZBoRr/+IwpW7E","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"59e9ebca172f483395e079a19837943e"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:44 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1660,10 +1634,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['1126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [82a7e414-051c-11e7-8659-a0b3ccf7272a]
+      x-ms-client-request-id: [a5a0f9de-0816-11e7-8ecc-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
   response:
@@ -1673,7 +1647,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1692,20 +1666,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [832b57b4-051c-11e7-9a0f-a0b3ccf7272a]
+      x-ms-client-request-id: [a613cb30-0816-11e7-aa80-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI5Sa/NMqETgvri2qBB+I+bLSc/tD+NDcKyk4Shalh2s1exynKWrCrPx3p46iY7RcC4egwE+WRRnyVV0IiDjASXp8Gyw85AFOcljlpKw1j7qqqUVhzUWhxaGCHhGnJokX+4XDLobTRjDhzD+zJ9qMBWZmnIRQtyJXZgBYne6s4Cs8JZhXppifOw5Vr9TU05C6U7VScGjddk+TGhvROhzCyYCGwdCkjsfJNl3RgY28Y788L2FFmbN+fdcRf2FIrUUy/evlahL+h8YzEy/0uvjtvvPDGEiPCMMy2cI2s2LLgE5leZlBh4vRXs2tymhxUN3ewjA/lA+oxpEOx3ff2kNSFsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQADh6uFJqUVbN6t2IBIfjnqMb8Lkj/mmxMse5EmEP8kSnPFbp7+0xZ9owufp1BAh3BLJpJL5zwnT5NJ8oCR+Dx4tAUcunDp4yWO77P+5tdNS0WtRmKtaZLUT9JKFxaZ7Ze5p5fP7J9iKc1WmJAy6T0Q4GhYC9gHayCokuVnOvRcoCno+DHTulvHIpH+R4AcnR6yccyK6a1aOOATU0DuhLKDyjVMfTU0LMnQYfbH1AATjtXFHEY2za6+Fhu9efB/o+JDLAlqe0CI1gm0JCwCWWBDdVCK5J4+7JzOUOBJTNDu0TAi44AygxlogecJtZ5ZHG2BsmVuVz1dEWX1EHVsS8AS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"672ed76a6e404543b509187f28187e69"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQubLQsqENEEQ121AVYornYPgUL7ksbDs4qIseqgtmwJW24OpnnS9BZU7ugVmZtNhEInuvStZUHEz4cuQ7drk5o18Mb/K/SlqVYI+wrjtGLEIOpTHUpWVag/f2cyM9nX57VZr2tCx/YdFHOG4BhyOnUDR2TkFu109GZNVtJOmNfBuGUF1Gp1TbgaKpix2bBcMvG0H4nPOXkHMNTX6gXjJVv1FuovcR0ThrmY+IAONJjpG27Tm79gY4E8hPeMK99B8C1Cy8gSdFjm6tfiv4Ry2hPUoqge5TJErdikElw1TLMHslxUuQTXYH0o9qQalWyGsLJojQ80vFL79GU4z5vkNUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAdLH9JBkJz7+UFicTz1wIU04Kw8Ho0mt5DzTVBtxakvtTFb4tIp05QrOYBG1IprIbW3K1pCi3uyCh3uEd7phT0l6frFHDVH5cyTicYpK7Dd5UTDSqlbAupdSaJ7wQQRFL/3zLA7NM+ELdFZdiEjhLUbdYJtEjvw8ZTPHRIGj3JzRXow3q+mlJNGDjisclKuVrOfeqmrR4WCFSGvhschOyDg7PTKM90GLh6SR1suMTAp4uxBl5FNMckldLqc/oxPxDJHU2QyKKsB2KVtPTmM7ZfeppmPWUxiqFo5ldhjBx44WR/be9rrmnm6zeQBtAXRAZBTAGSYBmZBoRr/+IwpW7E","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"59e9ebca172f483395e079a19837943e"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1723,10 +1697,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [83c11382-051c-11e7-b90e-a0b3ccf7272a]
+      x-ms-client-request-id: [a6979282-0816-11e7-91ce-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
@@ -1736,7 +1710,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['103']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1755,20 +1729,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [842c40f4-051c-11e7-94a8-a0b3ccf7272a]
+      x-ms-client-request-id: [a70d9798-0816-11e7-9931-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/e2b63e0c14a740febbb794c913b30811","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/e2b63e0c14a740febbb794c913b30811","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/e2b63e0c14a740febbb794c913b30811","x5t":"R6C-g9sdddM1KFe46P4w-a0tyyg","cer":"MIID3jCCAsagAwIBAgIQCvjPAND9T224LNcqszjIXTANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMwOTIyNTIxOFoXDTIxMDUwOTIzMDIxOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKDAyjF4HLrT95OxIWeaLwrFma5+8cMinbXqOWtMXE5wZUWHs3xRKSBvwsyLaiZXBG8Ge/OJTaRlcVxZvVeqfDgRChY7atFcyiV9fLOtIHG2FJwxi4mlz6KzORMilBOPIWn2FQoiCvqI9niOUMz8CiXhZf4AriFlLmAwPFB0ZpoIYI6oxPDwJNz+Z+62WwCnhlMkycr6DqoT4ead6RvdRtgbgBCegC6bNajYEly1wOXpdsLwNZp/8ANcjo568acTTXmfX5SAoBsgZmcJDu1/qAxKcUS/9MtosalDXeUGnzsMHrYqwINegqx7H9vdQhOG8zO02SDtP9tGIiGgAfF+rckCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFIkLmX3E+YY4f0ENvpLWkujOrmVpMB0GA1UdDgQWBBSJC5l9xPmGOH9BDb6S1pLozq5laTANBgkqhkiG9w0BAQsFAAOCAQEAenMkzlerbTy/P9FkDsxQALcjiOjf9aUceUa+ceMTHMU0FNVxtUONQALE1l67FzbLwhSe+k30LMPgIf99psZRCdCNvMwrdQOE+91clk5aB1qCvOUzID8ybK8W8jaHJjHCpL/w95WE83U+J0iqEjWndxNK44W+5tDz++ADE6cOv8lIs3slj3Cyo9kLAIc5CDUOe9TW8cqLgAIlfT7RP/a9ni55RvzWC5nf455/hRB+1URFMel+EQux8zeK9w1GuIiZvlLKjKsTeZlsqAShW8QGpiX/pCqZbAq3Gn8n32GNfUokuNLFw//qI+TWTizneKntVKr5SawhDEmbJEHSStcFww==","attributes":{"enabled":false,"nbf":1489099938,"exp":1620601338,"created":1489100538,"updated":1489100542},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100505,"updated":1489100542}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b50c859185a04f28828e6423a4940133","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b50c859185a04f28828e6423a4940133","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b50c859185a04f28828e6423a4940133","x5t":"1W6GnjhcTEn9QhcRyMb47k4jkWI","cer":"MIID3jCCAsagAwIBAgIQaqcBJQkiS2mIRlSvbJqXPDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDMxMzE3NDc0OVoXDTIxMDUxMzE3NTc0OVowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMnAlURKv7OBexA4NqRcr3gRvPlxzKVsQ2CC20vLZ6/tzPnWu/2LIXdSbHzQ9m0nDZWJjiiJIvG0woi4h9Rj2VVyh1LO/ZNARlETYZ10FBqYGsWzEmhROYMNP2O5A8Um2GJUTDMBzNDKUvzbRsA9gvfzDDisRi2QGEg92Citjxj4fvnU+piIoiCsPEYGZQGF6naMISyC85cOCpMsG49sjpG0jcIVyHTEPhXSVAKkd7dHtv/FsUH/LJ6N15j9sXwPVHhaut5rJHN9SbjHfMYRi2BEszQ18tDaoSkqzum8cPqutMCxJDt6IOa3BO9yvM9QF+13q4vq5EmKGCxMYwxZbNkCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFCiW0m3ad5jpa2aNyRmiJ0/CSc/ZMB0GA1UdDgQWBBQoltJt2neY6WtmjckZoidPwknP2TANBgkqhkiG9w0BAQsFAAOCAQEAd1cVR6+I3kCGy0vMpg7PajFMMsyYdKEwDw5zmDTrAQFE02ceLT2QK9rhdXmsTlOw5xrlIXZh0ddSgXPpn4sIXRNcP7anFGiia9MYr5WSt8cFUmcghp5TBIL7evMBfsyVnkJ92qwOO59qBzIXmdRMbfFeaoGHLXGF9syit4dOf2DIvn5Z4juRQeag4e7toaLT34eXPZBvxJl2EHgAlIQlpOMgkwnxfk621y90k9FFkOuWsFU5eu9debvPz+9B2h4s49AO9GUGPfjQlzSd5Xh6zVEFhdzQV0UaSig13GEP6OsEsC3PUbz+KsXAMnUSZJpwAdKaANTBkA4tQckptth8Jw==","attributes":{"enabled":false,"nbf":1489427269,"exp":1620928669,"created":1489427869,"updated":1489427878},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427825,"updated":1489427878}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2607']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:48 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1786,10 +1760,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [84b92880-051c-11e7-a145-a0b3ccf7272a]
+      x-ms-client-request-id: [a79b7270-0816-11e7-a25c-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
@@ -1798,7 +1772,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:48 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1810,31 +1784,30 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props": {"reuse_key":
-      false, "key_size": 2048, "kty": "RSA", "exportable": true}}, "value": "-----BEGIN
-      PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: '{"attributes": {"enabled": true}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}, "key_props": {"key_size": 2048, "reuse_key": false,
+      "exportable": true, "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3132']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [8530649e-051c-11e7-8674-a0b3ccf7272a]
+      x-ms-client-request-id: [a80a6f38-0816-11e7-a317-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/a3decff664ed433aa4f5bf7085a75eca","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/a3decff664ed433aa4f5bf7085a75eca","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/a3decff664ed433aa4f5bf7085a75eca","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489100570,"updated":1489100570},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100570,"updated":1489100570}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/71ca2a39922440ab9cd4ed345f6c210b","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/71ca2a39922440ab9cd4ed345f6c210b","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/71ca2a39922440ab9cd4ed345f6c210b","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1489427906,"updated":1489427906},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427906,"updated":1489427906}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2167']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:50 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1846,32 +1819,31 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "pwd": "1234", "policy": {"secret_props":
-      {"contentType": "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props":
-      {"reuse_key": false, "key_size": 2048, "kty": "RSA", "exportable": true}}, "value":
-      "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
+    body: '{"attributes": {"enabled": true}, "value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
       CERTIFICATE-----\n-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE6jAcBgoqhkiG9w0BDAEDMA4ECJiLClPM6t5JAgIIAASCBMigL+KlEA9fagX0\nPFhQBeFjDiebJbMuTfa9HcOVZEDyrqmGng2Lfz+TUa3ys/V86okbUp2N9MoGK7gx\ncPqdq7rnu563LT9wGhtn8mUn8Wul0FfV2K56wsBGehJ+MPmlEjs6OZR0nVdXkwAh\ndVIzH9eFdz8mhJZOZI61TQNKCKbCqsR7lslkL2VWrSFgnHCUj5bR/BLIA2oRpQZv\nnw0SeYFQWMRyXgKH4VWMqOlObXm/ELnVOr9dJVzvTG42DRaK5N8BA9NTMsK1+8m+\nenCg4iNI/s81MD8iIy/d7MmsJFh8WQoqzUZmOVxfqNHw0TPgDpbCpCWRNigkRoGS\nRosc7MIlCPPangjPMFZg5QeMuUBrE01fSvJtZ52jSMkyloSfQzQJJb9Aam6q6Dzo\nuPCH32zz1GV/56yJoO8IefOMIujvXFZku/QNzKWiXnuSA+xjFZhGEGQToU5wLtHX\neEhz1cF519c8CkM4Ll/UUHPWtb90vqO2+O2DLug9qUUnoQl7P0O3W2NpAoBCLxUO\nqrfSyLUosms7Eg1DIVo5pwxawPK8qk7gwLntATZc+aTSUR9Y1dn4vJ9j9GZWIu9J\nVKO616gDO7q8R1C3mT72k2oUuUG25TtZOxsl+Y3iJgEyp9N7jo/Rdx5KkcvvB8zt\ngPCh5diKDjbo3LxmYRt62heOLEPs2YDjKByn0Nikco3LqTnedJeXEH2mBc7x1VWE\n0qTV4xqOXL9F7000Mv1cJcE2E88fN6tDge1IpuJbs03Ij0OgpaFRfS57NciBthgm\nBp3lREHYNVa4sqWHlUqakoNtc2H62t9nmpzFV7zXJkqKPPpanKV5Q9zOD0VKgcoF\nyAuMkhuPV4IfOEbG8iiZozayk2nfRrm4+nz7b31/5Him2MEce3wbUtmWR6OPdswr\nB6K58j8TGGzOAEDTdWc9yOf/auSIBVDw+23/TbrVD3xRWdesKa4sj7rMW+3VZ1mh\n3/ghyhVPtvFcUKrAjjBjkdeMl84m+P+KcV9Ov57bojKVQdKc7kHrkpi4F66s4Z/J\nZvWHw4LyK4PRlRFzm8eKtXkYLFssxtTRYRydT4wh6VJaOQD2Ww1cPOc/D74Qr/ap\nwQu/fx1Guqk1artbE+BalJakMNKd5Cu2/MfWt8kEjNctGrAHeDmznk/TbvX2rEpv\n/P16WFcjB4bb1Nee96xfuGPUcHul3fG5TRmKJnaxWeg5FM4H4cP5jmeXyGNqdbDS\nrgqpXChenTBwS5JvAVgv8ZvxJxp4h8fLFlUOKuKUR95gB09nBGnwAtEM4zgjKkcC\nPcvDZ7YpzU40gx6QiCVb2UPtggiEp2WyIrpe8VfzK4C7pQGInLn3Rm4G7mEFacv5\nHlbGJO+2XIk3ibFJYTQvMFYc/ESeRSOw6TDoy1sg3+Yl5BXYC+90lCGR9JK/sBYs\n12eVEqxi8kmoNXJ4on0snfDuRDv/6bIIDpfPAKqZzbTq7h6wzIreoz3wx4Oa8A9V\nrtG8TOkCYaoJRYD5uV1lc6Ok3CpZrI7kTGAfvQNi+H0Obz+sSXGksNtfdwNUzUd6\np4CXrZmc/r6o3j4biteWTURnRQqkh67QM5qHJhmXuWD82sjSKU16MM0KqPze/Tl+\n+Figx8pgk29H6LM+N9Y=\n-----END
-      ENCRYPTED PRIVATE KEY-----"}'
+      ENCRYPTED PRIVATE KEY-----", "pwd": "1234", "policy": {"secret_props": {"contentType":
+      "application/x-pem-file"}, "issuer": {"name": "Self"}, "key_props": {"key_size":
+      2048, "reuse_key": false, "exportable": true, "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3357']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [8600b8b0-051c-11e7-b220-a0b3ccf7272a]
+      x-ms-client-request-id: [a8c6e01e-0816-11e7-a0f0-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/f738790eb505463c84f2b3ad34fcbc7d","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/f738790eb505463c84f2b3ad34fcbc7d","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/f738790eb505463c84f2b3ad34fcbc7d","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1489100571,"updated":1489100571},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
-        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100571,"updated":1489100571}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/dbb1edc694ac477b84589395fe11acad","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/dbb1edc694ac477b84589395fe11acad","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/dbb1edc694ac477b84589395fe11acad","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1489427906,"updated":1489427906},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
+        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427906,"updated":1489427906}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:51 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1883,29 +1855,30 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "policy": {"secret_props": {"contentType":
-      "application/x-pkcs12"}, "issuer": {"name": "Self"}, "key_props": {"reuse_key":
-      false, "key_size": 2048, "kty": "RSA", "exportable": true}}, "value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n"}'
+    body: '{"attributes": {"enabled": true}, "value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n",
+      "policy": {"secret_props": {"contentType": "application/x-pkcs12"}, "issuer":
+      {"name": "Self"}, "key_props": {"key_size": 2048, "reuse_key": false, "exportable":
+      true, "kty": "RSA"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3836']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [87211d92-051c-11e7-b40d-a0b3ccf7272a]
+      x-ms-client-request-id: [a9c5a5e4-0816-11e7-bf98-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/76a2f9f5b74d4e9eadac0dde65bd81d8","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/76a2f9f5b74d4e9eadac0dde65bd81d8","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/76a2f9f5b74d4e9eadac0dde65bd81d8","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1489100573,"updated":1489100573},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
-        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489100573,"updated":1489100573}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/36d63ef4eb6444c481180bd70b48b7f2","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/36d63ef4eb6444c481180bd70b48b7f2","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/36d63ef4eb6444c481180bd70b48b7f2","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1489427907,"updated":1489427907},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
+        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1489427907,"updated":1489427907}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2523']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:02:53 GMT']
+      Date: ['Mon, 13 Mar 2017 17:58:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]

--- a/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_key.yaml
+++ b/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_key.yaml
@@ -6,10 +6,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2338b7d2-051d-11e7-a322-a0b3ccf7272a]
+      x-ms-client-request-id: [671be78a-0814-11e7-be51-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
   response:
@@ -20,8 +20,8 @@ interactions:
       Content-Length: ['1236']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:07:15 GMT']
-      Duration: ['805909']
+      Date: ['Mon, 13 Mar 2017 17:42:18 GMT']
+      Duration: ['988287']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -29,36 +29,36 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [56zZWAq1XQXr8xK2nyB4qBeBFwYIjMGC2g7jBGLE53U=]
-      ocp-aad-session-key: [SZ-AfvM6GErjxMR-dsQYvLx3HUY9uMRrwF4rAM_46TmpnQ7pIEkfOOsL_hGyzBgiGoLUmK-wdO0URJn50yanT8LM8liG00T6fSL6MxyfNPN3WhcMJBsIq3cOv99eNRx-.FmFE3qx2aC-tfO_lbj8G3y9eOO2h8ksYOrzv8zWHMxo]
-      request-id: [556e30e4-0578-4f80-a2ef-2412cf671932]
+      ocp-aad-diagnostics-server-name: [FcRZ1kOT8fZYY1lIMA7Japlw14K1IPYlpFrpoKJj/+s=]
+      ocp-aad-session-key: [NCizG17SPUfpdqKe30O-MNfKnYHA4mRcwkfJEKfSsN8Gdn5Fhe-BkeTodana4q_6NrzkyiPYWcXgLBoV9_p3mw0T8Ax5I4--BMOy8F5YDwyCDt7uoQIA3o1Fg6hBOykT.8MpsBFG1CQ9bndV_ab4BKuud4pI5K3aJf96dcnpfCc8]
+      request-id: [28029f5b-8cf0-4d3a-b539-2da9d0d46aaa]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}, "objectId":
-      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "sku": {"family": "A", "name": "premium"}}}'
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"secrets":
+      ["all"], "certificates": ["all"], "keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore"]}}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "sku": {"name": "premium", "family": "A"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['407']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2388ffb0-051d-11e7-b993-a0b3ccf7272a]
+      x-ms-client-request-id: [6770bcd8-0814-11e7-85fc-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key?api-version=2015-06-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"secrets":["all"],"certificates":["all"],"keys":["get","create","delete","list","update","import","backup","restore"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:17 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -70,7 +70,7 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['703']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -79,10 +79,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [24d5a70c-051d-11e7-8900-a0b3ccf7272a]
+      x-ms-client-request-id: [6d8c5aba-0814-11e7-9e8d-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -90,7 +90,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Thu, 09 Mar 2017 23:07:22 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:32 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -110,10 +110,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [24d5a70c-051d-11e7-8900-a0b3ccf7272a]
+      x-ms-client-request-id: [6d8c5aba-0814-11e7-9e8d-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -122,7 +122,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['30']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:23 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -141,19 +141,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [28ce82e8-051d-11e7-ad2f-a0b3ccf7272a]
+      x-ms-client-request-id: [750e2336-0814-11e7-bfa0-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/055533553b6649deb6b33be25f3839fe","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"iupoQhIPlP_pm7Ml-k7OESUA-NVhyh9kWXU_61CWBzgXfc1nZQYqOG-WdR2rxftC9OuJ7D3GmhXRZkWMQlsSVKfnNE38NaXqkF-KzCrsftQKZMEfVDJKfTrvgsHrGnsmI4ZsKjG7EO5VEfRzv9mks3qRGuWuuLfbrL3ffXkMeWL2pAOaaqKB9h7uBC9jPZxsKZs-seDF5lFuCZwKWLhY0Xmka37IUwDrTjOtwrnyFx-mi1QC_BY1_QORUE7-053GF-iPFc6m05FO5K7vyEVvlrSUCWy7UyinbWUpZQJRWDnSVZVzsYqXpDUCDj6LDFWBbyJuGCsWYAki7JIdNueXwQ","e":"AQAB"},"attributes":{"enabled":true,"created":1489100846,"updated":1489100846,"purgedisabled":false}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/b0a78a72087a4cd2869bd78afd78245c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"x51PcisJvFlwgvDitWctjs6UAdCr08Qkv_3LkzU0K9poptaVGgQ8OqPtKzZqtSzdVxjc2WhKzYtW_iUD2F85mfsHoM4h8s8tnKVfK04liPHW7tbd4By10dUPkMkduTES4VZLnJnMl2SJPIn6MTy9I-UgxukBy_03u2JB_kss-uZyQ9pqXocxdb2LQJD6uGDKnX153dy3lmDQH_NVzgpQBZzS520fq02d8gNxSdcI1YIzMFpzvHy2qpvVjmzZ1AcO35pVFIHNKcOwxxqlclbKirLr3R8yDa43s5nEcyt87iHcHmJXjMTITRcAtfEBEMYJwLBLWXeAg-SwitoCjhPZWw","e":"AQAB"},"attributes":{"enabled":true,"created":1489426961,"updated":1489426961,"purgedisabled":false}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['642']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:26 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -171,19 +171,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [297acf62-051d-11e7-a832-a0b3ccf7272a]
+      x-ms-client-request-id: [7a9a020a-0814-11e7-8bce-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1489100846,"updated":1489100846}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1489426961,"updated":1489426961}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['165']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:25 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -195,27 +195,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"test": "foo"}, "attributes": {"enabled": false}, "key_ops":
-      ["encrypt", "decrypt"], "kty": "RSA"}'
+    body: '{"attributes": {"enabled": false}, "kty": "RSA", "tags": {"test": "foo"},
+      "key_ops": ["encrypt", "decrypt"]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [29e74a86-051d-11e7-a9bc-a0b3ccf7272a]
+      x-ms-client-request-id: [7fe29c46-0814-11e7-972c-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"6aceTxICrK4ZXt08OERN1KTCK-jPChM7FIthRlTW9DMkCl5NfdooppFiDe69Hq7LXo91l1VXrdlLqOyWhhxtaSD2sAleFjZU224sxzTF9qrdSB7b2JT7sAPHKpcfibcwhK2XvEtWZQy7aGtB-KgwHjBsEL-4Z3ZarjOA5u2EN5HqeLjTYKUNShj24yH9mjC-V9JAg3vM3IMJ3XGnOUX0Dajcde0TT6MUcRjAIH5B5jXB4kDlm0TGZN3pD2POXtundSvo3cUIOkzCVhoWHKZRuw2xjQud7UfkYeHB0vjNzK09iytW5KWjDk4blCVrzrPp9vS-TJoDNbYj5xBI1xd8WQ","e":"AQAB"},"attributes":{"enabled":false,"created":1489100846,"updated":1489100846,"purgedisabled":false},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"vJ0d2C1Qb0Z3T8v_QkOhfMuj89lmLMdRulow17kWmyMXid0YeqjmNiXYuFOVznqR0tb63gSH2Bal-4TEr9AU8sgIxvWoc641UsG5UnieDoQNYDipCDw8eOtjbTlZhBAovbnDlOkPQnunKTjZIgbmsXk3eXud2k0XKxjBUgz3r-FGWPjeSWgulrJ0QvGP4YOxFxePBByEmkKGET2sjVmRSYeRYQYSnCKeHQ6hRPEMVpG3znWE-dYFEVjIXE46Wg2CxT1MPH2VcYcjf91O2xY-H-jiZYx2GGsAk3JhtYxdCfpAqjB36OZZnSKo89gJHLCD4CwN-gizaz7VOWkefKeLZw","e":"AQAB"},"attributes":{"enabled":false,"created":1489426979,"updated":1489426979,"purgedisabled":false},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['627']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:25 GMT']
+      Date: ['Mon, 13 Mar 2017 17:42:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -233,19 +233,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2ac4bd14-051d-11e7-96df-a0b3ccf7272a]
+      x-ms-client-request-id: [85455ed2-0814-11e7-86c4-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/055533553b6649deb6b33be25f3839fe","attributes":{"enabled":true,"created":1489100846,"updated":1489100846}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","attributes":{"enabled":false,"created":1489100846,"updated":1489100846},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","attributes":{"enabled":false,"created":1489426979,"updated":1489426979},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/b0a78a72087a4cd2869bd78afd78245c","attributes":{"enabled":true,"created":1489426961,"updated":1489426961}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['392']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:26 GMT']
+      Date: ['Mon, 13 Mar 2017 17:43:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -263,19 +263,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b33b780-051d-11e7-b2b5-a0b3ccf7272a]
+      x-ms-client-request-id: [8a8911fe-0814-11e7-b512-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"6aceTxICrK4ZXt08OERN1KTCK-jPChM7FIthRlTW9DMkCl5NfdooppFiDe69Hq7LXo91l1VXrdlLqOyWhhxtaSD2sAleFjZU224sxzTF9qrdSB7b2JT7sAPHKpcfibcwhK2XvEtWZQy7aGtB-KgwHjBsEL-4Z3ZarjOA5u2EN5HqeLjTYKUNShj24yH9mjC-V9JAg3vM3IMJ3XGnOUX0Dajcde0TT6MUcRjAIH5B5jXB4kDlm0TGZN3pD2POXtundSvo3cUIOkzCVhoWHKZRuw2xjQud7UfkYeHB0vjNzK09iytW5KWjDk4blCVrzrPp9vS-TJoDNbYj5xBI1xd8WQ","e":"AQAB"},"attributes":{"enabled":false,"created":1489100846,"updated":1489100846,"purgedisabled":false},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"vJ0d2C1Qb0Z3T8v_QkOhfMuj89lmLMdRulow17kWmyMXid0YeqjmNiXYuFOVznqR0tb63gSH2Bal-4TEr9AU8sgIxvWoc641UsG5UnieDoQNYDipCDw8eOtjbTlZhBAovbnDlOkPQnunKTjZIgbmsXk3eXud2k0XKxjBUgz3r-FGWPjeSWgulrJ0QvGP4YOxFxePBByEmkKGET2sjVmRSYeRYQYSnCKeHQ6hRPEMVpG3znWE-dYFEVjIXE46Wg2CxT1MPH2VcYcjf91O2xY-H-jiZYx2GGsAk3JhtYxdCfpAqjB36OZZnSKo89gJHLCD4CwN-gizaz7VOWkefKeLZw","e":"AQAB"},"attributes":{"enabled":false,"created":1489426979,"updated":1489426979,"purgedisabled":false},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['627']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:43:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -293,19 +293,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b99431c-051d-11e7-befa-a0b3ccf7272a]
+      x-ms-client-request-id: [8fd04874-0814-11e7-853c-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/055533553b6649deb6b33be25f3839fe?api-version=2016-10-01
+    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/b0a78a72087a4cd2869bd78afd78245c?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/055533553b6649deb6b33be25f3839fe","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"iupoQhIPlP_pm7Ml-k7OESUA-NVhyh9kWXU_61CWBzgXfc1nZQYqOG-WdR2rxftC9OuJ7D3GmhXRZkWMQlsSVKfnNE38NaXqkF-KzCrsftQKZMEfVDJKfTrvgsHrGnsmI4ZsKjG7EO5VEfRzv9mks3qRGuWuuLfbrL3ffXkMeWL2pAOaaqKB9h7uBC9jPZxsKZs-seDF5lFuCZwKWLhY0Xmka37IUwDrTjOtwrnyFx-mi1QC_BY1_QORUE7-053GF-iPFc6m05FO5K7vyEVvlrSUCWy7UyinbWUpZQJRWDnSVZVzsYqXpDUCDj6LDFWBbyJuGCsWYAki7JIdNueXwQ","e":"AQAB"},"attributes":{"enabled":true,"created":1489100846,"updated":1489100846,"purgedisabled":false}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/b0a78a72087a4cd2869bd78afd78245c","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"x51PcisJvFlwgvDitWctjs6UAdCr08Qkv_3LkzU0K9poptaVGgQ8OqPtKzZqtSzdVxjc2WhKzYtW_iUD2F85mfsHoM4h8s8tnKVfK04liPHW7tbd4By10dUPkMkduTES4VZLnJnMl2SJPIn6MTy9I-UgxukBy_03u2JB_kss-uZyQ9pqXocxdb2LQJD6uGDKnX153dy3lmDQH_NVzgpQBZzS520fq02d8gNxSdcI1YIzMFpzvHy2qpvVjmzZ1AcO35pVFIHNKcOwxxqlclbKirLr3R8yDa43s5nEcyt87iHcHmJXjMTITRcAtfEBEMYJwLBLWXeAg-SwitoCjhPZWw","e":"AQAB"},"attributes":{"enabled":true,"created":1489426961,"updated":1489426961,"purgedisabled":false}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['642']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:29 GMT']
+      Date: ['Mon, 13 Mar 2017 17:43:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -324,19 +324,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['33']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2c060e80-051d-11e7-8a07-a0b3ccf7272a]
+      x-ms-client-request-id: [b3fcc266-0814-11e7-bc36-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"6aceTxICrK4ZXt08OERN1KTCK-jPChM7FIthRlTW9DMkCl5NfdooppFiDe69Hq7LXo91l1VXrdlLqOyWhhxtaSD2sAleFjZU224sxzTF9qrdSB7b2JT7sAPHKpcfibcwhK2XvEtWZQy7aGtB-KgwHjBsEL-4Z3ZarjOA5u2EN5HqeLjTYKUNShj24yH9mjC-V9JAg3vM3IMJ3XGnOUX0Dajcde0TT6MUcRjAIH5B5jXB4kDlm0TGZN3pD2POXtundSvo3cUIOkzCVhoWHKZRuw2xjQud7UfkYeHB0vjNzK09iytW5KWjDk4blCVrzrPp9vS-TJoDNbYj5xBI1xd8WQ","e":"AQAB"},"attributes":{"enabled":true,"created":1489100846,"updated":1489100850,"purgedisabled":false},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"vJ0d2C1Qb0Z3T8v_QkOhfMuj89lmLMdRulow17kWmyMXid0YeqjmNiXYuFOVznqR0tb63gSH2Bal-4TEr9AU8sgIxvWoc641UsG5UnieDoQNYDipCDw8eOtjbTlZhBAovbnDlOkPQnunKTjZIgbmsXk3eXud2k0XKxjBUgz3r-FGWPjeSWgulrJ0QvGP4YOxFxePBByEmkKGET2sjVmRSYeRYQYSnCKeHQ6hRPEMVpG3znWE-dYFEVjIXE46Wg2CxT1MPH2VcYcjf91O2xY-H-jiZYx2GGsAk3JhtYxdCfpAqjB36OZZnSKo89gJHLCD4CwN-gizaz7VOWkefKeLZw","e":"AQAB"},"attributes":{"enabled":true,"created":1489426979,"updated":1489427065,"purgedisabled":false},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['626']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:30 GMT']
+      Date: ['Mon, 13 Mar 2017 17:44:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -355,19 +355,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2c790848-051d-11e7-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [b94ff99c-0814-11e7-8382-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/backup?api-version=2016-10-01
   response:
-    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLldDTjdBYTlDY2hEMTBSRDVRWnM1Q1E2SWs4Qk5wejBpdUpJSW44UkVCS0Y3cGZKcXA4SE5ka1J6QmIwWldSaGtXcTUyTGhtemEzTnFtZllQbWU3OS1ncUc0Zl9ublJUMXJVLS1BWlJ4ZTZQUWNVZEpXS0RzMjZHeldJZ2tFQ3dWZS1YN2pyRnhSU3h6bk5QSUFXM0pjWlR6VW11ZnFuMjV0SjlQamlNMXNrTWI0MWRna3BxemdvX1ozdTJtaEEwazZJMjlCOEVNdTNpc1ZDVWQ4amJWTnhYcEo3bG41eHR0WHg0ZW4yOHd0MmtyRldQZFEzbWxRbm0teGI1LXNJMWNhZHBwaDBCNGlMVHZWTkVSQzJLYW5kcDBxU0l3UVcwRUhUTXUxMFFVQU9oc0pCTU9ycWxHcnJ5azdkTW5iNVBoMGtHajBZMTdtYWI4NnVkNXpMNnFPUS43eENVMzhFbDEtLUVIOWJjOUR4YkpRLjlXbEduSzlrSDd5dmlVbjItSEdjdE9zd2lvNHFmcHhYemZYZ2dEOEk3RlBkbHVVMXRRLTBZdzJPeGVzRkVaN3RhLXlqNmlrN0R1YXIyZmN3T2RWU2JaRDJJYk5FX0wxdkRXbWs1LTkzN1lWbVgzZWxHVkhHbF9SeVBFX1FDeTBXQXB0b1JnRmtjOXpHOFVULVRXYlkzTWYxdnlGcUphSnp0a3F5M3JaSUNWa1hPSkozVHc1WTRVaDBRV3BfRWpNZlFCNk5hZktWdHp0TDF5eFRuRWVhWjhQUmhEWVdweEdGVzV0ejhraEdTODhuZEJ1WlJ6V3lZSEJvZzNQUUZIRHlHaEVvWndqNERmSVZoRFNkTTZXamVlZVVrTmM0NTNaYmZlN3BENFhNTE5NcEJvdmxTUkFvQlZaVkFVeF9VdDlfT3hlZTlja093RUEyaVFhc1V3M0FGVW5US0w5Qjk2b2I1SUtoc3dqWTdFTURGT0hJYVlWVkNMSjNNSjR6SGV0WTc5RGdNTS1Dc2Fhekw5cEtQd2tCSmxoSWVYb3UwcjA2SEtXWGo0TFYzaWpSSmJwSkhqZDlkdkh0RUYtNzV6Q0M2WUZ5RzhRT0QtQkl2X2NXeHdkaF9UekRxZVRpdUNXcXREY2Z6RHVrOHYtV3B4VW9zMGoycmhFaTlrdHBRVlpqRUxaellXM2xySXhZdjRKelpETldoclVBX3F0bFFvay1hX3ZPdkZETTFHRmRzSjc2Y1BpNkc5SjVFOVJXT2lVM1hrWmlzemI3MXJoQklpaVE5UWRpOFVWaGFva2o5enhPS1lfSGNJcmZhVjh2eS1CNHp6Y211aTJPbng2OExaaXp5QmQwSDQ1ZTlmbDk3cFhiSjJsOHY0Z1VRb0kwVHVRLTlyYU9sXzQ4RHY1OU1XYmFXZTFHQ25idFNhbTVEenlOMmp2UDBnUG5GR3QxbUdXa3FDQmxUNjZOVWpYdTBuZDhLNUtERW1HWUVxXzF2MzctU0Y5NjhDclMzazJVeTBrdWI3cE5zby1NUlFRZ09CdzBsSVhrZm9QeUZhZnN0WDFzMUNKczNnYkVaOGM0SFZLa0otVXpwS3NRX200b3NKVm1mNXljM3JPX3M5dXJUZUp0NjlxWTJjYnEyY2ZwUnZzZlloWWJRSXRRUDUxdDk1bVVjaEFOODJKTkNPVGt6eVE5Zk1uOVNQOGdLazU5MERsSDBCQzJYNXRUSmY5VmZSdHBsVUtUeDZiNFE3SGI0XzI3azd1UnBpU2lXUFVpSVRZQXYyTVh6RHYyN1ZhdzRWckl3T0w5TVM5R3dTak5TODVkRVdBSzlnZXN1dTYwTk1PZ25zNS16WURFM0ZEWmwxUHNUNGxqdGFrNHg0eE1FZXU4eHBibWhUOXNRYzFIU2FrdVA0dUpHVWQzUDZ0Y0lCZGFja1RPN2s4RGpuRnBHdDRsZHJUd3NxQUU1TGxRcTF5Mjc0ckNKWVBjeEoyNHBLbnA5Ty1tX2FHaldIN18yZXF1aGxsOUlUdks5bmJ0X3JDdmtHbEZiQ3FtZktCNktuVE9SYzc1WFlRcFV6UVBUYlZwQjVpSU5OWlU1WXJpZFZ1U202TjA1VTY2SmxyMDh4dGlFU2RzeFAydUhyaW9GLVR3RkVjU1Z0LTFoVDU5RDhteUhFb2Y2LUNQVlRtOEtDS2ZiZGZndmVzUGpTYkhXZWRicE5oY0hzbzY2eDBnREhmWUtDaHN6VGF1cFlYdUMxa083SDR6S1J0Q2R4Nl9GMm5QTUo4b0U0YXJxbWp4WWM4WFRfbko0aEgwZUZGZzZZTEppTjFDTjltTnVlNU41c1FMWjJJSC1USjN3amVoLTZtMjkzc3dVeEV4SVVZdVFqLVBLYkNBRjY3UkE0T0wzQURGVVJDc25hV3E1VE9GV2hPZHQ3SVdVU3ZKT3VxalBJdXFmVmo4QUtHeEoxenhTSVFhVTEzME52ZVdvNlp1eDhMc2RBTXlhSkdCc2l6Q1RLajdsdy1JZ1BmdXpmLUdDUEJMZU5rcGw3MDZjTUNTdWEtMlpXUlZVblV0bmVKWDZnZ3hDS0VhWVBHejVpaUZZVkUtOGtwZTg1MjRJdFpKdTEydUNmaTdkcHdhVFl2RjdCa20xUmJwZE5oMXExOGRIYXdEM0pudVNyMXNKanR1TGt2VFo3R2tSdHA5Q0J5WmFGNGlMUldQOE5XWVktam53Q1hVeWFCSDBud0VEY3hacjgwcDlaLXh4Yl92WXdqVXc5c2UyMnZRZFQ0OTFRZUN4QVNxOHZtYU1RN3p1T0xRWDFJNXdvRkFicGxBakt3bFZHTDlpS0tPakNBek8tUW02dTlURDRtLXlXN3Z6QkRYRndxRTNLOHJHZjFBZmFrcTdBOGFFM3ozQXBRc012TU1zX1hBQ0pGdVItQ3hYVU1UOVowTFdwcjBmUm11Y3hocEs5U0ZpajJfUFFZWUtOWXljSDBHVTUwVnR5SFpPeEFiMHRvOE0zNk9HVFZRbGp0N3lsVldzcUtBck12TDkzbFVOS2d3aE5kOWV2MjhLaU1SdHY3dGtYYlFaaHczdldzRFhaMFN3ejl4Mk9MUl9NQ1lKQkxZNy1YTVdNTnRKV1FKZlFDbjBPd1JWSGZmc3lEMVNfLU1JcjEwWnp4ekJPcXc5d2lXYUgzYU5QVUNpTmg2MndENlA0dzBQNXI1QVFTUlhZcGRNQnJJX3NGMy1SX3BNZWM2SUljTTJFaU5xN0hNbHZhVWZLbkMtaGZJejR0el82ejdJLVU5dGk0UU5hdk5aQ3p0SlB3cHFGeko0R2RCRXJBRlhqMGd6c3p4RGhYQk1HVFF4UmVGN1JrSU0wQkdpVGJUSUxLdUlJeWZSRU9kZzFlY0lwa3pFc2pJQW10VkVuRjBZSFpkanhFMEpQU295UW03MXVtNGRDOF93MTd1OWFNakxlaWc1UHcxWFVJTTM5cGlUVGZ0cFBQT1p4Mk5DOElvYno0T2tuSUxEb2pBRzZDcGJCN3U2Z01MSGZ1R2RNRWRTSzdTaHpFb0tuZjNtVmFYeUtQampwa05TODh0bUl6aGRaY0g5WGszeEp6MDlmSTk3bExSMXE0Ym96RHlKek5mcl8tZEZGcFdxNUxRcDdwa3dFTVlUbnRIblh3aWsxM3N3MXZJZ2RjWm9NV2laMHBZMUhqODdtNXhsRGJDTHY3Y0dGWS1uMFk4cjlHUTRMLWNwZ1hIWFh2RVZzTmxJMDFTY0JSWUtSV1pkQTZ0VjlicGp2QXNYbWJvSllpa1RzcGFibFo1a0tXMFFOa3JadnVEOGxHTHNMd2dQMnl2TnhJX3dhd05JaWRlX2pUWVl0SldQd2NwZUpXUURFTFBqdWg2WUhGT2lDT0NDaGp5OFV2QjNvN0Q2VlpXNlRMN1pscFZiWDE3YXZjbEN6S284X0NZT1JSMEtKSm9za1dCRUpjMHQ3Rmk1N2wwRE1YZzdicVRULWkxOTNib0RVZUJSc0wySXpBUmlaTU9VOF83a08zUUY4ZGY0VF9mVTVjZVJFTUFQanpnZ0hBOUtCaG43OXRHZTFqb2ZZaFhrVTNKU2w4Vzc0MVU1b3NDZ1VONDVrc3Jndi1VMWktR29wNU1UYkJnbWhtQWduamN6NEJJaXFhUzVKaC1iYVVpUDhYZ29wdk1pRWFhNHhFWURqUHh0d3I4eE55Y0stYjM5VkMwUEVVTDU2c0J2LXExeE1DWUN0dno4LUtfUzVXMkZCY2ctNGRDSC1Va1pib1ZJT20xRVpEX2tLWUtWb2NLMzJhRUpFSFNHWHp4akZGVF95YzFxd0JNOGVBdENMTWtwZS13bGk5NUlqQ3doTTlaQ3Q0MjRnS01SbnlGYi1BbE1ITHlpVnk2UGVlb29jc1pJQi1JQUl2Wk5Za19ZVUtMREZta2hUYjB1dmVmUTN5dlpaSGkyV0loajZLcHkyckVtbVJMVVczN1BjTzl2aW5ZS0d3eDl0YnNmcTA0RVBIRnJTWmtkcDRHMmY1NTNZU2dPQUF3TUJmeE5sMmRQUVhCNGdYeFJBLTYtU3B4R04zR1FGS2VMNzJhOWR4UmhMWVJ0cXVaUUR2SGpDZUppTnJWRDl1ay1JZ2pJZnMyWWE0UTFud21oWFdrVlRwSmFPWXhXYURCX0cyOVNPS0Zra2RQQ0lKMEhfeUVIaV9wRlF5dTNHbFFmRWNiaFZYTWdRQk9VNjI0TDVBaGU2SGFSQVhxRDFjM1JIcV9Qb01QdHJTcF9UU2FjTnJ3eWtYU2JuMVp2bmQ5SEZWQWxsZUpLMllKdUJ3UkRNaHNJUWR0OE9YWEdQaXZYNlByLVJJd2l2aURLa21JMmswVFQ4LUxzSmdJNXlzRUktRkNCeEM3MVFLcXdLUmtMekI0Yzdya05PWkpTbUc0bGFGSk40bWhDOWZoUHpaUENNY3lseVA0b2d4dTR2QVEyeVA0dnVna3NqSl9IdVJWX21GMTRmODJvTzBDaXN3d2hLcVQteW55N0xzaFRVVF9wY1VzSzU1OHdCM1c4aHJWeVJYXzNyRVBMaGhQbkFIc2NadzJTQUp0THNhQ29fTmxvbVhXTXBiTFNodGtIOWVGdzdkWlU3OHV6MFZvWG5HVDdieXdPMUduZmtvSUZXdUlmLXRfSGVUZkpUYjQ4UmNIUGI4TXA1Qm1QNzN2Mk5mbUVCWkhFQmoxYWZzZ1U3UHo1Q0xmaUpzMTZqRmJOWHYwTnMwUFI0X0JOS2RKWHdWUzFnd1dmdzNhbWxmdURvQVVTVkZMWG9zQ0Z0Y0pqa3JheVkwY2phbXBQcXE4RVVCTWcwTmdVTERPTG1ZdmxBX2syc0wwSE4waUYzc3FzdkxIRzFUM2hsZlhpUWJBZDdvSnNEZlNoOTBMdzB3SWdfU1MxdzVCM0hoVTc1RzBVYlUtSVh5TFdsekJsenhFMVdtX0kya2ZyZDlFWGl2dWRGS3NRbVpjazVVbHpfOWdOcl8xemMxNTM3Z0o4WDYzNkxkTGc1QUI5RDlfU0FWdmV3WVZHNk1PUjYyaWs2cUw2SEpLOWdwNTZveWxmRHNUSzQ3Ny1Pc2tpdHRWQTNDbUNvUUdVYmh6YVN6NDNzQVZsZGxPRTFhNTM3MkQxS3U2cWd6bF82LXRJSzBleWNlRDFLSmZsSldYdWRUV1llWGktQVR6LUs5dzVueTdDckc1Y3o3a2JuNzBkYTQyVWcxQTVWVENTY3B3dm9MQThneXVYbkptN3RBMERYa09hZ3R3T2pUNV9URGR6QmpBT1R4SndUYzF1eDI4bU5fTVJhbnd1V29qYVVYTVp5WDZsbzhkX29RNnUweERuZDlXaDcySVBjb2NKOEtheFRFX3U3YWx6d3hWcV94NzZIT1ZuMVNUVERfYTViang0UlNSMHdBcEhabFEzWk84WEVpNFhaM2xhUWdUQ1Rna3pGbmVfWW0xMHBQMHMwZVhYZi1HWnR2V0NLTDFBTTJjX1czZUw4NUlnMXBkS1Q4ZTRkM2pWeHJpeUNPVHRkaU1wY3ZqQ0dwejUyVmhmdkw0SGtmdVAwbGJZTHFnek5kc2tkT3U2UjYyT3lOTEZmWHN3ZmIzVVd1OWRFU3E1TWdTaHN0bU5zVVVjTGpiSGFvQzU2TWVqTEplWWJMWGk3eGZURDFDR3lCREI2SUctbjJaeVF3MEEtam0xSUlhaW9HOGtiOGxrd1k5eHczNDA0VUpwRWNaM0RjeFhPQkh2Z2pUSU9ZeGV5WEQyQ2JqUmlfc1NpMkVBc3BkVWNqSURoeDdGRFMwMjA3VHlSdWF0Sm91ZFNmRUhqVGhjUDRFSEJuZjV1ekZURlpKMm5zVHpDdEQ3QWF6R2E3UHhyajkzdzdGS00yN3JsWmlIWUJtalFrd1VlQ2RXYkRzZ2hOakY2LW5VV0FGc01oT0FSYjlDMjBRaUExUFlkSFl2WWVXM2RxeEw0a2ZwSGV1SlBMVUZZcHZXSm5IeHN3RUpLSWZmd2tXYl8waUM1dmYxX1lRaUozT2dkR2J3Tmlaa05wMUF2MFd2ejJOb2t0bmhOZ21zd2JYbzNiaU1BQm5HdXdZN3VBdDF1aS00UF85VDkxVVJlVlBCVmhMRC1wQ1JjV0F3NDBWSWhyakJwWE8wLVgzZ0l2Y0Rxay1PNUc2c096MkFZWDNFdnNrcENGcktlUHBUSlNlbThVb1E5WnZmaHNzRTFQd25JSzFYTWwyLUh2XzFWM0tqUGhKRmV5aS1tLW5jVUpPMkZZNFRZNFJXRVBSTUEtTEVaMUVWTlAwNnktdjZyMEhVbkxNamxvemJ6dnJpci0ydG43d1BGdS1aMFE1UF9GMGVYQjh3N18xM1FIOU45b2RtbTk4ZkpzQml0WjY3TWlOaHdkRU1HYmpSRXhrcHgzemdpa3NBdV9LNEh3aFJfMjVVdXlDWURJWTNmTXpfTkNwMmpzY1AxZkFNdVE4bEFIQ3NuQ3IzSldMSmhUeC0tbE9oY2R6bEhMM2d3Z3pBSEdsbHFtc0NFaWYzVndkTnEwbW1XTHJ5Y25ONkFZYzdRQ3lmZjdfejF0Z19vNUN3Q2lheW5JcU9QSm5QWmU2bTJJRkpocWFlWkREYUFfVWlxNVlrXzVNd2FFNkZsR1FVdWd4OUlqU3ZLZUxiWllCRzNhd3R1STgtM29vS0JHVlRjX2FKWmZYSmFta0RKaDJra2NNODdyTzVyYjRKZVdlUjA4UHZvZ0pEcWlvV1FFVjNudGJsdjNkVEk2cHc4UThhX0p4anBHWExjNm1xaHBYNHJ3N18wWUtxQWphdlVlWG5BbnVrQWhWLXN2cmplbDRTME1uWHkybFVjTE1QcXktLTN4TkNvek1BbzNUZHpiNUlmTndlM2xlMXBsRGRIU1hHY2p0TmtnSkt3U3ZxWkNMUDlBVUYzd3NjM3ZWMGZ3TVJBb1EwOTB0OUlBaFczSnoxUU9mU2dEcFRBTlVaWkFLOHJQQXZ6aGJ6OThoWi1SVERocE1jemJMTU1fQlpCRzdZR2h3Y2UyektMcXlBVXNFUWVTY2M4eF9RUGtSUzBaUnlpd29ieHZ0dmJkSVNNNHJqamFfUkt2ZzZHbDNfREs4OGxSS1Y3Mlh5NExMTldZcmgyLXNYdFhpc3VWZDkyUDc1ZFJDTGhHSjhRc3FwZ0ZZVFJoN1RUbWx3MHZNZHJPYkVxRjIxc1FSRi0xV04xZUxsNWR6M0x6Q20xeHBvcEkyZWVLTmdDYnZINXpJQnZpUHB5NWwzaEtxaG1qbERmYUMyVm83eHcwRE82ZUkya0JiSVZaZEVBajFlcEtwU1NtbG9nZ0M2TGVyR2xVRk5kV0pkWWtQcV9qMlNURXZjLTI2el96WmFEOHp3NmNVTEZ1enM4Z2h6ZzJpbF9keHZub1c2Rm1FY0tleWtQNkZ3TnE4VmY2WENUaFNkWV9tTUJrSkU3NWlKekxNVHNZcGJBMHhIUUNITldGVC1JVmtLV0dFZjh4TlVDM1czUl84Y09iTzVvZ1ZfSTdnbHBqbFlUTVFsNEtvN044azFLTHdIS2gyRFhoZ0ZpLUdNVXZYX2hIWEtpa2dCYktxOTFRVEZ2SnR1ZE5SZjBER2NOMlpvLW5PNGtmMXFUVWVBU0dxUW01VzdZakNyamp5cG9mcUdjQU4tVVZxM05UaFAwcExpQk9pTi14QXpkZDdTaHc2RFV1S1ZpMXR1MjEwLXQzbks3c2hzYVdQQ3ZjVC1lc1o1bUlSSEUzMEIyM0lkc0laSXFCalhlSmpnNFh6Vkx0eDVQaURFcUt1aU5iMTc2dzFVMkF2QzhYZm05Z3dmMDN5LXVzaGNMREJod3V6NzhwN2pNZUF6d19IMFZHUGpaQmIwNUhTeEx3c3pQYjRjN2hqdllBZVNSajVUX0lvckxwMVhyWjlfeFQ4M25PVU9KY2FqeUtESERveTRUa3o4Y0x2bFVCemxmMkNHMWJhTS11YzQ5UEtMODUwWE9UUHlnUG5FSlFDU2FQWkM0V29zOTZicFNEVmZTMjJabUxkQjZnR0I2amdWa1o1Vmt5clRkOWRGYzRaQmphS3p3SF9fT2ZvY1Fhc3RWc2NIWHM4LS0yUTFiUWd0VWRkaHU4WmhoQjhVYmRPQ0k4RDlObUs1WDczVTRlci1ndkR5N3gtdklOdTE2WmI5ZzFKZXJ1MzJhakFYS0JXd0IwVlJXRWdwSXBYSmU4YXBMX2J4b0ZhMW85bGdjUlBXQUZvY1VyN2NvRUs2Qjc0ME9abzhZYmlRN3h4SnVBTTlBYnlFQXJnX1dXMGxSVFpVTTZOWXJKV3FOM25qSl85Nnp3QUVTM18tYXU4MV9vYVJKa19WSzRYeGZvZFFmam1meGl6NzllZVBmV2dzaklFdFlpUnowSWlJazZROUM1YUVVbDVTODNwY2d5YjFPb2VMcnpHbU9tMDRmTUl0dUNhNzRiYmFvb1EzUEhWaUNVdlE4MkZoLVNVM1I5bWNLTE42YnNQdnRsV1ZIOHlCXzhlUVVQakM3RmZDcnFFcWdnWkM1X3VpdjhnOHNxWHc5YUJLdmRON1JrcTJqS3AtSjZkTDN6MTdHdWJWZUdYR3hJRHpHTWRTc0t0eEJhQ3JvcFlRS2tXQ0VrZjE1MjFrNzZwelN6emktcmp6QWR6WEI2WEtkU2I5MzJvYTJ1ZWxWazR5Tm9Qc204bkNwZVIwbzhYbllKTExaZ0drMlg1eUR3YVY5RVpzMzA0T3haNDZxdDk1UFFHOU91MTZ0cnlfR2FLZHJ1LVp4V0s2R2FoeDlxN1psaW9oTF9MZllFSU1uZHRsQkg2UmZlY0E2eFdvZkNZY2xKb3Iybl83bkZtWVp2NGZmMkdMSTJPcmNfRW5BN1J1NlJoMTdMVnI1cDF0YTcwSHBkMmlEREVEeU5iNF9HVW1HdzVwaHpGQ2ZOMWQwZ2V0dElBY25EVFBpYVp4bXJkT2hZSC1EX2UwWGlQcWFQTFN6Ulk4ZEZwQWZEalBYcERlUVBYWllhTzVxYVZkazdsaFYtTWJ0RWFUeVNFSnFVNjYzYmVWS2hLaDZpUU1tN2l1WEZBMlBWdlhTeWcxUjdMYUpJN0dfX0huRldSYWNQblJPTlg3VmRQR1Atc2ZTTU55TFlUS3J2YUIzaDBTMzZ0RE9MaVF0MUpoQWt3Z1NSQUNyb3JWZVl6eDFPQmphSGZqSlpKXzN2QTZLWXZVWmRLRlNOZ2ttUGFRNkFDMi1IMUNHUXZnT0VFbTZ3V3NEOGkyMDBtNHZZTFgtQ1FuU3YyUnhBRV9pazNpaXU1LTFKRWNXVG5pZXlCaXFxZVJqSk9vVlM1UFQ4SmRtd0JnbU94VDMwQTlHaWk1OXhZaEh2cU04NnBjR19uYUpjcE9iS1A1ejNLMDljT2JlUXBFRzh0NWpBSDM4cy1CVVJ5U3QxeTlxVENPbnBHVHpvamt3YVBIVDJ1VWg3WV9yYkFlQnJWQ0d6TldWY3NpdDh0ay1SZFEya24zZTM5NzVwVGxUWWZ1UXFrXzhEVTZIZ2RQdTMyNWhNUkVZUGhTME5qNmVXVHoyd3U3akpBaEFlanZVb0k1VE5ncFJhTk5kN2FtZldTWkZxODhZRFRwd2RtQUVFYTZIMTdhM0pDQTM0MUFyVnptZUFaXzJqWkhtaTRKemFnV25WeHlFeWhRc3BkSmJabVVPQy1uQk12cDEtTGN2V3MzYjc3Nmh0UjFGWlFmLU05Q0NiZDQwY1JNWWhsSE9EOXUwbnhQaEVocEF0OHNSRk5SUjJMS09FYmVhY0NTRGRTaW5hUnpGNU1wQl81ZUk2VnlNN3ZmQTBYanBMVXZIcXpfbVQ0emFYMHRSdGstUVhJd0JzYVUwZ1lnbTc4cWN3ZFgxRllNa3hjMGtEb1lmMXhzbnNfeWo3SW9wcDlxZUhTLXRKQUM2dHh0SlBNY1JqbS1SSTVHQTZwZ0FwazVmVU95RjZrUVJUcWJNLTdCQ1JRT1MxSWdSaWJDTVdqcXFQZGJ0elM1eF9ZdDh0Vmo0cnR4SDktUUg4MjNncEgxa3R4TjlMWVNlc2phMTQzdXdPbFgySEFvRDJ2UVh0Ti1jb2xfb01ObG96b2NtMW9nNEh2OU8tYkxKODR3R3NWUmEwejBrcFN1a3J0cng2djhLZ0lhZHdBcS1CSUZvaFRPR0d0TzBZSHRBajl0WGhGZjdxd0dRaEJTZm1seXUyVUpnWlVJTW1lT0RHc3dsX1pxR3JuY0xmVzh5aFd5ZkNRQmY2OGJ0emtLMVZkUjJoejFmR0hKelVsZ3pidkxXMFd6aXZxeGU1S0Njd3ktSnN2NGFEcFJ0c3V5TGVHVEVHdzVnZkxsSFRFQ3RNcjVabHhObTVKeUQxS292OGZOVlNwX3ZFVXk5TTlVZklBZ1lYT2JQU3ZCYmJRYU5XaE1xa2F3R1NIVW5mOXk3WDVGbDhLV2M4R3RFajVENWt4UkhXMkluSjlqSGpMTG9XWEpmY1JhVWh4LXcwYXJpU09aREstXy1DTy1hSXMwTHpaODF5a1UyNmEtWUJROWpyd1hMYVNWVjd3OUIzLTlzOWdVNHhXeEFLMVJaMmxMUFp4NHRHR0ZKLVpSZ0YyQ283LUQ0RjBFT3hyeExsdUFNWVB4TFNwYkZYSmhkV3dxQU56c1ZPam5pVDdQNlhPeUdjQ3psWmFyUVRPRkpHbThqSXJtMVVnZ0ZEbExHeTBUQ1N4WTNjd293ZG80dEVKbU9wLXVWaVlwSGFJUFdMMGJQeF9EcVFhT1lKbnhCRDdEcVlYUDNnWHVQY3JGbWx6YmlPS1ZYTUlWWGhLUm1scDAxbHJEQ1h3aERSSmxDUjZ3Vnl2WGRpNmhCZC13ay1lcmxXR25Ycms1YTdURTNhTWJRaVRVNmM1VXFKN1ZHd3pJOVJjLWp6d2pHNGlFdkZUaENMYXEwNUUzdXNvUUFFZk5hYXY4UlJMYnNBTHBnVHVROUxaN0FxS2NQQS4tMFYtc1dMRm0xMXVNdEJOakx0TzRn"}'}
+    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLlNVNGJLa3NNMFo5c1ZfQ3BYb0hGbm04UXZheGdyUUpqMG1FTnlQdUkyNy1UdVR3VGsxUkM0cUx1VU1EV0dYbi05UFJ6V3lHaE9FWnhNc0lOdHRPVVVMaXhYRG5uMDF2R0dLdFVScXF5WERvVWh5MUhUQ2JFeV9LMXZ5TTZwZnhWbW5nTThRcmd4TWhRR3pDdVRxNXhleWRWSUw3M05kejRGbkNpRUFmLU5XbXJVWTB6RERoWTduaEdfa3VxYWRkT1c1aUZoQW13NWhFVV9Pc1NzNUMyU2FXSFA3WlZKMC11SXBfRWtlNlNwc3JvQjRrWURHeGNZcUdsa2ZFMjZpWXlRbkt5OWx2VzZpNVJvZFpEY2hIWE9ranVrWEJMVjBWdEd0djhZWFpYVGZLdmhYVWpYemlkMFJCUkRyMjMxQ2NTQ0lUaEJ2R2tQckpBNjloYjhTLXhnQS5UVmZSMW5zMTNZMzFjRFJ1ejhMRkNRLldhQk1vWG9HLXRDMWJWMHNVZ1JQVXJLckVlZ29nRGsxWFBiMzhPT3JmZzV3MWNNeTVkTU9YbFJmdThZNmFlTWFOckR4aVBtcHRwSzFrQjdBSGJzZ0tNNFV2QTUtZHQ4ZWZPRlhLdmxxdDYweTJJUlE5cm45dFhIYWFYN01kTnJORnBlTmpoeUJJbU5WeVBxRnhGcGdNMVg2UmpqZVp4a1FpTFJST0txQUcyRkpoV2NUSTBDLWZqNFZ5WVpveWlsajZYbjhjMHlsTnpHTzVoOUhwdlpLS2JTYVBibUQwU3B4YTZRTlhTdWRjSFRQbkpnX25GZU9JcWRJT3ptcF9HMjA1LXh5cV9qY2N3REtjaWtRU1R5eXI5bHd2ZElIcHM4Vkd5WXVTcS13M3dJZy1VR2pjaUVyVlNINGhUdVVYTEIyWG82ZkZqWDFjdkpLTF94QUU4dURyWS1QMHI1bG9XMnpSLVhSXy1WNHBlb0xiQmN5c29jS0h1amtVT1pXbnByeXgwbkN1YWFjUnBDWm9aUFpudjNqemJUdVc0aGJKcDdaZWtaaDhHRndyd19Td3lMeVcxM3BDb0l0aFlSUFJ0TVdSdkl0ZDVneGhFUHFmb1FWSjZxRm56c2l6eFZXZ1ppSmlFMHdVY3BWOVVGYjJYQUZncWl4MFUwVVUyTEJsLVZ4WkFLYndGblhfNTd0cHdVaFBsazhLZnJwQTNOVlN0VkhZVHNnOThyd19VNEpnSVdJTXR6akJOQzhJajljQmQyaXY0bzYxbDJqNHVZWUxtRlpoa25TeWNhUWVmRE4tTDd2el9Gd1hPRXM2LXoySWhrS3JwZ0xQejQ2WWkxYzY2Mzdfam5RSjFqT0ZGRjBsQU54eFlsOWZtQVRuWUM5a0ZsV2hJVjhhR3RHbTRqb1pqR0J3X2ZkX1VOTnZpbTdQZF9ZRTVkeENPYmRTWTJIVWpPNFRqZFdwcFZnT2szZGd3MzVIbXdSbWJBOXllSWFDSDhmLU54NzFHZHNVdU1OZW9zcDlQU3JRNkowQTVwOXFvaGJsZEt0ZGVCTndGNVJQck1aQlAxRjV6UWFtbWdwVmt2NDRXTXFlYkN6VThQZE1CUVlyVmNuRFNPVFNJTlRwZXN1MzhGS3h5Z211cTdfVUtCeWFCVGRNdlR3cFVza3pldnZWTl9TVlpaTVpBd1VsZTZPb3JtdG9vXzVleHdVQThHNl9ta2kyTHVyd0lMc3VGT2QtLVRwUUcwOTJVTkp1bWE4WFVkb25LU1pld2QyeVZrWW9oREpOOW40VmpwQWxnLTd3Q08wUVh3czQ2cmN1bmJwanpSN1AySXRZQ1pOTmJjc3R2V1R4d21tcXZnS3hjZG5lTWtVX0dXbGdyQmJVcmJ1cXdNSEdrc3hzR0xEZE9qSXNFWEVmOUdNYk10T0dITEVkQ0t1cjk2anFXekQ1azZCYXFiWmd1d25JbENrbkhTWGNHMXdhSUR3LTZwZk9POGhlX0FQcGh6OVdXNk1KU1FxU0laLUZqSGIwTUVRTV91QkNnbkoza0FOcVh0WndvdWtaeU5oWXRBV0N2M0lxaEFKbnBYOGZCUzFCczB6eTZNRzZCUm41X2V2bGF6dmRoOFVNMVJjTGxxOGViTS16Ty0tcWl5ZnNIb2N5SlRMTFNpSVcxb2ZHWk9DN3VrQ0dxNU1Sc1NZVmxCRU9TOWxvdkc1dG5aVm5BcXFaUC1MZ1BSalJSdFRZRjNmMktBdDZoMnB2aEJreExTWUN3bTBNZFFScHhIYXJ6WmtCYmxWb241eGVXU01objF2aEJOUThoU096RFp1cXFPS3pjem12LW14MmJQSnc0RV96dTI5VjlUbHBHOEhwS3JVMXNFcWpkN3lrbG9xQ0RKYTMzcDFmcWxBcGxnNlRZSXNyNE8wZ3JkelNKeGY4TVFTRFgzTVpsclg4dnB6bHpmWjczenRsNVlWNW5saV8wQ2R4VXdWV0VnS2lHWlZiZEoyRF81U2VScnZMMi16aUVZWVNJUXRCZTg0Z2ZPZWtwUjY1UEM0bU81SXFtXzFvX204T2xjdHd1WjNyUEpJb0dJOVZXQmFWT3BGTmZncExCek8xaVhkXzBxVzJJME9ScTZjTGl6ZGhaZzNRNVFuSjhHZEE3Sk9GOXJEazItQk5zV3NCSVVWcURiMUVscGNTaXBHb1RRR3dsYWRKODFWM1g4dlhFT29tX1NOUW9LQmxlT0tlYXVLZU1seVBKaVl6Slo5T21XdmpfdVJLVmsyLUJoSUc0SkJaUFh4QXR3MWxneDI2N096M2JWc1RIanRkTF96cG05TDVJZmg4THJKRDgtdXhOSUtpZm9EU3B6MUpvRlAzMXNtR1V1RUtzTVQ4X1VETDlJVElJVlhIbGp6eDBJbVZsQjA1RHlRZFk2dF9Wc1dmX2Y1ZGg2SlZ6cEo4Ym5nRFlZbGltTUppSUlyekRtZHl1cUU1ZmJtTldvOUk2OHF6RFAzNDJJc2pOMXZLbkpCMjlJQ1BjdEkxRFdmRWxxWF80eW5zbXczcncwNXVmRVNwSS1XeTR5TkVoc3BFMFdIdGFyTVRkbFdXbVljYldaX0E1SzZjRlBhYlN6aTNNbFJYVmVQZnQzeW5vZEtNX2ROemRZeFo2ZmF5aHRZZ3B0aHNuSXVjUElxNHVtVEItUkJxZENMMkV4LW5JeDFNMjFXaEVtUnpNLWdhZkZEMDZyVDlpenhnS1pSN05WR2Y3R09kTFpMRDhSQXpEZXdmWjBMM2Y4MzhMMXFkMWJLZnNKY1NzeGFydTEybnh4cnJqZmdMWEk1VjVZdURNUEZYdlVzRjRvVzR5Q05Denl2SVpMMzI3cVBLSm9BeG53WVhTQ0IxeE91Y296YjA4bU1ieUZHVVhIQVNxTXJ2Wk1TSUlzUTdhcGNSNnRqbjd4bFBPUFlTSTVpT1VlZ3RKdjhHcGJxcnRwRndPZ2lvOXJBV0lraWYxVlNtYy1NM3FSRW5Fak5KWWxKMFNnaWFGZ2JMeEdHR1dsV3J5cElONDB3Vm5hdG55YkxfNlM3U2FKRnZxV0VXdzhvY1lnUWVkMHYxOVR0ZVdab0dRZFZ4WVNZQnpWWkw2bHVnNktHbzN1dXU5NkhVXzBJM0ZFbk1aUkhqNV9ZMUZKcGFzRFdwOF9WTG9jUVYweVBOcUR5Rzc1dnF2YkFPQkJYNl9nRUNXNlVGZjdRSzdUaHhZUXo2MFVpWFZHOGFrcE9IVDNMWlBsd0JGR0IzT0hzMi12U0RKRTQySENSdXNqaEVKaVlnWFo3cFZ6NDVhS1p2UzlCZzVlVWJBV0RpUFZ6c3VKSkFNbVhjekV4ZXRDd045V3AtcXI2cUZ6eWt2Tm10anZkOHM4NGFweUJVSGRrYnhyMVN6S3JCNE1yQnVQeUNJR1ZXTU9XVy1TSHBoOFplbXZEMHpja2s2MHkzU0IzWXRteVVQc3RoQXE1MG1vSFBUbGNIZjZUZDFXNVFUYTNHNzhCcmU0UGlkTnVXX3ZzWlhCLXNUcjJ5bDFHWGp0Uk1MdWYtbWpXbWdwN1NiVEkyVGxxS2VUNFVDNHFiMkNfM1pVYS13NW9lbXVMeWVpVFVUTHV6TTJBeFhHVHhWTHVGbFB5Qnc2NlYwVmJZdm9rcmZhd3pVazVLOEIxMDJiaXV6OWtMZEdEczI5WGE5TkJ0RXpCWERjNkRjZlNCbHpTQm5ldGppRFNZcFlIa2RtLW5SUGNXcXV6bGhQVEhnbEd0aEFzNVhfekN5NnlHOU9vSEExUmF2Z1VRV0kwWjA3eUpkWThYVnNoOWhvSHYwVFN6WjhMT05FUEVpaVlHQ01mV0lqR21UN2Mwbm1IRFRRZ1hhcVg1ZDd5bHYwaHdHYkl2LWFKcXRNOXF4MmttaXY4ZDR1cUlOU3l4NndhTjFpaFNPb3RjVHhQNWhvRGRMR3VweGJwZHgxZ3JRZlRuNVYzZExHZU9ObFdNS3pjSUx6ZmRwZ3ZIbEN3TDJvQXZLakFHQ2dmaFNkYmtxUjRzb3NsM1hDR3lzbzdNVTJfbUN6TUZueVFodkNTeURvTGpRbzd6VWVSc1FOVldoeG9yVUJYRWFVR1dVVl9IdlJnbnU4UlFHSDh2cXNvQldfUGxRZ1FZV2hyUWZ2dWs5blpfWDN0VWhzRmFtT093R2RlRnctQ1JKNGN0QWJFbXZSakRHRVdENVhzb1JSY1FJWjRoUDc4dGxwcGpjWVdWcnMwTTAxYXJsTXhsUVFOZkRfREl3dlkzWjBOeDRXdGxvXzlpZERqX0dVX0g1YUo3V29jczZyc0hJU05WdEl1XzJCdE1RbnJnQk9BNEx0SWhrLTZ2V0JNajAtSXdfQ1dBbDhoWFQyRmw4WHhoWHZXbTgtMVU5dWJ2TXdUd0IxOVhBMkUwNDIwUHZNSUFNWVJFLVZnU3NjNUo0N0dtcTVvYjg5RFc2MUVJLXVvT29HZkVHLUFXbXpvc21pdlcyN18wRDdPTF9iQXJlNUNfMUdWTVduNWcyNlcyaVdPUjVQTWRRbVhGZC1Ma295RVl6dmo2dDZ2RVpkcjRocHNXWTdVWXdadmx3cktJUHlZX3F3OHM1dlNLZkVFcmhtOUM1ZTN3eFBwME1ONlV1dE56cU85eF9CZFBEZERrTHlMdk1WRHQwTzkyU3dPNTdmUnBNTUhYRE5OekxLMGN4aG84Z29KNC1aTEhmY2dreHQxNVdTbjJ6THNHMTFlbUpKaGF2ODFBcGZfY1dKZk1LaTF2ckF0TEltOG8weXczNXFVenF5d0hHTTRFTjFPdUNDckN5Ty1JZlc4blFBRWhsNC1UaG1JSTNpRUFwQllmc29DR09zSjFWWlRDMUdtbzZ0T09tVEh5NFlJMVUtYVRXOGNjNU9QbkQwRm1aanZ6OGpUb21RRFVUQmZzclk0WHVCaHVzMTRZNEFyNDE4SDFoVVFSa2dmNlhqME5KTFp4c0l3eHhldWJMR1RZYTlGd3d3U0diVmFMWDYwSlBIZ1Q5cnQ3QzNnZWhiUkJiMFRNdktnLVdxTUNGcjZ0Q0FNQjFFN1lfUnFVVERqN2NORURXaVR3dnZYYzZnb2t0NzllcEVCX2U5Q3dMdUpjX1Fwb2dKLVpfTHY4VU45SGtXT3FIUWVxQ3VMYVF6aDVSUkhZTlRKMFdGQXJHZHRYZ3dlQnlQdWc4TmlhQ2t6YndXc0c4aVJHWkdfZ01fVmdJSlEyLThhMFJEM0NpeXFNVzRscjVEYzdjanlubndGRDA1b0lKdHktWHpSbUpPYk43Mm9vcFd5Z3A4X1RDWXU1QThVZVlWUzhMdDItWnBGSWVmSHBsRnN2THRmbE5CUkZqU3Zfc2FlRTNTMUt4Rzd6T3FwbzNWczFnS0hnaHRmUnROTkR6V0RWd294M09FWGkxUm0wYlE4TUNKYm9jdkphcWVYRGdmTUNjWVVPN0FVN256a1lOT0FJYllYN0hUU1RLVElmQk5XaDFteldZVENXTDM2eFJTWHdrVXJDQzlzMGZidm5vRFpyd1BCdURLUDR4MThtNnR6WjBCR2p5V1VsM2EzQ3d0MlMwSWdzdFcwOVFPWFVrQzFXY0JqdGNoUy10TlRhbDdMZUkwUEdrQnBJcHdBNlBGOWhJa3FLcXVqWGRYWmljOFZJMV85dVBqMnp3cjA0V3dIdEE5aXA3T3Z3Y1lIQ0NNem5xckp4SFFrcnFFNEhvRDVMbjJEQVpZRFN0ZnlDRjRhQi1Rc2cweDlwaDV2R21zWFVUSEgxQWltRTc5R0F3QllBeWtYdVdXRFdLWTFQMFJ2RkhIVmsxdm9TVlhEbmZDZjVTLXg0T04wSXZfc2Q0Mm9RczhaMjBINXBVNVR5RndBd0tCRzVpNnhWZnlLUXlYdGxTWjNHVTRrd2pfU1V5N0ZBZ3hEMHk0YnZuZVd0VDRTemczTzBXX0M3VWtOakNRYVpVY1o3T3E2NG1zSWR1VVR3Ykdudm5hR1RtQWtGSGdjaEcxS1RMbUdvUnI3WU1KVkZ3NGFDcTR2UWJYWkxsc0QteWJEdm5uRDNOTFBsUGpETW0zTmJ3QnFKbmlLcC02cHd1dUtsel9CRnl2QU94QTNSbDdlMThrRXZjQnZxM0ZVaDdZVU51TUMxcFF2aGlhaUx0Z2RjM19Ba3huVUYwSDRxb2FRbE11N2NlcHdDNGZNNFA0d19iZmgtTGhDN1JwQ1EzTk04dXkyRlh6UzlxMTdROWM3RVp6RWNPb1VNbjRwMmwyQVNjOTlCdW1XMHVXdHVaeUFSR2lHSDgyaWpVS1VWSkRkOE9DTTBjTlo2ZzAyeGNtUWpkWlhjLTYzNUcwekxwQXdub09NT3VRRmdRbi1DWUZIY2lyRmV0a2ttczFiMGZvWlRrMHRTSFJVY0hYUlZpRTdUUDBqS2N1cXo3SGVSUHhHOTM1T3FERWJFMTFoRTRONmVFVG9FRmhZVEoyYjZMcnNFNktQeE8xLWE3SjVBU2Ztek9VOTZ3eFhxSGJuVmtFOW9MQ0JDRWZfYzFlQW1oWjJxbmozcWR5ZU81dHRxd01oUnZ0c3dFZ0xGNkxDZ21UWWpYdmNTUmdzRXVjc3gzb1QwaEU5bVkzckxXSXhRTFNiNTgyWFRZeVVCazFMQVV3WFdZbEtWZEc5WEZPLUJTTzhBdVZVWlNjYjVVRWx0OVRXbW5UUzBIdEgxanR6Tm1Icm41QVI3eDRQNG1BY2J4VXdoUXdYdlVpN1J3SGZzc0FaM2dqTlJfZUtBLXpKSGg2N2VUUHdaOGtKT2xLODJsV0pnZHFDZHpwX0U0c3l6QU90aTNaVFVjQ2VBQXBKblVRalpJcXJkWDlPRHhoUXNIay1QR1laRURtSE52d2t0bVVlR1hhRGRrLS01bzVFNzlsU05PclNhdTdTOWwwN19maG9sWjljRS16dHZjY1NxTWpiaHdzdzgyWUFNTEJheFdvSGxVT1pOdWtoQWNnNENJZXZ0aXBCQUIxTmlhWUZvcnAzWU1lOVFLbW5aM2FYWDM0N1k2bHBmRERhMVliRV9YM0ZId2k4VDVXMGFuZ2FEZHY5N0tUTVg0WlRvM3lud1ktNThQUE9ERFlFc18xWnJ2NklCSmtnYjh4Z1Q0WTFNaF9rTWxQdklpWWhfSkxkRE16OURHaFRSNFVxVDhScHZxV1dMaGV2bDM0QXdieG1VNy1WU0hlSlR2VGRMTWFWcHlpZm04eTBwREZ0eWtHUmU2WkF2MDFlQ0tja05WRU11dGwyaExCR3ZCWmlfT3RqM2JWMkZpLWxaQVFieTFDOU1OV0lmS0szLVNSUkp3NHd3eVpocnUxY2ZVNTZ0R1h6RWNONzg5V20xNXkyRXA3Yk1mOUw4OXBfaGN2TkVIZFZGa2F6U0V2LXRmcHV5TDJTTjdzTVFLeHZnRjhqVjhqTVplMUNCZERWNnNEcDd0VV9XS2l4VmtMYXM2SHdndE5WelRwbENTMHM1aUFGSkxONjZfWlJraEtwSVBHZktDVWRLTG9IODFxLWgzbkRjckI2U2c0X0xEMEU2YmdsVDYzcmtNNkZhWEMxNUNUUHlOMkN4OHUzUWZ4aHRWa0k5Y3FNNnFMR0JETGQyaW5TaG9hXzRZLXhVenoya3gxTHdQb01EOWtRWHZXQU9aek5VRC1EZHh5Yzk4V2R0S1E4bC1zRWozT3E0WUVsYlVLT2ZwRFFXSnhhU2t5aWl2LWNUbjBvMlNnZVZveU9qbzZUdjNBaUR2UEJaeWdUcElnWEx3bVpEaXlZU25raTR3Vkl4ekh6ZWVJQzdDekgxNDcxRTA2VnRkb2g0UXB0a3dPb1FyM3dVaFJ6YU4tMGZDdVFETHlhMHJvU0NKSGNKTlRIcW15a2hkcmNFQUw0YWtDeDV3UTZLUDJfNFJIN0lYVUlIY3ZCNHdWbTRnTk9oNzZGTjZaY3VYbEFKWk9SZ1kzeW5EYWE5RWhhN282bVVMck1TaUJkRVQ5TXR6VDk5YnlsanJxOUxTNDhNSk9mTk5NQXBrQ0R1dEd2NmFqT3J4LXFFWUh1OFA3enczUVVITlZOeFMzdjFBZ2tWbWctY0FTU0JzQUtjZjlueU9DMGFPRzN2NDRvdng2YmZHNXdna1QyOHJJSTFWV1VVUGUyTmFBdVlFUnRqWnNEUUgzTTdDZGtJZ19OU0NNY1dPcExWMzF3aUdFdjhzd1IyaHJaSWg1NURwOEZ0enhESWlhcEl4TmNySV94UjRXWW5qSVJKR1FicXE1Z1VYVGZqa0FTRUVvVE5teWd0WkRvZ2Vqd0Z5Z0FQLTJLY3BJeFVOZ3BId0ZvRXIyS051TWVaWE4zVExBclNadktkS1N5WHlSRVRNd0xjUm5zZzk1MUpEbHg4eDVyanlXTHRraFhoSktzTF9oMmZST0dzQTZFRUJyS1djYVpGNFA0VlhoTzByRFoxSGozYUVpa2c0YWVLYlphalNmZ0VGT0RrZVpmUnlfTndHY3dFNnJQTzQwTGR0X0QwWkNiekxGS3lranpIQWdkWHVrY1J5ODdndHhaSjE2QTNrRW55UHlqdUZWbTJsQTNaRVpLMEcwLUE3N3JvU0t5alQxWEJEMW1XNFFrdG1IVzcxNXdmVUEtS19aNUdSRktpWERLR0JQNmRZVS0wbDFNejBIN3B4dFdVcC02dlZ6YmtBZUZnUHNKNXc1Q2pCeTZLeFgtRWtrT1lLd2Q2LVgyUEtrUEVXNFRyM2FVRFczODJlRzNDbWN1d0RydC1lenlyOWJZX2Z6MVl3aEdBVGxsWTh5aWt5RDFibmZSSDZMNFRqb09qUGcxenZzN3otMno4cDg3R2hlMEFHU2J0RjFXeGFmZmY2T0tDYktaeC05S0JycWYxS21YckRpUHptR1ItNmZvbl9PY0MwV2pMT2h4b1BOclpGa3pZNGNYVU51MTFNVWhMbFlZMUFxY1pkNm9QbmxRMUdqNWhlQnVueWdQSDBIYW9XUzZYaFVZVDY4cGdzdkRnVHM2NFFGLVdpdnVVMXRYVlNLOUoxVmtXOElEUTlUYnhWZUNHcGlHR3p3ZnA4LUZfZ25sX3RCejRIZURaQUJwajk0ZHZZbDdfbDFETk55cVJ5VENMUENvUWlleUxxVkJHU2hycmZBem9RSHZZMmk0OU5icVhFYkNoZkJwUUU1eFBINDM2eGJhRVZsd09LNnJQUHlrQkVPbEItYWdFa3ZmT1d2RWpNUU11N3d2YklNdHB6aGNnLU9TbTFiVXRGNmRkaW1MeEdjRFA3ZXpsSEhiUU1yb2VfWG9EcVVoLTRXQ1lOOUR6eE90aWdlNUhvc2NGUTJTNktZdnNaUWw1dURZXzJwaW90MjJzQlItVklHbElXS1dQQXUyZnRmSDRLNktkaFRZMU9nUGE2WFJmRXUzU3BoeWx3VV9CeWFQUWV2aVBTQUxOZ3Vwc0lheFhFdmNCeGp5bFN1NWVzU1FsZUczbTZuMmpvNVpJc3E3Vy1OWDBaNzExeTRMNjR1RW9MdHBCdWwtbUc1cnhrOTJKeXpwY0dRTWV0bDlsa3RFMkxPcXRGWG1fNzhMQTJqLVlpaFRDUjVTUXZqNzBkVC1HWHZkRjhQRmkzLXl3TUJqcVBGWGQ3NHR5ZGJaTVVTOXYySUEzUXh5Si1kOEQzSF9ib2E5bEJTQ0c5TFIxUTNVMl9kQXBlQ2VPSjQtOG0waTJCalZxeGRxejA5SkNNZGkxVkZPVEhSZEdsbUNlRlQxbzJYY211RlFlYWFZcUFCWjN5SDFBWkFhVm5PdzhsRmtqMS1lQjg4enVSaUVTaDE4TWhHRWFTd0VNTDZwOXY2TlphNnpSdVFzUWR2ckVWTUI4V21tUkNXWS1MZW1NVjB6Ui13NEh6TmRsQ1cwak1OT0tJcGRJTmlIVDVzLTJLNDkxNDhLcEduQW11RjVwN2RxV3k2TlBrQzIzcE5LQVh1c05pMFc2NTNWQnoycnI4S3FlZ2Ryb1ZhanB2TnpNdkk1dU9xWTVnbnhRZ0l5Uk4zdE5YemNiN1ZuMDB6RmdZTmJ3UVNFc0ZfbHlRVkduVnBJZXhPWWpXLWpkU1ROZzJUbzRzV0pEdEtYa2ZsNkZCb0I5X0tGUndDSFd0YTBrQ1hXUllXc2RsTmdRd3paS1Vyb2s0TmJOTWtnekpnTWtMXzNhbWVnVmYtTHRSTENzMjhMeXVibm9MWDlPZXphMmhfc1RYSXlHRzFZY1laSzM5cWlieGpLM1ZLSGdDZ2loV0pfNzhQR3VHYnlSYzVhc0FjdEE2MU5tdDJJUnZxUG9JdFZsREtrT0V1Qy15bU9zd3NwS3RNRUQxcUl0STNHcHI1R3lUdFNHVU90Ynh3bWNzYXNJcDJvUkhrR2N5VXJNRE5JUXZoQ1ZSbjRZOXRPYlFoQjlPczJYOGRRWERHWlJfLTNIRFprRFpyT1c1b0x2cXA2M1hEblhldmltU1B3M0xqMkdVeUJtMUZXTzJLb3lESXhoeVZCS09OZl9hY2cyWXFzRTNyWHVTQ0N0VW11UGxMdERraTNaNkVGem9YdXpwQ3MtSTkycS0ya2txenhQeF9VYlJORl9RZGZSclAwZnMzWnNNa0E1clNpRDNSSzFEclpTaEs5ckFaY29IRkNUWkFzYThpQWY4YkxKTW91dzZiZlR4cGY1VFlJT21TX0ZGcVRLOVpSenBjTGV6Vkg5djZyZVVXNnk4QXAxTUNnZmFCUjFjNlhwU1ZxM2ItdFFqbmZpMDhycDVlYUNBRXZDUWl3b09iQWYyelluMWY4dG1heWhCME53QmdhbUVYd3FQQW01aVhrS2NWeHZyN3g1LUE5Z1JGbm9peHhSc1c3ME00bUJsZ0dsU2tVUGg2LWtPcXUySmVQQ015aXlPcDVtV3ZDZk9LWXZlMjIxMjYxSUNPS09vVzBTVEtiZVJpQ2k5U3Njd0dMbHRCdW90cE9TVzhvd3Z3TGQzbFBzWjJ2ZHpMemYxMC5FUjRDbDVnd0V1TFFwNWtBQThpY3FB"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['11716']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:30 GMT']
+      Date: ['Mon, 13 Mar 2017 17:44:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -386,19 +386,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2cee1e48-051d-11e7-85d3-a0b3ccf7272a]
+      x-ms-client-request-id: [bebba8a2-0814-11e7-bcd8-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"6aceTxICrK4ZXt08OERN1KTCK-jPChM7FIthRlTW9DMkCl5NfdooppFiDe69Hq7LXo91l1VXrdlLqOyWhhxtaSD2sAleFjZU224sxzTF9qrdSB7b2JT7sAPHKpcfibcwhK2XvEtWZQy7aGtB-KgwHjBsEL-4Z3ZarjOA5u2EN5HqeLjTYKUNShj24yH9mjC-V9JAg3vM3IMJ3XGnOUX0Dajcde0TT6MUcRjAIH5B5jXB4kDlm0TGZN3pD2POXtundSvo3cUIOkzCVhoWHKZRuw2xjQud7UfkYeHB0vjNzK09iytW5KWjDk4blCVrzrPp9vS-TJoDNbYj5xBI1xd8WQ","e":"AQAB"},"attributes":{"enabled":true,"created":1489100846,"updated":1489100850,"purgedisabled":false},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"vJ0d2C1Qb0Z3T8v_QkOhfMuj89lmLMdRulow17kWmyMXid0YeqjmNiXYuFOVznqR0tb63gSH2Bal-4TEr9AU8sgIxvWoc641UsG5UnieDoQNYDipCDw8eOtjbTlZhBAovbnDlOkPQnunKTjZIgbmsXk3eXud2k0XKxjBUgz3r-FGWPjeSWgulrJ0QvGP4YOxFxePBByEmkKGET2sjVmRSYeRYQYSnCKeHQ6hRPEMVpG3znWE-dYFEVjIXE46Wg2CxT1MPH2VcYcjf91O2xY-H-jiZYx2GGsAk3JhtYxdCfpAqjB36OZZnSKo89gJHLCD4CwN-gizaz7VOWkefKeLZw","e":"AQAB"},"attributes":{"enabled":true,"created":1489426979,"updated":1489427065,"purgedisabled":false},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['626']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:31 GMT']
+      Date: ['Mon, 13 Mar 2017 17:44:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -416,10 +416,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2d621d90-051d-11e7-9fb4-a0b3ccf7272a]
+      x-ms-client-request-id: [c402060c-0814-11e7-adaa-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -428,7 +428,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:31 GMT']
+      Date: ['Mon, 13 Mar 2017 17:44:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -440,26 +440,26 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLldDTjdBYTlDY2hEMTBSRDVRWnM1Q1E2SWs4Qk5wejBpdUpJSW44UkVCS0Y3cGZKcXA4SE5ka1J6QmIwWldSaGtXcTUyTGhtemEzTnFtZllQbWU3OS1ncUc0Zl9ublJUMXJVLS1BWlJ4ZTZQUWNVZEpXS0RzMjZHeldJZ2tFQ3dWZS1YN2pyRnhSU3h6bk5QSUFXM0pjWlR6VW11ZnFuMjV0SjlQamlNMXNrTWI0MWRna3BxemdvX1ozdTJtaEEwazZJMjlCOEVNdTNpc1ZDVWQ4amJWTnhYcEo3bG41eHR0WHg0ZW4yOHd0MmtyRldQZFEzbWxRbm0teGI1LXNJMWNhZHBwaDBCNGlMVHZWTkVSQzJLYW5kcDBxU0l3UVcwRUhUTXUxMFFVQU9oc0pCTU9ycWxHcnJ5azdkTW5iNVBoMGtHajBZMTdtYWI4NnVkNXpMNnFPUS43eENVMzhFbDEtLUVIOWJjOUR4YkpRLjlXbEduSzlrSDd5dmlVbjItSEdjdE9zd2lvNHFmcHhYemZYZ2dEOEk3RlBkbHVVMXRRLTBZdzJPeGVzRkVaN3RhLXlqNmlrN0R1YXIyZmN3T2RWU2JaRDJJYk5FX0wxdkRXbWs1LTkzN1lWbVgzZWxHVkhHbF9SeVBFX1FDeTBXQXB0b1JnRmtjOXpHOFVULVRXYlkzTWYxdnlGcUphSnp0a3F5M3JaSUNWa1hPSkozVHc1WTRVaDBRV3BfRWpNZlFCNk5hZktWdHp0TDF5eFRuRWVhWjhQUmhEWVdweEdGVzV0ejhraEdTODhuZEJ1WlJ6V3lZSEJvZzNQUUZIRHlHaEVvWndqNERmSVZoRFNkTTZXamVlZVVrTmM0NTNaYmZlN3BENFhNTE5NcEJvdmxTUkFvQlZaVkFVeF9VdDlfT3hlZTlja093RUEyaVFhc1V3M0FGVW5US0w5Qjk2b2I1SUtoc3dqWTdFTURGT0hJYVlWVkNMSjNNSjR6SGV0WTc5RGdNTS1Dc2Fhekw5cEtQd2tCSmxoSWVYb3UwcjA2SEtXWGo0TFYzaWpSSmJwSkhqZDlkdkh0RUYtNzV6Q0M2WUZ5RzhRT0QtQkl2X2NXeHdkaF9UekRxZVRpdUNXcXREY2Z6RHVrOHYtV3B4VW9zMGoycmhFaTlrdHBRVlpqRUxaellXM2xySXhZdjRKelpETldoclVBX3F0bFFvay1hX3ZPdkZETTFHRmRzSjc2Y1BpNkc5SjVFOVJXT2lVM1hrWmlzemI3MXJoQklpaVE5UWRpOFVWaGFva2o5enhPS1lfSGNJcmZhVjh2eS1CNHp6Y211aTJPbng2OExaaXp5QmQwSDQ1ZTlmbDk3cFhiSjJsOHY0Z1VRb0kwVHVRLTlyYU9sXzQ4RHY1OU1XYmFXZTFHQ25idFNhbTVEenlOMmp2UDBnUG5GR3QxbUdXa3FDQmxUNjZOVWpYdTBuZDhLNUtERW1HWUVxXzF2MzctU0Y5NjhDclMzazJVeTBrdWI3cE5zby1NUlFRZ09CdzBsSVhrZm9QeUZhZnN0WDFzMUNKczNnYkVaOGM0SFZLa0otVXpwS3NRX200b3NKVm1mNXljM3JPX3M5dXJUZUp0NjlxWTJjYnEyY2ZwUnZzZlloWWJRSXRRUDUxdDk1bVVjaEFOODJKTkNPVGt6eVE5Zk1uOVNQOGdLazU5MERsSDBCQzJYNXRUSmY5VmZSdHBsVUtUeDZiNFE3SGI0XzI3azd1UnBpU2lXUFVpSVRZQXYyTVh6RHYyN1ZhdzRWckl3T0w5TVM5R3dTak5TODVkRVdBSzlnZXN1dTYwTk1PZ25zNS16WURFM0ZEWmwxUHNUNGxqdGFrNHg0eE1FZXU4eHBibWhUOXNRYzFIU2FrdVA0dUpHVWQzUDZ0Y0lCZGFja1RPN2s4RGpuRnBHdDRsZHJUd3NxQUU1TGxRcTF5Mjc0ckNKWVBjeEoyNHBLbnA5Ty1tX2FHaldIN18yZXF1aGxsOUlUdks5bmJ0X3JDdmtHbEZiQ3FtZktCNktuVE9SYzc1WFlRcFV6UVBUYlZwQjVpSU5OWlU1WXJpZFZ1U202TjA1VTY2SmxyMDh4dGlFU2RzeFAydUhyaW9GLVR3RkVjU1Z0LTFoVDU5RDhteUhFb2Y2LUNQVlRtOEtDS2ZiZGZndmVzUGpTYkhXZWRicE5oY0hzbzY2eDBnREhmWUtDaHN6VGF1cFlYdUMxa083SDR6S1J0Q2R4Nl9GMm5QTUo4b0U0YXJxbWp4WWM4WFRfbko0aEgwZUZGZzZZTEppTjFDTjltTnVlNU41c1FMWjJJSC1USjN3amVoLTZtMjkzc3dVeEV4SVVZdVFqLVBLYkNBRjY3UkE0T0wzQURGVVJDc25hV3E1VE9GV2hPZHQ3SVdVU3ZKT3VxalBJdXFmVmo4QUtHeEoxenhTSVFhVTEzME52ZVdvNlp1eDhMc2RBTXlhSkdCc2l6Q1RLajdsdy1JZ1BmdXpmLUdDUEJMZU5rcGw3MDZjTUNTdWEtMlpXUlZVblV0bmVKWDZnZ3hDS0VhWVBHejVpaUZZVkUtOGtwZTg1MjRJdFpKdTEydUNmaTdkcHdhVFl2RjdCa20xUmJwZE5oMXExOGRIYXdEM0pudVNyMXNKanR1TGt2VFo3R2tSdHA5Q0J5WmFGNGlMUldQOE5XWVktam53Q1hVeWFCSDBud0VEY3hacjgwcDlaLXh4Yl92WXdqVXc5c2UyMnZRZFQ0OTFRZUN4QVNxOHZtYU1RN3p1T0xRWDFJNXdvRkFicGxBakt3bFZHTDlpS0tPakNBek8tUW02dTlURDRtLXlXN3Z6QkRYRndxRTNLOHJHZjFBZmFrcTdBOGFFM3ozQXBRc012TU1zX1hBQ0pGdVItQ3hYVU1UOVowTFdwcjBmUm11Y3hocEs5U0ZpajJfUFFZWUtOWXljSDBHVTUwVnR5SFpPeEFiMHRvOE0zNk9HVFZRbGp0N3lsVldzcUtBck12TDkzbFVOS2d3aE5kOWV2MjhLaU1SdHY3dGtYYlFaaHczdldzRFhaMFN3ejl4Mk9MUl9NQ1lKQkxZNy1YTVdNTnRKV1FKZlFDbjBPd1JWSGZmc3lEMVNfLU1JcjEwWnp4ekJPcXc5d2lXYUgzYU5QVUNpTmg2MndENlA0dzBQNXI1QVFTUlhZcGRNQnJJX3NGMy1SX3BNZWM2SUljTTJFaU5xN0hNbHZhVWZLbkMtaGZJejR0el82ejdJLVU5dGk0UU5hdk5aQ3p0SlB3cHFGeko0R2RCRXJBRlhqMGd6c3p4RGhYQk1HVFF4UmVGN1JrSU0wQkdpVGJUSUxLdUlJeWZSRU9kZzFlY0lwa3pFc2pJQW10VkVuRjBZSFpkanhFMEpQU295UW03MXVtNGRDOF93MTd1OWFNakxlaWc1UHcxWFVJTTM5cGlUVGZ0cFBQT1p4Mk5DOElvYno0T2tuSUxEb2pBRzZDcGJCN3U2Z01MSGZ1R2RNRWRTSzdTaHpFb0tuZjNtVmFYeUtQampwa05TODh0bUl6aGRaY0g5WGszeEp6MDlmSTk3bExSMXE0Ym96RHlKek5mcl8tZEZGcFdxNUxRcDdwa3dFTVlUbnRIblh3aWsxM3N3MXZJZ2RjWm9NV2laMHBZMUhqODdtNXhsRGJDTHY3Y0dGWS1uMFk4cjlHUTRMLWNwZ1hIWFh2RVZzTmxJMDFTY0JSWUtSV1pkQTZ0VjlicGp2QXNYbWJvSllpa1RzcGFibFo1a0tXMFFOa3JadnVEOGxHTHNMd2dQMnl2TnhJX3dhd05JaWRlX2pUWVl0SldQd2NwZUpXUURFTFBqdWg2WUhGT2lDT0NDaGp5OFV2QjNvN0Q2VlpXNlRMN1pscFZiWDE3YXZjbEN6S284X0NZT1JSMEtKSm9za1dCRUpjMHQ3Rmk1N2wwRE1YZzdicVRULWkxOTNib0RVZUJSc0wySXpBUmlaTU9VOF83a08zUUY4ZGY0VF9mVTVjZVJFTUFQanpnZ0hBOUtCaG43OXRHZTFqb2ZZaFhrVTNKU2w4Vzc0MVU1b3NDZ1VONDVrc3Jndi1VMWktR29wNU1UYkJnbWhtQWduamN6NEJJaXFhUzVKaC1iYVVpUDhYZ29wdk1pRWFhNHhFWURqUHh0d3I4eE55Y0stYjM5VkMwUEVVTDU2c0J2LXExeE1DWUN0dno4LUtfUzVXMkZCY2ctNGRDSC1Va1pib1ZJT20xRVpEX2tLWUtWb2NLMzJhRUpFSFNHWHp4akZGVF95YzFxd0JNOGVBdENMTWtwZS13bGk5NUlqQ3doTTlaQ3Q0MjRnS01SbnlGYi1BbE1ITHlpVnk2UGVlb29jc1pJQi1JQUl2Wk5Za19ZVUtMREZta2hUYjB1dmVmUTN5dlpaSGkyV0loajZLcHkyckVtbVJMVVczN1BjTzl2aW5ZS0d3eDl0YnNmcTA0RVBIRnJTWmtkcDRHMmY1NTNZU2dPQUF3TUJmeE5sMmRQUVhCNGdYeFJBLTYtU3B4R04zR1FGS2VMNzJhOWR4UmhMWVJ0cXVaUUR2SGpDZUppTnJWRDl1ay1JZ2pJZnMyWWE0UTFud21oWFdrVlRwSmFPWXhXYURCX0cyOVNPS0Zra2RQQ0lKMEhfeUVIaV9wRlF5dTNHbFFmRWNiaFZYTWdRQk9VNjI0TDVBaGU2SGFSQVhxRDFjM1JIcV9Qb01QdHJTcF9UU2FjTnJ3eWtYU2JuMVp2bmQ5SEZWQWxsZUpLMllKdUJ3UkRNaHNJUWR0OE9YWEdQaXZYNlByLVJJd2l2aURLa21JMmswVFQ4LUxzSmdJNXlzRUktRkNCeEM3MVFLcXdLUmtMekI0Yzdya05PWkpTbUc0bGFGSk40bWhDOWZoUHpaUENNY3lseVA0b2d4dTR2QVEyeVA0dnVna3NqSl9IdVJWX21GMTRmODJvTzBDaXN3d2hLcVQteW55N0xzaFRVVF9wY1VzSzU1OHdCM1c4aHJWeVJYXzNyRVBMaGhQbkFIc2NadzJTQUp0THNhQ29fTmxvbVhXTXBiTFNodGtIOWVGdzdkWlU3OHV6MFZvWG5HVDdieXdPMUduZmtvSUZXdUlmLXRfSGVUZkpUYjQ4UmNIUGI4TXA1Qm1QNzN2Mk5mbUVCWkhFQmoxYWZzZ1U3UHo1Q0xmaUpzMTZqRmJOWHYwTnMwUFI0X0JOS2RKWHdWUzFnd1dmdzNhbWxmdURvQVVTVkZMWG9zQ0Z0Y0pqa3JheVkwY2phbXBQcXE4RVVCTWcwTmdVTERPTG1ZdmxBX2syc0wwSE4waUYzc3FzdkxIRzFUM2hsZlhpUWJBZDdvSnNEZlNoOTBMdzB3SWdfU1MxdzVCM0hoVTc1RzBVYlUtSVh5TFdsekJsenhFMVdtX0kya2ZyZDlFWGl2dWRGS3NRbVpjazVVbHpfOWdOcl8xemMxNTM3Z0o4WDYzNkxkTGc1QUI5RDlfU0FWdmV3WVZHNk1PUjYyaWs2cUw2SEpLOWdwNTZveWxmRHNUSzQ3Ny1Pc2tpdHRWQTNDbUNvUUdVYmh6YVN6NDNzQVZsZGxPRTFhNTM3MkQxS3U2cWd6bF82LXRJSzBleWNlRDFLSmZsSldYdWRUV1llWGktQVR6LUs5dzVueTdDckc1Y3o3a2JuNzBkYTQyVWcxQTVWVENTY3B3dm9MQThneXVYbkptN3RBMERYa09hZ3R3T2pUNV9URGR6QmpBT1R4SndUYzF1eDI4bU5fTVJhbnd1V29qYVVYTVp5WDZsbzhkX29RNnUweERuZDlXaDcySVBjb2NKOEtheFRFX3U3YWx6d3hWcV94NzZIT1ZuMVNUVERfYTViang0UlNSMHdBcEhabFEzWk84WEVpNFhaM2xhUWdUQ1Rna3pGbmVfWW0xMHBQMHMwZVhYZi1HWnR2V0NLTDFBTTJjX1czZUw4NUlnMXBkS1Q4ZTRkM2pWeHJpeUNPVHRkaU1wY3ZqQ0dwejUyVmhmdkw0SGtmdVAwbGJZTHFnek5kc2tkT3U2UjYyT3lOTEZmWHN3ZmIzVVd1OWRFU3E1TWdTaHN0bU5zVVVjTGpiSGFvQzU2TWVqTEplWWJMWGk3eGZURDFDR3lCREI2SUctbjJaeVF3MEEtam0xSUlhaW9HOGtiOGxrd1k5eHczNDA0VUpwRWNaM0RjeFhPQkh2Z2pUSU9ZeGV5WEQyQ2JqUmlfc1NpMkVBc3BkVWNqSURoeDdGRFMwMjA3VHlSdWF0Sm91ZFNmRUhqVGhjUDRFSEJuZjV1ekZURlpKMm5zVHpDdEQ3QWF6R2E3UHhyajkzdzdGS00yN3JsWmlIWUJtalFrd1VlQ2RXYkRzZ2hOakY2LW5VV0FGc01oT0FSYjlDMjBRaUExUFlkSFl2WWVXM2RxeEw0a2ZwSGV1SlBMVUZZcHZXSm5IeHN3RUpLSWZmd2tXYl8waUM1dmYxX1lRaUozT2dkR2J3Tmlaa05wMUF2MFd2ejJOb2t0bmhOZ21zd2JYbzNiaU1BQm5HdXdZN3VBdDF1aS00UF85VDkxVVJlVlBCVmhMRC1wQ1JjV0F3NDBWSWhyakJwWE8wLVgzZ0l2Y0Rxay1PNUc2c096MkFZWDNFdnNrcENGcktlUHBUSlNlbThVb1E5WnZmaHNzRTFQd25JSzFYTWwyLUh2XzFWM0tqUGhKRmV5aS1tLW5jVUpPMkZZNFRZNFJXRVBSTUEtTEVaMUVWTlAwNnktdjZyMEhVbkxNamxvemJ6dnJpci0ydG43d1BGdS1aMFE1UF9GMGVYQjh3N18xM1FIOU45b2RtbTk4ZkpzQml0WjY3TWlOaHdkRU1HYmpSRXhrcHgzemdpa3NBdV9LNEh3aFJfMjVVdXlDWURJWTNmTXpfTkNwMmpzY1AxZkFNdVE4bEFIQ3NuQ3IzSldMSmhUeC0tbE9oY2R6bEhMM2d3Z3pBSEdsbHFtc0NFaWYzVndkTnEwbW1XTHJ5Y25ONkFZYzdRQ3lmZjdfejF0Z19vNUN3Q2lheW5JcU9QSm5QWmU2bTJJRkpocWFlWkREYUFfVWlxNVlrXzVNd2FFNkZsR1FVdWd4OUlqU3ZLZUxiWllCRzNhd3R1STgtM29vS0JHVlRjX2FKWmZYSmFta0RKaDJra2NNODdyTzVyYjRKZVdlUjA4UHZvZ0pEcWlvV1FFVjNudGJsdjNkVEk2cHc4UThhX0p4anBHWExjNm1xaHBYNHJ3N18wWUtxQWphdlVlWG5BbnVrQWhWLXN2cmplbDRTME1uWHkybFVjTE1QcXktLTN4TkNvek1BbzNUZHpiNUlmTndlM2xlMXBsRGRIU1hHY2p0TmtnSkt3U3ZxWkNMUDlBVUYzd3NjM3ZWMGZ3TVJBb1EwOTB0OUlBaFczSnoxUU9mU2dEcFRBTlVaWkFLOHJQQXZ6aGJ6OThoWi1SVERocE1jemJMTU1fQlpCRzdZR2h3Y2UyektMcXlBVXNFUWVTY2M4eF9RUGtSUzBaUnlpd29ieHZ0dmJkSVNNNHJqamFfUkt2ZzZHbDNfREs4OGxSS1Y3Mlh5NExMTldZcmgyLXNYdFhpc3VWZDkyUDc1ZFJDTGhHSjhRc3FwZ0ZZVFJoN1RUbWx3MHZNZHJPYkVxRjIxc1FSRi0xV04xZUxsNWR6M0x6Q20xeHBvcEkyZWVLTmdDYnZINXpJQnZpUHB5NWwzaEtxaG1qbERmYUMyVm83eHcwRE82ZUkya0JiSVZaZEVBajFlcEtwU1NtbG9nZ0M2TGVyR2xVRk5kV0pkWWtQcV9qMlNURXZjLTI2el96WmFEOHp3NmNVTEZ1enM4Z2h6ZzJpbF9keHZub1c2Rm1FY0tleWtQNkZ3TnE4VmY2WENUaFNkWV9tTUJrSkU3NWlKekxNVHNZcGJBMHhIUUNITldGVC1JVmtLV0dFZjh4TlVDM1czUl84Y09iTzVvZ1ZfSTdnbHBqbFlUTVFsNEtvN044azFLTHdIS2gyRFhoZ0ZpLUdNVXZYX2hIWEtpa2dCYktxOTFRVEZ2SnR1ZE5SZjBER2NOMlpvLW5PNGtmMXFUVWVBU0dxUW01VzdZakNyamp5cG9mcUdjQU4tVVZxM05UaFAwcExpQk9pTi14QXpkZDdTaHc2RFV1S1ZpMXR1MjEwLXQzbks3c2hzYVdQQ3ZjVC1lc1o1bUlSSEUzMEIyM0lkc0laSXFCalhlSmpnNFh6Vkx0eDVQaURFcUt1aU5iMTc2dzFVMkF2QzhYZm05Z3dmMDN5LXVzaGNMREJod3V6NzhwN2pNZUF6d19IMFZHUGpaQmIwNUhTeEx3c3pQYjRjN2hqdllBZVNSajVUX0lvckxwMVhyWjlfeFQ4M25PVU9KY2FqeUtESERveTRUa3o4Y0x2bFVCemxmMkNHMWJhTS11YzQ5UEtMODUwWE9UUHlnUG5FSlFDU2FQWkM0V29zOTZicFNEVmZTMjJabUxkQjZnR0I2amdWa1o1Vmt5clRkOWRGYzRaQmphS3p3SF9fT2ZvY1Fhc3RWc2NIWHM4LS0yUTFiUWd0VWRkaHU4WmhoQjhVYmRPQ0k4RDlObUs1WDczVTRlci1ndkR5N3gtdklOdTE2WmI5ZzFKZXJ1MzJhakFYS0JXd0IwVlJXRWdwSXBYSmU4YXBMX2J4b0ZhMW85bGdjUlBXQUZvY1VyN2NvRUs2Qjc0ME9abzhZYmlRN3h4SnVBTTlBYnlFQXJnX1dXMGxSVFpVTTZOWXJKV3FOM25qSl85Nnp3QUVTM18tYXU4MV9vYVJKa19WSzRYeGZvZFFmam1meGl6NzllZVBmV2dzaklFdFlpUnowSWlJazZROUM1YUVVbDVTODNwY2d5YjFPb2VMcnpHbU9tMDRmTUl0dUNhNzRiYmFvb1EzUEhWaUNVdlE4MkZoLVNVM1I5bWNLTE42YnNQdnRsV1ZIOHlCXzhlUVVQakM3RmZDcnFFcWdnWkM1X3VpdjhnOHNxWHc5YUJLdmRON1JrcTJqS3AtSjZkTDN6MTdHdWJWZUdYR3hJRHpHTWRTc0t0eEJhQ3JvcFlRS2tXQ0VrZjE1MjFrNzZwelN6emktcmp6QWR6WEI2WEtkU2I5MzJvYTJ1ZWxWazR5Tm9Qc204bkNwZVIwbzhYbllKTExaZ0drMlg1eUR3YVY5RVpzMzA0T3haNDZxdDk1UFFHOU91MTZ0cnlfR2FLZHJ1LVp4V0s2R2FoeDlxN1psaW9oTF9MZllFSU1uZHRsQkg2UmZlY0E2eFdvZkNZY2xKb3Iybl83bkZtWVp2NGZmMkdMSTJPcmNfRW5BN1J1NlJoMTdMVnI1cDF0YTcwSHBkMmlEREVEeU5iNF9HVW1HdzVwaHpGQ2ZOMWQwZ2V0dElBY25EVFBpYVp4bXJkT2hZSC1EX2UwWGlQcWFQTFN6Ulk4ZEZwQWZEalBYcERlUVBYWllhTzVxYVZkazdsaFYtTWJ0RWFUeVNFSnFVNjYzYmVWS2hLaDZpUU1tN2l1WEZBMlBWdlhTeWcxUjdMYUpJN0dfX0huRldSYWNQblJPTlg3VmRQR1Atc2ZTTU55TFlUS3J2YUIzaDBTMzZ0RE9MaVF0MUpoQWt3Z1NSQUNyb3JWZVl6eDFPQmphSGZqSlpKXzN2QTZLWXZVWmRLRlNOZ2ttUGFRNkFDMi1IMUNHUXZnT0VFbTZ3V3NEOGkyMDBtNHZZTFgtQ1FuU3YyUnhBRV9pazNpaXU1LTFKRWNXVG5pZXlCaXFxZVJqSk9vVlM1UFQ4SmRtd0JnbU94VDMwQTlHaWk1OXhZaEh2cU04NnBjR19uYUpjcE9iS1A1ejNLMDljT2JlUXBFRzh0NWpBSDM4cy1CVVJ5U3QxeTlxVENPbnBHVHpvamt3YVBIVDJ1VWg3WV9yYkFlQnJWQ0d6TldWY3NpdDh0ay1SZFEya24zZTM5NzVwVGxUWWZ1UXFrXzhEVTZIZ2RQdTMyNWhNUkVZUGhTME5qNmVXVHoyd3U3akpBaEFlanZVb0k1VE5ncFJhTk5kN2FtZldTWkZxODhZRFRwd2RtQUVFYTZIMTdhM0pDQTM0MUFyVnptZUFaXzJqWkhtaTRKemFnV25WeHlFeWhRc3BkSmJabVVPQy1uQk12cDEtTGN2V3MzYjc3Nmh0UjFGWlFmLU05Q0NiZDQwY1JNWWhsSE9EOXUwbnhQaEVocEF0OHNSRk5SUjJMS09FYmVhY0NTRGRTaW5hUnpGNU1wQl81ZUk2VnlNN3ZmQTBYanBMVXZIcXpfbVQ0emFYMHRSdGstUVhJd0JzYVUwZ1lnbTc4cWN3ZFgxRllNa3hjMGtEb1lmMXhzbnNfeWo3SW9wcDlxZUhTLXRKQUM2dHh0SlBNY1JqbS1SSTVHQTZwZ0FwazVmVU95RjZrUVJUcWJNLTdCQ1JRT1MxSWdSaWJDTVdqcXFQZGJ0elM1eF9ZdDh0Vmo0cnR4SDktUUg4MjNncEgxa3R4TjlMWVNlc2phMTQzdXdPbFgySEFvRDJ2UVh0Ti1jb2xfb01ObG96b2NtMW9nNEh2OU8tYkxKODR3R3NWUmEwejBrcFN1a3J0cng2djhLZ0lhZHdBcS1CSUZvaFRPR0d0TzBZSHRBajl0WGhGZjdxd0dRaEJTZm1seXUyVUpnWlVJTW1lT0RHc3dsX1pxR3JuY0xmVzh5aFd5ZkNRQmY2OGJ0emtLMVZkUjJoejFmR0hKelVsZ3pidkxXMFd6aXZxeGU1S0Njd3ktSnN2NGFEcFJ0c3V5TGVHVEVHdzVnZkxsSFRFQ3RNcjVabHhObTVKeUQxS292OGZOVlNwX3ZFVXk5TTlVZklBZ1lYT2JQU3ZCYmJRYU5XaE1xa2F3R1NIVW5mOXk3WDVGbDhLV2M4R3RFajVENWt4UkhXMkluSjlqSGpMTG9XWEpmY1JhVWh4LXcwYXJpU09aREstXy1DTy1hSXMwTHpaODF5a1UyNmEtWUJROWpyd1hMYVNWVjd3OUIzLTlzOWdVNHhXeEFLMVJaMmxMUFp4NHRHR0ZKLVpSZ0YyQ283LUQ0RjBFT3hyeExsdUFNWVB4TFNwYkZYSmhkV3dxQU56c1ZPam5pVDdQNlhPeUdjQ3psWmFyUVRPRkpHbThqSXJtMVVnZ0ZEbExHeTBUQ1N4WTNjd293ZG80dEVKbU9wLXVWaVlwSGFJUFdMMGJQeF9EcVFhT1lKbnhCRDdEcVlYUDNnWHVQY3JGbWx6YmlPS1ZYTUlWWGhLUm1scDAxbHJEQ1h3aERSSmxDUjZ3Vnl2WGRpNmhCZC13ay1lcmxXR25Ycms1YTdURTNhTWJRaVRVNmM1VXFKN1ZHd3pJOVJjLWp6d2pHNGlFdkZUaENMYXEwNUUzdXNvUUFFZk5hYXY4UlJMYnNBTHBnVHVROUxaN0FxS2NQQS4tMFYtc1dMRm0xMXVNdEJOakx0TzRn"}'
+    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLlNVNGJLa3NNMFo5c1ZfQ3BYb0hGbm04UXZheGdyUUpqMG1FTnlQdUkyNy1UdVR3VGsxUkM0cUx1VU1EV0dYbi05UFJ6V3lHaE9FWnhNc0lOdHRPVVVMaXhYRG5uMDF2R0dLdFVScXF5WERvVWh5MUhUQ2JFeV9LMXZ5TTZwZnhWbW5nTThRcmd4TWhRR3pDdVRxNXhleWRWSUw3M05kejRGbkNpRUFmLU5XbXJVWTB6RERoWTduaEdfa3VxYWRkT1c1aUZoQW13NWhFVV9Pc1NzNUMyU2FXSFA3WlZKMC11SXBfRWtlNlNwc3JvQjRrWURHeGNZcUdsa2ZFMjZpWXlRbkt5OWx2VzZpNVJvZFpEY2hIWE9ranVrWEJMVjBWdEd0djhZWFpYVGZLdmhYVWpYemlkMFJCUkRyMjMxQ2NTQ0lUaEJ2R2tQckpBNjloYjhTLXhnQS5UVmZSMW5zMTNZMzFjRFJ1ejhMRkNRLldhQk1vWG9HLXRDMWJWMHNVZ1JQVXJLckVlZ29nRGsxWFBiMzhPT3JmZzV3MWNNeTVkTU9YbFJmdThZNmFlTWFOckR4aVBtcHRwSzFrQjdBSGJzZ0tNNFV2QTUtZHQ4ZWZPRlhLdmxxdDYweTJJUlE5cm45dFhIYWFYN01kTnJORnBlTmpoeUJJbU5WeVBxRnhGcGdNMVg2UmpqZVp4a1FpTFJST0txQUcyRkpoV2NUSTBDLWZqNFZ5WVpveWlsajZYbjhjMHlsTnpHTzVoOUhwdlpLS2JTYVBibUQwU3B4YTZRTlhTdWRjSFRQbkpnX25GZU9JcWRJT3ptcF9HMjA1LXh5cV9qY2N3REtjaWtRU1R5eXI5bHd2ZElIcHM4Vkd5WXVTcS13M3dJZy1VR2pjaUVyVlNINGhUdVVYTEIyWG82ZkZqWDFjdkpLTF94QUU4dURyWS1QMHI1bG9XMnpSLVhSXy1WNHBlb0xiQmN5c29jS0h1amtVT1pXbnByeXgwbkN1YWFjUnBDWm9aUFpudjNqemJUdVc0aGJKcDdaZWtaaDhHRndyd19Td3lMeVcxM3BDb0l0aFlSUFJ0TVdSdkl0ZDVneGhFUHFmb1FWSjZxRm56c2l6eFZXZ1ppSmlFMHdVY3BWOVVGYjJYQUZncWl4MFUwVVUyTEJsLVZ4WkFLYndGblhfNTd0cHdVaFBsazhLZnJwQTNOVlN0VkhZVHNnOThyd19VNEpnSVdJTXR6akJOQzhJajljQmQyaXY0bzYxbDJqNHVZWUxtRlpoa25TeWNhUWVmRE4tTDd2el9Gd1hPRXM2LXoySWhrS3JwZ0xQejQ2WWkxYzY2Mzdfam5RSjFqT0ZGRjBsQU54eFlsOWZtQVRuWUM5a0ZsV2hJVjhhR3RHbTRqb1pqR0J3X2ZkX1VOTnZpbTdQZF9ZRTVkeENPYmRTWTJIVWpPNFRqZFdwcFZnT2szZGd3MzVIbXdSbWJBOXllSWFDSDhmLU54NzFHZHNVdU1OZW9zcDlQU3JRNkowQTVwOXFvaGJsZEt0ZGVCTndGNVJQck1aQlAxRjV6UWFtbWdwVmt2NDRXTXFlYkN6VThQZE1CUVlyVmNuRFNPVFNJTlRwZXN1MzhGS3h5Z211cTdfVUtCeWFCVGRNdlR3cFVza3pldnZWTl9TVlpaTVpBd1VsZTZPb3JtdG9vXzVleHdVQThHNl9ta2kyTHVyd0lMc3VGT2QtLVRwUUcwOTJVTkp1bWE4WFVkb25LU1pld2QyeVZrWW9oREpOOW40VmpwQWxnLTd3Q08wUVh3czQ2cmN1bmJwanpSN1AySXRZQ1pOTmJjc3R2V1R4d21tcXZnS3hjZG5lTWtVX0dXbGdyQmJVcmJ1cXdNSEdrc3hzR0xEZE9qSXNFWEVmOUdNYk10T0dITEVkQ0t1cjk2anFXekQ1azZCYXFiWmd1d25JbENrbkhTWGNHMXdhSUR3LTZwZk9POGhlX0FQcGh6OVdXNk1KU1FxU0laLUZqSGIwTUVRTV91QkNnbkoza0FOcVh0WndvdWtaeU5oWXRBV0N2M0lxaEFKbnBYOGZCUzFCczB6eTZNRzZCUm41X2V2bGF6dmRoOFVNMVJjTGxxOGViTS16Ty0tcWl5ZnNIb2N5SlRMTFNpSVcxb2ZHWk9DN3VrQ0dxNU1Sc1NZVmxCRU9TOWxvdkc1dG5aVm5BcXFaUC1MZ1BSalJSdFRZRjNmMktBdDZoMnB2aEJreExTWUN3bTBNZFFScHhIYXJ6WmtCYmxWb241eGVXU01objF2aEJOUThoU096RFp1cXFPS3pjem12LW14MmJQSnc0RV96dTI5VjlUbHBHOEhwS3JVMXNFcWpkN3lrbG9xQ0RKYTMzcDFmcWxBcGxnNlRZSXNyNE8wZ3JkelNKeGY4TVFTRFgzTVpsclg4dnB6bHpmWjczenRsNVlWNW5saV8wQ2R4VXdWV0VnS2lHWlZiZEoyRF81U2VScnZMMi16aUVZWVNJUXRCZTg0Z2ZPZWtwUjY1UEM0bU81SXFtXzFvX204T2xjdHd1WjNyUEpJb0dJOVZXQmFWT3BGTmZncExCek8xaVhkXzBxVzJJME9ScTZjTGl6ZGhaZzNRNVFuSjhHZEE3Sk9GOXJEazItQk5zV3NCSVVWcURiMUVscGNTaXBHb1RRR3dsYWRKODFWM1g4dlhFT29tX1NOUW9LQmxlT0tlYXVLZU1seVBKaVl6Slo5T21XdmpfdVJLVmsyLUJoSUc0SkJaUFh4QXR3MWxneDI2N096M2JWc1RIanRkTF96cG05TDVJZmg4THJKRDgtdXhOSUtpZm9EU3B6MUpvRlAzMXNtR1V1RUtzTVQ4X1VETDlJVElJVlhIbGp6eDBJbVZsQjA1RHlRZFk2dF9Wc1dmX2Y1ZGg2SlZ6cEo4Ym5nRFlZbGltTUppSUlyekRtZHl1cUU1ZmJtTldvOUk2OHF6RFAzNDJJc2pOMXZLbkpCMjlJQ1BjdEkxRFdmRWxxWF80eW5zbXczcncwNXVmRVNwSS1XeTR5TkVoc3BFMFdIdGFyTVRkbFdXbVljYldaX0E1SzZjRlBhYlN6aTNNbFJYVmVQZnQzeW5vZEtNX2ROemRZeFo2ZmF5aHRZZ3B0aHNuSXVjUElxNHVtVEItUkJxZENMMkV4LW5JeDFNMjFXaEVtUnpNLWdhZkZEMDZyVDlpenhnS1pSN05WR2Y3R09kTFpMRDhSQXpEZXdmWjBMM2Y4MzhMMXFkMWJLZnNKY1NzeGFydTEybnh4cnJqZmdMWEk1VjVZdURNUEZYdlVzRjRvVzR5Q05Denl2SVpMMzI3cVBLSm9BeG53WVhTQ0IxeE91Y296YjA4bU1ieUZHVVhIQVNxTXJ2Wk1TSUlzUTdhcGNSNnRqbjd4bFBPUFlTSTVpT1VlZ3RKdjhHcGJxcnRwRndPZ2lvOXJBV0lraWYxVlNtYy1NM3FSRW5Fak5KWWxKMFNnaWFGZ2JMeEdHR1dsV3J5cElONDB3Vm5hdG55YkxfNlM3U2FKRnZxV0VXdzhvY1lnUWVkMHYxOVR0ZVdab0dRZFZ4WVNZQnpWWkw2bHVnNktHbzN1dXU5NkhVXzBJM0ZFbk1aUkhqNV9ZMUZKcGFzRFdwOF9WTG9jUVYweVBOcUR5Rzc1dnF2YkFPQkJYNl9nRUNXNlVGZjdRSzdUaHhZUXo2MFVpWFZHOGFrcE9IVDNMWlBsd0JGR0IzT0hzMi12U0RKRTQySENSdXNqaEVKaVlnWFo3cFZ6NDVhS1p2UzlCZzVlVWJBV0RpUFZ6c3VKSkFNbVhjekV4ZXRDd045V3AtcXI2cUZ6eWt2Tm10anZkOHM4NGFweUJVSGRrYnhyMVN6S3JCNE1yQnVQeUNJR1ZXTU9XVy1TSHBoOFplbXZEMHpja2s2MHkzU0IzWXRteVVQc3RoQXE1MG1vSFBUbGNIZjZUZDFXNVFUYTNHNzhCcmU0UGlkTnVXX3ZzWlhCLXNUcjJ5bDFHWGp0Uk1MdWYtbWpXbWdwN1NiVEkyVGxxS2VUNFVDNHFiMkNfM1pVYS13NW9lbXVMeWVpVFVUTHV6TTJBeFhHVHhWTHVGbFB5Qnc2NlYwVmJZdm9rcmZhd3pVazVLOEIxMDJiaXV6OWtMZEdEczI5WGE5TkJ0RXpCWERjNkRjZlNCbHpTQm5ldGppRFNZcFlIa2RtLW5SUGNXcXV6bGhQVEhnbEd0aEFzNVhfekN5NnlHOU9vSEExUmF2Z1VRV0kwWjA3eUpkWThYVnNoOWhvSHYwVFN6WjhMT05FUEVpaVlHQ01mV0lqR21UN2Mwbm1IRFRRZ1hhcVg1ZDd5bHYwaHdHYkl2LWFKcXRNOXF4MmttaXY4ZDR1cUlOU3l4NndhTjFpaFNPb3RjVHhQNWhvRGRMR3VweGJwZHgxZ3JRZlRuNVYzZExHZU9ObFdNS3pjSUx6ZmRwZ3ZIbEN3TDJvQXZLakFHQ2dmaFNkYmtxUjRzb3NsM1hDR3lzbzdNVTJfbUN6TUZueVFodkNTeURvTGpRbzd6VWVSc1FOVldoeG9yVUJYRWFVR1dVVl9IdlJnbnU4UlFHSDh2cXNvQldfUGxRZ1FZV2hyUWZ2dWs5blpfWDN0VWhzRmFtT093R2RlRnctQ1JKNGN0QWJFbXZSakRHRVdENVhzb1JSY1FJWjRoUDc4dGxwcGpjWVdWcnMwTTAxYXJsTXhsUVFOZkRfREl3dlkzWjBOeDRXdGxvXzlpZERqX0dVX0g1YUo3V29jczZyc0hJU05WdEl1XzJCdE1RbnJnQk9BNEx0SWhrLTZ2V0JNajAtSXdfQ1dBbDhoWFQyRmw4WHhoWHZXbTgtMVU5dWJ2TXdUd0IxOVhBMkUwNDIwUHZNSUFNWVJFLVZnU3NjNUo0N0dtcTVvYjg5RFc2MUVJLXVvT29HZkVHLUFXbXpvc21pdlcyN18wRDdPTF9iQXJlNUNfMUdWTVduNWcyNlcyaVdPUjVQTWRRbVhGZC1Ma295RVl6dmo2dDZ2RVpkcjRocHNXWTdVWXdadmx3cktJUHlZX3F3OHM1dlNLZkVFcmhtOUM1ZTN3eFBwME1ONlV1dE56cU85eF9CZFBEZERrTHlMdk1WRHQwTzkyU3dPNTdmUnBNTUhYRE5OekxLMGN4aG84Z29KNC1aTEhmY2dreHQxNVdTbjJ6THNHMTFlbUpKaGF2ODFBcGZfY1dKZk1LaTF2ckF0TEltOG8weXczNXFVenF5d0hHTTRFTjFPdUNDckN5Ty1JZlc4blFBRWhsNC1UaG1JSTNpRUFwQllmc29DR09zSjFWWlRDMUdtbzZ0T09tVEh5NFlJMVUtYVRXOGNjNU9QbkQwRm1aanZ6OGpUb21RRFVUQmZzclk0WHVCaHVzMTRZNEFyNDE4SDFoVVFSa2dmNlhqME5KTFp4c0l3eHhldWJMR1RZYTlGd3d3U0diVmFMWDYwSlBIZ1Q5cnQ3QzNnZWhiUkJiMFRNdktnLVdxTUNGcjZ0Q0FNQjFFN1lfUnFVVERqN2NORURXaVR3dnZYYzZnb2t0NzllcEVCX2U5Q3dMdUpjX1Fwb2dKLVpfTHY4VU45SGtXT3FIUWVxQ3VMYVF6aDVSUkhZTlRKMFdGQXJHZHRYZ3dlQnlQdWc4TmlhQ2t6YndXc0c4aVJHWkdfZ01fVmdJSlEyLThhMFJEM0NpeXFNVzRscjVEYzdjanlubndGRDA1b0lKdHktWHpSbUpPYk43Mm9vcFd5Z3A4X1RDWXU1QThVZVlWUzhMdDItWnBGSWVmSHBsRnN2THRmbE5CUkZqU3Zfc2FlRTNTMUt4Rzd6T3FwbzNWczFnS0hnaHRmUnROTkR6V0RWd294M09FWGkxUm0wYlE4TUNKYm9jdkphcWVYRGdmTUNjWVVPN0FVN256a1lOT0FJYllYN0hUU1RLVElmQk5XaDFteldZVENXTDM2eFJTWHdrVXJDQzlzMGZidm5vRFpyd1BCdURLUDR4MThtNnR6WjBCR2p5V1VsM2EzQ3d0MlMwSWdzdFcwOVFPWFVrQzFXY0JqdGNoUy10TlRhbDdMZUkwUEdrQnBJcHdBNlBGOWhJa3FLcXVqWGRYWmljOFZJMV85dVBqMnp3cjA0V3dIdEE5aXA3T3Z3Y1lIQ0NNem5xckp4SFFrcnFFNEhvRDVMbjJEQVpZRFN0ZnlDRjRhQi1Rc2cweDlwaDV2R21zWFVUSEgxQWltRTc5R0F3QllBeWtYdVdXRFdLWTFQMFJ2RkhIVmsxdm9TVlhEbmZDZjVTLXg0T04wSXZfc2Q0Mm9RczhaMjBINXBVNVR5RndBd0tCRzVpNnhWZnlLUXlYdGxTWjNHVTRrd2pfU1V5N0ZBZ3hEMHk0YnZuZVd0VDRTemczTzBXX0M3VWtOakNRYVpVY1o3T3E2NG1zSWR1VVR3Ykdudm5hR1RtQWtGSGdjaEcxS1RMbUdvUnI3WU1KVkZ3NGFDcTR2UWJYWkxsc0QteWJEdm5uRDNOTFBsUGpETW0zTmJ3QnFKbmlLcC02cHd1dUtsel9CRnl2QU94QTNSbDdlMThrRXZjQnZxM0ZVaDdZVU51TUMxcFF2aGlhaUx0Z2RjM19Ba3huVUYwSDRxb2FRbE11N2NlcHdDNGZNNFA0d19iZmgtTGhDN1JwQ1EzTk04dXkyRlh6UzlxMTdROWM3RVp6RWNPb1VNbjRwMmwyQVNjOTlCdW1XMHVXdHVaeUFSR2lHSDgyaWpVS1VWSkRkOE9DTTBjTlo2ZzAyeGNtUWpkWlhjLTYzNUcwekxwQXdub09NT3VRRmdRbi1DWUZIY2lyRmV0a2ttczFiMGZvWlRrMHRTSFJVY0hYUlZpRTdUUDBqS2N1cXo3SGVSUHhHOTM1T3FERWJFMTFoRTRONmVFVG9FRmhZVEoyYjZMcnNFNktQeE8xLWE3SjVBU2Ztek9VOTZ3eFhxSGJuVmtFOW9MQ0JDRWZfYzFlQW1oWjJxbmozcWR5ZU81dHRxd01oUnZ0c3dFZ0xGNkxDZ21UWWpYdmNTUmdzRXVjc3gzb1QwaEU5bVkzckxXSXhRTFNiNTgyWFRZeVVCazFMQVV3WFdZbEtWZEc5WEZPLUJTTzhBdVZVWlNjYjVVRWx0OVRXbW5UUzBIdEgxanR6Tm1Icm41QVI3eDRQNG1BY2J4VXdoUXdYdlVpN1J3SGZzc0FaM2dqTlJfZUtBLXpKSGg2N2VUUHdaOGtKT2xLODJsV0pnZHFDZHpwX0U0c3l6QU90aTNaVFVjQ2VBQXBKblVRalpJcXJkWDlPRHhoUXNIay1QR1laRURtSE52d2t0bVVlR1hhRGRrLS01bzVFNzlsU05PclNhdTdTOWwwN19maG9sWjljRS16dHZjY1NxTWpiaHdzdzgyWUFNTEJheFdvSGxVT1pOdWtoQWNnNENJZXZ0aXBCQUIxTmlhWUZvcnAzWU1lOVFLbW5aM2FYWDM0N1k2bHBmRERhMVliRV9YM0ZId2k4VDVXMGFuZ2FEZHY5N0tUTVg0WlRvM3lud1ktNThQUE9ERFlFc18xWnJ2NklCSmtnYjh4Z1Q0WTFNaF9rTWxQdklpWWhfSkxkRE16OURHaFRSNFVxVDhScHZxV1dMaGV2bDM0QXdieG1VNy1WU0hlSlR2VGRMTWFWcHlpZm04eTBwREZ0eWtHUmU2WkF2MDFlQ0tja05WRU11dGwyaExCR3ZCWmlfT3RqM2JWMkZpLWxaQVFieTFDOU1OV0lmS0szLVNSUkp3NHd3eVpocnUxY2ZVNTZ0R1h6RWNONzg5V20xNXkyRXA3Yk1mOUw4OXBfaGN2TkVIZFZGa2F6U0V2LXRmcHV5TDJTTjdzTVFLeHZnRjhqVjhqTVplMUNCZERWNnNEcDd0VV9XS2l4VmtMYXM2SHdndE5WelRwbENTMHM1aUFGSkxONjZfWlJraEtwSVBHZktDVWRLTG9IODFxLWgzbkRjckI2U2c0X0xEMEU2YmdsVDYzcmtNNkZhWEMxNUNUUHlOMkN4OHUzUWZ4aHRWa0k5Y3FNNnFMR0JETGQyaW5TaG9hXzRZLXhVenoya3gxTHdQb01EOWtRWHZXQU9aek5VRC1EZHh5Yzk4V2R0S1E4bC1zRWozT3E0WUVsYlVLT2ZwRFFXSnhhU2t5aWl2LWNUbjBvMlNnZVZveU9qbzZUdjNBaUR2UEJaeWdUcElnWEx3bVpEaXlZU25raTR3Vkl4ekh6ZWVJQzdDekgxNDcxRTA2VnRkb2g0UXB0a3dPb1FyM3dVaFJ6YU4tMGZDdVFETHlhMHJvU0NKSGNKTlRIcW15a2hkcmNFQUw0YWtDeDV3UTZLUDJfNFJIN0lYVUlIY3ZCNHdWbTRnTk9oNzZGTjZaY3VYbEFKWk9SZ1kzeW5EYWE5RWhhN282bVVMck1TaUJkRVQ5TXR6VDk5YnlsanJxOUxTNDhNSk9mTk5NQXBrQ0R1dEd2NmFqT3J4LXFFWUh1OFA3enczUVVITlZOeFMzdjFBZ2tWbWctY0FTU0JzQUtjZjlueU9DMGFPRzN2NDRvdng2YmZHNXdna1QyOHJJSTFWV1VVUGUyTmFBdVlFUnRqWnNEUUgzTTdDZGtJZ19OU0NNY1dPcExWMzF3aUdFdjhzd1IyaHJaSWg1NURwOEZ0enhESWlhcEl4TmNySV94UjRXWW5qSVJKR1FicXE1Z1VYVGZqa0FTRUVvVE5teWd0WkRvZ2Vqd0Z5Z0FQLTJLY3BJeFVOZ3BId0ZvRXIyS051TWVaWE4zVExBclNadktkS1N5WHlSRVRNd0xjUm5zZzk1MUpEbHg4eDVyanlXTHRraFhoSktzTF9oMmZST0dzQTZFRUJyS1djYVpGNFA0VlhoTzByRFoxSGozYUVpa2c0YWVLYlphalNmZ0VGT0RrZVpmUnlfTndHY3dFNnJQTzQwTGR0X0QwWkNiekxGS3lranpIQWdkWHVrY1J5ODdndHhaSjE2QTNrRW55UHlqdUZWbTJsQTNaRVpLMEcwLUE3N3JvU0t5alQxWEJEMW1XNFFrdG1IVzcxNXdmVUEtS19aNUdSRktpWERLR0JQNmRZVS0wbDFNejBIN3B4dFdVcC02dlZ6YmtBZUZnUHNKNXc1Q2pCeTZLeFgtRWtrT1lLd2Q2LVgyUEtrUEVXNFRyM2FVRFczODJlRzNDbWN1d0RydC1lenlyOWJZX2Z6MVl3aEdBVGxsWTh5aWt5RDFibmZSSDZMNFRqb09qUGcxenZzN3otMno4cDg3R2hlMEFHU2J0RjFXeGFmZmY2T0tDYktaeC05S0JycWYxS21YckRpUHptR1ItNmZvbl9PY0MwV2pMT2h4b1BOclpGa3pZNGNYVU51MTFNVWhMbFlZMUFxY1pkNm9QbmxRMUdqNWhlQnVueWdQSDBIYW9XUzZYaFVZVDY4cGdzdkRnVHM2NFFGLVdpdnVVMXRYVlNLOUoxVmtXOElEUTlUYnhWZUNHcGlHR3p3ZnA4LUZfZ25sX3RCejRIZURaQUJwajk0ZHZZbDdfbDFETk55cVJ5VENMUENvUWlleUxxVkJHU2hycmZBem9RSHZZMmk0OU5icVhFYkNoZkJwUUU1eFBINDM2eGJhRVZsd09LNnJQUHlrQkVPbEItYWdFa3ZmT1d2RWpNUU11N3d2YklNdHB6aGNnLU9TbTFiVXRGNmRkaW1MeEdjRFA3ZXpsSEhiUU1yb2VfWG9EcVVoLTRXQ1lOOUR6eE90aWdlNUhvc2NGUTJTNktZdnNaUWw1dURZXzJwaW90MjJzQlItVklHbElXS1dQQXUyZnRmSDRLNktkaFRZMU9nUGE2WFJmRXUzU3BoeWx3VV9CeWFQUWV2aVBTQUxOZ3Vwc0lheFhFdmNCeGp5bFN1NWVzU1FsZUczbTZuMmpvNVpJc3E3Vy1OWDBaNzExeTRMNjR1RW9MdHBCdWwtbUc1cnhrOTJKeXpwY0dRTWV0bDlsa3RFMkxPcXRGWG1fNzhMQTJqLVlpaFRDUjVTUXZqNzBkVC1HWHZkRjhQRmkzLXl3TUJqcVBGWGQ3NHR5ZGJaTVVTOXYySUEzUXh5Si1kOEQzSF9ib2E5bEJTQ0c5TFIxUTNVMl9kQXBlQ2VPSjQtOG0waTJCalZxeGRxejA5SkNNZGkxVkZPVEhSZEdsbUNlRlQxbzJYY211RlFlYWFZcUFCWjN5SDFBWkFhVm5PdzhsRmtqMS1lQjg4enVSaUVTaDE4TWhHRWFTd0VNTDZwOXY2TlphNnpSdVFzUWR2ckVWTUI4V21tUkNXWS1MZW1NVjB6Ui13NEh6TmRsQ1cwak1OT0tJcGRJTmlIVDVzLTJLNDkxNDhLcEduQW11RjVwN2RxV3k2TlBrQzIzcE5LQVh1c05pMFc2NTNWQnoycnI4S3FlZ2Ryb1ZhanB2TnpNdkk1dU9xWTVnbnhRZ0l5Uk4zdE5YemNiN1ZuMDB6RmdZTmJ3UVNFc0ZfbHlRVkduVnBJZXhPWWpXLWpkU1ROZzJUbzRzV0pEdEtYa2ZsNkZCb0I5X0tGUndDSFd0YTBrQ1hXUllXc2RsTmdRd3paS1Vyb2s0TmJOTWtnekpnTWtMXzNhbWVnVmYtTHRSTENzMjhMeXVibm9MWDlPZXphMmhfc1RYSXlHRzFZY1laSzM5cWlieGpLM1ZLSGdDZ2loV0pfNzhQR3VHYnlSYzVhc0FjdEE2MU5tdDJJUnZxUG9JdFZsREtrT0V1Qy15bU9zd3NwS3RNRUQxcUl0STNHcHI1R3lUdFNHVU90Ynh3bWNzYXNJcDJvUkhrR2N5VXJNRE5JUXZoQ1ZSbjRZOXRPYlFoQjlPczJYOGRRWERHWlJfLTNIRFprRFpyT1c1b0x2cXA2M1hEblhldmltU1B3M0xqMkdVeUJtMUZXTzJLb3lESXhoeVZCS09OZl9hY2cyWXFzRTNyWHVTQ0N0VW11UGxMdERraTNaNkVGem9YdXpwQ3MtSTkycS0ya2txenhQeF9VYlJORl9RZGZSclAwZnMzWnNNa0E1clNpRDNSSzFEclpTaEs5ckFaY29IRkNUWkFzYThpQWY4YkxKTW91dzZiZlR4cGY1VFlJT21TX0ZGcVRLOVpSenBjTGV6Vkg5djZyZVVXNnk4QXAxTUNnZmFCUjFjNlhwU1ZxM2ItdFFqbmZpMDhycDVlYUNBRXZDUWl3b09iQWYyelluMWY4dG1heWhCME53QmdhbUVYd3FQQW01aVhrS2NWeHZyN3g1LUE5Z1JGbm9peHhSc1c3ME00bUJsZ0dsU2tVUGg2LWtPcXUySmVQQ015aXlPcDVtV3ZDZk9LWXZlMjIxMjYxSUNPS09vVzBTVEtiZVJpQ2k5U3Njd0dMbHRCdW90cE9TVzhvd3Z3TGQzbFBzWjJ2ZHpMemYxMC5FUjRDbDVnd0V1TFFwNWtBQThpY3FB"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['11717']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2dca6794-051d-11e7-90f7-a0b3ccf7272a]
+      x-ms-client-request-id: [c947d4f4-0814-11e7-a352-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/restore?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"6aceTxICrK4ZXt08OERN1KTCK-jPChM7FIthRlTW9DMkCl5NfdooppFiDe69Hq7LXo91l1VXrdlLqOyWhhxtaSD2sAleFjZU224sxzTF9qrdSB7b2JT7sAPHKpcfibcwhK2XvEtWZQy7aGtB-KgwHjBsEL-4Z3ZarjOA5u2EN5HqeLjTYKUNShj24yH9mjC-V9JAg3vM3IMJ3XGnOUX0Dajcde0TT6MUcRjAIH5B5jXB4kDlm0TGZN3pD2POXtundSvo3cUIOkzCVhoWHKZRuw2xjQud7UfkYeHB0vjNzK09iytW5KWjDk4blCVrzrPp9vS-TJoDNbYj5xBI1xd8WQ","e":"AQAB"},"attributes":{"enabled":true,"created":1489100846,"updated":1489100850,"purgedisabled":false},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"vJ0d2C1Qb0Z3T8v_QkOhfMuj89lmLMdRulow17kWmyMXid0YeqjmNiXYuFOVznqR0tb63gSH2Bal-4TEr9AU8sgIxvWoc641UsG5UnieDoQNYDipCDw8eOtjbTlZhBAovbnDlOkPQnunKTjZIgbmsXk3eXud2k0XKxjBUgz3r-FGWPjeSWgulrJ0QvGP4YOxFxePBByEmkKGET2sjVmRSYeRYQYSnCKeHQ6hRPEMVpG3znWE-dYFEVjIXE46Wg2CxT1MPH2VcYcjf91O2xY-H-jiZYx2GGsAk3JhtYxdCfpAqjB36OZZnSKo89gJHLCD4CwN-gizaz7VOWkefKeLZw","e":"AQAB"},"attributes":{"enabled":true,"created":1489426979,"updated":1489427065,"purgedisabled":false},"tags":{"test":"foo"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['626']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:32 GMT']
+      Date: ['Mon, 13 Mar 2017 17:45:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -477,19 +477,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e608054-051d-11e7-9b47-a0b3ccf7272a]
+      x-ms-client-request-id: [ce943b02-0814-11e7-8711-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/055533553b6649deb6b33be25f3839fe","attributes":{"enabled":true,"created":1489100846,"updated":1489100846}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/456ec2c169714536b00bf1029db70022","attributes":{"enabled":true,"created":1489100846,"updated":1489100850},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/08fb29a7e222497e8fd8c3781a68c6e8","attributes":{"enabled":true,"created":1489426979,"updated":1489427065},"tags":{"test":"foo"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/b0a78a72087a4cd2869bd78afd78245c","attributes":{"enabled":true,"created":1489426961,"updated":1489426961}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['391']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:33 GMT']
+      Date: ['Mon, 13 Mar 2017 17:45:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -501,13 +501,13 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "key": {"dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
+    body: '{"attributes": {"enabled": true}, "key": {"q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
+      "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1",
       "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
-      "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0",
-      "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
-      "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
-      "e": "AQAB", "q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
-      "kty": "RSA", "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1"},
+      "dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
+      "e": "AQAB", "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
+      "kty": "RSA", "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
+      "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0"},
       "Hsm": false}'
     headers:
       Accept: [application/json]
@@ -515,19 +515,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['926']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f10550a-051d-11e7-9e4e-a0b3ccf7272a]
+      x-ms-client-request-id: [d3f5434a-0814-11e7-a3a6-a0b3ccf7272a]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/8a131ab3da8b4911a042c1b1ce963ad7","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1489100855,"updated":1489100855,"purgedisabled":false}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/24f44e60ad4b4bc7b5f419eefac157dd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1489427120,"updated":1489427120,"purgedisabled":false}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['484']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:35 GMT']
+      Date: ['Mon, 13 Mar 2017 17:45:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -539,13 +539,13 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "key": {"dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
+    body: '{"attributes": {"enabled": true}, "key": {"q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
+      "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE",
       "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
-      "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL",
-      "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
-      "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
-      "e": "AQAB", "q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
-      "kty": "RSA", "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE"},
+      "dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
+      "e": "AQAB", "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
+      "kty": "RSA", "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
+      "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL"},
       "Hsm": false}'
     headers:
       Accept: [application/json]
@@ -553,19 +553,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['1693']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2fbc1c68-051d-11e7-8e85-a0b3ccf7272a]
+      x-ms-client-request-id: [d93d6350-0814-11e7-af81-a0b3ccf7272a]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/1a5c3af4b1b24616acfd65dd906f55c5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1489100856,"updated":1489100856,"purgedisabled":false}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/b75cc5237ffa4d9fb782945508df8ab9","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1489427130,"updated":1489427130,"purgedisabled":false}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['659']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:36 GMT']
+      Date: ['Mon, 13 Mar 2017 17:45:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -577,28 +577,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "key": {"kty": "RSA-HSM", "key_hsm":
-      "QBlUZW5hbnRHZW5lcmF0ZWRLZXlEZXRhaWxzCQFpKWh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlQA1TY2hlbWFWZXJzaW9uiQJADFRlbmFudEJwb3NJZJkgMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTBAB1ZhdWx0SWSBQAdLZXlCbG9ioM0RQAtCWU9LS2V5QmxvYgkBaSlodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZUAMS2V5VG9rZW5UeXBlmRRuQ29yZUtleVByb3RlY3RlZEtleUAYU2VjdXJpdHlXb3JsZEVudmlyb25tZW50mQpQcm9kdWN0aW9uQBRTZWN1cml0eVdvcmxkVmVyc2lvbpkoZThkMzIzZjdjYTk1OTRkNDk2M2ViYjJkMmI0NDU1Yjc5YzYwNjA4NEAIS2V5VG9rZW6gLxBuQ2lwaGVyIEtNIGRhdGFmaWxlAAAAAABuDBFYDQAAAAkAAAAEAAAAeGZlcggAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAGUAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAMwAAAAUAAAA0Cuga_VfEgfw7SAUKjFvt8MYOxvIAAAAqAQAAAkAAACEBAAAhAQAAAABAAB0gG6diDcaCBCbyLYaRDnz7LwLxz5w58hi18n0tnX9DpYY2NikXNEh3mtijUh2FmiaKjsBhfdlvA_9ijQkLmnvoUEG-UJ8b-s8XBxl3jca06eefYOrjbcfVWuZ_ZiiT8FSNsmE62u70nS9H6Rb05q-xHEhgF_MYa6qBwx5wBjccsK-pxw4Jli7Vhck4UCecbjmJNtvs3eo5gCY0QMtVcKRrXrjL7BLbil9ttue645coCL1CdfaAMnqyn_On8WhTmF_y--Gsh2cVqUKAvKgIcfAB6qNfF_VfYglcwUJfpMgHkqQsLCncAucDXTzD3dGFpXWxDRZzZMlR3guq80Zqv2nrbQMPWUfclHBcEOYcEAN5osbvxmCbeVJTAD1jegPO7pxcRFJW3BhOKJ1519JDzPlBeTnEP3nQkDvD5DaDm3dcvnLctQTARKfx32kbTusDwntrGbgrQGoXfe-McQPufr8xG_ooNaGLwdu9Q415h0BLWfmTOhUWguNP_dJ-KvXGJfl-8uxZCdc6vQ9v6TLEWCuvhOtVSusoIr82NJqSLGWefEBsUgmd7HZZ9iTvwYdxaK_zt5pgXS09NqYinGXgC2s2dpxKQteUtKTfU7eL4_AMMCk7FMQl7-dI1WNv6S5Be-29FYc-rUVume4GuZhX3ZAlrsE6qbydPpKLoQZ02_HtaTIJrPRxmSFCHmlJr4bp-qyamotVOFC8vNr_HQRf0ma-Y9fomij3dIzXgC-qzTu-9LHo4BsUJwk7AWAHw4K8dJ7LwTGuZlCW0u9LbgrrsBe2tRmH267ImKWfXouElC5SzsjTaugEzERIg7Ps2l17qrUdwbrbFfUmdF53RNJ1e8b_MbOGOv78WnBcGtBC6fAnrZfM2bgWYuzWjTLxBoDJyz-gyyr0pzATleTcBbeXaE-zuQ6dSmKbnAqktzZZ62uM8pZ0Y0hBuPK-R7taR0VDi0UlcI9GSiAC0E43euWNt6u0nbZKFshM6363R8detNQeS0dDk1G1ZhvYlFSn7YCzOGVp1-trTeP7J_yi46x8U6Gj8_0Iffie-q3gXUIyMrrSl4JEL32slwdgYsZB7X8CfrmL7wdfKgvme6TBYvgBXswbsEo1QK6PqxB5WIlaH7QYiTm3f5kHJMiriiAw1i9UafKRtd_KmqVEBwjv-aIqRB6fJdENGXn3IlpqRRaMBX3qnPiD1GXEabtDFcTf-M9acPzuzaNdICzUWKL64R4vIeGZutps5sHspFGySKVkXBhiAEB0joBBNnBStLr0MR57o_ulfb7YizGf37lOR_tdZXirkbt02244ZvnGtK1z-ic_1NhvrJKdnM2IrLVOeewfcTZOP-FQyqQkkCs1lCKiR9GwvL-8WPXEZFACbvHOyRA97jdAmdeGs2P4QCDFbT2ZkXHO45rbqsekoW1yrNuUOwfqKgKgXp9vC_bIYrgxzDwLPYqjgrUAM-cSbZfGgVSK5sNSzT5GfVaCk9PD0BL9wk0D-Mc4naIMsHfHimNBx6hjCVVPPvf-NRHfwrVUCqOSTcN_uxCUa4fSNyYUgzA9v24fNhJh5UAAIAtAQAAvAEAAAUAAAB4AQAAmAEAAGCZMjznblVgOMQfO3_hCqfX_OJ4bcG0lWfHxkcE2PvwNdY46lKF2i5kd3xZZymnS9DaHxTgNUq5r_dXiC4yEbFTKLHcgUhFtUSC-OtZ0Icv4JwJDFgcA4d0YByIEIC_GwOOU2s5mRdt1eQWn3my94txvaxBvT2TRbflLt5aTM_aIOrgeYYIl2I1D4AgsiwMBsi5XszOnrSY6yGxquEigOj9L-apNbLggRVAqesXmP0WwIF6cGxQ-HKFaNG-tk3S0D73lLJgmKbmz2KAdL34cktkLRIpA2QziDArRBZLJYKh027IRkALBtImz8vYs1nQhRj50T7fVQ9uqnrmyQ0crNuKdRXGrlSiik_vMSkn-zr29RTms7xobMIb0ThzMboQiMtBu9Re8zReO50YKtRx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyg5nRgq93HX-Bp8Q-zSETsoOZ0YKvdx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyhXpi6gU4oCWsoPsksuak-rCRt3r6rxFb-0w5wztMypwB1XIgG-Uz68ifMP3Y8_rGyjOVvwAgAAADEBAABUAAAARFNBIDlkYjVjMWQ5NGQyZWM3YjMxNjM2ZWYzM2MxNDQxMDM3MDQ4NDNlZDcgOGYzMmFiNDMyOTRjZmIxNGQ5OTA0ZTIxZjQwMjM3MDhhZWVjYTZmMgEAAAgBAAACAAAAAAAAAAIAAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAEAAAABAAAAK7UAAAAAAAABAAAAAQAAAAoNBi4vXFmbgqoB36DcmiZO4Q8BAQAAAAEAAAACAAAABwAAAKguzTXTQ9jeYOS3tl07jVQr8XBDAwAAAAAAAAADAAAAAQAAAH0gAAACAAAAIwAAAAMAAAAAAAAAAAAAACxQlW3zsI67wvS4LjOVEX1rkEj-AAAAAAEAAAABAAAA11RPixBxfBwAqwxziDuQyd_QgokBAAAAAQAAAAMAAAABAAAAmAAAAIt0hPH7wP06zsM6O2x7pykTHR2-0Cuga_VfEgfw7SAUKjFvt8MYOxu6AAAADgAAAEM2RTItMEYzMy02NDMwAAAwAQAAVAIAAAUAAAAQAgAAMAIAAB_RO40YWSHshjD_nAwFEKNv2dXQbIWcFhGajKgazEE1y3TwUYo0ZqBgnKSbrBr71gyhaRHZVRDWFyZBnZpWW2pI-wHAipUk-MUHw5AIpoLINHbdg4K9A_acM3aCY8jI4_jiHqjtAY2dY_rce6bXLHcLmAtFEkrB8nevB_75bZ5WwpkvPjwm8cPK-0uVaR2i5oXluNE0wMtEfGstg6UX2WBlZ3kuOFkuKFJR5Svt1vqAJ2-4NfLwYFet0AOsQcK-9a-EMA1jBkAJll6qbizbxLm18OXKBrs5h175PvxpzSABcmgXeO9nF-vWhhPcfF4UyGNHV4op2dhgOceu-uD9PkhjBY88FYhc09-iW9TFgcuXZHXsw-72_h-hj0VSCe5nK6pa2r__yExgkAUjxUXOkTS6fcusYtwfKECeADMiBhsba3q9Nu9Oh1s21YhaULoUEAXiMMdzusPgrZ1lqXX0dj1SoejBYFDczcqzey9eVGjL0ABZI3MvvAhcTCCIp8BRwG0FDvooa-DzywfsLxZovz196RwSN1Qz6RNxdgZHFW3CFv0FDANKhRo_Apg3OB51frLWCqHcYK67XRqk7CX6xpEHCdz5h9FZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XAUJ3Pmk0VllBBdYkpH-eVwFCdz5pNFZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XOPR1sCh9NUF12rh1xdXHOz3p8wbjTM7XazayR2mSnmxHVciAb5TPryJ8w_djz-sbKM5W_ACAAAA0gAAAFUAAABEU0EgNjg1YjAzNTIxM2E1ZWNiNTkwM2Q2MDFiM2NkZjdmYjQ0NjJmZGIxNCAxMDViMzdmYTQwZWIzMGMzZTgyNjczYjc4ZjFmMDhhMGUxNDBlNTI5AAAANgEAAFUAAABEU0EgN2FlMDJlYzMxMzg5MjhkZDBkNjM1NDIxYzQ0ODQ3YjVkYmY3OWY1ZiAzYjBjNzY4YTliOTZiMGEwYTNkMmI0OGI1MTIzYzMyZmU3ZGUyY2E4AAAANwEAACQEAAAEAAAAAAAAAAUAAAACAAAADwAAAEM2RTItMEYzMy02NDMwAAADAAAAjk1RfgZf1R_8A57vXNxdwH_ihO4DAAAAgAAAAAuGoHd-tMQPlUD0fAutd27moUrisH7-4RcGpSHp22kuitX6YVc46FWYatocYEgQ4C6nUAd7flUy8QY3SFvoVO35kDaIjKOtNRdRiu7WAbbB1qiTNrlX8enguHhoaMCggXM6B-bms-NRWP_1jF_D-QNgUziXeq7_wsf-EyuXEm7lFAAAALeUqwX3mGldp-bGrbgmG3ADb8a6gAAAAM-BnRsV6vzlILw_9wkBMYpi_1ZiA9mVDTBR9QtqgXB3PrLjf3ZRro2GQxKOiIMcHCatj4Nv9sllnHLg1-ikrxQ5TQYniKrkJPh6_Rn5thMlfwxIJ5rqOpL9DGWxD9PJILOc_VdVb1QlPMKwRFBeJvD7C_7nuWKHwcBA0F9jQPkagAAAALp9jfmfGa06ZT9J3ZG128OE1bEza-aKT_OOrEgSwaYJHgcoRz4vAR61GvWn5_P3aInUctEasdZWx8RdlQgilIseTLllhXYbW_zmn5nlkQc1eKECKmdgfoWYYmhB28YPssoBHt9Eugf921UeyqOFP-C-D7nD6PLSwz3OMHVGJEjeCgAAAAQAAADoEYehs28sQEWqzJblqeAsJNpQWAMAAACAAAAAC4agd360xA-VQPR8C613buahSuKwfv7hFwalIenbaS6K1fphVzjoVZhq2hxgSBDgLqdQB3t-VTLxBjdIW-hU7fmQNoiMo601F1GK7tYBtsHWqJM2uVfx6eC4eGhowKCBczoH5uaz41FY__WMX8P5A2BTOJd6rv_Cx_4TK5cSbuUUAAAAt5SrBfeYaV2n5satuCYbcANvxrqAAAAAz4GdGxXq_OUgvD_3CQEximL_VmID2ZUNMFH1C2qBcHc-suN_dlGujYZDEo6IgxwcJq2Pg2_2yWWccuDX6KSvFDlNBieIquQk-Hr9Gfm2EyV_DEgnmuo6kv0MZbEP08kgs5z9V1VvVCU8wrBEUF4m8PsL_ue5YofBwEDQX2NA-RqAAAAA17VcyMlv24n13tkNnZ_V2_qsFQE5sWsCLwlWYIwa7ft_Q87Tk_e508-7GpytTy__UAcAvDGWs_zpt4hlEZV-P3lH4ESChA9bbQ0d3CI6FlkHZaCg2xF_On_g0LyuCfJ16pK1L1ANYCOb4I9UNJPz04mXjG_zksWqjxV01YcPr40KAAAABQAAACxQlW3zsI67wvS4LjOVEX1rkEj-T04AAAYAAAADAAAAnV8PC1whObYArS3iIOqwV5CgO6aJAAAASQAAAB1XIgG-Uz68ifMP3Y8_rGyjOVvwhAAAACUAAACoLs0100PY3mDkt7ZdO41UK_FwQ4kAAABJAACfAQBAEEtleVRva2VuRmlsZU5hbWWZU2tleV94ZmVyXzAyMGIxZjY0NzExYmYwNGRkYWFlYzNjYjkyNzJmMDk1OTA2ZGU1ZDNkN2NjNmQ4MTI4OWFiOGQ1ZWJiNjgwOGI3ZTk5ZTNhNWNhQBhLZXlFeGNoYW5nZUtleUlkZW50aWZpZXKZGnhmZXJ3cmFwcGluZyxrZWstcHJvZC1uYS0xQBJLZXlFeGNoYW5nZUtleUhhc2ieEg3-7EJRrh9I3JhSDMD2_bh82J8CSYcBAUALR2xvYmFsS2V5SWSZSjAyMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTA2REU1RDNEN0NDNkQ4MTI4OUFCOEQ1RUJCNjgwOEI3RTk5RTNBNUNBQAlQdWJsaWNLZXmhFAEGAgAAACQAAFJTQTEACAAAAQABALfXlEXHlqJgFPMI-hvgm8cNzb39ddxpubJ1efgninUpvpuyeyNBhxopiGOZcC_Snn2oW-AtxbRHdmwIvniWBniUAyEdgKP5UmV3VKnArzrBovI9rZA3_7OuxbLPC8slQyOp0ZdDqyZniAOROcQdAz0rQ47haCWl-FVre7kGoKH9uyOeAt-iP8CSyU0GcY6R6Pm-vs5O7OlQp-tGclehzuaXv7aeYzamPBzC_x7I9z4hGEEpfSnWPQrIB-pPF3LE-aSPxEKlqk5h0bKO6vRPKHGd9pWwciYvGL_-RBF2g9nOqUakJWKKi6q-GtTnEOGXpPUCBUe4f0QuZx4nvOR7fKFADENyZWF0aW9uVGltZZdzjWVf2_3TiEAPS2V5RnJpZW5kbHlOYW1lmUxLZXktVmF1bHQtQllPSy1LZXlfU3ViLTBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MF9FbnYtTkFfU2l6ZS0yMDQ4QAlTaWduYXR1cmWe_ybf6ysRwd4l3gRDKGBJ2GW_woEOsAz5XszkYdn-nsBtkGO4aTbhagHEa4SASJ5Kz69CeC-yoEFmWBNEsXwLIRkQULkPG3uBaySgeBWouarheAkxZOIuI1hjXBQxulTw1jbvlqHxM7l_LOAdYKCQFRZ3sFxuj71yU0fRHNOXECt-8bKRpGgZSchxNplRUsNNSvTu2oPeBPMszrwmK50seVdvO33D2Z964gnUXpgFUPuuwhK-X8kswAx8Vx03RaK9iEycX-_vIbMaLjEusMAell7l-BXHQmkiOFz5IR1fUobqZaRzP7p52x_aBfVN9kc1-on3fe0YfUTwEbkAV_sKUZ8B5wE"},
-      "Hsm": false}'
+    body: '{"attributes": {"enabled": true}, "key": {"key_hsm": "QBlUZW5hbnRHZW5lcmF0ZWRLZXlEZXRhaWxzCQFpKWh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlQA1TY2hlbWFWZXJzaW9uiQJADFRlbmFudEJwb3NJZJkgMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTBAB1ZhdWx0SWSBQAdLZXlCbG9ioM0RQAtCWU9LS2V5QmxvYgkBaSlodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZUAMS2V5VG9rZW5UeXBlmRRuQ29yZUtleVByb3RlY3RlZEtleUAYU2VjdXJpdHlXb3JsZEVudmlyb25tZW50mQpQcm9kdWN0aW9uQBRTZWN1cml0eVdvcmxkVmVyc2lvbpkoZThkMzIzZjdjYTk1OTRkNDk2M2ViYjJkMmI0NDU1Yjc5YzYwNjA4NEAIS2V5VG9rZW6gLxBuQ2lwaGVyIEtNIGRhdGFmaWxlAAAAAABuDBFYDQAAAAkAAAAEAAAAeGZlcggAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAGUAAABKAAAAMDIwYjFmNjQ3MTFiZjA0ZGRhYWVjM2NiOTI3MmYwOTU5MDZkZTVkM2Q3Y2M2ZDgxMjg5YWI4ZDVlYmI2ODA4YjdlOTllM2E1Y2EAAMwAAAAUAAAA0Cuga_VfEgfw7SAUKjFvt8MYOxvIAAAAqAQAAAkAAACEBAAAhAQAAAABAAB0gG6diDcaCBCbyLYaRDnz7LwLxz5w58hi18n0tnX9DpYY2NikXNEh3mtijUh2FmiaKjsBhfdlvA_9ijQkLmnvoUEG-UJ8b-s8XBxl3jca06eefYOrjbcfVWuZ_ZiiT8FSNsmE62u70nS9H6Rb05q-xHEhgF_MYa6qBwx5wBjccsK-pxw4Jli7Vhck4UCecbjmJNtvs3eo5gCY0QMtVcKRrXrjL7BLbil9ttue645coCL1CdfaAMnqyn_On8WhTmF_y--Gsh2cVqUKAvKgIcfAB6qNfF_VfYglcwUJfpMgHkqQsLCncAucDXTzD3dGFpXWxDRZzZMlR3guq80Zqv2nrbQMPWUfclHBcEOYcEAN5osbvxmCbeVJTAD1jegPO7pxcRFJW3BhOKJ1519JDzPlBeTnEP3nQkDvD5DaDm3dcvnLctQTARKfx32kbTusDwntrGbgrQGoXfe-McQPufr8xG_ooNaGLwdu9Q415h0BLWfmTOhUWguNP_dJ-KvXGJfl-8uxZCdc6vQ9v6TLEWCuvhOtVSusoIr82NJqSLGWefEBsUgmd7HZZ9iTvwYdxaK_zt5pgXS09NqYinGXgC2s2dpxKQteUtKTfU7eL4_AMMCk7FMQl7-dI1WNv6S5Be-29FYc-rUVume4GuZhX3ZAlrsE6qbydPpKLoQZ02_HtaTIJrPRxmSFCHmlJr4bp-qyamotVOFC8vNr_HQRf0ma-Y9fomij3dIzXgC-qzTu-9LHo4BsUJwk7AWAHw4K8dJ7LwTGuZlCW0u9LbgrrsBe2tRmH267ImKWfXouElC5SzsjTaugEzERIg7Ps2l17qrUdwbrbFfUmdF53RNJ1e8b_MbOGOv78WnBcGtBC6fAnrZfM2bgWYuzWjTLxBoDJyz-gyyr0pzATleTcBbeXaE-zuQ6dSmKbnAqktzZZ62uM8pZ0Y0hBuPK-R7taR0VDi0UlcI9GSiAC0E43euWNt6u0nbZKFshM6363R8detNQeS0dDk1G1ZhvYlFSn7YCzOGVp1-trTeP7J_yi46x8U6Gj8_0Iffie-q3gXUIyMrrSl4JEL32slwdgYsZB7X8CfrmL7wdfKgvme6TBYvgBXswbsEo1QK6PqxB5WIlaH7QYiTm3f5kHJMiriiAw1i9UafKRtd_KmqVEBwjv-aIqRB6fJdENGXn3IlpqRRaMBX3qnPiD1GXEabtDFcTf-M9acPzuzaNdICzUWKL64R4vIeGZutps5sHspFGySKVkXBhiAEB0joBBNnBStLr0MR57o_ulfb7YizGf37lOR_tdZXirkbt02244ZvnGtK1z-ic_1NhvrJKdnM2IrLVOeewfcTZOP-FQyqQkkCs1lCKiR9GwvL-8WPXEZFACbvHOyRA97jdAmdeGs2P4QCDFbT2ZkXHO45rbqsekoW1yrNuUOwfqKgKgXp9vC_bIYrgxzDwLPYqjgrUAM-cSbZfGgVSK5sNSzT5GfVaCk9PD0BL9wk0D-Mc4naIMsHfHimNBx6hjCVVPPvf-NRHfwrVUCqOSTcN_uxCUa4fSNyYUgzA9v24fNhJh5UAAIAtAQAAvAEAAAUAAAB4AQAAmAEAAGCZMjznblVgOMQfO3_hCqfX_OJ4bcG0lWfHxkcE2PvwNdY46lKF2i5kd3xZZymnS9DaHxTgNUq5r_dXiC4yEbFTKLHcgUhFtUSC-OtZ0Icv4JwJDFgcA4d0YByIEIC_GwOOU2s5mRdt1eQWn3my94txvaxBvT2TRbflLt5aTM_aIOrgeYYIl2I1D4AgsiwMBsi5XszOnrSY6yGxquEigOj9L-apNbLggRVAqesXmP0WwIF6cGxQ-HKFaNG-tk3S0D73lLJgmKbmz2KAdL34cktkLRIpA2QziDArRBZLJYKh027IRkALBtImz8vYs1nQhRj50T7fVQ9uqnrmyQ0crNuKdRXGrlSiik_vMSkn-zr29RTms7xobMIb0ThzMboQiMtBu9Re8zReO50YKtRx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyg5nRgq93HX-Bp8Q-zSETsoOZ0YKvdx1_gafEPs0hE7KDmdGCr3cdf4GnxD7NIROyhXpi6gU4oCWsoPsksuak-rCRt3r6rxFb-0w5wztMypwB1XIgG-Uz68ifMP3Y8_rGyjOVvwAgAAADEBAABUAAAARFNBIDlkYjVjMWQ5NGQyZWM3YjMxNjM2ZWYzM2MxNDQxMDM3MDQ4NDNlZDcgOGYzMmFiNDMyOTRjZmIxNGQ5OTA0ZTIxZjQwMjM3MDhhZWVjYTZmMgEAAAgBAAACAAAAAAAAAAIAAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAEAAAABAAAAK7UAAAAAAAABAAAAAQAAAAoNBi4vXFmbgqoB36DcmiZO4Q8BAQAAAAEAAAACAAAABwAAAKguzTXTQ9jeYOS3tl07jVQr8XBDAwAAAAAAAAADAAAAAQAAAH0gAAACAAAAIwAAAAMAAAAAAAAAAAAAACxQlW3zsI67wvS4LjOVEX1rkEj-AAAAAAEAAAABAAAA11RPixBxfBwAqwxziDuQyd_QgokBAAAAAQAAAAMAAAABAAAAmAAAAIt0hPH7wP06zsM6O2x7pykTHR2-0Cuga_VfEgfw7SAUKjFvt8MYOxu6AAAADgAAAEM2RTItMEYzMy02NDMwAAAwAQAAVAIAAAUAAAAQAgAAMAIAAB_RO40YWSHshjD_nAwFEKNv2dXQbIWcFhGajKgazEE1y3TwUYo0ZqBgnKSbrBr71gyhaRHZVRDWFyZBnZpWW2pI-wHAipUk-MUHw5AIpoLINHbdg4K9A_acM3aCY8jI4_jiHqjtAY2dY_rce6bXLHcLmAtFEkrB8nevB_75bZ5WwpkvPjwm8cPK-0uVaR2i5oXluNE0wMtEfGstg6UX2WBlZ3kuOFkuKFJR5Svt1vqAJ2-4NfLwYFet0AOsQcK-9a-EMA1jBkAJll6qbizbxLm18OXKBrs5h175PvxpzSABcmgXeO9nF-vWhhPcfF4UyGNHV4op2dhgOceu-uD9PkhjBY88FYhc09-iW9TFgcuXZHXsw-72_h-hj0VSCe5nK6pa2r__yExgkAUjxUXOkTS6fcusYtwfKECeADMiBhsba3q9Nu9Oh1s21YhaULoUEAXiMMdzusPgrZ1lqXX0dj1SoejBYFDczcqzey9eVGjL0ABZI3MvvAhcTCCIp8BRwG0FDvooa-DzywfsLxZovz196RwSN1Qz6RNxdgZHFW3CFv0FDANKhRo_Apg3OB51frLWCqHcYK67XRqk7CX6xpEHCdz5h9FZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XAUJ3Pmk0VllBBdYkpH-eVwFCdz5pNFZZQQXWJKR_nlcBQnc-aTRWWUEF1iSkf55XOPR1sCh9NUF12rh1xdXHOz3p8wbjTM7XazayR2mSnmxHVciAb5TPryJ8w_djz-sbKM5W_ACAAAA0gAAAFUAAABEU0EgNjg1YjAzNTIxM2E1ZWNiNTkwM2Q2MDFiM2NkZjdmYjQ0NjJmZGIxNCAxMDViMzdmYTQwZWIzMGMzZTgyNjczYjc4ZjFmMDhhMGUxNDBlNTI5AAAANgEAAFUAAABEU0EgN2FlMDJlYzMxMzg5MjhkZDBkNjM1NDIxYzQ0ODQ3YjVkYmY3OWY1ZiAzYjBjNzY4YTliOTZiMGEwYTNkMmI0OGI1MTIzYzMyZmU3ZGUyY2E4AAAANwEAACQEAAAEAAAAAAAAAAUAAAACAAAADwAAAEM2RTItMEYzMy02NDMwAAADAAAAjk1RfgZf1R_8A57vXNxdwH_ihO4DAAAAgAAAAAuGoHd-tMQPlUD0fAutd27moUrisH7-4RcGpSHp22kuitX6YVc46FWYatocYEgQ4C6nUAd7flUy8QY3SFvoVO35kDaIjKOtNRdRiu7WAbbB1qiTNrlX8enguHhoaMCggXM6B-bms-NRWP_1jF_D-QNgUziXeq7_wsf-EyuXEm7lFAAAALeUqwX3mGldp-bGrbgmG3ADb8a6gAAAAM-BnRsV6vzlILw_9wkBMYpi_1ZiA9mVDTBR9QtqgXB3PrLjf3ZRro2GQxKOiIMcHCatj4Nv9sllnHLg1-ikrxQ5TQYniKrkJPh6_Rn5thMlfwxIJ5rqOpL9DGWxD9PJILOc_VdVb1QlPMKwRFBeJvD7C_7nuWKHwcBA0F9jQPkagAAAALp9jfmfGa06ZT9J3ZG128OE1bEza-aKT_OOrEgSwaYJHgcoRz4vAR61GvWn5_P3aInUctEasdZWx8RdlQgilIseTLllhXYbW_zmn5nlkQc1eKECKmdgfoWYYmhB28YPssoBHt9Eugf921UeyqOFP-C-D7nD6PLSwz3OMHVGJEjeCgAAAAQAAADoEYehs28sQEWqzJblqeAsJNpQWAMAAACAAAAAC4agd360xA-VQPR8C613buahSuKwfv7hFwalIenbaS6K1fphVzjoVZhq2hxgSBDgLqdQB3t-VTLxBjdIW-hU7fmQNoiMo601F1GK7tYBtsHWqJM2uVfx6eC4eGhowKCBczoH5uaz41FY__WMX8P5A2BTOJd6rv_Cx_4TK5cSbuUUAAAAt5SrBfeYaV2n5satuCYbcANvxrqAAAAAz4GdGxXq_OUgvD_3CQEximL_VmID2ZUNMFH1C2qBcHc-suN_dlGujYZDEo6IgxwcJq2Pg2_2yWWccuDX6KSvFDlNBieIquQk-Hr9Gfm2EyV_DEgnmuo6kv0MZbEP08kgs5z9V1VvVCU8wrBEUF4m8PsL_ue5YofBwEDQX2NA-RqAAAAA17VcyMlv24n13tkNnZ_V2_qsFQE5sWsCLwlWYIwa7ft_Q87Tk_e508-7GpytTy__UAcAvDGWs_zpt4hlEZV-P3lH4ESChA9bbQ0d3CI6FlkHZaCg2xF_On_g0LyuCfJ16pK1L1ANYCOb4I9UNJPz04mXjG_zksWqjxV01YcPr40KAAAABQAAACxQlW3zsI67wvS4LjOVEX1rkEj-T04AAAYAAAADAAAAnV8PC1whObYArS3iIOqwV5CgO6aJAAAASQAAAB1XIgG-Uz68ifMP3Y8_rGyjOVvwhAAAACUAAACoLs0100PY3mDkt7ZdO41UK_FwQ4kAAABJAACfAQBAEEtleVRva2VuRmlsZU5hbWWZU2tleV94ZmVyXzAyMGIxZjY0NzExYmYwNGRkYWFlYzNjYjkyNzJmMDk1OTA2ZGU1ZDNkN2NjNmQ4MTI4OWFiOGQ1ZWJiNjgwOGI3ZTk5ZTNhNWNhQBhLZXlFeGNoYW5nZUtleUlkZW50aWZpZXKZGnhmZXJ3cmFwcGluZyxrZWstcHJvZC1uYS0xQBJLZXlFeGNoYW5nZUtleUhhc2ieEg3-7EJRrh9I3JhSDMD2_bh82J8CSYcBAUALR2xvYmFsS2V5SWSZSjAyMEIxRjY0NzExQkYwNEREQUFFQzNDQjkyNzJGMDk1OTA2REU1RDNEN0NDNkQ4MTI4OUFCOEQ1RUJCNjgwOEI3RTk5RTNBNUNBQAlQdWJsaWNLZXmhFAEGAgAAACQAAFJTQTEACAAAAQABALfXlEXHlqJgFPMI-hvgm8cNzb39ddxpubJ1efgninUpvpuyeyNBhxopiGOZcC_Snn2oW-AtxbRHdmwIvniWBniUAyEdgKP5UmV3VKnArzrBovI9rZA3_7OuxbLPC8slQyOp0ZdDqyZniAOROcQdAz0rQ47haCWl-FVre7kGoKH9uyOeAt-iP8CSyU0GcY6R6Pm-vs5O7OlQp-tGclehzuaXv7aeYzamPBzC_x7I9z4hGEEpfSnWPQrIB-pPF3LE-aSPxEKlqk5h0bKO6vRPKHGd9pWwciYvGL_-RBF2g9nOqUakJWKKi6q-GtTnEOGXpPUCBUe4f0QuZx4nvOR7fKFADENyZWF0aW9uVGltZZdzjWVf2_3TiEAPS2V5RnJpZW5kbHlOYW1lmUxLZXktVmF1bHQtQllPSy1LZXlfU3ViLTBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MF9FbnYtTkFfU2l6ZS0yMDQ4QAlTaWduYXR1cmWe_ybf6ysRwd4l3gRDKGBJ2GW_woEOsAz5XszkYdn-nsBtkGO4aTbhagHEa4SASJ5Kz69CeC-yoEFmWBNEsXwLIRkQULkPG3uBaySgeBWouarheAkxZOIuI1hjXBQxulTw1jbvlqHxM7l_LOAdYKCQFRZ3sFxuj71yU0fRHNOXECt-8bKRpGgZSchxNplRUsNNSvTu2oPeBPMszrwmK50seVdvO33D2Z964gnUXpgFUPuuwhK-X8kswAx8Vx03RaK9iEycX-_vIbMaLjEusMAell7l-BXHQmkiOFz5IR1fUobqZaRzP7p52x_aBfVN9kc1-on3fe0YfUTwEbkAV_sKUZ8B5wE",
+      "kty": "RSA-HSM"}, "Hsm": false}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['7404']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3035594a-051d-11e7-8126-a0b3ccf7272a]
+      x-ms-client-request-id: [df239166-0814-11e7-9ec9-a0b3ccf7272a]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-byok?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-byok/14ee98f7b9cd47c1acee7f80fee19c68","kty":"RSA-HSM","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oXx75LwnHmcuRH-4RwUC9aSX4RDn1Bq-qouKYiWkRqnO2YN2EUT-vxgvJnKwlfadcShP9OqOstFhTqqlQsSPpPnEchdP6gfICj3WKX0pQRghPvfIHv_CHDymNmOetr-X5s6hV3JG66dQ6exOzr6--eiRjnEGTcmSwD-i3wKeI7v9oaAGuXtrVfilJWjhjkMrPQMdxDmRA4hnJqtDl9GpI0MlywvPssWus_83kK098qLBOq_AqVR3ZVL5o4AdIQOUeAaWeL4IbHZHtMUt4FuofZ7SL3CZY4gpGodBI3uym74pdYon-Hl1srlp3HX9vc0Nx5vgG_oI8xRgopbHRZTXtw","e":"AAEAAQ"},"attributes":{"enabled":true,"created":1489100858,"updated":1489100858,"purgedisabled":false}}'}
+    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-byok/235cf1ac9c104bf48f0243cccb3d0822","kty":"RSA-HSM","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"oXx75LwnHmcuRH-4RwUC9aSX4RDn1Bq-qouKYiWkRqnO2YN2EUT-vxgvJnKwlfadcShP9OqOstFhTqqlQsSPpPnEchdP6gfICj3WKX0pQRghPvfIHv_CHDymNmOetr-X5s6hV3JG66dQ6exOzr6--eiRjnEGTcmSwD-i3wKeI7v9oaAGuXtrVfilJWjhjkMrPQMdxDmRA4hnJqtDl9GpI0MlywvPssWus_83kK098qLBOq_AqVR3ZVL5o4AdIQOUeAaWeL4IbHZHtMUt4FuofZ7SL3CZY4gpGodBI3uym74pdYon-Hl1srlp3HX9vc0Nx5vgG_oI8xRgopbHRZTXtw","e":"AAEAAQ"},"attributes":{"enabled":true,"created":1489427139,"updated":1489427139,"purgedisabled":false}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['659']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:07:37 GMT']
+      Date: ['Mon, 13 Mar 2017 17:45:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]

--- a/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_mgmt.yaml
+++ b/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_mgmt.yaml
@@ -6,51 +6,50 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d2fb5e2-051c-11e7-a0c0-a0b3ccf7272a]
+      x-ms-client-request-id: [8cbc1738-0811-11e7-a917-a0b3ccf7272a]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27example%40example.com%27
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/5963f50c-7c43-405c-af7e-53294de76abd/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1236']
+      Content-Length: ['1344']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:03:03 GMT']
-      Duration: ['762923']
+      Date: ['Mon, 13 Mar 2017 17:21:52 GMT']
+      Duration: ['1290362']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [DR19pqY8f0NwIf7uWlwUtWuxMpUjmBOYROdsxaOBGDc=]
-      ocp-aad-session-key: [9bFJtv5SvNAoN3-ubP1PLYL0w1Xq8so8RgtYTZsyqCzazZBQb6yRKowIKXnzZ1e58KFf64kafXL7ppZOg9CtuHeripVKPItwfLZJD9Nq5BReTlpr9I6hvDMGBktNm9sk.fvs3uBvcYLbZUJ_Vi5XIuZ6pSDiuFnTeSbnesxRhmeE]
-      request-id: [993c3fb2-9c8c-4a6a-8d34-e63427f49731]
+      ocp-aad-diagnostics-server-name: [bSnKcXevpmTNEtRt8qPcShr0MpTaOPGs6CEkQjCW/I0=]
+      ocp-aad-session-key: [fm8jTs12PMhhl907KZvavWHbVxBpgR0x00BHBNjhqHYZusu2NwnMP35c108bdIAMWB82rqoVckqwlei9pA2J6p5Lw-kVD1ngy90Cc76CM6jM95XmFqCkqZ_AFf3n2I-I.a1r1kFH2sOJYny1EXO_bcFnk2rJsJYTyaeFfcEyBG9Y]
+      request-id: [7be16f33-8f63-46c9-b765-dee02305c83c]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies":
-      [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}}]}}'
+    body: '{"properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku":
+      {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
+      ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["all"]}}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['408']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d543438-051c-11e7-9770-a0b3ccf7272a]
+      x-ms-client-request-id: [8ce7f5e8-0811-11e7-8fbb-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
@@ -58,7 +57,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:04 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -70,7 +69,7 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['702']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -79,24 +78,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8e7c5798-051c-11e7-bef5-a0b3ccf7272a]
+      x-ms-client-request-id: [8e8b7e6e-0811-11e7-95d4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert_3m6c_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_qm3y_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/python-sdk-test-keyvault","name":"python-sdk-test-keyvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjpkeyvault3","name":"tjpkeyvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert_mjxr_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_m7lg_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjp-keyvault-test","name":"tjp-keyvault-test","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:06 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['1251']
+      content-length: ['1018']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -105,11 +104,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8e8c37dc-051c-11e7-b9ad-a0b3ccf7272a]
+      x-ms-client-request-id: [8eb64268-0811-11e7-b19b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
@@ -117,7 +116,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:06 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -137,11 +136,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f1f5e9c-051c-11e7-ba35-a0b3ccf7272a]
+      x-ms-client-request-id: [8f6d7f6e-0811-11e7-ab2f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01
   response:
@@ -149,7 +148,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:07 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -169,11 +168,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f782cc2-051c-11e7-95f4-a0b3ccf7272a]
+      x-ms-client-request-id: [9004786c-0811-11e7-882e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA=
   response:
@@ -181,7 +180,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:08 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -201,11 +200,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [901c157a-051c-11e7-a93a-a0b3ccf7272a]
+      x-ms-client-request-id: [90afaff4-0811-11e7-a0ca-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
@@ -213,7 +212,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:09 GMT']
+      Date: ['Mon, 13 Mar 2017 17:21:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -227,23 +226,23 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.153]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "premium", "family":
-      "A"}, "enabledForDeployment": false, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"properties": {"vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku": {"family": "A", "name":
+      "premium"}, "enabledForDeployment": false, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
       "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
       ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
-      "secrets": ["all"], "certificates": ["all"]}}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/"}}'
+      "secrets": ["all"], "certificates": ["all"]}}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['499']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9050bda8-051c-11e7-ad61-a0b3ccf7272a]
+      x-ms-client-request-id: [91127166-0811-11e7-b674-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
   response:
@@ -251,7 +250,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:09 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -262,264 +261,6 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['702']
-      x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [90e46952-051c-11e7-8daf-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['702']
-      x-ms-keyvault-service-version: [1.0.0.153]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "tags": {}, "properties": {"sku": {"name": "premium",
-      "family": "A"}, "enabledForDeployment": false, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["get", "list"]}}],
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['519']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9122af36-051c-11e7-861e-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['709']
-      x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [91bad436-051c-11e7-8250-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['709']
-      x-ms-keyvault-service-version: [1.0.0.153]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "tags": {}, "properties": {"sku": {"name": "premium",
-      "family": "A"}, "enabledForDeployment": false, "accessPolicies": [], "tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['259']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [91e0b96e-051c-11e7-9f0f-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['467']
-      x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [92653026-051c-11e7-b1d5-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert_3m6c_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_qm3y_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/python-sdk-test-keyvault","name":"python-sdk-test-keyvault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjpkeyvault3","name":"tjpkeyvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['1251']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [92769cee-051c-11e7-bbdc-a0b3ccf7272a]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Thu, 09 Mar 2017 23:03:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [934a5136-051c-11e7-a82d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01
-  response:
-    body: {string: '{"value":[]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['12']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies":
-      []}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['156']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [93afa942-051c-11e7-8201-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1?api-version=2015-06-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['467']
       x-ms-keyvault-service-version: [1.0.0.153]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
@@ -530,12 +271,271 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [91e6d910-0811-11e7-976a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["all"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['702']
+      x-ms-keyvault-service-version: [1.0.0.153]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku": {"family": "A", "name":
+      "premium"}, "enabledForDeployment": false, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
+      ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["get", "list"]}}]}, "location": "westus",
+      "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['519']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9245eae8-0811-11e7-9537-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['709']
+      x-ms-keyvault-service-version: [1.0.0.153]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [930aec0c-0811-11e7-9e76-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore"],"secrets":["all"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['709']
+      x-ms-keyvault-service-version: [1.0.0.153]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku": {"family": "A", "name":
+      "premium"}, "enabledForDeployment": false, "accessPolicies": []}, "location":
+      "westus", "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['259']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9372b0be-0811-11e7-a4eb-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['467']
+      x-ms-keyvault-service-version: [1.0.0.153]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9438b0c0-0811-11e7-97ba-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_m7lg_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjp-keyvault-test","name":"tjp-keyvault-test","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['755']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9461149a-0811-11e7-8265-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2015-06-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 13 Mar 2017 17:22:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-service-version: [1.0.0.153]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [95f132f8-0811-11e7-90b0-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2015-06-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku":
+      {"family": "A", "name": "standard"}, "accessPolicies": []}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['156']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.0+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [96731894-0811-11e7-af48-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 13 Mar 2017 17:22:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['467']
+      x-ms-keyvault-service-version: [1.0.0.153]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [949be32c-051c-11e7-8626-a0b3ccf7272a]
+      x-ms-client-request-id: [976bcc10-0811-11e7-81b5-a0b3ccf7272a]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27example%40example.com%27
   response:
     body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
     headers:
@@ -544,8 +544,8 @@ interactions:
       Content-Length: ['1236']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:03:16 GMT']
-      Duration: ['4400273']
+      Date: ['Mon, 13 Mar 2017 17:22:10 GMT']
+      Duration: ['1453189']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -553,30 +553,29 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [9Hup3hradlTbl1hoIuTil/LL0QosWkIK20JWNAo+3Oo=]
-      ocp-aad-session-key: [xBTCvUvQ1mI72WoKAxx9NH_jSVn5IdQj9dwczOu0GSP8aabAYUfGkGTbt2gzWQjHV2eBMNMJmqr9HZfqHtRiDMDYBCWgra-hYm94g4pbCW31YeuPS1uf0zCIeo20aU3k.XoOvh7-tubY1gPUZq0YORq831vAe_wV83B3ZSQv0KII]
-      request-id: [134e9a9d-c62c-41dc-b3ad-bad5dd448f81]
+      ocp-aad-diagnostics-server-name: [R71qQ12Ay8jWIvnAjg40ZY4zpB1WSnPjRZdmcGAoUUg=]
+      ocp-aad-session-key: [lLgKhqSL2md8UKR6p4gggCe9ACfg0YBmNmauAWkhnRHAE-1OY4WK83ttEktw_5fzJMlA9kLCD7JFh-P7JEka0PdETGr7NaatISyNduPWvnVs4M0DNkI2XyGvYZogn-fO.IC7wSp57KLhvubTN57IPdTOa7e5YwtSkCnXi3vdHX2w]
+      request-id: [46568a42-fca6-4833-94e3-5081f8ff115b]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "enabledForDiskEncryption":
-      true, "enabledForDeployment": true, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
-      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
-      ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
-      "secrets": ["all"], "certificates": ["all"]}}], "enabledForTemplateDeployment":
-      true}}'
+    body: '{"properties": {"enabledForDeployment": true, "accessPolicies": [{"tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}}], "enabledForTemplateDeployment":
+      true, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku": {"family":
+      "A", "name": "standard"}, "enabledForDiskEncryption": true}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['510']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [94f833ec-051c-11e7-99a7-a0b3ccf7272a]
+      x-ms-client-request-id: [979d149e-0811-11e7-b843-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2?api-version=2015-06-01
   response:
@@ -584,7 +583,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:17 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -596,7 +595,7 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['769']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -605,51 +604,50 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [95c327e2-051c-11e7-ae5a-a0b3ccf7272a]
+      x-ms-client-request-id: [99785198-0811-11e7-9944-a0b3ccf7272a]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27example%40example.com%27
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/5963f50c-7c43-405c-af7e-53294de76abd/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1236']
+      Content-Length: ['1344']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:03:18 GMT']
-      Duration: ['742961']
+      Date: ['Mon, 13 Mar 2017 17:22:13 GMT']
+      Duration: ['8898208']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [DR19pqY8f0NwIf7uWlwUtWuxMpUjmBOYROdsxaOBGDc=]
-      ocp-aad-session-key: [IeYUT2nmxNXEwBwJ3pgrr8P09JybWcOaB5cy7M9elyUuOTuJR_1N843B5rSatqwZ1wTzq_zV3GxSVwHY_kCEBDjHRhn8AixL0K8bPqUDfUVa-oTHLUeTKgbAouV_SHi6.vZ2SEqmTJ-HJwVbcLOJuxUwrW2wS4jT68bVv8fJBl1s]
-      request-id: [729d3489-3b37-445c-adcc-58da802a42e8]
+      ocp-aad-diagnostics-server-name: [C6wUGxPx6EyCvip7rXtseehyCnwl+vm9NBkEKCUjowE=]
+      ocp-aad-session-key: [DpwkwyqUVoZ8u4WkpHJ7MqhF8bkEBpOe0zJzM3kpAF9Bo5lpbKEn9gXPjm_dWbQ264ER8Y_7eIig-CGYhiqT1d1WaJAjhBf5QEVAWlJy_Dl6XwlnBNOUG_meGRB40hEB.fEbq8p8WvpPBMa6VfeCNgDDJWTlVaWS9nwtdVXXUO4k]
+      request-id: [fdc6a3a5-77c6-4c0f-874d-7000155ff452]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "premium", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies":
-      [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}}]}}'
+    body: '{"properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
+      ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["all"]}}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['407']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [95e68b9a-051c-11e7-b362-a0b3ccf7272a]
+      x-ms-client-request-id: [9a184b18-0811-11e7-a0c8-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3?api-version=2015-06-01
   response:
@@ -657,7 +655,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:19 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -669,6 +667,6 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['701']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_secret.yaml
+++ b/src/command_modules/azure-cli-keyvault/tests/recordings/test_keyvault_secret.yaml
@@ -6,12 +6,12 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9837e9d0-051c-11e7-9aaf-a0b3ccf7272a]
+      x-ms-client-request-id: [9d6543e8-0811-11e7-866b-a0b3ccf7272a]
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?$filter=userPrincipalName%20eq%20%27example%40example.com%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27example%40example.com%27
   response:
     body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-01-03T20:58:19Z","showInAddressList":null,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/5963f50c-7c43-405c-af7e-53294de76abd/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}]}'}
     headers:
@@ -20,36 +20,36 @@ interactions:
       Content-Length: ['1344']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Thu, 09 Mar 2017 23:03:22 GMT']
-      Duration: ['783651']
+      Date: ['Mon, 13 Mar 2017 17:22:20 GMT']
+      Duration: ['984965']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [IdgG7lnYmOU4bPZc1rl4En8HkGAFbFac5GSZUaXAPBU=]
-      ocp-aad-session-key: [QKUCth5QnUZyLCbh3HR8JarWTC0-mERBEtsUB-8DnXycaGWHI7NPD5PD2yFFTQNx2gv_BuuyjDT03PHJZoONUTPoeOBW2xCgXYlBSOWBmHvKuIo62pCCF7sDnPSk5Igt.xkPueBdZ8oC7r1PGnggUNmui36O9hjARb8jFPA3Zn8g]
-      request-id: [232dbc86-2ddd-4efc-a3e6-dd204f386092]
+      ocp-aad-diagnostics-server-name: [sKIqLiBHUSH37X3OEYlDghcjgQjFy4i/DiAtI58+UAk=]
+      ocp-aad-session-key: [a_bsOW5GdmtOBSaHeXE3iX82kTifEAdma0e2NKVI56ExT2Mc6kPWIKGjCtjJx6j2ObG9BlXKFUrY2KEFMldbXLkxmxg65qkHR_ySiUXC7rlyfTysnVkzB0r0yh4u176b.BbKf2LkkXoe5Px3g9dYs8k_HjKxzTpFVJYWoHal-a24]
+      request-id: [28549ea9-2b88-4c62-b495-2b71f8741e03]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "premium", "family":
-      "A"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies":
-      [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore"], "secrets": ["all"], "certificates": ["all"]}}]}}'
+    body: '{"properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "sku":
+      {"family": "A", "name": "premium"}, "accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "permissions": {"keys":
+      ["get", "create", "delete", "list", "update", "import", "backup", "restore"],
+      "secrets": ["all"], "certificates": ["all"]}}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['407']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultmanagementclient/0.30.0 Azure-SDK-For-Python
           AZURECLI/TEST/2.0.0+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [985c5128-051c-11e7-9ab8-a0b3ccf7272a]
+      x-ms-client-request-id: [9d8db4b8-0811-11e7-9664-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret?api-version=2015-06-01
   response:
@@ -57,7 +57,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:22 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -69,7 +69,7 @@ interactions:
       X-Powered-By: [ASP.NET]
       content-length: ['715']
       x-ms-keyvault-service-version: [1.0.0.153]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -78,10 +78,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [99339412-051c-11e7-82b6-a0b3ccf7272a]
+      x-ms-client-request-id: [9ebde9b4-0811-11e7-9eae-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -89,7 +89,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Thu, 09 Mar 2017 23:03:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -109,10 +109,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [99339412-051c-11e7-82b6-a0b3ccf7272a]
+      x-ms-client-request-id: [9ebde9b4-0811-11e7-9eae-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
   response:
@@ -121,7 +121,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['30']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -133,7 +133,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "utf-8"}, "attributes": {"enabled": true}, "value":
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-8"}, "value":
       "ABC123"}'
     headers:
       Accept: [application/json]
@@ -141,19 +141,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9be9dc08-051c-11e7-b9f1-a0b3ccf7272a]
+      x-ms-client-request-id: [9f517a88-0811-11e7-9379-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/afb7946260ad483b91b5a75286b77323","attributes":{"enabled":true,"created":1489100608,"updated":1489100608},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/713fb366307e41ef8b20c6df34a2dce6","attributes":{"enabled":true,"created":1489425743,"updated":1489425743},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -171,19 +171,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9c6b2894-051c-11e7-a8df-a0b3ccf7272a]
+      x-ms-client-request-id: [9fce79d4-0811-11e7-9152-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1489100608,"updated":1489100608},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1489425743,"updated":1489425743},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['206']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:27 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -195,27 +195,27 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"test": "foo", "file-encoding": "utf-8"}, "value": "DEF456",
-      "attributes": {"enabled": true}, "contentType": "test type"}'
+    body: '{"attributes": {"enabled": true}, "tags": {"test": "foo", "file-encoding":
+      "utf-8"}, "contentType": "test type", "value": "DEF456"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9cd7923a-051c-11e7-b67e-a0b3ccf7272a]
+      x-ms-client-request-id: [a04144b8-0811-11e7-857f-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/3f5101c4e8d64cec9e66123cd2a61a34","attributes":{"enabled":true,"created":1489100610,"updated":1489100610},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/15c7668113d741cd97321b1ba77bd5a4","attributes":{"enabled":true,"created":1489425745,"updated":1489425745},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:30 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -233,19 +233,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9d55b880-051c-11e7-89b7-a0b3ccf7272a]
+      x-ms-client-request-id: [a0bd87f6-0811-11e7-8fa7-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/3f5101c4e8d64cec9e66123cd2a61a34","attributes":{"enabled":true,"created":1489100610,"updated":1489100610},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/afb7946260ad483b91b5a75286b77323","attributes":{"enabled":true,"created":1489100608,"updated":1489100608},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/15c7668113d741cd97321b1ba77bd5a4","attributes":{"enabled":true,"created":1489425745,"updated":1489425745},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/713fb366307e41ef8b20c6df34a2dce6","attributes":{"enabled":true,"created":1489425743,"updated":1489425743},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['490']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:30 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -263,19 +263,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9dcd7f6c-051c-11e7-be97-a0b3ccf7272a]
+      x-ms-client-request-id: [a1411d9c-0811-11e7-9afb-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/3f5101c4e8d64cec9e66123cd2a61a34","attributes":{"enabled":true,"created":1489100610,"updated":1489100610},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/15c7668113d741cd97321b1ba77bd5a4","attributes":{"enabled":true,"created":1489425745,"updated":1489425745},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:33 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -293,19 +293,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9e45f8de-051c-11e7-a8bc-a0b3ccf7272a]
+      x-ms-client-request-id: [a1be2b1a-0811-11e7-9132-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/afb7946260ad483b91b5a75286b77323?api-version=2016-10-01
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/713fb366307e41ef8b20c6df34a2dce6?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/afb7946260ad483b91b5a75286b77323","attributes":{"enabled":true,"created":1489100608,"updated":1489100608},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/713fb366307e41ef8b20c6df34a2dce6","attributes":{"enabled":true,"created":1489425743,"updated":1489425743},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:31 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -324,19 +324,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9eaffa10-051c-11e7-9398-a0b3ccf7272a]
+      x-ms-client-request-id: [a2305a70-0811-11e7-a8cb-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/3f5101c4e8d64cec9e66123cd2a61a34","attributes":{"enabled":false,"created":1489100610,"updated":1489100614},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/15c7668113d741cd97321b1ba77bd5a4","attributes":{"enabled":false,"created":1489425745,"updated":1489425748},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:33 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -355,19 +355,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9fcaf2e4-051c-11e7-9db2-a0b3ccf7272a]
+      x-ms-client-request-id: [a2ad432c-0811-11e7-ab90-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/3f5101c4e8d64cec9e66123cd2a61a34","attributes":{"enabled":false,"created":1489100610,"updated":1489100614},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/15c7668113d741cd97321b1ba77bd5a4","attributes":{"enabled":false,"created":1489425745,"updated":1489425748},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:34 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -385,10 +385,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0493366-051c-11e7-aed0-a0b3ccf7272a]
+      x-ms-client-request-id: [a32b070c-0811-11e7-8c09-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
@@ -397,7 +397,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:34 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -409,7 +409,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "utf-8"}, "attributes": {"enabled": true}, "value":
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-8"}, "value":
       "TestSecretTestSecretTestSecretTestSecret\n"}'
     headers:
       Accept: [application/json]
@@ -417,19 +417,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0b21e22-051c-11e7-9438-a0b3ccf7272a]
+      x-ms-client-request-id: [a39e5c48-0811-11e7-9baf-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/0adf935c4e874872a546ea46356c6be3","attributes":{"enabled":true,"created":1489100615,"updated":1489100615},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/92dbbec694184867b13fdb04f44a95a9","attributes":{"enabled":true,"created":1489425750,"updated":1489425750},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:35 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -447,19 +447,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a14227b6-051c-11e7-b219-a0b3ccf7272a]
+      x-ms-client-request-id: [a419144c-0811-11e7-b2bb-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/0adf935c4e874872a546ea46356c6be3","attributes":{"enabled":true,"created":1489100615,"updated":1489100615},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/92dbbec694184867b13fdb04f44a95a9","attributes":{"enabled":true,"created":1489425750,"updated":1489425750},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:36 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -471,7 +471,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "utf-16le"}, "attributes": {"enabled": true},
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-16le"},
       "value": "TestSecretTestSecretTestSecretTestSecret\n"}'
     headers:
       Accept: [application/json]
@@ -479,19 +479,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1b68af8-051c-11e7-91fe-a0b3ccf7272a]
+      x-ms-client-request-id: [a48b6f28-0811-11e7-af75-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/d1b8bbc193704b1c96aa378da8f58015","attributes":{"enabled":true,"created":1489100617,"updated":1489100617},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/28230d7b0f4a445bad8a49c0e8e3127f","attributes":{"enabled":true,"created":1489425751,"updated":1489425751},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:36 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -509,19 +509,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a231bdd4-051c-11e7-b7ab-a0b3ccf7272a]
+      x-ms-client-request-id: [a508a182-0811-11e7-993f-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/d1b8bbc193704b1c96aa378da8f58015","attributes":{"enabled":true,"created":1489100617,"updated":1489100617},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/28230d7b0f4a445bad8a49c0e8e3127f","attributes":{"enabled":true,"created":1489425751,"updated":1489425751},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:40 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -533,7 +533,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "utf-16be"}, "attributes": {"enabled": true},
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-16be"},
       "value": "TestSecretTestSecretTestSecretTestSecret\n"}'
     headers:
       Accept: [application/json]
@@ -541,19 +541,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2b3e164-051c-11e7-b29e-a0b3ccf7272a]
+      x-ms-client-request-id: [a57866e4-0811-11e7-8ffa-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/b9da65c1801e4b0c9e11e33c07e0a441","attributes":{"enabled":true,"created":1489100619,"updated":1489100619},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/d97bb59a64fb4ac5918c69d81069cf1b","attributes":{"enabled":true,"created":1489425755,"updated":1489425755},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:39 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -571,19 +571,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a324a4d0-051c-11e7-a7a7-a0b3ccf7272a]
+      x-ms-client-request-id: [a5f7a126-0811-11e7-930c-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/b9da65c1801e4b0c9e11e33c07e0a441","attributes":{"enabled":true,"created":1489100619,"updated":1489100619},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/d97bb59a64fb4ac5918c69d81069cf1b","attributes":{"enabled":true,"created":1489425755,"updated":1489425755},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['277']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:39 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -595,7 +595,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "ascii"}, "attributes": {"enabled": true}, "value":
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "ascii"}, "value":
       "TestSecretTestSecretTestSecretTestSecret\n"}'
     headers:
       Accept: [application/json]
@@ -603,19 +603,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a3a8444c-051c-11e7-8fa5-a0b3ccf7272a]
+      x-ms-client-request-id: [a6861762-0811-11e7-af7a-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/cf532ff409024b068a15f9c39d118abd","attributes":{"enabled":true,"created":1489100620,"updated":1489100620},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/de41aa6073644422a09e40c2dc4e9dbe","attributes":{"enabled":true,"created":1489425755,"updated":1489425755},"tags":{"file-encoding":"ascii"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:40 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -633,19 +633,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4217b46-051c-11e7-95b1-a0b3ccf7272a]
+      x-ms-client-request-id: [a6fecf52-0811-11e7-86b4-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/cf532ff409024b068a15f9c39d118abd","attributes":{"enabled":true,"created":1489100620,"updated":1489100620},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/de41aa6073644422a09e40c2dc4e9dbe","attributes":{"enabled":true,"created":1489425755,"updated":1489425755},"tags":{"file-encoding":"ascii"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:41 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -657,7 +657,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "base64"}, "attributes": {"enabled": true},
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "base64"},
       "value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n"}'
     headers:
       Accept: [application/json]
@@ -665,19 +665,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5104038-051c-11e7-89e3-a0b3ccf7272a]
+      x-ms-client-request-id: [a7777e2e-0811-11e7-934c-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/9503cd9d71194c65b72e21fc7947fb55","attributes":{"enabled":true,"created":1489100624,"updated":1489100624},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/50b6bcc33938417b8bda3815c4ca919a","attributes":{"enabled":true,"created":1489425756,"updated":1489425756},"tags":{"file-encoding":"base64"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['289']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:44 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -695,19 +695,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a58af036-051c-11e7-8070-a0b3ccf7272a]
+      x-ms-client-request-id: [a7f867f4-0811-11e7-9d6d-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/9503cd9d71194c65b72e21fc7947fb55","attributes":{"enabled":true,"created":1489100624,"updated":1489100624},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/50b6bcc33938417b8bda3815c4ca919a","attributes":{"enabled":true,"created":1489425756,"updated":1489425756},"tags":{"file-encoding":"base64"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['289']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:43 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -719,7 +719,7 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.802]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"file-encoding": "hex"}, "attributes": {"enabled": true}, "value":
+    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "hex"}, "value":
       "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a"}'
     headers:
       Accept: [application/json]
@@ -727,19 +727,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['164']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5f55d66-051c-11e7-9c7c-a0b3ccf7272a]
+      x-ms-client-request-id: [a86f1aac-0811-11e7-af0c-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/5bb6a0ad91604401acbee956a71e1f47","attributes":{"enabled":true,"created":1489100624,"updated":1489100624},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/a01b89c887ae469ba7966b877d885993","attributes":{"enabled":true,"created":1489425758,"updated":1489425758},"tags":{"file-encoding":"hex"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['309']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:44 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -757,19 +757,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 keyvaultclient/0.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a6a0524a-051c-11e7-8f04-a0b3ccf7272a]
+      x-ms-client-request-id: [a8efb99c-0811-11e7-860e-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/5bb6a0ad91604401acbee956a71e1f47","attributes":{"enabled":true,"created":1489100624,"updated":1489100624},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/a01b89c887ae469ba7966b877d885993","attributes":{"enabled":true,"created":1489425758,"updated":1489425758},"tags":{"file-encoding":"hex"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['309']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 09 Mar 2017 23:03:45 GMT']
+      Date: ['Mon, 13 Mar 2017 17:22:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]

--- a/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
@@ -295,8 +295,6 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('provider', 'Test'),
             JMESPathCheck('attributes.enabled', True)
         ])
-        with self.assertRaises(CLIError):
-            self.cmd('keyvault certificate issuer create --vault-name {} --issuer-name issuer1 --provider-name Test'.format(kv))
         self.cmd('keyvault certificate issuer show --vault-name {} --issuer-name issuer1'.format(kv), checks=[
             JMESPathCheck('provider', 'Test'),
             JMESPathCheck('attributes.enabled', True)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -22,7 +22,8 @@ from azure.cli.core.commands import \
 from azure.cli.core.commands.parameters import (location_type, get_resource_name_completion_list,
                                                 enum_choice_list, tags_type, ignore_type,
                                                 get_generic_completion_list, file_type)
-from azure.cli.core.commands.validators import MarkSpecifiedAction
+from azure.cli.core.commands.validators import \
+    (MarkSpecifiedAction, get_default_location_from_resource_group)
 from azure.cli.core.commands.template_create import get_folded_parameter_help_string
 from azure.cli.command_modules.network._client_factory import _network_client_factory
 from azure.cli.command_modules.network._validators import \
@@ -39,7 +40,7 @@ from azure.cli.command_modules.network._validators import \
      validate_auth_cert, validate_cert, validate_inbound_nat_rule_id_list,
      validate_address_pool_id_list, validate_inbound_nat_rule_name_or_id,
      validate_address_pool_name_or_id, validate_servers, load_cert_file, validate_metadata,
-     validate_peering_type, validate_dns_record_type, validate_location,
+     validate_peering_type, validate_dns_record_type,
      get_public_ip_validator, get_nsg_validator, get_subnet_validator,
      get_virtual_network_validator)
 from azure.mgmt.network.models import ApplicationGatewaySslProtocol
@@ -244,7 +245,7 @@ register_cli_argument('network express-route', 'service_provider_name', options_
 register_cli_argument('network express-route', 'peering_location', help="Name of the peering location. It must exactly match one of the available peering locations from the 'list-service-providers' command.")
 register_cli_argument('network express-route', 'device_path', options_list=('--path',), **enum_choice_list(device_path_values))
 register_cli_argument('network express-route', 'vlan_id', type=int)
-register_cli_argument('network express-route', 'location', location_type, validator=validate_location)
+register_cli_argument('network express-route', 'location', location_type, validator=get_default_location_from_resource_group)
 
 register_cli_argument('network express-route auth', 'circuit_name', circuit_name_type)
 register_cli_argument('network express-route auth', 'authorization_name', name_arg_type, id_part='child_name', help='Authorization name')
@@ -328,7 +329,7 @@ register_cli_argument('network nic ip-config inbound-nat-rule', 'inbound_nat_rul
 # NSG
 register_cli_argument('network nsg', 'network_security_group_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'), id_part='name')
 register_cli_argument('network nsg create', 'name', name_arg_type)
-register_cli_argument('network nsg create', 'location', location_type, validator=validate_location)
+register_cli_argument('network nsg create', 'location', location_type, validator=get_default_location_from_resource_group)
 
 # NSG Rule
 register_cli_argument('network nsg rule', 'security_rule_name', name_arg_type, id_part='child_name', help='Name of the network security group rule')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -11,6 +11,7 @@ from azure.mgmt.compute.models import (CachingTypes,
 from azure.mgmt.storage.models import SkuName
 
 from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
+from azure.cli.core.commands.validators import get_default_location_from_resource_group
 from azure.cli.core.commands.parameters import \
     (location_type, get_one_of_subscription_locations,
      get_resource_name_completion_list, tags_type, file_type, enum_choice_list, ignore_type)
@@ -19,7 +20,7 @@ from azure.cli.command_modules.vm._actions import \
 from azure.cli.command_modules.vm._validators import \
     (validate_nsg_name, validate_vm_nics, validate_vm_nic, process_vm_create_namespace,
      process_vmss_create_namespace, process_image_create_namespace,
-     process_disk_or_snapshot_create_namespace, validate_vm_disk, validate_location,
+     process_disk_or_snapshot_create_namespace, validate_vm_disk,
      process_disk_encryption_namespace)
 
 
@@ -86,7 +87,7 @@ register_cli_argument('vm disk', 'lun', type=int, help='0-based logical unit num
 
 register_cli_argument('vm availability-set', 'availability_set_name', name_arg_type, id_part='name',
                       completer=get_resource_name_completion_list('Microsoft.Compute/availabilitySets'), help='Name of the availability set')
-register_cli_argument('vm availability-set create', 'availability_set_name', name_arg_type, validator=validate_location, help='Name of the availability set')
+register_cli_argument('vm availability-set create', 'availability_set_name', name_arg_type, validator=get_default_location_from_resource_group, help='Name of the availability set')
 register_cli_argument('vm availability-set create', 'unmanaged', action='store_true', help='contained VMs should use unmanaged disks')
 register_cli_argument('vm availability-set create', 'platform_update_domain_count', type=int, help='Update Domain count. Example: 2')
 register_cli_argument('vm availability-set create', 'platform_fault_domain_count', type=int, help='Fault Domain count. Example: 2')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -10,6 +10,7 @@ from msrestazure.azure_exceptions import CloudError
 
 from azure.mgmt.keyvault import KeyVaultManagementClient
 from azure.cli.core.commands.arm import resource_id, parse_resource_id, is_valid_resource_id
+from azure.cli.core.commands.validators import get_default_location_from_resource_group
 from azure.cli.core._util import CLIError, random_string
 from ._client_factory import _compute_client_factory
 from azure.cli.command_modules.vm._vm_utils import check_existence, load_json
@@ -72,15 +73,6 @@ def validate_vm_nics(namespace):
 
     if hasattr(namespace, 'primary_nic') and namespace.primary_nic:
         namespace.primary_nic = _get_nic_id(namespace.primary_nic, rg)
-
-
-def validate_location(namespace):
-    if not namespace.location:
-        from azure.mgmt.resource.resources import ResourceManagementClient
-        from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        resource_client = get_mgmt_service_client(ResourceManagementClient)
-        rg = resource_client.resource_groups.get(namespace.resource_group_name)
-        namespace.location = rg.location  # pylint: disable=no-member
 
 
 def _validate_secrets(secrets, os_type):
@@ -647,7 +639,7 @@ def _is_valid_ssh_rsa_public_key(openssh_pubkey):
 
 
 def process_vm_create_namespace(namespace):
-    validate_location(namespace)
+    get_default_location_from_resource_group(namespace)
     _validate_vm_create_storage_profile(namespace)
     if namespace.storage_profile in [StorageProfile.SACustomImage,
                                      StorageProfile.SAPirImage]:
@@ -694,7 +686,7 @@ def _validate_vmss_create_load_balancer(namespace):
 
 
 def process_vmss_create_namespace(namespace):
-    validate_location(namespace)
+    get_default_location_from_resource_group(namespace)
     _validate_vm_create_storage_profile(namespace, for_scale_set=True)
     _validate_vmss_create_load_balancer(namespace)
     _validate_vm_create_vnet(namespace, for_scale_set=True)


### PR DESCRIPTION
- Fixes #2332. Adds METAVAR for vault
- Fixes #2362. Makes resource group required for keyvault create. 
- Adds reusable method in core to get location from resource group. Updates references. Makes location optional for keyvault create.
- Fixes #2420. Fixes #2361. Adds "three_state_flag" to core parameters to allow true/false or flag-like behavior (avoids breaking changes and allows create/update consistency).
- Closes #2421. Adds convenience parameters for this update command.
- Fixes #2418. Corrects bug with enabled/disabled flags. Makes keyvault certificate create idempotent. 