### PR TITLE
Add datalake package to setup.py

### DIFF
--- a/src/command_modules/azure-cli-datalake/setup.py
+++ b/src/command_modules/azure-cli-datalake/setup.py
@@ -55,6 +55,7 @@ setup(
         'azure.cli.command_modules',
     ],
     packages=[
+        'azure.cli.command_modules.datalake',
         'azure.cli.command_modules.datalake.store',
         'azure.cli.command_modules.datalake.analytics',
     ],


### PR DESCRIPTION
FYI @begoldsm
Currently the __init__.py of azure.cli.command_modules.datalake is not included in the package.