### PR TITLE
Fix issue with "single tuple" options_list

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -41,6 +41,9 @@ class CliArgumentType(object):
     def __init__(self, overrides=None, **kwargs):
         if isinstance(overrides, str):
             raise ValueError("Overrides has to be a CliArgumentType (cannot be a string)")
+        options_list = kwargs.get('options_list', None)
+        if options_list and isinstance(options_list, str):
+            kwargs['options_list'] = [options_list]
         self.settings = {}
         self.update(overrides, **kwargs)
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -115,7 +115,7 @@ for item in ['key', 'secret', 'certificate']:
 # TODO: Fix once service side issue is fixed that there is no way to list pending certificates
 register_cli_argument('keyvault certificate pending', 'certificate_name', options_list=('--name', '-n'), help='Name of the pending certificate.', id_part='child_name', completer=None)
 
-register_cli_argument('keyvault key', 'key_ops', options_list=('--ops',), nargs='*', help='Space separated list of permitted JSON web key operations. Possible values: {}'.format(json_web_key_op_values), validator=validate_key_ops, type=str.lower)
+register_cli_argument('keyvault key', 'key_ops', options_list=('--ops'), nargs='*', help='Space separated list of permitted JSON web key operations. Possible values: {}'.format(json_web_key_op_values), validator=validate_key_ops, type=str.lower)
 register_cli_argument('keyvault key', 'key_version', options_list=('--version', '-v'), help='The key version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('key'))
 
 for item in ['create', 'import']:


### PR DESCRIPTION
Fixes #2456. Previously, providing an options list like `options_list=('--foo')` would cause a cryptic, hard to diagnose error because it was lacking a comma.  This PR wraps anything of this form as a list internally, which doesn't require the comma.