### PR TITLE
vm:catch more general exception on querying encryption extension's status

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -254,7 +254,7 @@ def show(resource_group_name, vm_name):
     if is_linux:
         try:
             message_object = json.loads(substatus_message)
-        except json.decoder.JSONDecodeError:
+        except Exception:  # pylint: disable=broad-except
             message_object = None  # might be from outdated extension
 
         if message_object and ('os' in message_object):


### PR DESCRIPTION
The exception type of `json.decoder.JSONDecodeError` is only available on Python 3+, so the code might break on python 2.7. I can find a more universal json decode exception to catch, but on a second thought, it might better off to be the same like [xplat version](https://github.com/Azure/azure-xplat-cli/blob/dev/lib/commands/arm/vm/vmClient._js#L2036). The encryption extension is not very well documented, so capturing a general exception might end up being the best option. 