### PR TITLE
Require confirmation for destructive SQL commands.

### DIFF
--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
@@ -72,17 +72,19 @@ class CommandGroup(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def command(self, name, method_name):
+    def command(self, name, method_name, confirmation=None):
         cli_command(self._scope,
                     '{} {}'.format(self._group_name, name),
                     self._service_adapter(method_name),
-                    client_factory=self._client_factory)
+                    client_factory=self._client_factory,
+                    confirmation=confirmation)
 
-    def custom_command(self, name, custom_func_name):
+    def custom_command(self, name, custom_func_name, confirmation=None):
         cli_command(self._scope,
                     '{} {}'.format(self._group_name, name),
                     self._custom_path.format(custom_func_name),
-                    client_factory=self._client_factory)
+                    client_factory=self._client_factory,
+                    confirmation=confirmation)
 
     def generic_update_command(self, name, getter_op, setter_op, custom_func_name=None):
         if custom_func_name:

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
@@ -22,20 +22,20 @@ with ServiceGroup(__name__, get_sql_database_operations, database_operations) as
         c.custom_command('list', 'db_list')
         # # Usages will not be included in the first batch of GA commands
         # c.command('show-usage', 'list_usages')
-        c.command('delete', 'delete')
+        c.command('delete', 'delete', confirmation=True)
         c.generic_update_command('update', 'get', 'create_or_update', custom_func_name='db_update')
 
     with s.group('sql db replica') as c:
         c.custom_command('create', 'db_create_replica')
         c.command('list-links', 'list_replication_links')
-        c.custom_command('delete-link', 'db_delete_replica_link')
+        c.custom_command('delete-link', 'db_delete_replica_link', confirmation=True)
         c.custom_command('set-primary', 'db_failover')
 
     with s.group('sql dw') as c:
         c.custom_command('create', 'dw_create')
         c.command('show', 'get')
         c.custom_command('list', 'dw_list')
-        c.command('delete', 'delete')
+        c.command('delete', 'delete', confirmation=True)
         c.command('pause', 'pause_data_warehouse')
         c.command('resume', 'resume_data_warehouse')
         c.generic_update_command('update', 'get', 'create_or_update', custom_func_name='dw_update')
@@ -101,7 +101,7 @@ server_operations = create_service_adapter('azure.mgmt.sql.operations.servers_op
 with ServiceGroup(__name__, get_sql_servers_operation, server_operations) as s:
     with s.group('sql server') as c:
         c.command('create', 'create_or_update')
-        c.command('delete', 'delete')
+        c.command('delete', 'delete', confirmation=True)
         c.command('show', 'get_by_resource_group')
         # Usages will not be included in the first batch of GA commands
         # c.command('show-usage', 'list_usages')

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -235,7 +235,12 @@ def db_delete_replica_link(  # pylint: disable=too-many-arguments
         resource_group_name,
         # Partner dbs must have the same name as one another
         partner_server_name,
-        partner_resource_group_name=None):
+        partner_resource_group_name=None,
+        # Base command code handles confirmation, but it passes '--yes' parameter to us if
+        # provided. We don't care about this parameter and it gets handled weirdly if we
+        # expliclty specify it with default value here (e.g. `yes=None` or `yes=True`), receiving
+        # it in kwargs seems to work.
+        **kwargs):  # pylint: disable=unused-argument
 
     # Determine optional values
     partner_resource_group_name = partner_resource_group_name or resource_group_name

--- a/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
@@ -110,9 +110,9 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('administratorLogin', user)])
 
         # test delete sql server
-        self.cmd('sql server delete -g {} --name {}'
+        self.cmd('sql server delete -g {} --name {} --yes'
                  .format(rg, servers[0]), checks=NoneCheck())
-        self.cmd('sql server delete -g {} --name {}'
+        self.cmd('sql server delete -g {} --name {} --yes'
                  .format(rg, servers[1]), checks=NoneCheck())
 
         # test list sql server should be 0
@@ -280,7 +280,7 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('maxSizeBytes', update_storage_bytes),
                      JMESPathCheck('tags.key1', 'value1')])
 
-        self.cmd('sql db delete -g {} --server {} --name {}'
+        self.cmd('sql db delete -g {} --server {} --name {} --yes'
                  .format(rg, server, database_name),
                  checks=[NoneCheck()])
 
@@ -498,7 +498,7 @@ class SqlServerDwMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('tags.key1', 'value1')])
 
         # Delete DW
-        self.cmd('sql dw delete -g {} --server {} --name {}'
+        self.cmd('sql dw delete -g {} --server {} --name {} --yes'
                  .format(rg, server, database_name),
                  checks=[NoneCheck()])
 
@@ -612,7 +612,7 @@ class SqlServerDbReplicaMgmtScenarioTest(ScenarioTest):
         for _ in range(2):
             # Delete link
             self.cmd('sql db replica delete-link -g {} -s {} -n {} --partner-resource-group {}'
-                     ' --partner-server {}'
+                     ' --partner-server {} --yes'
                      .format(s3.group, s3.name, database_name, s2.group, s2.name),
                      checks=[NoneCheck()])
 
@@ -858,7 +858,7 @@ class SqlElasticPoolsMgmtScenarioTest(ScenarioTest):
         # self.verify_activities(activities, resource_group)
 
         # delete sql server database
-        self.cmd('sql db delete -g {} --server {} --name {}'
+        self.cmd('sql db delete -g {} --server {} --name {} --yes'
                  .format(rg, server, database_name),
                  checks=[NoneCheck()])
 


### PR DESCRIPTION
Only commands that are irreversible are included. For example delete firewall rule does not require confirmation because it can be easily undone.