### PR TITLE
Add wait commands and --no-wait support

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -246,15 +246,18 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
     def handler(args):  # pylint: disable=too-many-branches,too-many-statements
         from msrestazure.azure_operation import AzureOperationPoller
 
-        ordered_arguments = args.pop('ordered_arguments') if 'ordered_arguments' in args else []
+        ordered_arguments = args.pop('ordered_arguments', [])
+        for item in ['properties_to_add', 'properties_to_set', 'properties_to_remove']:
+            if args[item]:
+                raise CLIError("Unexpected '{}' was not empty.".format(item))
+            del args[item]
 
         try:
             client = factory() if factory else None
         except TypeError:
             client = factory(None) if factory else None
 
-        getterargs = {key: val for key, val in args.items()
-                      if key in get_arguments_loader()}
+        getterargs = {key: val for key, val in args.items() if key in get_arguments_loader()}
         getter = get_op_handler(getter_op)
         if child_collection_prop_name:
             parent = getter(client, **getterargs) if client else getter(**getterargs)
@@ -278,13 +281,7 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
                 instance = custom_function(instance, **custom_func_args)
 
         # apply generic updates after custom updates
-        setterargs = set_arguments_loader()
-        for k in args.copy().keys():
-            if k in get_arguments_loader() or k in setterargs \
-                    or k in ('properties_to_add', 'properties_to_remove', 'properties_to_set'):
-                args.pop(k)
-        for key, val in args.items():
-            ordered_arguments.append((key, val))
+        setterargs = {key: val for key, val in args.items() if key in set_arguments_loader()}
 
         for arg in ordered_arguments:
             arg_type, arg_values = arg
@@ -306,15 +303,12 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
                     raise CLIError('invalid syntax: {}'.format(remove_usage))
 
         # Done... update the instance!
-        getterargs[setter_arg_name] = parent if child_collection_prop_name else instance
+        setterargs[setter_arg_name] = parent if child_collection_prop_name else instance
         setter = get_op_handler(setter_op)
-        no_wait = no_wait_param and setterargs.get(no_wait_param, None)
-        if no_wait:
-            getterargs[no_wait_param] = True
 
-        opres = setter(client, **getterargs) if client else setter(**getterargs)
+        opres = setter(client, **setterargs) if client else setter(**setterargs)
 
-        if no_wait:
+        if setterargs.get(no_wait_param, None):
             return None
 
         result = opres.result() if isinstance(opres, AzureOperationPoller) else opres

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -100,18 +100,20 @@ cli_generic_update_command(__name__, 'network express-route peering update',
 cli_command(__name__, 'network express-route peering create', custom_path.format('create_express_route_peering'), cf_express_route_circuit_peerings)
 
 # ExpressRouteCircuitsOperations
-cli_command(__name__, 'network express-route delete', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.delete', cf_express_route_circuits)
+cli_command(__name__, 'network express-route delete', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.delete', cf_express_route_circuits, no_wait_param='raw')
 cli_command(__name__, 'network express-route show', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits, exception_handler=empty_on_404)
 cli_command(__name__, 'network express-route get-stats', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get_stats', cf_express_route_circuits)
 cli_command(__name__, 'network express-route list-arp-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_arp_table', cf_express_route_circuits)
 cli_command(__name__, 'network express-route list-route-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_routes_table', cf_express_route_circuits)
-cli_command(__name__, 'network express-route create', custom_path.format('create_express_route'))
+cli_command(__name__, 'network express-route create', custom_path.format('create_express_route'), no_wait_param='no_wait')
 cli_command(__name__, 'network express-route list', custom_path.format('list_express_route_circuits'))
 cli_generic_update_command(__name__, 'network express-route update',
                            'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get',
                            'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.create_or_update',
                            cf_express_route_circuits,
-                           custom_function_op=custom_path.format('update_express_route'))
+                           custom_function_op=custom_path.format('update_express_route'),
+                           no_wait_param='raw')
+cli_generic_wait_command(__name__, 'network express-route wait', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits)
 
 # ExpressRouteServiceProvidersOperations
 cli_command(__name__, 'network express-route list-service-providers', 'azure.mgmt.network.operations.express_route_service_providers_operations#ExpressRouteServiceProvidersOperations.list', cf_express_route_service_providers)
@@ -181,15 +183,16 @@ cli_generic_update_command(__name__, 'network lb probe update',
                            custom_function_op=custom_path.format('set_lb_probe'))
 
 # LocalNetworkGatewaysOperations
-cli_command(__name__, 'network local-gateway delete', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.delete', cf_local_network_gateways)
+cli_command(__name__, 'network local-gateway delete', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.delete', cf_local_network_gateways, no_wait_param='raw')
 cli_command(__name__, 'network local-gateway show', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get', cf_local_network_gateways, exception_handler=empty_on_404)
 cli_command(__name__, 'network local-gateway list', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.list', cf_local_network_gateways, table_transformer=transform_local_gateway_table_output)
-cli_command(__name__, 'network local-gateway create', custom_path.format('create_local_gateway'))
+cli_command(__name__, 'network local-gateway create', custom_path.format('create_local_gateway'), no_wait_param='no_wait')
 cli_generic_update_command(__name__, 'network local-gateway update',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.create_or_update',
                            cf_local_network_gateways,
-                           custom_function_op=custom_path.format('update_local_gateway'))
+                           custom_function_op=custom_path.format('update_local_gateway'), no_wait_param='raw')
+cli_generic_wait_command(__name__, 'network local-gateway wait', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get', cf_local_network_gateways)
 
 # NetworkInterfacesOperations
 cli_command(__name__, 'network nic create', custom_path.format('create_nic'), transform=transform_nic_create_output)
@@ -312,7 +315,7 @@ cli_generic_update_command(__name__, 'network vpn-connection shared-key update',
                            cf_virtual_network_gateway_connections)
 
 # VirtualNetworkGatewaysOperations
-cli_command(__name__, 'network vnet-gateway delete', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.delete', cf_virtual_network_gateways)
+cli_command(__name__, 'network vnet-gateway delete', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.delete', cf_virtual_network_gateways, no_wait_param='raw')
 cli_command(__name__, 'network vnet-gateway show', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.get', cf_virtual_network_gateways, exception_handler=empty_on_404)
 cli_command(__name__, 'network vnet-gateway list', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.list', cf_virtual_network_gateways)
 cli_command(__name__, 'network vnet-gateway reset', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.reset', cf_virtual_network_gateways)
@@ -323,13 +326,12 @@ cli_generic_update_command(__name__, 'network vnet-gateway update',
                            cf_virtual_network_gateways,
                            custom_function_op=custom_path.format('update_vnet_gateway'),
                            no_wait_param='raw')
+cli_generic_wait_command(__name__, 'network vnet-gateway wait', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.get', cf_virtual_network_gateways)
+
 cli_command(__name__, 'network vnet-gateway root-cert create', custom_path.format('create_vnet_gateway_root_cert'))
 cli_command(__name__, 'network vnet-gateway root-cert delete', custom_path.format('delete_vnet_gateway_root_cert'))
 cli_command(__name__, 'network vnet-gateway revoked-cert create', custom_path.format('create_vnet_gateway_revoked_cert'))
 cli_command(__name__, 'network vnet-gateway revoked-cert delete', custom_path.format('delete_vnet_gateway_revoked_cert'))
-
-
-cli_generic_wait_command(__name__, 'network vnet-gateway wait', 'azure.mgmt.network.operations.virtual_network_gateways_operations#VirtualNetworkGatewaysOperations.get', cf_virtual_network_gateways)
 
 # VirtualNetworksOperations
 cli_command(__name__, 'network vnet delete', 'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.delete', cf_virtual_networks)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1248,7 +1248,7 @@ def update_vnet_gateway(instance, address_prefixes=None, sku=None, vpn_type=None
 # region Express Route commands
 
 def create_express_route(circuit_name, resource_group_name, bandwidth_in_mbps, peering_location,
-                         service_provider_name, location=None, tags=None,
+                         service_provider_name, location=None, tags=None, no_wait=False,
                          sku_family=ExpressRouteCircuitSkuFamily.metered_data.value,
                          sku_tier=ExpressRouteCircuitSkuTier.standard.value):
     from azure.mgmt.network.models import \
@@ -1261,7 +1261,7 @@ def create_express_route(circuit_name, resource_group_name, bandwidth_in_mbps, p
             service_provider_name, peering_location, bandwidth_in_mbps),
         sku=ExpressRouteCircuitSku(sku_name, sku_tier, sku_family)
     )
-    return client.create_or_update(resource_group_name, circuit_name, circuit)
+    return client.create_or_update(resource_group_name, circuit_name, circuit, raw=no_wait)
 
 def update_express_route(instance, bandwidth_in_mbps=None, peering_location=None,
                          service_provider_name=None, sku_family=None, sku_tier=None, tags=None):
@@ -1409,7 +1409,7 @@ update_route.__doc__ = Route.__doc__
 
 def create_local_gateway(resource_group_name, local_network_gateway_name, gateway_ip_address,
                          location=None, tags=None, local_address_prefix=None, asn=None,
-                         bgp_peering_address=None, peer_weight=None):
+                         bgp_peering_address=None, peer_weight=None, no_wait=False):
     from azure.mgmt.network.models import LocalNetworkGateway, BgpSettings
     client = _network_client_factory().local_network_gateways
     local_gateway = LocalNetworkGateway(
@@ -1417,7 +1417,8 @@ def create_local_gateway(resource_group_name, local_network_gateway_name, gatewa
         gateway_ip_address=gateway_ip_address)
     if bgp_peering_address or asn or peer_weight:
         local_gateway.bgp_settings = BgpSettings(asn, bgp_peering_address, peer_weight)
-    return client.create_or_update(resource_group_name, local_network_gateway_name, local_gateway)
+    return client.create_or_update(
+        resource_group_name, local_network_gateway_name, local_gateway, raw=no_wait)
 
 def update_local_gateway(instance, gateway_ip_address=None, local_address_prefix=None, asn=None,
                          bgp_peering_address=None, peer_weight=None, tags=None):

--- a/src/command_modules/azure-cli-network/tests/recordings/test_network_app_gateway_with_private_ip.yaml
+++ b/src/command_modules/azure-cli-network/tests/recordings/test_network_app_gateway_with_private_ip.yaml
@@ -6,19 +6,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d67482f4-c7c3-11e6-992c-a0b3ccf7272a]
+      x-ms-client-request-id: [c6ec822e-0a5c-11e7-bd87-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_ag_private_ip%27%20and%20name%20eq%20%27None%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cli_test_ag_private_ip%27%20and%20name%20eq%20%27None%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27&api-version=2016-09-01
   response:
     body: {string: '{"value":[]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:20 GMT']
+      Date: ['Thu, 16 Mar 2017 15:25:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -26,44 +26,45 @@ interactions:
       content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"publicIpAddressType": {"value": "none"},
-      "subnet": {"value": "subnet1"}, "capacity": {"value": 2}, "skuTier": {"value":
-      "Standard"}, "servers": {"value": []}, "frontendPort": {"value": 443}, "subnetAddressPrefix":
-      {"value": "10.0.0.0/24"}, "httpListenerProtocol": {"value": "https"}, "httpSettingsProtocol":
-      {"value": "http"}, "publicIpAddressAllocation": {"value": "dynamic"}, "applicationGatewayName":
-      {"value": "ag3"}, "privateIpAddress": {"value": "10.0.0.15"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16"},
-      "httpSettingsPort": {"value": 80}, "routingRuleType": {"value": "Basic"}, "privateIpAddressAllocation":
-      {"value": "static"}, "certData": {"value": "MIIJuwIBAzCCCXcGCSqGSIb3DQEHAaCCCWgEgglkMIIJYDCCBgkGCSqGSIb3DQEHAaCCBfoEggX2MIIF8jCCBe4GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAhXEBfBWkIAigICB9AEggTY4EM/sz3ldecsIvpg3F/ymL4YqRboZbvA4LwwdTC1fuOwcxs4sJ/b3OPDwiWqEE9GinOh7+Kr1dVpH1lff+d8B/ZIM8qTC/ywoHwGJch8zNZIpLQZ997cyI64MyhpFx7Fyf5AcDdw0wTS2cvl1P531TR3epCVH/3EPHbn43nj7BClm9isGD3rxURfw/NIdAwremab16tsnl8OTKSBv1goCnuvVpPGDwSNb1B5VmF7zVQ80oIOp0EGiTMSeMAz1LDTwZIBzC1hU+xd8N+n2FI2GIb6w05aTob1qa6jui0aIzCe851mHS75zGTvVyzDRqDrRsmI34wvmk+H1VY1kuhHUAOLVU5c1KTNTCWhmVx2utl7yuh2vI8ss/HBYGAqJ89o7LzOqNEH1moempkuUqPKC/NhTTUkfM5Z+KjOvBQwGmUXWbMJrlpJIMf1NmOJLFVdIqrEQ3ndhvjiORjcv5IDQj5ZQ47KHm3Fwmvx9gXzucpsaO+PAIDivg9jNEQswgzdu7pqqnABZ1v/1mbR1cGp6uVRPT7PRka7R7vwLS7dejqL5WN0A5p/x+JvZeXrjvupKZo90EF5TLzLVKxynu4kwCCBdF7C18x4u2DiH4vRCjnrfdX7FFmSiOoqkGbvbsKPOFNz76eGM4glwrp0k48iJO85usn4DaYVdGRi/ANFP1gkJBh1M79F1oDAp1jGczd119xoyXoDLqgkjID6E7Gu/W0rUvCyC8Hh0rL/jUirQ9nus7tqcecpvptNuMT3grNQMyQEchibSCNxCBRZ5xAesvNvJahxO2PmckztvP9sokij6KroVkjR2EpVcddOI0T6hgWGsaaaF6ea2NDfiPMnjk/yEs5CEGfHhXHYYYGOwpDBReJLzJAaMviy/znYOsnxbWhVHra7ftQW/qqgwQzOocNoJab9lxR2Jp98J0m4VLH26xkbyjJZ/cPn7kjmSUFgYB7rNILUoBvzeEGk2ZiihMhjxhWs6VPwF8RBiybmP9rnzLmnJGsQlvGf8zmaDpitllyZODLUvm0BcU009AX6EGLy6IfXJ7XV/N78w9QuqaAWc7XxHiwDjCWRjgolj4v62LoP7blXdKTvFxrEdWMEuViAnDHaEQlZFGgPzF6MRm/59Wl194ZNcjq/jAD/uhuTX88IZtqRgdtbbUT1sHMOHTz/FkcWBnC2LFP/aTJOBvIYM0iyoEWHpprUol0mNCRyfWmA7ILg+kYC1AUVXwk9VGoTeXNCQcRQwqehhmCeD+h5Iu/U9qpuJw8zy+6EovHYrBMYEK9JUXBn1K7rFikDDXK3O1SDkzvqfvrc0pOceU5H2OXygdsUIzyYSEBE09MaWw8q2/JbZ9b3h9FcDZ0efWoKMXlk24EZAOfh+xLyg6dtk7iCBmQSggCJUbHut8Rz6McGzkJ0Bzh+iF6dg1Ob+wwEWRwN9rQfU0wKUaoEm3E7kT3UvR6tOp87jUDVlO7suaoZhe6mkNtrhHPFMd5viPeYGpbobogxjI3xawC0PMhTsVjydVZha5LA2T6OvkfYQN69XQDGVyfmh3m6JBNDKW8BiKHvhZfvRKYAAnDerGYkOqoSyICwLpUUAjKZYMFpuSYjE5/XWO2ETCcYSjonWvckpP1CcdVAaG+5kGVhu2G24Q6nwPPWYjGB3DANBgkrBgEEAYI3EQIxADATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGQAMABkADcAMAA3ADgANQAtAGEAOAAxADIALQA0AGIAYgAyAC0AYgA1AGEANAAtAGUAYgA5ADIAYQA4ADQAMABiAGEAZAAxMF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAHQAcgBvAG4AZwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHIwggNPBgkqhkiG9w0BBwGgggNABIIDPDCCAzgwggM0BgsqhkiG9w0BDAoBA6CCAwwwggMIBgoqhkiG9w0BCRYBoIIC+ASCAvQwggLwMIIB3KADAgECAhD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQAwEzERMA8GA1UEAxMIVGVzdENlcnQwHhcNMTYwNjI5MTc0MTIwWhcNMzkxMjMxMjM1OTU5WjATMREwDwYDVQQDEwhUZXN0Q2VydDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF6nktMamqvOBxXkuAIzYdxItr9m9MV4M2i+Qxm2Ri4tOmzmtTnu6P1sHfFz0p2IYepsJFts2QxeRfGrwKE7qwk/IXYaE8RjFhwxmCia7pqUjDisjujYoTvP1yNp1XWnjofzR10Lcob8Fx1p6FsWnaVQzWS4OA+RuipiUUGWxjLc5aS1Uottq5LDY1NEQBpR/AN8u3OC4dPFnJBv1RUoLo3DFIa4CgzPxIQA1yr6BFlpb3knUewkNJmnafRFdhfFWSOCi+0DVb2ScuMJb1n9zKvyQMxRukj+IvwNbUVJM8lSnbVoZVtK1AYlAs400rgSFGV4luP03sCRjrPyzQGAOUCAwEAAaNIMEYwRAYDVR0BBD0wO4AQRkxt5Eke37a7P2NW7iszwKEVMBMxETAPBgNVBAMTCFRlc3RDZXJ0ghD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQADggEBABmf90zy2ajVzH6qc6LzD3dlV3h1r4gR0U3yvghdHzdySZCqRtiJMlGAzj8XtziimbvzUKrqmKMsdpwxhPrn70dXH8hJw3i0ZjY25iY6AsJAJ4D0tnnm8Bddn5tyA2IaC0ndGoYWzsFWGFcioeNs8FQ2T2za5mNN8mKQeAZetJVmYn6YYFzj9Btzl7xfnr+SEttQnfNlep1OpRfCKnLiVdCxWaoLtZxlNxy161kEQENcosdF+7L2HgSa+GC+37B8fDg8XMc54skEPeB/1udtmr/i/jRcoPd6yb0K/4wxpz6eMaB55sIApCmZIouBmUnXaLv3nevZeeVw3clRzRYDcFwxFTATBgkqhkiG9w0BCRUxBgQEAQAAADA7MB8wBwYFKw4DAhoEFIU1dNT51rcRzemh6df/sdBkw/zHBBQaMyWKXs+KqGKxMPShgpXMX03s8gICB9A="},
-      "skuName": {"value": "Standard_Medium"}, "vnetAddressPrefix": {"value": "10.0.0.0/16"},
-      "httpSettingsCookieBasedAffinity": {"value": "disabled"}, "subnetType": {"value":
-      "new"}, "frontendType": {"value": "privateIp"}, "certPassword": {"value": "password"}}}}'
+    body: '{"properties": {"parameters": {"_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16"},
+      "publicIpAddressAllocation": {"value": "dynamic"}, "httpSettingsPort": {"value":
+      80}, "publicIpAddressType": {"value": "none"}, "routingRuleType": {"value":
+      "Basic"}, "httpSettingsProtocol": {"value": "http"}, "subnetType": {"value":
+      "new"}, "skuTier": {"value": "Standard"}, "servers": {"value": []}, "capacity":
+      {"value": 2}, "certPassword": {"value": "password"}, "frontendPort": {"value":
+      443}, "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "frontendType": {"value":
+      "privateIp"}, "subnet": {"value": "subnet1"}, "skuName": {"value": "Standard_Medium"},
+      "privateIpAddress": {"value": "10.0.0.15"}, "subnetAddressPrefix": {"value":
+      "10.0.0.0/24"}, "applicationGatewayName": {"value": "ag3"}, "httpSettingsCookieBasedAffinity":
+      {"value": "disabled"}, "certData": {"value": "MIIJuwIBAzCCCXcGCSqGSIb3DQEHAaCCCWgEgglkMIIJYDCCBgkGCSqGSIb3DQEHAaCCBfoEggX2MIIF8jCCBe4GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAhXEBfBWkIAigICB9AEggTY4EM/sz3ldecsIvpg3F/ymL4YqRboZbvA4LwwdTC1fuOwcxs4sJ/b3OPDwiWqEE9GinOh7+Kr1dVpH1lff+d8B/ZIM8qTC/ywoHwGJch8zNZIpLQZ997cyI64MyhpFx7Fyf5AcDdw0wTS2cvl1P531TR3epCVH/3EPHbn43nj7BClm9isGD3rxURfw/NIdAwremab16tsnl8OTKSBv1goCnuvVpPGDwSNb1B5VmF7zVQ80oIOp0EGiTMSeMAz1LDTwZIBzC1hU+xd8N+n2FI2GIb6w05aTob1qa6jui0aIzCe851mHS75zGTvVyzDRqDrRsmI34wvmk+H1VY1kuhHUAOLVU5c1KTNTCWhmVx2utl7yuh2vI8ss/HBYGAqJ89o7LzOqNEH1moempkuUqPKC/NhTTUkfM5Z+KjOvBQwGmUXWbMJrlpJIMf1NmOJLFVdIqrEQ3ndhvjiORjcv5IDQj5ZQ47KHm3Fwmvx9gXzucpsaO+PAIDivg9jNEQswgzdu7pqqnABZ1v/1mbR1cGp6uVRPT7PRka7R7vwLS7dejqL5WN0A5p/x+JvZeXrjvupKZo90EF5TLzLVKxynu4kwCCBdF7C18x4u2DiH4vRCjnrfdX7FFmSiOoqkGbvbsKPOFNz76eGM4glwrp0k48iJO85usn4DaYVdGRi/ANFP1gkJBh1M79F1oDAp1jGczd119xoyXoDLqgkjID6E7Gu/W0rUvCyC8Hh0rL/jUirQ9nus7tqcecpvptNuMT3grNQMyQEchibSCNxCBRZ5xAesvNvJahxO2PmckztvP9sokij6KroVkjR2EpVcddOI0T6hgWGsaaaF6ea2NDfiPMnjk/yEs5CEGfHhXHYYYGOwpDBReJLzJAaMviy/znYOsnxbWhVHra7ftQW/qqgwQzOocNoJab9lxR2Jp98J0m4VLH26xkbyjJZ/cPn7kjmSUFgYB7rNILUoBvzeEGk2ZiihMhjxhWs6VPwF8RBiybmP9rnzLmnJGsQlvGf8zmaDpitllyZODLUvm0BcU009AX6EGLy6IfXJ7XV/N78w9QuqaAWc7XxHiwDjCWRjgolj4v62LoP7blXdKTvFxrEdWMEuViAnDHaEQlZFGgPzF6MRm/59Wl194ZNcjq/jAD/uhuTX88IZtqRgdtbbUT1sHMOHTz/FkcWBnC2LFP/aTJOBvIYM0iyoEWHpprUol0mNCRyfWmA7ILg+kYC1AUVXwk9VGoTeXNCQcRQwqehhmCeD+h5Iu/U9qpuJw8zy+6EovHYrBMYEK9JUXBn1K7rFikDDXK3O1SDkzvqfvrc0pOceU5H2OXygdsUIzyYSEBE09MaWw8q2/JbZ9b3h9FcDZ0efWoKMXlk24EZAOfh+xLyg6dtk7iCBmQSggCJUbHut8Rz6McGzkJ0Bzh+iF6dg1Ob+wwEWRwN9rQfU0wKUaoEm3E7kT3UvR6tOp87jUDVlO7suaoZhe6mkNtrhHPFMd5viPeYGpbobogxjI3xawC0PMhTsVjydVZha5LA2T6OvkfYQN69XQDGVyfmh3m6JBNDKW8BiKHvhZfvRKYAAnDerGYkOqoSyICwLpUUAjKZYMFpuSYjE5/XWO2ETCcYSjonWvckpP1CcdVAaG+5kGVhu2G24Q6nwPPWYjGB3DANBgkrBgEEAYI3EQIxADATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGQAMABkADcAMAA3ADgANQAtAGEAOAAxADIALQA0AGIAYgAyAC0AYgA1AGEANAAtAGUAYgA5ADIAYQA4ADQAMABiAGEAZAAxMF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAHQAcgBvAG4AZwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHIwggNPBgkqhkiG9w0BBwGgggNABIIDPDCCAzgwggM0BgsqhkiG9w0BDAoBA6CCAwwwggMIBgoqhkiG9w0BCRYBoIIC+ASCAvQwggLwMIIB3KADAgECAhD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQAwEzERMA8GA1UEAxMIVGVzdENlcnQwHhcNMTYwNjI5MTc0MTIwWhcNMzkxMjMxMjM1OTU5WjATMREwDwYDVQQDEwhUZXN0Q2VydDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF6nktMamqvOBxXkuAIzYdxItr9m9MV4M2i+Qxm2Ri4tOmzmtTnu6P1sHfFz0p2IYepsJFts2QxeRfGrwKE7qwk/IXYaE8RjFhwxmCia7pqUjDisjujYoTvP1yNp1XWnjofzR10Lcob8Fx1p6FsWnaVQzWS4OA+RuipiUUGWxjLc5aS1Uottq5LDY1NEQBpR/AN8u3OC4dPFnJBv1RUoLo3DFIa4CgzPxIQA1yr6BFlpb3knUewkNJmnafRFdhfFWSOCi+0DVb2ScuMJb1n9zKvyQMxRukj+IvwNbUVJM8lSnbVoZVtK1AYlAs400rgSFGV4luP03sCRjrPyzQGAOUCAwEAAaNIMEYwRAYDVR0BBD0wO4AQRkxt5Eke37a7P2NW7iszwKEVMBMxETAPBgNVBAMTCFRlc3RDZXJ0ghD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQADggEBABmf90zy2ajVzH6qc6LzD3dlV3h1r4gR0U3yvghdHzdySZCqRtiJMlGAzj8XtziimbvzUKrqmKMsdpwxhPrn70dXH8hJw3i0ZjY25iY6AsJAJ4D0tnnm8Bddn5tyA2IaC0ndGoYWzsFWGFcioeNs8FQ2T2za5mNN8mKQeAZetJVmYn6YYFzj9Btzl7xfnr+SEttQnfNlep1OpRfCKnLiVdCxWaoLtZxlNxy161kEQENcosdF+7L2HgSa+GC+37B8fDg8XMc54skEPeB/1udtmr/i/jRcoPd6yb0K/4wxpz6eMaB55sIApCmZIouBmUnXaLv3nevZeeVw3clRzRYDcFwxFTATBgkqhkiG9w0BCRUxBgQEAQAAADA7MB8wBwYFKw4DAhoEFIU1dNT51rcRzemh6df/sdBkw/zHBBQaMyWKXs+KqGKxMPShgpXMX03s8gICB9A="},
+      "privateIpAddressAllocation": {"value": "static"}, "httpListenerProtocol": {"value":
+      "https"}}, "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16/azuredeploy.json"},
+      "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['4504']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 appgatewaycreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 appgatewaycreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d68ec86e-c7c3-11e6-97b5-a0b3ccf7272a]
+      x-ms-client-request-id: [c724d574-0a5c-11e7-b750-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/azurecli1482355461.3430485821","name":"azurecli1482355461.3430485821","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16"},"applicationGatewayName":{"type":"String","value":"ag3"},"capacity":{"type":"Int","value":2},"certData":{"type":"String","value":"MIIJuwIBAzCCCXcGCSqGSIb3DQEHAaCCCWgEgglkMIIJYDCCBgkGCSqGSIb3DQEHAaCCBfoEggX2MIIF8jCCBe4GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAhXEBfBWkIAigICB9AEggTY4EM/sz3ldecsIvpg3F/ymL4YqRboZbvA4LwwdTC1fuOwcxs4sJ/b3OPDwiWqEE9GinOh7+Kr1dVpH1lff+d8B/ZIM8qTC/ywoHwGJch8zNZIpLQZ997cyI64MyhpFx7Fyf5AcDdw0wTS2cvl1P531TR3epCVH/3EPHbn43nj7BClm9isGD3rxURfw/NIdAwremab16tsnl8OTKSBv1goCnuvVpPGDwSNb1B5VmF7zVQ80oIOp0EGiTMSeMAz1LDTwZIBzC1hU+xd8N+n2FI2GIb6w05aTob1qa6jui0aIzCe851mHS75zGTvVyzDRqDrRsmI34wvmk+H1VY1kuhHUAOLVU5c1KTNTCWhmVx2utl7yuh2vI8ss/HBYGAqJ89o7LzOqNEH1moempkuUqPKC/NhTTUkfM5Z+KjOvBQwGmUXWbMJrlpJIMf1NmOJLFVdIqrEQ3ndhvjiORjcv5IDQj5ZQ47KHm3Fwmvx9gXzucpsaO+PAIDivg9jNEQswgzdu7pqqnABZ1v/1mbR1cGp6uVRPT7PRka7R7vwLS7dejqL5WN0A5p/x+JvZeXrjvupKZo90EF5TLzLVKxynu4kwCCBdF7C18x4u2DiH4vRCjnrfdX7FFmSiOoqkGbvbsKPOFNz76eGM4glwrp0k48iJO85usn4DaYVdGRi/ANFP1gkJBh1M79F1oDAp1jGczd119xoyXoDLqgkjID6E7Gu/W0rUvCyC8Hh0rL/jUirQ9nus7tqcecpvptNuMT3grNQMyQEchibSCNxCBRZ5xAesvNvJahxO2PmckztvP9sokij6KroVkjR2EpVcddOI0T6hgWGsaaaF6ea2NDfiPMnjk/yEs5CEGfHhXHYYYGOwpDBReJLzJAaMviy/znYOsnxbWhVHra7ftQW/qqgwQzOocNoJab9lxR2Jp98J0m4VLH26xkbyjJZ/cPn7kjmSUFgYB7rNILUoBvzeEGk2ZiihMhjxhWs6VPwF8RBiybmP9rnzLmnJGsQlvGf8zmaDpitllyZODLUvm0BcU009AX6EGLy6IfXJ7XV/N78w9QuqaAWc7XxHiwDjCWRjgolj4v62LoP7blXdKTvFxrEdWMEuViAnDHaEQlZFGgPzF6MRm/59Wl194ZNcjq/jAD/uhuTX88IZtqRgdtbbUT1sHMOHTz/FkcWBnC2LFP/aTJOBvIYM0iyoEWHpprUol0mNCRyfWmA7ILg+kYC1AUVXwk9VGoTeXNCQcRQwqehhmCeD+h5Iu/U9qpuJw8zy+6EovHYrBMYEK9JUXBn1K7rFikDDXK3O1SDkzvqfvrc0pOceU5H2OXygdsUIzyYSEBE09MaWw8q2/JbZ9b3h9FcDZ0efWoKMXlk24EZAOfh+xLyg6dtk7iCBmQSggCJUbHut8Rz6McGzkJ0Bzh+iF6dg1Ob+wwEWRwN9rQfU0wKUaoEm3E7kT3UvR6tOp87jUDVlO7suaoZhe6mkNtrhHPFMd5viPeYGpbobogxjI3xawC0PMhTsVjydVZha5LA2T6OvkfYQN69XQDGVyfmh3m6JBNDKW8BiKHvhZfvRKYAAnDerGYkOqoSyICwLpUUAjKZYMFpuSYjE5/XWO2ETCcYSjonWvckpP1CcdVAaG+5kGVhu2G24Q6nwPPWYjGB3DANBgkrBgEEAYI3EQIxADATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGQAMABkADcAMAA3ADgANQAtAGEAOAAxADIALQA0AGIAYgAyAC0AYgA1AGEANAAtAGUAYgA5ADIAYQA4ADQAMABiAGEAZAAxMF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAHQAcgBvAG4AZwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHIwggNPBgkqhkiG9w0BBwGgggNABIIDPDCCAzgwggM0BgsqhkiG9w0BDAoBA6CCAwwwggMIBgoqhkiG9w0BCRYBoIIC+ASCAvQwggLwMIIB3KADAgECAhD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQAwEzERMA8GA1UEAxMIVGVzdENlcnQwHhcNMTYwNjI5MTc0MTIwWhcNMzkxMjMxMjM1OTU5WjATMREwDwYDVQQDEwhUZXN0Q2VydDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF6nktMamqvOBxXkuAIzYdxItr9m9MV4M2i+Qxm2Ri4tOmzmtTnu6P1sHfFz0p2IYepsJFts2QxeRfGrwKE7qwk/IXYaE8RjFhwxmCia7pqUjDisjujYoTvP1yNp1XWnjofzR10Lcob8Fx1p6FsWnaVQzWS4OA+RuipiUUGWxjLc5aS1Uottq5LDY1NEQBpR/AN8u3OC4dPFnJBv1RUoLo3DFIa4CgzPxIQA1yr6BFlpb3knUewkNJmnafRFdhfFWSOCi+0DVb2ScuMJb1n9zKvyQMxRukj+IvwNbUVJM8lSnbVoZVtK1AYlAs400rgSFGV4luP03sCRjrPyzQGAOUCAwEAAaNIMEYwRAYDVR0BBD0wO4AQRkxt5Eke37a7P2NW7iszwKEVMBMxETAPBgNVBAMTCFRlc3RDZXJ0ghD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQADggEBABmf90zy2ajVzH6qc6LzD3dlV3h1r4gR0U3yvghdHzdySZCqRtiJMlGAzj8XtziimbvzUKrqmKMsdpwxhPrn70dXH8hJw3i0ZjY25iY6AsJAJ4D0tnnm8Bddn5tyA2IaC0ndGoYWzsFWGFcioeNs8FQ2T2za5mNN8mKQeAZetJVmYn6YYFzj9Btzl7xfnr+SEttQnfNlep1OpRfCKnLiVdCxWaoLtZxlNxy161kEQENcosdF+7L2HgSa+GC+37B8fDg8XMc54skEPeB/1udtmr/i/jRcoPd6yb0K/4wxpz6eMaB55sIApCmZIouBmUnXaLv3nevZeeVw3clRzRYDcFwxFTATBgkqhkiG9w0BCRUxBgQEAQAAADA7MB8wBwYFKw4DAhoEFIU1dNT51rcRzemh6df/sdBkw/zHBBQaMyWKXs+KqGKxMPShgpXMX03s8gICB9A="},"certPassword":{"type":"SecureString"},"frontendPort":{"type":"Int","value":443},"frontendType":{"type":"String","value":"privateIp"},"httpListenerProtocol":{"type":"String","value":"https"},"httpSettingsCookieBasedAffinity":{"type":"String","value":"disabled"},"httpSettingsPort":{"type":"Int","value":80},"httpSettingsProtocol":{"type":"String","value":"http"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"PublicIPag3"},"publicIpAddressType":{"type":"String","value":"none"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"routingRuleType":{"type":"String","value":"Basic"},"servers":{"type":"Array","value":[]},"skuName":{"type":"String","value":"Standard_Medium"},"skuTier":{"type":"String","value":"Standard"},"subnet":{"type":"String","value":"subnet1"},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"new"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"ag3Vnet"},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-21T21:24:22.4115261Z","duration":"PT0.4093448S","correlationId":"8ebac06c-37f6-477c-a5ad-169c6610d4d9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"applicationGateways","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/VNETag3","resourceType":"Microsoft.Resources/deployments","resourceName":"VNETag3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/PublicIpag3","resourceType":"Microsoft.Resources/deployments","resourceName":"PublicIpag3"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3","resourceType":"Microsoft.Network/applicationGateways","resourceName":"ag3"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/azurecli1489677924.860695674692","name":"azurecli1489677924.860695674692","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"3276783378463952418","parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAppGateway_2016-11-16"},"applicationGatewayName":{"type":"String","value":"ag3"},"capacity":{"type":"Int","value":2},"certData":{"type":"String","value":"MIIJuwIBAzCCCXcGCSqGSIb3DQEHAaCCCWgEgglkMIIJYDCCBgkGCSqGSIb3DQEHAaCCBfoEggX2MIIF8jCCBe4GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAhXEBfBWkIAigICB9AEggTY4EM/sz3ldecsIvpg3F/ymL4YqRboZbvA4LwwdTC1fuOwcxs4sJ/b3OPDwiWqEE9GinOh7+Kr1dVpH1lff+d8B/ZIM8qTC/ywoHwGJch8zNZIpLQZ997cyI64MyhpFx7Fyf5AcDdw0wTS2cvl1P531TR3epCVH/3EPHbn43nj7BClm9isGD3rxURfw/NIdAwremab16tsnl8OTKSBv1goCnuvVpPGDwSNb1B5VmF7zVQ80oIOp0EGiTMSeMAz1LDTwZIBzC1hU+xd8N+n2FI2GIb6w05aTob1qa6jui0aIzCe851mHS75zGTvVyzDRqDrRsmI34wvmk+H1VY1kuhHUAOLVU5c1KTNTCWhmVx2utl7yuh2vI8ss/HBYGAqJ89o7LzOqNEH1moempkuUqPKC/NhTTUkfM5Z+KjOvBQwGmUXWbMJrlpJIMf1NmOJLFVdIqrEQ3ndhvjiORjcv5IDQj5ZQ47KHm3Fwmvx9gXzucpsaO+PAIDivg9jNEQswgzdu7pqqnABZ1v/1mbR1cGp6uVRPT7PRka7R7vwLS7dejqL5WN0A5p/x+JvZeXrjvupKZo90EF5TLzLVKxynu4kwCCBdF7C18x4u2DiH4vRCjnrfdX7FFmSiOoqkGbvbsKPOFNz76eGM4glwrp0k48iJO85usn4DaYVdGRi/ANFP1gkJBh1M79F1oDAp1jGczd119xoyXoDLqgkjID6E7Gu/W0rUvCyC8Hh0rL/jUirQ9nus7tqcecpvptNuMT3grNQMyQEchibSCNxCBRZ5xAesvNvJahxO2PmckztvP9sokij6KroVkjR2EpVcddOI0T6hgWGsaaaF6ea2NDfiPMnjk/yEs5CEGfHhXHYYYGOwpDBReJLzJAaMviy/znYOsnxbWhVHra7ftQW/qqgwQzOocNoJab9lxR2Jp98J0m4VLH26xkbyjJZ/cPn7kjmSUFgYB7rNILUoBvzeEGk2ZiihMhjxhWs6VPwF8RBiybmP9rnzLmnJGsQlvGf8zmaDpitllyZODLUvm0BcU009AX6EGLy6IfXJ7XV/N78w9QuqaAWc7XxHiwDjCWRjgolj4v62LoP7blXdKTvFxrEdWMEuViAnDHaEQlZFGgPzF6MRm/59Wl194ZNcjq/jAD/uhuTX88IZtqRgdtbbUT1sHMOHTz/FkcWBnC2LFP/aTJOBvIYM0iyoEWHpprUol0mNCRyfWmA7ILg+kYC1AUVXwk9VGoTeXNCQcRQwqehhmCeD+h5Iu/U9qpuJw8zy+6EovHYrBMYEK9JUXBn1K7rFikDDXK3O1SDkzvqfvrc0pOceU5H2OXygdsUIzyYSEBE09MaWw8q2/JbZ9b3h9FcDZ0efWoKMXlk24EZAOfh+xLyg6dtk7iCBmQSggCJUbHut8Rz6McGzkJ0Bzh+iF6dg1Ob+wwEWRwN9rQfU0wKUaoEm3E7kT3UvR6tOp87jUDVlO7suaoZhe6mkNtrhHPFMd5viPeYGpbobogxjI3xawC0PMhTsVjydVZha5LA2T6OvkfYQN69XQDGVyfmh3m6JBNDKW8BiKHvhZfvRKYAAnDerGYkOqoSyICwLpUUAjKZYMFpuSYjE5/XWO2ETCcYSjonWvckpP1CcdVAaG+5kGVhu2G24Q6nwPPWYjGB3DANBgkrBgEEAYI3EQIxADATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGQAMABkADcAMAA3ADgANQAtAGEAOAAxADIALQA0AGIAYgAyAC0AYgA1AGEANAAtAGUAYgA5ADIAYQA4ADQAMABiAGEAZAAxMF0GCSsGAQQBgjcRATFQHk4ATQBpAGMAcgBvAHMAbwBmAHQAIABTAHQAcgBvAG4AZwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHIwggNPBgkqhkiG9w0BBwGgggNABIIDPDCCAzgwggM0BgsqhkiG9w0BDAoBA6CCAwwwggMIBgoqhkiG9w0BCRYBoIIC+ASCAvQwggLwMIIB3KADAgECAhD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQAwEzERMA8GA1UEAxMIVGVzdENlcnQwHhcNMTYwNjI5MTc0MTIwWhcNMzkxMjMxMjM1OTU5WjATMREwDwYDVQQDEwhUZXN0Q2VydDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALF6nktMamqvOBxXkuAIzYdxItr9m9MV4M2i+Qxm2Ri4tOmzmtTnu6P1sHfFz0p2IYepsJFts2QxeRfGrwKE7qwk/IXYaE8RjFhwxmCia7pqUjDisjujYoTvP1yNp1XWnjofzR10Lcob8Fx1p6FsWnaVQzWS4OA+RuipiUUGWxjLc5aS1Uottq5LDY1NEQBpR/AN8u3OC4dPFnJBv1RUoLo3DFIa4CgzPxIQA1yr6BFlpb3knUewkNJmnafRFdhfFWSOCi+0DVb2ScuMJb1n9zKvyQMxRukj+IvwNbUVJM8lSnbVoZVtK1AYlAs400rgSFGV4luP03sCRjrPyzQGAOUCAwEAAaNIMEYwRAYDVR0BBD0wO4AQRkxt5Eke37a7P2NW7iszwKEVMBMxETAPBgNVBAMTCFRlc3RDZXJ0ghD1d2qdRhm1lEOMNQvVO7VDMAkGBSsOAwIdBQADggEBABmf90zy2ajVzH6qc6LzD3dlV3h1r4gR0U3yvghdHzdySZCqRtiJMlGAzj8XtziimbvzUKrqmKMsdpwxhPrn70dXH8hJw3i0ZjY25iY6AsJAJ4D0tnnm8Bddn5tyA2IaC0ndGoYWzsFWGFcioeNs8FQ2T2za5mNN8mKQeAZetJVmYn6YYFzj9Btzl7xfnr+SEttQnfNlep1OpRfCKnLiVdCxWaoLtZxlNxy161kEQENcosdF+7L2HgSa+GC+37B8fDg8XMc54skEPeB/1udtmr/i/jRcoPd6yb0K/4wxpz6eMaB55sIApCmZIouBmUnXaLv3nevZeeVw3clRzRYDcFwxFTATBgkqhkiG9w0BCRUxBgQEAQAAADA7MB8wBwYFKw4DAhoEFIU1dNT51rcRzemh6df/sdBkw/zHBBQaMyWKXs+KqGKxMPShgpXMX03s8gICB9A="},"certPassword":{"type":"SecureString"},"frontendPort":{"type":"Int","value":443},"frontendType":{"type":"String","value":"privateIp"},"httpListenerProtocol":{"type":"String","value":"https"},"httpSettingsCookieBasedAffinity":{"type":"String","value":"disabled"},"httpSettingsPort":{"type":"Int","value":80},"httpSettingsProtocol":{"type":"String","value":"http"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"PublicIPag3"},"publicIpAddressType":{"type":"String","value":"none"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"routingRuleType":{"type":"String","value":"Basic"},"servers":{"type":"Array","value":[]},"skuName":{"type":"String","value":"Standard_Medium"},"skuTier":{"type":"String","value":"Standard"},"subnet":{"type":"String","value":"subnet1"},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"new"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"ag3Vnet"},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-03-16T15:25:28.0775577Z","duration":"PT1.1466793S","correlationId":"37cea6ec-9b38-4180-b33e-ab7e74f20826","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"applicationGateways","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/VNETag3","resourceType":"Microsoft.Resources/deployments","resourceName":"VNETag3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/PublicIpag3","resourceType":"Microsoft.Resources/deployments","resourceName":"PublicIpag3"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3","resourceType":"Microsoft.Network/applicationGateways","resourceName":"ag3"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/azurecli1482355461.3430485821/operationStatuses/08587192514234755195?api-version=2015-11-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_ag_private_ip/providers/Microsoft.Resources/deployments/azurecli1489677924.860695674692/operationStatuses/08587119289585467839?api-version=2015-11-01']
       Cache-Control: [no-cache]
-      Content-Length: ['6329']
+      Content-Length: ['6370']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:22 GMT']
+      Date: ['Thu, 16 Mar 2017 15:25:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -72,10 +73,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d78e0ecc-c7c3-11e6-8a31-a0b3ccf7272a]
+      x-ms-client-request-id: [c973bb62-0a5c-11e7-935d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
@@ -85,7 +86,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['173']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:22 GMT']
+      Date: ['Thu, 16 Mar 2017 15:25:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -98,29 +99,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9893ef4-c7c3-11e6-8e11-a0b3ccf7272a]
+      x-ms-client-request-id: [db9480c0-0a5c-11e7-b3a6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
         ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
         : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
         : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
         \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -128,7 +129,7 @@ interactions:
         \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
         : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
@@ -137,21 +138,21 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
         \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
         appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
         \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
@@ -160,7 +161,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
         \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
@@ -173,7 +174,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
         \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
         \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -186,8 +187,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:52 GMT']
-      ETag: [W/"d4ce673a-275b-4381-8f81-053b1bd9d3f8"]
+      Date: ['Thu, 16 Mar 2017 15:25:59 GMT']
+      ETag: [W/"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -203,29 +204,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9ff0292-c7c3-11e6-87d7-a0b3ccf7272a]
+      x-ms-client-request-id: [dc23872e-0a5c-11e7-9f07-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
         ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
         : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
         : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
         \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -233,7 +234,7 @@ interactions:
         \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
         : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
@@ -242,21 +243,21 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
         \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
         appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
         \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
@@ -265,7 +266,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
         \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
@@ -278,7 +279,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
         \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
         \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -291,8 +292,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:53 GMT']
-      ETag: [W/"d4ce673a-275b-4381-8f81-053b1bd9d3f8"]
+      Date: ['Thu, 16 Mar 2017 15:26:00 GMT']
+      ETag: [W/"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -308,29 +309,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea6b7914-c7c3-11e6-af40-a0b3ccf7272a]
+      x-ms-client-request-id: [dcdff3ca-0a5c-11e7-9d05-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
         ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
         : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
         : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
         \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -338,7 +339,7 @@ interactions:
         \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
         : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
@@ -347,21 +348,21 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
         \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
         appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
         \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
@@ -370,7 +371,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
         \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
@@ -383,7 +384,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
         \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
         \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -396,8 +397,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:54 GMT']
-      ETag: [W/"d4ce673a-275b-4381-8f81-053b1bd9d3f8"]
+      Date: ['Thu, 16 Mar 2017 15:26:01 GMT']
+      ETag: [W/"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -407,71 +408,73 @@ interactions:
       content-length: ['8287']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"urlPathMaps": [], "sslCertificates": [{"properties": {"data":
-      "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIpWxHMQn3nwMCAggAgIIEqOPQ4cNTz/41hY7gS1uVf46gL7kB9BNecRpprnR2uOMoWlB8I8K3GiXAzNJyX8ry9P+HHBQoGrP1klaRsUFjiVGoGLOXWaZP2N201J1ARVfo3nm6dVm3H4gkIrsuKL9O7vKr1GSZsyFpcb7j738O4cw4W5o70pozFFLw8/2ecD2Zdq+9StN8Bf/mnPSC97Qtp0K70gT6STh9UuFEObjg+3TDjiCveqsHTLTxjdUdMMFgunl5siJ0UOnIUh9P2v9fbQwXGh5s1uE18dq4P625m8msh3nQ8RRXoC9PnL1/m2TDpWwanox5P3EaA1aQMORleS6a3BoSjyegBW6ZrA581Fa62I+WXseZ/o/CCWqw5u2fMWMsfTyUzuyEAG3hyaJan+Lq8LOfDf7ZKw2dC1IWRaQF8DNRlrf658ELeIwzydXTLsI3Rv2zhNPmQa4yTpy/FpQZtHomlSvQTZy0s7hA9JwsxQInRAtv+3Auwp5m7hofrXJyOWCrGThcN17rYDVh+vCJFxGUeWOBZ4bF7Blv95PKSNuaXYdb5XsYY+DZ7WnU0Tkdk0r1W0ZThjrUOnGG0rCClSGOKruyvmymhTQXnL8hzXjvvdbjm/nmUnZOOrr5k4gunD817MmqGmvVxxdAcdtipx6vUeJMgj40b/MU9z75ygHFZEYAtvMwh/Qtl3Qv01HyOHGDH7sT53KggcU+0IcAMCFkZOx6ZY62WjEtZeoGeaA7xbSTbLL32X9vPBC8s6l2KAJCRy7FLXT8VSpX/C+YM2w97YpCSJ0qtRqcj/U3OuazdupN/62CvnesYRk7d7W764nyTiHiPI6SrkdqBV65XiJfOalE1A0OFJlaUD+a0VBFRZa+9WffFXuUmrd0LIXSLlEJWNJtQGKk/5iNjjA5bcxZ69DTuvX3EihbzUQOLz5dAMG/FuKvjAcxJd2u0ioGFKCJeRIS9NtSXzVytaVv7f6FVEjLArER0lskvI6FnpZmOtUXaoBAlvlsHaN0sY+787dcdLs4HRm3HxLoxbLl1ygZtSEi2AL+o9PA/cGh3KdpoJz/QSoF7c40ABSZ+QbJ+PefS7ncTy0dHjch8gQbXARKn20ROdspbEGW7CGyxl6ipOTwkhi/HhBeFhKk4ofwu/Tmh6Q75QoxJDHp7BMCI4Z5+hvZZ6DmeybxonyNvpwdxR1DIScA0X4mkZSyJECRpOGIZZxKUhd3Uxv7UREgOs/xiCgdUoRUpoOunqROpgSb/WmjOtFVYyVh03emEnfZoaEyCNB1Dk5NzstdtWZhbvmZQBZv7xkcFw65SoEAsPgPfR7LIqN5sJcUY1KSUgvZXalb2qkEST8NB5IImxPr/GBxygo6FE/f21wfPpwNDUIvYBtBQmDlJpLVz8n6CExl5EEIi612is1vusvCEXf3m83SLJmJn77b2lqyaZjhs0UW00B8kVEfpSOndW/P1/D7HvrSCWsnPsqJF66BUHxdI9V89Coo7suMiOlL0PMUI3D3I5l5UKO3JkOFxJQwBy/GPTkcYKF6MlQdnhH62p3AnIynBbQw3nebBP5wT3WGCbDIRFMBtm9ramYg4KTP7qjQwPoKbRcwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQIcHIlDzfEz0wCAggABIIEyMsmW+kFfagAyQQ2z9kBF/LyvpePCVMWq4eDT09zQ6M978RBuDXMOIUz6ylfzx+JgLuwEfYTifac35NyexKxJjCWj8H0U+xwG6NoSL9bfgmv3O2EkUx/G7OLaShr8/S7Aq7rtbLVDxXMv8qO11g6td0JDSx1CN5Ibtyo2YZqpadlOSlL+qHa1BzxFfpX+Ef9pE2Gs25D4icMqskaA0M78Qst7usPqMM4YVIA94HZvBxvu07LbZJF9gFB0x6nIQDZEJSmCObFdyiTuVhDTbea2JKgERauuodkniSGU+U6++iQ70mV7cQcBy5tP5m/CiXmFmp+UnOHKN5TK7t1e6nGq+KPLkqBaH33XUX+xdy2PsTv12+4oetKLEBVumQDTvLFOUth/CzRfWseAk/CSX7H1XC9KlW9XfULNKFQ5G7Bguk9RrS/Sf94OOO8fZRLICMN/Q8MnIz+x5QIT2wXfspFs0x0DWPSpFUUXAlVpt4XLhOmsvcfRm3GMRetvGzSb3IgdtSyGekzs+nmDYAGQJKrYCKTpsRRlKt3e/My8nsKfVh4Pa9vPQgHU/KaxDeSKIsTRe0Hy2t9WMF8US+LbjMjCRqazWUkVwQzbYq4FXjs7QYeiHx9Mo7jVacnjqyFMaWTx8czQo7QYSfbL5+YxJJR/iuHBrLIdR1L5MHa8S3VE3I5U5wrAEoCcqtc8HRmOwX2vhEDMRzz/jmrmyQ4l4EliCTG6fQV8aOfljj3zgvPahaTf9lfx1AjhD+x2ZjgjamLtYdNAUIYgMo3wo+qjh6QUA8gxcGoUv6d3Q8INBAJgiNLGSscs/omdU4EZ+l+3QUgQzfBmKltxuW472+tEbRkucR7Myci/UacdLhs38xGcnpaKh68J/SQ3q9jqKi8coGSQFOTNoHVcVVk/XmvpP+Hd6YMOfwmWdiSzhCEM70zWd7jXNK/PDfpXgncQf7GRTgxxGE9CejERaoScy+hypGWhtNARwZCpJk/joEWRd5gQDOqZS7uTgXRxgUkhgngiYAkGqTwW/x2iItXeU/A03vazLK8wch2/cz04Gh8RPQIWDK0n3APNY/OuoqzxYfIEaORwZh8PpGJsxGWI5sqTMKVuI3EndQj32SbWMry2vCixuDz6mYUkzyCmCUtkxWvGaS1iotIl7fHGL/kvOJSPI3te/Kc3SAGRHYaYSkYvi3D15/6Z/yw12vJWy3Q6XwlYvgYiTJuBUtOXanvvckXwzBAEA9gqiYovF5Ebs3CLbeFkBaD8dj9g2PpWr39qVRwUCqMRz7RF/g1+r638NfoVnLG7/QKppsfaC5b404jIUHfKqH6m55T6ivwhV102c0wwulmsdT9O2/BlhB1eUpJD5t5J3x475zeP4ReC5EH/2/wy3nc+cx+CdsPtyufpNj3nCTq0REB455OthLRLWRMj7iUwQnsodQvzqEvfOKsZPfV0DXbdvH9QDrte2jIyMCV2SKcw2idwaETghfMl34ifAXWkqsD0gFNLhtdwsFwaHMHGaI87AewmzxHptqcQiiLQkPnlRDHy7k8SPxasD4K05tC8nEQHzDnREPdkEncYqztF39l0nEtaxxphDWmFWGfcZZgfM8rEz+mIBOMGjmZL098i8so7ZxRmeNlizElMCMGCSqGSIb3DQEJFTEWBBRu6e5XeVt2l1MEKSdEQ+zgY8oXzTAxMCEwCQYFKw4DAhoFAAQUESCBobdy+D6h9P96kWPsxzgJ78wECHPJpxxkog9ZAgIIAA==",
-      "publicCertData": "", "password": "password", "provisioningState": "Updating"},
-      "name": "ag3SslCert", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "authenticationCertificates":
-      [], "frontendIPConfigurations": [{"properties": {"privateIPAllocationMethod":
-      "Static", "privateIPAddress": "10.0.0.15", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "backendHttpSettingsCollection":
-      [{"properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
-      "requestTimeout": 30, "provisioningState": "Updating"}, "name": "appGatewayBackendHttpSettings",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "frontendPorts": [{"properties":
-      {"port": 443, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
+    body: '{"properties": {"httpListeners": [{"properties": {"provisioningState":
+      "Updating", "protocol": "Https", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
+      "sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
+      "requireServerNameIndication": false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"}},
+      "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
+      "name": "appGatewayHttpListener"}], "resourceGuid": "0e8c9a3c-aa7b-4e20-9801-560856b1063e",
+      "authenticationCertificates": [], "frontendPorts": [{"properties": {"provisioningState":
+      "Updating", "port": 443}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "probes": [], "sku":
-      {"name": "Standard_Medium", "tier": "Standard", "capacity": 2}, "gatewayIPConfigurations":
-      [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Updating"}, "name": "appGatewayIpConfig", "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\"",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig"}],
-      "requestRoutingRules": [{"properties": {"backendHttpSettings": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
-      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"},
-      "ruleType": "Basic", "httpListener": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
-      "provisioningState": "Updating"}, "name": "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "resourceGuid": "e365a028-fd74-4d8e-997c-8dc75a79b044",
-      "backendAddressPools": [{"properties": {"backendAddresses": [], "provisioningState":
-      "Updating"}, "name": "appGatewayBackendPool", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "httpListeners": [{"properties":
-      {"sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
-      "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"},
-      "provisioningState": "Updating", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
-      "protocol": "Https", "requireServerNameIndication": false}, "name": "appGatewayHttpListener",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}], "provisioningState":
-      "Updating"}, "location": "westus", "tags": {}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
-      "etag": "W/\"d4ce673a-275b-4381-8f81-053b1bd9d3f8\""}'
+      "name": "appGatewayFrontendPort"}], "requestRoutingRules": [{"properties": {"backendHttpSettings":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "provisioningState": "Updating", "ruleType": "Basic", "httpListener": {"id":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
+      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"}},
+      "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
+      "name": "rule1"}], "gatewayIPConfigurations": [{"properties": {"provisioningState":
+      "Updating", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"}},
+      "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig",
+      "name": "appGatewayIpConfig"}], "probes": [], "urlPathMaps": [], "provisioningState":
+      "Updating", "backendHttpSettingsCollection": [{"properties": {"requestTimeout":
+      30, "provisioningState": "Updating", "cookieBasedAffinity": "Disabled", "port":
+      80, "protocol": "Http"}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "name": "appGatewayBackendHttpSettings"}], "backendAddressPools": [{"properties":
+      {"provisioningState": "Updating", "backendAddresses": []}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
+      "name": "appGatewayBackendPool"}], "sku": {"capacity": 2, "tier": "Standard",
+      "name": "Standard_Medium"}, "frontendIPConfigurations": [{"properties": {"privateIPAddress":
+      "10.0.0.15", "provisioningState": "Updating", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
+      "privateIPAllocationMethod": "Static"}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
+      "name": "appGatewayFrontendIP"}], "sslCertificates": [{"properties": {"provisioningState":
+      "Updating", "password": "password", "data": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIpWxHMQn3nwMCAggAgIIEqOPQ4cNTz/41hY7gS1uVf46gL7kB9BNecRpprnR2uOMoWlB8I8K3GiXAzNJyX8ry9P+HHBQoGrP1klaRsUFjiVGoGLOXWaZP2N201J1ARVfo3nm6dVm3H4gkIrsuKL9O7vKr1GSZsyFpcb7j738O4cw4W5o70pozFFLw8/2ecD2Zdq+9StN8Bf/mnPSC97Qtp0K70gT6STh9UuFEObjg+3TDjiCveqsHTLTxjdUdMMFgunl5siJ0UOnIUh9P2v9fbQwXGh5s1uE18dq4P625m8msh3nQ8RRXoC9PnL1/m2TDpWwanox5P3EaA1aQMORleS6a3BoSjyegBW6ZrA581Fa62I+WXseZ/o/CCWqw5u2fMWMsfTyUzuyEAG3hyaJan+Lq8LOfDf7ZKw2dC1IWRaQF8DNRlrf658ELeIwzydXTLsI3Rv2zhNPmQa4yTpy/FpQZtHomlSvQTZy0s7hA9JwsxQInRAtv+3Auwp5m7hofrXJyOWCrGThcN17rYDVh+vCJFxGUeWOBZ4bF7Blv95PKSNuaXYdb5XsYY+DZ7WnU0Tkdk0r1W0ZThjrUOnGG0rCClSGOKruyvmymhTQXnL8hzXjvvdbjm/nmUnZOOrr5k4gunD817MmqGmvVxxdAcdtipx6vUeJMgj40b/MU9z75ygHFZEYAtvMwh/Qtl3Qv01HyOHGDH7sT53KggcU+0IcAMCFkZOx6ZY62WjEtZeoGeaA7xbSTbLL32X9vPBC8s6l2KAJCRy7FLXT8VSpX/C+YM2w97YpCSJ0qtRqcj/U3OuazdupN/62CvnesYRk7d7W764nyTiHiPI6SrkdqBV65XiJfOalE1A0OFJlaUD+a0VBFRZa+9WffFXuUmrd0LIXSLlEJWNJtQGKk/5iNjjA5bcxZ69DTuvX3EihbzUQOLz5dAMG/FuKvjAcxJd2u0ioGFKCJeRIS9NtSXzVytaVv7f6FVEjLArER0lskvI6FnpZmOtUXaoBAlvlsHaN0sY+787dcdLs4HRm3HxLoxbLl1ygZtSEi2AL+o9PA/cGh3KdpoJz/QSoF7c40ABSZ+QbJ+PefS7ncTy0dHjch8gQbXARKn20ROdspbEGW7CGyxl6ipOTwkhi/HhBeFhKk4ofwu/Tmh6Q75QoxJDHp7BMCI4Z5+hvZZ6DmeybxonyNvpwdxR1DIScA0X4mkZSyJECRpOGIZZxKUhd3Uxv7UREgOs/xiCgdUoRUpoOunqROpgSb/WmjOtFVYyVh03emEnfZoaEyCNB1Dk5NzstdtWZhbvmZQBZv7xkcFw65SoEAsPgPfR7LIqN5sJcUY1KSUgvZXalb2qkEST8NB5IImxPr/GBxygo6FE/f21wfPpwNDUIvYBtBQmDlJpLVz8n6CExl5EEIi612is1vusvCEXf3m83SLJmJn77b2lqyaZjhs0UW00B8kVEfpSOndW/P1/D7HvrSCWsnPsqJF66BUHxdI9V89Coo7suMiOlL0PMUI3D3I5l5UKO3JkOFxJQwBy/GPTkcYKF6MlQdnhH62p3AnIynBbQw3nebBP5wT3WGCbDIRFMBtm9ramYg4KTP7qjQwPoKbRcwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQIcHIlDzfEz0wCAggABIIEyMsmW+kFfagAyQQ2z9kBF/LyvpePCVMWq4eDT09zQ6M978RBuDXMOIUz6ylfzx+JgLuwEfYTifac35NyexKxJjCWj8H0U+xwG6NoSL9bfgmv3O2EkUx/G7OLaShr8/S7Aq7rtbLVDxXMv8qO11g6td0JDSx1CN5Ibtyo2YZqpadlOSlL+qHa1BzxFfpX+Ef9pE2Gs25D4icMqskaA0M78Qst7usPqMM4YVIA94HZvBxvu07LbZJF9gFB0x6nIQDZEJSmCObFdyiTuVhDTbea2JKgERauuodkniSGU+U6++iQ70mV7cQcBy5tP5m/CiXmFmp+UnOHKN5TK7t1e6nGq+KPLkqBaH33XUX+xdy2PsTv12+4oetKLEBVumQDTvLFOUth/CzRfWseAk/CSX7H1XC9KlW9XfULNKFQ5G7Bguk9RrS/Sf94OOO8fZRLICMN/Q8MnIz+x5QIT2wXfspFs0x0DWPSpFUUXAlVpt4XLhOmsvcfRm3GMRetvGzSb3IgdtSyGekzs+nmDYAGQJKrYCKTpsRRlKt3e/My8nsKfVh4Pa9vPQgHU/KaxDeSKIsTRe0Hy2t9WMF8US+LbjMjCRqazWUkVwQzbYq4FXjs7QYeiHx9Mo7jVacnjqyFMaWTx8czQo7QYSfbL5+YxJJR/iuHBrLIdR1L5MHa8S3VE3I5U5wrAEoCcqtc8HRmOwX2vhEDMRzz/jmrmyQ4l4EliCTG6fQV8aOfljj3zgvPahaTf9lfx1AjhD+x2ZjgjamLtYdNAUIYgMo3wo+qjh6QUA8gxcGoUv6d3Q8INBAJgiNLGSscs/omdU4EZ+l+3QUgQzfBmKltxuW472+tEbRkucR7Myci/UacdLhs38xGcnpaKh68J/SQ3q9jqKi8coGSQFOTNoHVcVVk/XmvpP+Hd6YMOfwmWdiSzhCEM70zWd7jXNK/PDfpXgncQf7GRTgxxGE9CejERaoScy+hypGWhtNARwZCpJk/joEWRd5gQDOqZS7uTgXRxgUkhgngiYAkGqTwW/x2iItXeU/A03vazLK8wch2/cz04Gh8RPQIWDK0n3APNY/OuoqzxYfIEaORwZh8PpGJsxGWI5sqTMKVuI3EndQj32SbWMry2vCixuDz6mYUkzyCmCUtkxWvGaS1iotIl7fHGL/kvOJSPI3te/Kc3SAGRHYaYSkYvi3D15/6Z/yw12vJWy3Q6XwlYvgYiTJuBUtOXanvvckXwzBAEA9gqiYovF5Ebs3CLbeFkBaD8dj9g2PpWr39qVRwUCqMRz7RF/g1+r638NfoVnLG7/QKppsfaC5b404jIUHfKqH6m55T6ivwhV102c0wwulmsdT9O2/BlhB1eUpJD5t5J3x475zeP4ReC5EH/2/wy3nc+cx+CdsPtyufpNj3nCTq0REB455OthLRLWRMj7iUwQnsodQvzqEvfOKsZPfV0DXbdvH9QDrte2jIyMCV2SKcw2idwaETghfMl34ifAXWkqsD0gFNLhtdwsFwaHMHGaI87AewmzxHptqcQiiLQkPnlRDHy7k8SPxasD4K05tC8nEQHzDnREPdkEncYqztF39l0nEtaxxphDWmFWGfcZZgfM8rEz+mIBOMGjmZL098i8so7ZxRmeNlizElMCMGCSqGSIb3DQEJFTEWBBRu6e5XeVt2l1MEKSdEQ+zgY8oXzTAxMCEwCQYFKw4DAhoFAAQUESCBobdy+D6h9P96kWPsxzgJ78wECHPJpxxkog9ZAgIIAA==",
+      "publicCertData": ""}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
+      "name": "ag3SslCert"}]}, "etag": "W/\"1bbacd16-1fc3-4dd8-aadd-25baea3b76a2\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
+      "location": "westus", "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['8983']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea958970-c7c3-11e6-8025-a0b3ccf7272a]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
         ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
         : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
         : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
         \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -479,7 +482,7 @@ interactions:
         \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
         : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
@@ -488,21 +491,21 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
         \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
         appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
         \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
@@ -511,7 +514,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
         \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
@@ -524,7 +527,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
         \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"196f099f-597c-43e0-9d11-0512485d7d63\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
         \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -535,10 +538,10 @@ interactions:
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
         \  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/775bcc7c-6a69-4396-9055-2b4285fb9bee?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:54 GMT']
+      Date: ['Thu, 16 Mar 2017 15:26:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -547,4353 +550,6 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['8287']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [eb1af024-c7c3-11e6-a579-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:24:55 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fd24bdee-c7c3-11e6-8327-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:25:25 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0f3946fe-c7c4-11e6-b553-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:25:56 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [212f420a-c7c4-11e6-9559-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:26:26 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [335fd96c-c7c4-11e6-b550-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:26:56 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4590424a-c7c4-11e6-9af7-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:27:27 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [57c72bc6-c7c4-11e6-a6a7-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:27:58 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [69f47c62-c7c4-11e6-9b01-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:28:27 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7bfdcd62-c7c4-11e6-8fef-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:28:58 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8e07444a-c7c4-11e6-86c4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:29:28 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a01797d4-c7c4-11e6-a161-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:29:59 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b2218b10-c7c4-11e6-a85e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:30:29 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c42c532c-c7c4-11e6-ab74-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:30:59 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d634931e-c7c4-11e6-9ab6-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:31:30 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e86b79da-c7c4-11e6-92f0-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:32:01 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fb0771d8-c7c4-11e6-beef-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:32:31 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0d187c2c-c7c5-11e6-a881-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:33:02 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1f4f58d8-c7c5-11e6-81ba-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:33:32 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [315e12ca-c7c5-11e6-9489-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:34:03 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [439074d4-c7c5-11e6-a396-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:34:33 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [55c2a424-c7c5-11e6-8f7d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:35:04 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [67f0ad86-c7c5-11e6-a0ff-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:35:34 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7a001cda-c7c5-11e6-b4a0-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:36:04 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8bf9ef46-c7c5-11e6-9f56-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:36:35 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9e047b10-c7c5-11e6-b06a-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:37:05 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b00d0f38-c7c5-11e6-a88e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:37:35 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c2155a9a-c7c5-11e6-a93c-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:38:05 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d429eb64-c7c5-11e6-b8eb-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:38:36 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e6307ef8-c7c5-11e6-99e7-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:39:05 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f8463536-c7c5-11e6-8ade-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:39:36 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0a4d5a40-c7c6-11e6-9e2b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:40:07 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1c9595f0-c7c6-11e6-a3fc-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:40:37 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2ed17eb0-c7c6-11e6-88b7-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:41:07 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [40e55a68-c7c6-11e6-b1b4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:41:38 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [52ee7db4-c7c6-11e6-979f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:42:08 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [650079d4-c7c6-11e6-87f6-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:42:39 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7706fc36-c7c6-11e6-a17d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:43:09 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8911f750-c7c6-11e6-b179-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"\",\r\n          \"httpListeners\": [\r\
-        \n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"56070f5b-6026-4e11-b992-d6488b00c7d0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:43:39 GMT']
-      ETag: [W/"56070f5b-6026-4e11-b992-d6488b00c7d0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['8287']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9b21c594-c7c6-11e6-8a25-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:10 GMT']
-      ETag: [W/"711df66c-16c4-4c0e-92de-0e50a52470b0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['9760']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9b8ea7f0-c7c6-11e6-913b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"711df66c-16c4-4c0e-92de-0e50a52470b0\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:10 GMT']
-      ETag: [W/"711df66c-16c4-4c0e-92de-0e50a52470b0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['9760']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"urlPathMaps": [], "sslCertificates": [{"properties": {"publicCertData":
-      "MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=",
-      "provisioningState": "Succeeded"}, "name": "ag3SslCert", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "authenticationCertificates":
-      [], "frontendIPConfigurations": [{"properties": {"privateIPAllocationMethod":
-      "Static", "privateIPAddress": "10.0.0.15", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Succeeded"}, "name": "appGatewayFrontendIP", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "backendHttpSettingsCollection":
-      [{"properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
-      "requestTimeout": 30, "provisioningState": "Succeeded"}, "name": "appGatewayBackendHttpSettings",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "frontendPorts": [{"properties":
-      {"port": 443, "provisioningState": "Succeeded"}, "name": "appGatewayFrontendPort",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "probes": [], "sku":
-      {"name": "Standard_Medium", "tier": "Standard", "capacity": 2}, "sslPolicy":
-      {"disabledSslProtocols": ["TLSv1_0", "TLSv1_1"]}, "gatewayIPConfigurations":
-      [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Succeeded"}, "name": "appGatewayIpConfig", "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\"",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig"}],
-      "requestRoutingRules": [{"properties": {"backendHttpSettings": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
-      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"},
-      "ruleType": "Basic", "httpListener": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
-      "provisioningState": "Succeeded"}, "name": "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "resourceGuid": "e365a028-fd74-4d8e-997c-8dc75a79b044",
-      "backendAddressPools": [{"properties": {"backendAddresses": [], "provisioningState":
-      "Succeeded"}, "name": "appGatewayBackendPool", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "httpListeners": [{"properties":
-      {"sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
-      "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"},
-      "provisioningState": "Succeeded", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
-      "protocol": "Https", "requireServerNameIndication": false}, "name": "appGatewayHttpListener",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}], "provisioningState":
-      "Succeeded"}, "location": "westus", "tags": {}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
-      "etag": "W/\"711df66c-16c4-4c0e-92de-0e50a52470b0\""}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['6879']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9bb35780-c7c6-11e6-a286-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
-        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
-        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/e56eebfc-9fae-4d96-b147-89c0a336480c?api-version=2016-09-01']
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['9860']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -4903,346 +559,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9c2f311c-c7c6-11e6-8761-a0b3ccf7272a]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
   response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
-        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
-        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:11 GMT']
-      ETag: [W/"d27d7909-6ea3-4758-83ce-e7b55373e7af"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['9860']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9c845e98-c7c6-11e6-bc2d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"d27d7909-6ea3-4758-83ce-e7b55373e7af\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
-        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
-        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:11 GMT']
-      ETag: [W/"d27d7909-6ea3-4758-83ce-e7b55373e7af"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['9860']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"urlPathMaps": [], "sslCertificates": [{"properties": {"publicCertData":
-      "MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=",
-      "provisioningState": "Updating"}, "name": "ag3SslCert", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "authenticationCertificates":
-      [], "frontendIPConfigurations": [{"properties": {"privateIPAllocationMethod":
-      "Static", "privateIPAddress": "10.0.0.15", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Updating"}, "name": "appGatewayFrontendIP", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "backendHttpSettingsCollection":
-      [{"properties": {"port": 80, "protocol": "Http", "cookieBasedAffinity": "Disabled",
-      "requestTimeout": 30, "provisioningState": "Updating"}, "name": "appGatewayBackendHttpSettings",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "frontendPorts": [{"properties":
-      {"port": 443, "provisioningState": "Updating"}, "name": "appGatewayFrontendPort",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "probes": [], "sku":
-      {"name": "Standard_Medium", "tier": "Standard", "capacity": 2}, "gatewayIPConfigurations":
-      [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
-      "provisioningState": "Updating"}, "name": "appGatewayIpConfig", "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\"",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig"}],
-      "requestRoutingRules": [{"properties": {"backendHttpSettings": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
-      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"},
-      "ruleType": "Basic", "httpListener": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
-      "provisioningState": "Updating"}, "name": "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "resourceGuid": "e365a028-fd74-4d8e-997c-8dc75a79b044",
-      "backendAddressPools": [{"properties": {"backendAddresses": [], "provisioningState":
-      "Updating"}, "name": "appGatewayBackendPool", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "httpListeners": [{"properties":
-      {"sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
-      "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"},
-      "provisioningState": "Updating", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
-      "protocol": "Https", "requireServerNameIndication": false}, "name": "appGatewayHttpListener",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}], "provisioningState":
-      "Updating"}, "location": "westus", "tags": {}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
-      "etag": "W/\"d27d7909-6ea3-4758-83ce-e7b55373e7af\""}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['6807']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9caa729a-c7c6-11e6-8f81-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
-        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
-        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
-        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
-        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
-        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
-        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
-        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
-        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
-        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
-        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
-        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
-        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
-        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
-        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
-        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
-        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
-        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
-        \  }\r\n}"}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/43dd189a-bbb7-486c-ae99-55a0911dc811?api-version=2016-09-01']
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:12 GMT']
+      Date: ['Thu, 16 Mar 2017 15:26:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -5250,8 +578,7 @@ interactions:
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['9751']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-length: ['30']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -5260,38 +587,2465 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9d3cbac8-c7c6-11e6-9899-a0b3ccf7272a]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:26:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:26:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:26:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:26:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:27:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:28:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:28:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:28:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:28:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:28:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:29:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:30:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:31:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:32:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:33:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:33:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:33:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:33:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:33:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:34:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:35:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:36:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:37:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:38:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:38:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:38:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:38:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:38:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/aec19d1b-48ed-4d80-bc48-43de7caa2fe1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd1b6134-0a5c-11e7-8b23-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
-        ,\r\n  \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
         \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Updating\",\r\n    \"resourceGuid\": \"e365a028-fd74-4d8e-997c-8dc75a79b044\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
         ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
         : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
         : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"publicCertData\": \"MIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3g=\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
         ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
         : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
+        \  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:02 GMT']
+      ETag: [W/"1a8ec330-724c-498a-b64f-9dbef1191407"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9824']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ae93b1ba-0a5e-11e7-bd7a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
+        \  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:03 GMT']
+      ETag: [W/"1a8ec330-724c-498a-b64f-9dbef1191407"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9824']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [af5501a4-0a5e-11e7-8b92-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"1a8ec330-724c-498a-b64f-9dbef1191407\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
+        \  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:04 GMT']
+      ETag: [W/"1a8ec330-724c-498a-b64f-9dbef1191407"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9824']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"httpListeners": [{"properties": {"provisioningState":
+      "Succeeded", "protocol": "Https", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
+      "sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
+      "requireServerNameIndication": false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"}},
+      "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
+      "name": "appGatewayHttpListener"}], "resourceGuid": "0e8c9a3c-aa7b-4e20-9801-560856b1063e",
+      "authenticationCertificates": [], "frontendPorts": [{"properties": {"provisioningState":
+      "Succeeded", "port": 443}, "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort",
+      "name": "appGatewayFrontendPort"}], "requestRoutingRules": [{"properties": {"backendHttpSettings":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "provisioningState": "Succeeded", "ruleType": "Basic", "httpListener": {"id":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
+      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"}},
+      "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
+      "name": "rule1"}], "gatewayIPConfigurations": [{"properties": {"provisioningState":
+      "Succeeded", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"}},
+      "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig",
+      "name": "appGatewayIpConfig"}], "probes": [], "urlPathMaps": [], "provisioningState":
+      "Succeeded", "backendHttpSettingsCollection": [{"properties": {"requestTimeout":
+      30, "provisioningState": "Succeeded", "cookieBasedAffinity": "Disabled", "port":
+      80, "protocol": "Http"}, "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "name": "appGatewayBackendHttpSettings"}], "backendAddressPools": [{"properties":
+      {"provisioningState": "Succeeded", "backendAddresses": []}, "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
+      "name": "appGatewayBackendPool"}], "sslPolicy": {"disabledSslProtocols": ["TLSv1_0",
+      "TLSv1_1"]}, "sku": {"capacity": 2, "tier": "Standard", "name": "Standard_Medium"},
+      "frontendIPConfigurations": [{"properties": {"privateIPAddress": "10.0.0.15",
+      "provisioningState": "Succeeded", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
+      "privateIPAllocationMethod": "Static"}, "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
+      "name": "appGatewayFrontendIP"}], "sslCertificates": [{"properties": {"provisioningState":
+      "Succeeded", "publicCertData": "MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA=="},
+      "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
+      "name": "ag3SslCert"}]}, "etag": "W/\"1a8ec330-724c-498a-b64f-9dbef1191407\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
+      "location": "westus", "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['6943']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [afa2deca-0a5e-11e7-84ac-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
         : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
@@ -5300,21 +3054,21 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
         \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
         : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
         appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
         \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
@@ -5323,7 +3077,7 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
         \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
@@ -5336,7 +3090,475 @@ interactions:
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
         \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
-        ,\r\n        \"etag\": \"W/\\\"a105eae5-2aa4-4b5d-99ea-93fc3189296e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
+        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
+        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/3c981351-a440-4757-bf41-ac49fef295fa?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9924']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b06f535c-0a5e-11e7-8d82-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
+        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
+        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:05 GMT']
+      ETag: [W/"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9924']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b11a3770-0a5e-11e7-8c78-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [],\r\
+        \n    \"sslPolicy\": {\r\n      \"disabledSslProtocols\": [\r\n        \"\
+        TLSv1_0\",\r\n        \"TLSv1_1\"\r\n      ]\r\n    }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:06 GMT']
+      ETag: [W/"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9924']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"httpListeners": [{"properties": {"provisioningState":
+      "Updating", "protocol": "Https", "frontendPort": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort"},
+      "sslCertificate": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert"},
+      "requireServerNameIndication": false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP"}},
+      "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener",
+      "name": "appGatewayHttpListener"}], "resourceGuid": "0e8c9a3c-aa7b-4e20-9801-560856b1063e",
+      "authenticationCertificates": [], "frontendPorts": [{"properties": {"provisioningState":
+      "Updating", "port": 443}, "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort",
+      "name": "appGatewayFrontendPort"}], "requestRoutingRules": [{"properties": {"backendHttpSettings":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings"},
+      "provisioningState": "Updating", "ruleType": "Basic", "httpListener": {"id":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener"},
+      "backendAddressPool": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool"}},
+      "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1",
+      "name": "rule1"}], "gatewayIPConfigurations": [{"properties": {"provisioningState":
+      "Updating", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"}},
+      "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig",
+      "name": "appGatewayIpConfig"}], "probes": [], "urlPathMaps": [], "provisioningState":
+      "Updating", "backendHttpSettingsCollection": [{"properties": {"requestTimeout":
+      30, "provisioningState": "Updating", "cookieBasedAffinity": "Disabled", "port":
+      80, "protocol": "Http"}, "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings",
+      "name": "appGatewayBackendHttpSettings"}], "backendAddressPools": [{"properties":
+      {"provisioningState": "Updating", "backendAddresses": []}, "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool",
+      "name": "appGatewayBackendPool"}], "sku": {"capacity": 2, "tier": "Standard",
+      "name": "Standard_Medium"}, "frontendIPConfigurations": [{"properties": {"privateIPAddress":
+      "10.0.0.15", "provisioningState": "Updating", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1"},
+      "privateIPAllocationMethod": "Static"}, "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP",
+      "name": "appGatewayFrontendIP"}], "sslCertificates": [{"properties": {"provisioningState":
+      "Updating", "publicCertData": "MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA=="},
+      "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert",
+      "name": "ag3SslCert"}]}, "etag": "W/\"01bc1a1a-a845-4562-b8e1-e18bb9b0ba9e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3",
+      "location": "westus", "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['6871']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b1778926-0a5e-11e7-a432-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n          },\r\n          \"backendAddressPool\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        \r\n          },\r\n          \"backendHttpSettings\": {\r\n            \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": []\r\n\
+        \  }\r\n}"}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7802027c-1dfb-45f9-a115-285d6d6b4710?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 15:39:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9815']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b245eae4-0a5e-11e7-bd5f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"ag3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3\"\
+        ,\r\n  \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/applicationGateways\",\r\n  \"location\":\
+        \ \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Updating\",\r\n    \"resourceGuid\": \"0e8c9a3c-aa7b-4e20-9801-560856b1063e\"\
+        ,\r\n    \"sku\": {\r\n      \"name\": \"Standard_Medium\",\r\n      \"tier\"\
+        : \"Standard\",\r\n      \"capacity\": 2\r\n    },\r\n    \"gatewayIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayIpConfig\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/gatewayIPConfigurations/appGatewayIpConfig\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"sslCertificates\"\
+        : [\r\n      {\r\n        \"name\": \"ag3SslCert\",\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"publicCertData\": \"MIIEdAYJKoZIhvcNAQcCoIIEZTCCBGECAQExADALBgkqhkiG9w0BBwGgggRJMIIERTCCAy2gAwIBAgIJAMkWKAMjve9hMA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjcxNzA3MTFaFw0xNzEwMjcxNzA3MTFaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKA6lGpANeDumo1Hmt2xb3+mGQboF0eG9HGZYE3Z9s1FaqyuhWIo7VT8Ewi+wWpbJMmhnOdiJLuzCCAj0alKizX4V/55TLqzJcSte+T5QAu3tCm4u0VmJoazoRXXCEA/bKkn0CdYfY28uaxpilS+CX8yVBSrzrtd45mIMAuQm6Q3ZAZf3gj7t1SBY96R7PGEkuSjRgdG4EtKmSHhrSymlCmyVSAXN+WUzC/BHA7XcqzBCd+VEUQ3nYgv7qMj49lZaTvmTTSqZWvoGC0Pus0t7ZgUi6TXI5m3Z1irlIKWflY4kXLIPTZCsY8el8LEPJamCu+uiReEBRlTyyOV5KpyMMkCAwEAAaOB2TCB1jAdBgNVHQ4EFgQUycSGeAF/LvJDEiB/HnKKvsIzfPYwgaYGA1UdIwSBnjCBm4AUycSGeAF/LvJDEiB/HnKKvsIzfPaheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJAMkWKAMjve9hMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAF9DbBlr4GxCpavUN/Ms+2dh8dQjbF7LEUe5E6kSxcj2J6mdq1WdeZzgN38LsLrkzzPMm+osOhfrr1Wo1ZGzfV42D6fAnZ1RaNOiSnv9vfhEopz6ogPYP8fzqlzvxNojdBdHjJJjbagL57ZpMxtP9WaQEEx1oHLloFBA7ldtGTeNm6AbMWHJLCOepeu8G0s+olXNDyzDNup9MOTLcPqbP3HN9x4coLgqK+IQvBGXlKe0OiUCm4ae7XDjKzueWI/fuOuFdNnpUZZuu63Y1EHpOk0NXswCD3tmznNg2vqclBYlm/X7KD8ajRD0sBGvz6xeA4J0BYg46AjBX1mTTW0XQ3gxAA==\"\
+        ,\r\n          \"httpListeners\": [\r\n            {\r\n              \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"authenticationCertificates\": [],\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"appGatewayFrontendIP\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.15\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Static\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/virtualNetworks/ag3Vnet/subnets/subnet1\"\
+        \r\n          },\r\n          \"httpListeners\": [\r\n            {\r\n  \
+        \            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"frontendPorts\": [\r\n      {\r\n        \"name\": \"appGatewayFrontendPort\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 443,\r\n          \"httpListeners\": [\r\n      \
+        \      {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"appGatewayBackendPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendAddressPools/appGatewayBackendPool\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"backendAddresses\": [],\r\n          \"requestRoutingRules\"\
+        : [\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendHttpSettingsCollection\": [\r\n      {\r\n        \"name\": \"\
+        appGatewayBackendHttpSettings\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/backendHttpSettingsCollection/appGatewayBackendHttpSettings\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"port\": 80,\r\n          \"protocol\": \"Http\",\r\n    \
+        \      \"cookieBasedAffinity\": \"Disabled\",\r\n          \"requestTimeout\"\
+        : 30,\r\n          \"requestRoutingRules\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"httpListeners\": [\r\n      {\r\n        \"name\": \"appGatewayHttpListener\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendIPConfigurations/appGatewayFrontendIP\"\
+        \r\n          },\r\n          \"frontendPort\": {\r\n            \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/frontendPorts/appGatewayFrontendPort\"\
+        \r\n          },\r\n          \"protocol\": \"Https\",\r\n          \"sslCertificate\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/sslCertificates/ag3SslCert\"\
+        \r\n          },\r\n          \"requireServerNameIndication\": false,\r\n\
+        \          \"requestRoutingRules\": [\r\n            {\r\n              \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"urlPathMaps\": [],\r\n    \"requestRoutingRules\": [\r\n      {\r\n  \
+        \      \"name\": \"rule1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/requestRoutingRules/rule1\"\
+        ,\r\n        \"etag\": \"W/\\\"02369a48-04b9-493c-a541-800a51fc7ac2\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"ruleType\": \"Basic\",\r\n          \"httpListener\": {\r\
         \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_ag_private_ip/providers/Microsoft.Network/applicationGateways/ag3/httpListeners/appGatewayHttpListener\"\
@@ -5349,14 +3571,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 21 Dec 2016 21:44:13 GMT']
-      ETag: [W/"a105eae5-2aa4-4b5d-99ea-93fc3189296e"]
+      Date: ['Thu, 16 Mar 2017 15:39:09 GMT']
+      ETag: [W/"02369a48-04b9-493c-a541-800a51fc7ac2"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['9751']
+      content-length: ['9815']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/tests/recordings/test_network_express_route.yaml
+++ b/src/command_modules/azure-cli-network/tests/recordings/test_network_express_route.yaml
@@ -6,15 +6,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [edf6a14f-fd16-11e6-b607-a0b3ccf7272a]
+      x-ms-client-request-id: [455eb15e-09db-11e7-8853-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/expressRouteServiceProviders?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"AT&T Netbond Test\",\r\n      \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/expressRouteServiceProviders/\"\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"AT&T Netbond\
+        \ Test\",\r\n      \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/expressRouteServiceProviders/\"\
         ,\r\n      \"type\": \"Microsoft.Network/expressRouteServiceProviders\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringLocations\": [\r\n          \"Area51\",\r\n        \
@@ -172,16 +172,16 @@ interactions:
         \        \"offerName\": \"10Gbps\",\r\n            \"valueInMbps\": 10000\r\
         \n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['10732']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:02:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -190,49 +190,48 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.2rc2+dev]
+          AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f12a5511-fd16-11e6-b307-a0b3ccf7272a]
+      x-ms-client-request-id: [4766ba2c-09db-11e7-9440-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route","name":"cli_test_express_route","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route","name":"cli_test_express_route","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
       content-length: ['234']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:02:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"sku": {"tier": "Premium", "name": "Premium_MeteredData",
-      "family": "MeteredData"}, "location": "westus", "properties": {"serviceProviderProperties":
-      {"serviceProviderName": "Microsoft ER Test", "bandwidthInMbps": 50, "peeringLocation":
-      "Area51"}}}'
+    body: '{"location": "westus", "sku": {"family": "MeteredData", "tier": "Premium",
+      "name": "Premium_MeteredData"}, "properties": {"serviceProviderProperties":
+      {"bandwidthInMbps": 50, "peeringLocation": "Area51", "serviceProviderName":
+      "Microsoft ER Test"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['249']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f139be5e-fd16-11e6-b990-a0b3ccf7272a]
+      x-ms-client-request-id: [47758f48-09db-11e7-a990-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"ad387923-d2c5-4191-bfd5-4a05c1767418\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"befbce91-ad35-4a82-bc2e-6dd630558df8\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n \
+        ,\r\n    \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n \
         \   \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
@@ -242,17 +241,17 @@ interactions:
         ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
         \n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8fae3e13-4033-4a86-9b3c-18d867ad148a?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['966']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:02:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/db48f183-e7b0-4ed5-a91e-ca89ab5b7c86?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['966']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -261,26 +260,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f139be5e-fd16-11e6-b990-a0b3ccf7272a]
+      x-ms-client-request-id: [47758f48-09db-11e7-a990-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8fae3e13-4033-4a86-9b3c-18d867ad148a?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/db48f183-e7b0-4ed5-a91e-ca89ab5b7c86?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:02:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -289,25 +288,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f139be5e-fd16-11e6-b990-a0b3ccf7272a]
+      x-ms-client-request-id: [47758f48-09db-11e7-a990-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8fae3e13-4033-4a86-9b3c-18d867ad148a?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/db48f183-e7b0-4ed5-a91e-ca89ab5b7c86?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -316,38 +315,37 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f139be5e-fd16-11e6-b990-a0b3ccf7272a]
+      x-ms-client-request-id: [47758f48-09db-11e7-a990-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"6eb66be4-5416-46d5-b1a4-449df2591e09\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n \
+        ,\r\n    \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n \
         \   \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['997']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -356,124 +354,70 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff354d8f-fd16-11e6-a4d2-a0b3ccf7272a]
+      x-ms-client-request-id: [55f2ecec-09db-11e7-82c1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"6eb66be4-5416-46d5-b1a4-449df2591e09\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"circuit1\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n      \"etag\": \"W/\\\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\"\
-        : \"Succeeded\",\r\n        \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\"\
+        : \"Succeeded\",\r\n        \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\"\
         ,\r\n        \"peerings\": [],\r\n        \"authorizations\": [],\r\n    \
         \    \"serviceProviderProperties\": {\r\n          \"serviceProviderName\"\
         : \"Microsoft ER Test\",\r\n          \"peeringLocation\": \"Area51\",\r\n\
         \          \"bandwidthInMbps\": 50\r\n        },\r\n        \"circuitProvisioningState\"\
         : \"Enabled\",\r\n        \"allowClassicOperations\": false,\r\n        \"\
-        serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\n        \"serviceProviderProvisioningState\"\
-        : \"NotProvisioned\"\r\n      },\r\n      \"sku\": {\r\n        \"name\":\
-        \ \"Premium_MeteredData\",\r\n        \"tier\": \"Premium\",\r\n        \"\
-        family\": \"MeteredData\"\r\n      }\r\n    },\r\n    {\r\n      \"name\"\
-        : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_n0f8_/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"d9b33c82-53b5-4e5c-9a8c-c833fcb133a9\\\"\",\r\
-        \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
-        location\": \"westus\",\r\n      \"tags\": {\r\n        \"test\": \"Test\"\
-        \r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\":\
-        \ \"Deleting\",\r\n        \"resourceGuid\": \"f7f701c0-f84e-45bd-bd78-db1f8e338f44\"\
-        ,\r\n        \"peerings\": [\r\n          {\r\n            \"name\": \"AzurePublicPeering\"\
-        ,\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_n0f8_/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n            \"etag\": \"W/\\\"d9b33c82-53b5-4e5c-9a8c-c833fcb133a9\\\"\
-        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
-        : \"Deleting\",\r\n              \"peeringType\": \"AzurePublicPeering\",\r\
-        \n              \"azureASN\": 12076,\r\n              \"peerASN\": 10000,\r\
-        \n              \"primaryPeerAddressPrefix\": \"100.0.0.0/30\",\r\n      \
-        \        \"secondaryPeerAddressPrefix\": \"101.0.0.0/30\",\r\n           \
-        \   \"primaryAzurePort\": \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n            \
-        \  \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\",\r\n           \
-        \   \"state\": \"Enabled\",\r\n              \"vlanId\": 100,\r\n        \
-        \      \"gatewayManagerEtag\": \"\",\r\n              \"lastModifiedBy\":\
-        \ \"Customer\"\r\n            }\r\n          },\r\n          {\r\n       \
-        \     \"name\": \"AzurePrivatePeering\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_n0f8_/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n            \"etag\": \"W/\\\"d9b33c82-53b5-4e5c-9a8c-c833fcb133a9\\\"\
-        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
-        : \"Deleting\",\r\n              \"peeringType\": \"AzurePrivatePeering\"\
-        ,\r\n              \"azureASN\": 12076,\r\n              \"peerASN\": 10001,\r\
-        \n              \"primaryPeerAddressPrefix\": \"102.0.0.0/30\",\r\n      \
-        \        \"secondaryPeerAddressPrefix\": \"103.0.0.0/30\",\r\n           \
-        \   \"primaryAzurePort\": \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n            \
-        \  \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\",\r\n           \
-        \   \"state\": \"Enabled\",\r\n              \"vlanId\": 101,\r\n        \
-        \      \"gatewayManagerEtag\": \"\",\r\n              \"lastModifiedBy\":\
-        \ \"Customer\"\r\n            }\r\n          },\r\n          {\r\n       \
-        \     \"name\": \"MicrosoftPeering\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_n0f8_/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n            \"etag\": \"W/\\\"d9b33c82-53b5-4e5c-9a8c-c833fcb133a9\\\"\
-        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
-        : \"Deleting\",\r\n              \"peeringType\": \"MicrosoftPeering\",\r\n\
-        \              \"azureASN\": 12076,\r\n              \"peerASN\": 10002,\r\
-        \n              \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\n      \
-        \        \"secondaryPeerAddressPrefix\": \"105.0.0.0/30\",\r\n           \
-        \   \"primaryAzurePort\": \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n            \
-        \  \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\",\r\n           \
-        \   \"state\": \"Enabled\",\r\n              \"vlanId\": 103,\r\n        \
-        \      \"gatewayManagerEtag\": \"\",\r\n              \"lastModifiedBy\":\
-        \ \"Customer\",\r\n              \"microsoftPeeringConfig\": {\r\n       \
-        \         \"advertisedPublicPrefixes\": [\r\n                  \"104.0.0.0/30\"\
-        \r\n                ],\r\n                \"advertisedPublicPrefixesState\"\
-        : \"ValidationNeeded\",\r\n                \"customerASN\": 10000,\r\n   \
-        \             \"routingRegistryName\": \"LEVEL3\"\r\n              }\r\n \
-        \           }\r\n          }\r\n        ],\r\n        \"authorizations\":\
-        \ [],\r\n        \"serviceProviderProperties\": {\r\n          \"serviceProviderName\"\
-        : \"Microsoft ER Test\",\r\n          \"peeringLocation\": \"Area51\",\r\n\
-        \          \"bandwidthInMbps\": 50\r\n        },\r\n        \"circuitProvisioningState\"\
-        : \"Enabled\",\r\n        \"allowClassicOperations\": false,\r\n        \"\
-        serviceKey\": \"5484ad48-68fd-4771-b47c-2a263a7186eb\",\r\n        \"serviceProviderProvisioningState\"\
+        serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\n        \"serviceProviderProvisioningState\"\
         : \"NotProvisioned\"\r\n      },\r\n      \"sku\": {\r\n        \"name\":\
         \ \"Premium_MeteredData\",\r\n        \"tier\": \"Premium\",\r\n        \"\
         family\": \"MeteredData\"\r\n      }\r\n    },\r\n    {\r\n      \"name\"\
         : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/errg/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"d5c2b35e-8668-4ddf-bd55-649e52e4f379\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"3ddb9cca-d22c-40d9-a4f5-6d02724a788c\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\
         \n        \"provisioningState\": \"Failed\",\r\n        \"resourceGuid\":\
-        \ \"c8515ed3-58b1-4acf-b1ea-ce5b3ab48cf7\",\r\n        \"peerings\": [\r\n\
-        \          {\r\n            \"name\": \"MicrosoftPeering\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/errg/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n            \"etag\": \"W/\\\"d5c2b35e-8668-4ddf-bd55-649e52e4f379\\\"\
-        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
-        : \"Failed\",\r\n              \"peeringType\": \"MicrosoftPeering\",\r\n\
-        \              \"azureASN\": 0,\r\n              \"peerASN\": 135313,\r\n\
-        \              \"primaryPeerAddressPrefix\": \"30.0.0.0/30\",\r\n        \
-        \      \"secondaryPeerAddressPrefix\": \"30.0.0.4/30\",\r\n              \"\
-        state\": \"Disabled\",\r\n              \"vlanId\": 553,\r\n             \
-        \ \"lastModifiedBy\": \"\",\r\n              \"microsoftPeeringConfig\": {\r\
-        \n                \"advertisedPublicPrefixes\": [\r\n                  \"\
-        103.207.92.40/29\"\r\n                ],\r\n                \"advertisedPublicPrefixesState\"\
-        : \"NotConfigured\",\r\n                \"customerASN\": 0,\r\n          \
-        \      \"routingRegistryName\": \"NONE\"\r\n              }\r\n          \
-        \  }\r\n          }\r\n        ],\r\n        \"authorizations\": [],\r\n \
-        \       \"serviceProviderProperties\": {\r\n          \"serviceProviderName\"\
-        : \"Microsoft ER Test\",\r\n          \"peeringLocation\": \"Area51\",\r\n\
-        \          \"bandwidthInMbps\": 50\r\n        },\r\n        \"circuitProvisioningState\"\
+        \ \"c8515ed3-58b1-4acf-b1ea-ce5b3ab48cf7\",\r\n        \"peerings\": [],\r\
+        \n        \"authorizations\": [],\r\n        \"serviceProviderProperties\"\
+        : {\r\n          \"serviceProviderName\": \"Microsoft ER Test\",\r\n     \
+        \     \"peeringLocation\": \"Area51\",\r\n          \"bandwidthInMbps\": 50\r\
+        \n        },\r\n        \"circuitProvisioningState\": \"Enabled\",\r\n   \
+        \     \"allowClassicOperations\": false,\r\n        \"serviceKey\": \"fcfe8e55-f165-41aa-a393-6ccde9f0b745\"\
+        ,\r\n        \"serviceProviderProvisioningState\": \"Provisioning\"\r\n  \
+        \    },\r\n      \"sku\": {\r\n        \"name\": \"Premium_MeteredData\",\r\
+        \n        \"tier\": \"Premium\",\r\n        \"family\": \"MeteredData\"\r\n\
+        \      }\r\n    },\r\n    {\r\n      \"name\": \"circuit1\",\r\n      \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-er/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n      \"etag\": \"W/\\\"d80a9293-8980-4838-a3b0-558fe52ac308\\\"\",\r\
+        \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
+        location\": \"westus\",\r\n      \"tags\": {\r\n        \"best\": \"woot\"\
+        ,\r\n        \"test\": \"Test\",\r\n        \"nest\": \"woot2\"\r\n      },\r\
+        \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
+        ,\r\n        \"resourceGuid\": \"dd8cb2d7-3557-4f39-ab99-da36d2a1d683\",\r\
+        \n        \"peerings\": [],\r\n        \"authorizations\": [],\r\n       \
+        \ \"serviceProviderProperties\": {\r\n          \"serviceProviderName\": \"\
+        Microsoft ER Test\",\r\n          \"peeringLocation\": \"Area51\",\r\n   \
+        \       \"bandwidthInMbps\": 100\r\n        },\r\n        \"circuitProvisioningState\"\
         : \"Enabled\",\r\n        \"allowClassicOperations\": false,\r\n        \"\
-        serviceKey\": \"fcfe8e55-f165-41aa-a393-6ccde9f0b745\",\r\n        \"serviceProviderProvisioningState\"\
-        : \"Provisioning\"\r\n      },\r\n      \"sku\": {\r\n        \"name\": \"\
-        Premium_MeteredData\",\r\n        \"tier\": \"Premium\",\r\n        \"family\"\
-        : \"MeteredData\"\r\n      }\r\n    }\r\n  ]\r\n}"}
+        serviceKey\": \"893dbc30-b902-4a3f-b1b2-b1db623f0d2e\",\r\n        \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n      },\r\n      \"sku\": {\r\n        \"name\":\
+        \ \"Standard_MeteredData\",\r\n        \"tier\": \"Standard\",\r\n       \
+        \ \"family\": \"MeteredData\"\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['7542']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['3326']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -482,39 +426,39 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ffb775de-fd16-11e6-bd3c-a0b3ccf7272a]
+      x-ms-client-request-id: [56e89bf8-09db-11e7-baa6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"6eb66be4-5416-46d5-b1a4-449df2591e09\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"circuit1\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n      \"etag\": \"W/\\\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\"\
-        : \"Succeeded\",\r\n        \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\"\
+        : \"Succeeded\",\r\n        \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\"\
         ,\r\n        \"peerings\": [],\r\n        \"authorizations\": [],\r\n    \
         \    \"serviceProviderProperties\": {\r\n          \"serviceProviderName\"\
         : \"Microsoft ER Test\",\r\n          \"peeringLocation\": \"Area51\",\r\n\
         \          \"bandwidthInMbps\": 50\r\n        },\r\n        \"circuitProvisioningState\"\
         : \"Enabled\",\r\n        \"allowClassicOperations\": false,\r\n        \"\
-        serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\n        \"serviceProviderProvisioningState\"\
+        serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\n        \"serviceProviderProvisioningState\"\
         : \"NotProvisioned\"\r\n      },\r\n      \"sku\": {\r\n        \"name\":\
         \ \"Premium_MeteredData\",\r\n        \"tier\": \"Premium\",\r\n        \"\
         family\": \"MeteredData\"\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1099']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -523,38 +467,37 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0035cda1-fd17-11e6-8109-a0b3ccf7272a]
+      x-ms-client-request-id: [57e131b4-09db-11e7-b1f7-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"6eb66be4-5416-46d5-b1a4-449df2591e09\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n \
+        ,\r\n    \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n \
         \   \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['997']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -563,26 +506,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [00e03e6e-fd17-11e6-be08-a0b3ccf7272a]
+      x-ms-client-request-id: [590859c0-09db-11e7-a5c8-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/stats?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"primaryBytesIn\": 0,\r\n  \"primaryBytesOut\"\
-        : 0,\r\n  \"secondaryBytesIn\": 0,\r\n  \"secondaryBytesOut\": 0\r\n}"}
+    body: {string: "{\r\n  \"primaryBytesIn\": 0,\r\n  \"primaryBytesOut\": 0,\r\n\
+        \  \"secondaryBytesIn\": 0,\r\n  \"secondaryBytesOut\": 0\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['105']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -591,90 +534,89 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [018705c0-fd17-11e6-85ca-a0b3ccf7272a]
+      x-ms-client-request-id: [5a7745e2-09db-11e7-9aef-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"6eb66be4-5416-46d5-b1a4-449df2591e09\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n \
+        ,\r\n    \"resourceGuid\": \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n \
         \   \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:58:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['997']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"sku": {"tier": "Premium", "name": "Premium_MeteredData",
-      "family": "MeteredData"}, "etag": "W/\"6eb66be4-5416-46d5-b1a4-449df2591e09\"",
-      "location": "westus", "tags": {"test": "Test"}, "properties": {"allowClassicOperations":
-      false, "serviceKey": "57e5d6fa-192b-4f37-a49c-60e3de51546c", "serviceProviderProvisioningState":
-      "NotProvisioned", "circuitProvisioningState": "Enabled", "authorizations": [],
-      "gatewayManagerEtag": "", "peerings": [], "serviceProviderProperties": {"serviceProviderName":
-      "Microsoft ER Test", "bandwidthInMbps": 50, "peeringLocation": "Area51"}, "provisioningState":
-      "Succeeded"}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1"}'
+    body: '{"sku": {"family": "MeteredData", "tier": "Premium", "name": "Premium_MeteredData"},
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1",
+      "etag": "W/\"cfe5a378-53d5-40e4-b1b3-c91995ea2140\"", "location": "westus",
+      "tags": {"test": "Test"}, "properties": {"serviceProviderProperties": {"bandwidthInMbps":
+      50, "peeringLocation": "Area51", "serviceProviderName": "Microsoft ER Test"},
+      "circuitProvisioningState": "Enabled", "allowClassicOperations": false, "serviceProviderProvisioningState":
+      "NotProvisioned", "gatewayManagerEtag": "", "provisioningState": "Succeeded",
+      "serviceKey": "edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2", "peerings": [], "authorizations":
+      []}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['770']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [01d0e000-fd17-11e6-88a7-a0b3ccf7272a]
+      x-ms-client-request-id: [5ad6dbe8-09db-11e7-b9ff-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"fc705433-c591-42a2-9b05-a21a0572b543\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"3e333fed-58e7-415b-abae-b234dabda3d9\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"\
-        fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n    \"peerings\": [],\r\n    \"\
+        39613741-2792-4edf-95fe-9f553e29c63f\",\r\n    \"peerings\": [],\r\n    \"\
         authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n      \"\
         serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Disabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/e2a99f1e-1d78-40e8-9bd1-aa35d0e0ebef?api-version=2016-09-01']
-      cache-control: [no-cache]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4d1a5a56-5f4d-44a0-95f8-e8b3ec9cfc90?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1036']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -683,26 +625,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [01d0e000-fd17-11e6-88a7-a0b3ccf7272a]
+      x-ms-client-request-id: [5ad6dbe8-09db-11e7-b9ff-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e2a99f1e-1d78-40e8-9bd1-aa35d0e0ebef?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4d1a5a56-5f4d-44a0-95f8-e8b3ec9cfc90?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -711,25 +653,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [01d0e000-fd17-11e6-88a7-a0b3ccf7272a]
+      x-ms-client-request-id: [5ad6dbe8-09db-11e7-b9ff-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e2a99f1e-1d78-40e8-9bd1-aa35d0e0ebef?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4d1a5a56-5f4d-44a0-95f8-e8b3ec9cfc90?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -738,72 +681,98 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [01d0e000-fd17-11e6-88a7-a0b3ccf7272a]
+      x-ms-client-request-id: [5ad6dbe8-09db-11e7-b9ff-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4d1a5a56-5f4d-44a0-95f8-e8b3ec9cfc90?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [5ad6dbe8-09db-11e7-b9ff-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"c125a95f-d926-4617-a21b-5abe03c2ccb3\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"6e8c315e-1f00-456d-a23c-8cdb58869481\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n    \"peerings\": [],\r\n \
+        \ \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n    \"peerings\": [],\r\n \
         \   \"authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n  \
         \    \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1036']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f50af80-fd17-11e6-bbb3-a0b3ccf7272a]
+      x-ms-client-request-id: [6f33a2a4-09db-11e7-b9f2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"eb40ff82-c283-4249-94b6-458906a59e77\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"573e9b80-933f-4df4-9ab2-a436d46d6fd4\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        authorizationKey\": \"a1c9e842-ab88-4756-aa3d-ea609683f118\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"26e5f318-4f32-443c-9f9f-151092d1951f\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d8e638a1-a128-43c0-a999-06d4e747ba2b?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['438']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/671236b3-9735-4daf-aeeb-e45544fd260b?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['438']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -812,25 +781,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f50af80-fd17-11e6-bbb3-a0b3ccf7272a]
+      x-ms-client-request-id: [6f33a2a4-09db-11e7-b9f2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d8e638a1-a128-43c0-a999-06d4e747ba2b?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/671236b3-9735-4daf-aeeb-e45544fd260b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -839,29 +808,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f50af80-fd17-11e6-bbb3-a0b3ccf7272a]
+      x-ms-client-request-id: [6f33a2a4-09db-11e7-b9f2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"ccd2327a-3722-4a35-86d5-59f683766582\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"23144278-411f-445d-9f41-c7e8f39aaf86\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        authorizationKey\": \"a1c9e842-ab88-4756-aa3d-ea609683f118\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"26e5f318-4f32-443c-9f9f-151092d1951f\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['439']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -870,31 +839,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [16cabf80-fd17-11e6-b724-a0b3ccf7272a]
+      x-ms-client-request-id: [76b07c6c-09db-11e7-842c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"auth1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n      \"etag\": \"W/\\\"ccd2327a-3722-4a35-86d5-59f683766582\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"auth1\",\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n      \"etag\": \"W/\\\"23144278-411f-445d-9f41-c7e8f39aaf86\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"authorizationKey\": \"a1c9e842-ab88-4756-aa3d-ea609683f118\"\
+        ,\r\n        \"authorizationKey\": \"26e5f318-4f32-443c-9f9f-151092d1951f\"\
         ,\r\n        \"authorizationUseStatus\": \"Available\"\r\n      }\r\n    }\r\
         \n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['504']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:48 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -903,29 +872,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [177d1f91-fd17-11e6-a86b-a0b3ccf7272a]
+      x-ms-client-request-id: [772dbca4-09db-11e7-b83f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"ccd2327a-3722-4a35-86d5-59f683766582\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"23144278-411f-445d-9f41-c7e8f39aaf86\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        authorizationKey\": \"a1c9e842-ab88-4756-aa3d-ea609683f118\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"26e5f318-4f32-443c-9f9f-151092d1951f\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['439']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:03:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -935,25 +904,25 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [182c4b51-fd17-11e6-8b86-a0b3ccf7272a]
+      x-ms-client-request-id: [77ae2ede-09db-11e7-98da-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ade79dcb-ad66-42ba-aa83-71886a0ec0b5?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Mon, 27 Feb 2017 18:03:50 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/ade79dcb-ad66-42ba-aa83-71886a0ec0b5?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/6df6278a-1cfe-44b7-915d-3c304d07be49?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 15 Mar 2017 23:59:46 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/6df6278a-1cfe-44b7-915d-3c304d07be49?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
@@ -963,26 +932,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [182c4b51-fd17-11e6-8b86-a0b3ccf7272a]
+      x-ms-client-request-id: [77ae2ede-09db-11e7-98da-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ade79dcb-ad66-42ba-aa83-71886a0ec0b5?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6df6278a-1cfe-44b7-915d-3c304d07be49?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 15 Mar 2017 23:59:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -991,25 +960,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [182c4b51-fd17-11e6-8b86-a0b3ccf7272a]
+      x-ms-client-request-id: [77ae2ede-09db-11e7-98da-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ade79dcb-ad66-42ba-aa83-71886a0ec0b5?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6df6278a-1cfe-44b7-915d-3c304d07be49?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1018,25 +987,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [259cff9e-fd17-11e6-a517-a0b3ccf7272a]
+      x-ms-client-request-id: [8522b100-09db-11e7-8731-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1045,76 +1014,74 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [262e9140-fd17-11e6-8455-a0b3ccf7272a]
+      x-ms-client-request-id: [8603e858-09db-11e7-b256-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"edfe0bfc-5017-4a41-9e33-ac7865919520\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"db33354b-494a-4115-b777-58e9eb554659\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n    \"peerings\": [],\r\n \
+        \ \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n    \"peerings\": [],\r\n \
         \   \"authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n  \
         \    \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1036']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "101.0.0.0/30",
-      "peeringType": "AzurePublicPeering", "vlanId": 100, "primaryPeerAddressPrefix":
-      "100.0.0.0/30", "peerASN": 10000}}'
+    body: '{"properties": {"peerASN": 10000, "secondaryPeerAddressPrefix": "101.0.0.0/30",
+      "vlanId": 100, "peeringType": "AzurePublicPeering", "primaryPeerAddressPrefix":
+      "100.0.0.0/30"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [269f7b80-fd17-11e6-b1a2-a0b3ccf7272a]
+      x-ms-client-request-id: [867770d0-09db-11e7-bed1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"35e6c5a7-2be3-421e-85ee-388f7f37d2a1\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"67056f81-a1a1-4345-9367-6da481b1a1f5\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 0,\r\n    \"peerASN\"\
         : 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\",\r\n    \"\
         secondaryPeerAddressPrefix\": \"101.0.0.0/30\",\r\n    \"state\": \"Disabled\"\
         ,\r\n    \"vlanId\": 100,\r\n    \"lastModifiedBy\": \"\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d7cb2d04-d9ed-4b6c-aa03-22c374a1e628?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['607']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/caab8374-389e-49f0-b4d4-db6a6060e978?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['607']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -1124,26 +1091,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [269f7b80-fd17-11e6-b1a2-a0b3ccf7272a]
+      x-ms-client-request-id: [867770d0-09db-11e7-bed1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d7cb2d04-d9ed-4b6c-aa03-22c374a1e628?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/caab8374-389e-49f0-b4d4-db6a6060e978?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1152,25 +1119,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [269f7b80-fd17-11e6-b1a2-a0b3ccf7272a]
+      x-ms-client-request-id: [867770d0-09db-11e7-bed1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d7cb2d04-d9ed-4b6c-aa03-22c374a1e628?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/caab8374-389e-49f0-b4d4-db6a6060e978?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1179,16 +1146,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [269f7b80-fd17-11e6-b1a2-a0b3ccf7272a]
+      x-ms-client-request-id: [867770d0-09db-11e7-bed1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"a09ebc23-5942-49e7-81d2-e29b0fda838e\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"6bba404f-7229-4bbb-87c3-95f912c58a09\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1197,16 +1163,16 @@ interactions:
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 100,\r\n    \"gatewayManagerEtag\"\
         : \"\",\r\n    \"lastModifiedBy\": \"Customer\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:34 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['762']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:37 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1215,22 +1181,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [34a3480f-fd17-11e6-9194-a0b3ccf7272a]
+      x-ms-client-request-id: [9518e526-09db-11e7-ac85-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"a09ebc23-5942-49e7-81d2-e29b0fda838e\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"6bba404f-7229-4bbb-87c3-95f912c58a09\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n    \"peerings\": [\r\n   \
+        \ \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n    \"peerings\": [\r\n   \
         \   {\r\n        \"name\": \"AzurePublicPeering\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n        \"etag\": \"W/\\\"a09ebc23-5942-49e7-81d2-e29b0fda838e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"6bba404f-7229-4bbb-87c3-95f912c58a09\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"peeringType\": \"AzurePublicPeering\",\r\n          \"azureASN\"\
         : 12076,\r\n          \"peerASN\": 10000,\r\n          \"primaryPeerAddressPrefix\"\
@@ -1243,42 +1208,41 @@ interactions:
         : \"Microsoft ER Test\",\r\n      \"peeringLocation\": \"Area51\",\r\n   \
         \   \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1868']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "103.0.0.0/30",
-      "peeringType": "AzurePrivatePeering", "vlanId": 101, "primaryPeerAddressPrefix":
-      "102.0.0.0/30", "peerASN": 10001}}'
+    body: '{"properties": {"peerASN": 10001, "secondaryPeerAddressPrefix": "103.0.0.0/30",
+      "vlanId": 101, "peeringType": "AzurePrivatePeering", "primaryPeerAddressPrefix":
+      "102.0.0.0/30"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['177']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [352ee640-fd17-11e6-b11d-a0b3ccf7272a]
+      x-ms-client-request-id: [9585bf9c-09db-11e7-8bbf-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n  \"etag\": \"W/\\\"b0cb50bb-0055-422b-99c3-68af8b85f6a6\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
+        ,\r\n  \"etag\": \"W/\\\"e554de98-8f0b-4ae6-afa0-5369738352cc\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePrivatePeering\",\r\n    \"azureASN\": 0,\r\n    \"\
         peerASN\": 10001,\r\n    \"primaryPeerAddressPrefix\": \"102.0.0.0/30\",\r\
@@ -1286,16 +1250,16 @@ interactions:
         \ \"Disabled\",\r\n    \"vlanId\": 101,\r\n    \"lastModifiedBy\": \"\"\r\n\
         \  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b686b7d9-dce8-4f4a-90fb-733c3aa18340?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['610']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/c4fc37ab-ffb9-425b-8b26-94fc4972ddfa?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['610']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -1305,26 +1269,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [352ee640-fd17-11e6-b11d-a0b3ccf7272a]
+      x-ms-client-request-id: [9585bf9c-09db-11e7-8bbf-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b686b7d9-dce8-4f4a-90fb-733c3aa18340?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4fc37ab-ffb9-425b-8b26-94fc4972ddfa?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:04:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1333,25 +1297,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [352ee640-fd17-11e6-b11d-a0b3ccf7272a]
+      x-ms-client-request-id: [9585bf9c-09db-11e7-8bbf-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b686b7d9-dce8-4f4a-90fb-733c3aa18340?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4fc37ab-ffb9-425b-8b26-94fc4972ddfa?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:00:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1360,16 +1325,42 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [352ee640-fd17-11e6-b11d-a0b3ccf7272a]
+      x-ms-client-request-id: [9585bf9c-09db-11e7-8bbf-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4fc37ab-ffb9-425b-8b26-94fc4972ddfa?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9585bf9c-09db-11e7-8bbf-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n  \"etag\": \"W/\\\"67d089ea-618f-4df8-9abf-dfe39205ab67\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
+        ,\r\n  \"etag\": \"W/\\\"03003687-1b51-43e3-a737-ace769c50c77\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePrivatePeering\",\r\n    \"azureASN\": 12076,\r\n  \
         \  \"peerASN\": 10001,\r\n    \"primaryPeerAddressPrefix\": \"102.0.0.0/30\"\
@@ -1378,16 +1369,16 @@ interactions:
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 101,\r\n    \"gatewayManagerEtag\"\
         : \"\",\r\n    \"lastModifiedBy\": \"Customer\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['765']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1396,22 +1387,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42a16f4f-fd17-11e6-8da0-a0b3ccf7272a]
+      x-ms-client-request-id: [aa28e776-09db-11e7-8f43-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"67d089ea-618f-4df8-9abf-dfe39205ab67\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"03003687-1b51-43e3-a737-ace769c50c77\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"fe378fa0-2749-442a-99a2-71cf958c2d3e\",\r\n    \"peerings\": [\r\n   \
+        \ \"39613741-2792-4edf-95fe-9f553e29c63f\",\r\n    \"peerings\": [\r\n   \
         \   {\r\n        \"name\": \"AzurePublicPeering\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n        \"etag\": \"W/\\\"67d089ea-618f-4df8-9abf-dfe39205ab67\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"03003687-1b51-43e3-a737-ace769c50c77\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"peeringType\": \"AzurePublicPeering\",\r\n          \"azureASN\"\
         : 12076,\r\n          \"peerASN\": 10000,\r\n          \"primaryPeerAddressPrefix\"\
@@ -1421,7 +1411,7 @@ interactions:
         \n          \"gatewayManagerEtag\": \"\",\r\n          \"lastModifiedBy\"\
         : \"Customer\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AzurePrivatePeering\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n        \"etag\": \"W/\\\"67d089ea-618f-4df8-9abf-dfe39205ab67\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"03003687-1b51-43e3-a737-ace769c50c77\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"peeringType\": \"AzurePrivatePeering\",\r\n          \"azureASN\"\
         : 12076,\r\n          \"peerASN\": 10001,\r\n          \"primaryPeerAddressPrefix\"\
@@ -1434,43 +1424,42 @@ interactions:
         : \"Microsoft ER Test\",\r\n      \"peeringLocation\": \"Area51\",\r\n   \
         \   \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"gatewayManagerEtag\"\
-        : \"\",\r\n    \"serviceKey\": \"57e5d6fa-192b-4f37-a49c-60e3de51546c\",\r\
+        : \"\",\r\n    \"serviceKey\": \"edd0e13f-9ac7-4ac9-bb91-9d2f2000e8b2\",\r\
         \n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\n\
         \  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\": \"\
         Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['2698']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "105.0.0.0/30",
-      "microsoftPeeringConfig": {"routingRegistryName": "LEVEL3", "advertisedPublicPrefixes":
-      ["104.0.0.0/30"], "customerASN": 10000}, "primaryPeerAddressPrefix": "104.0.0.0/30",
-      "peerASN": 10002, "vlanId": 103, "peeringType": "MicrosoftPeering"}}'
+    body: '{"properties": {"vlanId": 103, "peerASN": 10002, "microsoftPeeringConfig":
+      {"advertisedPublicPrefixes": ["104.0.0.0/30"], "routingRegistryName": "LEVEL3",
+      "customerASN": 10000}, "secondaryPeerAddressPrefix": "105.0.0.0/30", "peeringType":
+      "MicrosoftPeering", "primaryPeerAddressPrefix": "104.0.0.0/30"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['303']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42f3d50f-fd17-11e6-b3ee-a0b3ccf7272a]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"8e56bf90-b8a6-4d45-ac5a-a7827bda5dc3\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"a2a6b628-f92f-4d49-af9f-ff4b74bdbbcd\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"MicrosoftPeering\",\r\n    \"azureASN\": 0,\r\n    \"peerASN\"\
         : 10002,\r\n    \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\n    \"\
@@ -1481,17 +1470,17 @@ interactions:
         \n      \"customerASN\": 10000,\r\n      \"routingRegistryName\": \"LEVEL3\"\
         \r\n    }\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8031ee31-291f-4452-b95c-9c18b1c2178c?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['838']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['838']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1500,26 +1489,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42f3d50f-fd17-11e6-b3ee-a0b3ccf7272a]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8031ee31-291f-4452-b95c-9c18b1c2178c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1528,25 +1517,109 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42f3d50f-fd17-11e6-b3ee-a0b3ccf7272a]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8031ee31-291f-4452-b95c-9c18b1c2178c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:01:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/40e5ed7e-dfa5-40ff-b4bc-2ad2017d723f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1555,16 +1628,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42f3d50f-fd17-11e6-b3ee-a0b3ccf7272a]
+      x-ms-client-request-id: [ab058bde-09db-11e7-9201-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"0b024f1d-8235-4172-a95a-be66dfa0c800\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"d6e3fc9b-4900-4780-a484-4abd43fab139\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"MicrosoftPeering\",\r\n    \"azureASN\": 12076,\r\n    \"\
         peerASN\": 10002,\r\n    \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\
@@ -1577,16 +1649,16 @@ interactions:
         ,\r\n      \"customerASN\": 10000,\r\n      \"routingRegistryName\": \"LEVEL3\"\
         \r\n    }\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['996']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1595,16 +1667,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [505df9b0-fd17-11e6-9487-a0b3ccf7272a]
+      x-ms-client-request-id: [cd59ef06-09db-11e7-840a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"0b024f1d-8235-4172-a95a-be66dfa0c800\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"d6e3fc9b-4900-4780-a484-4abd43fab139\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"MicrosoftPeering\",\r\n    \"azureASN\": 12076,\r\n    \"\
         peerASN\": 10002,\r\n    \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\
@@ -1617,16 +1688,16 @@ interactions:
         ,\r\n      \"customerASN\": 10000,\r\n      \"routingRegistryName\": \"LEVEL3\"\
         \r\n    }\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['996']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1636,26 +1707,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [50f4e280-fd17-11e6-9539-a0b3ccf7272a]
+      x-ms-client-request-id: [ce01f09e-09db-11e7-a32f-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9eede138-7d9f-4b90-8e1e-2a75df3771a1?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Mon, 27 Feb 2017 18:05:26 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/9eede138-7d9f-4b90-8e1e-2a75df3771a1?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 16 Mar 2017 00:02:11 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1664,26 +1735,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [50f4e280-fd17-11e6-9539-a0b3ccf7272a]
+      x-ms-client-request-id: [ce01f09e-09db-11e7-a32f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9eede138-7d9f-4b90-8e1e-2a75df3771a1?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1692,25 +1763,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [50f4e280-fd17-11e6-9539-a0b3ccf7272a]
+      x-ms-client-request-id: [ce01f09e-09db-11e7-a32f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9eede138-7d9f-4b90-8e1e-2a75df3771a1?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1719,16 +1791,71 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5e58776e-fd17-11e6-bae4-a0b3ccf7272a]
+      x-ms-client-request-id: [ce01f09e-09db-11e7-a32f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ce01f09e-09db-11e7-a32f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/034c26be-871f-40a2-b809-e7d94a2ac161?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:02:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e7666702-09db-11e7-933a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"AzurePublicPeering\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n      \"etag\": \"W/\\\"d4febb36-1714-41fe-af6e-52987451c595\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"AzurePublicPeering\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n      \"etag\": \"W/\\\"2c76a970-6713-4bad-abb1-1ef44b659c27\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringType\": \"AzurePublicPeering\",\r\n        \"azureASN\"\
         : 12076,\r\n        \"peerASN\": 10000,\r\n        \"primaryPeerAddressPrefix\"\
@@ -1738,7 +1865,7 @@ interactions:
         state\": \"Enabled\",\r\n        \"vlanId\": 100,\r\n        \"gatewayManagerEtag\"\
         : \"\",\r\n        \"lastModifiedBy\": \"Customer\"\r\n      }\r\n    },\r\
         \n    {\r\n      \"name\": \"AzurePrivatePeering\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n      \"etag\": \"W/\\\"d4febb36-1714-41fe-af6e-52987451c595\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"2c76a970-6713-4bad-abb1-1ef44b659c27\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringType\": \"AzurePrivatePeering\",\r\n        \"azureASN\"\
         : 12076,\r\n        \"peerASN\": 10001,\r\n        \"primaryPeerAddressPrefix\"\
@@ -1749,16 +1876,16 @@ interactions:
         : \"\",\r\n        \"lastModifiedBy\": \"Customer\"\r\n      }\r\n    }\r\n\
         \  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1707']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1767,16 +1894,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5f5cc80f-fd17-11e6-b418-a0b3ccf7272a]
+      x-ms-client-request-id: [eb7789ca-09db-11e7-932c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"d4febb36-1714-41fe-af6e-52987451c595\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"2c76a970-6713-4bad-abb1-1ef44b659c27\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1785,41 +1911,40 @@ interactions:
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 100,\r\n    \"gatewayManagerEtag\"\
         : \"\",\r\n    \"lastModifiedBy\": \"Customer\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['762']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering",
-      "etag": "W/\"d4febb36-1714-41fe-af6e-52987451c595\"", "properties": {"secondaryPeerAddressPrefix":
-      "101.0.0.0/30", "secondaryAzurePort": "A51-TEST-06GMR-CIS-2-SEC-A", "primaryPeerAddressPrefix":
-      "100.0.0.0/30", "gatewayManagerEtag": "", "peerASN": 10000, "vlanId": 200, "peeringType":
-      "AzurePublicPeering", "lastModifiedBy": "Customer", "primaryAzurePort": "A51-TEST-06GMR-CIS-1-PRI-A",
-      "state": "Enabled", "azureASN": 12076, "provisioningState": "Succeeded"}, "name":
-      "AzurePublicPeering"}'
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering",
+      "properties": {"state": "Enabled", "vlanId": 200, "provisioningState": "Succeeded",
+      "lastModifiedBy": "Customer", "secondaryAzurePort": "A51-TEST-06GMR-CIS-2-SEC-A",
+      "peerASN": 10000, "primaryAzurePort": "A51-TEST-06GMR-CIS-1-PRI-A", "azureASN":
+      12076, "primaryPeerAddressPrefix": "100.0.0.0/30", "gatewayManagerEtag": "",
+      "peeringType": "AzurePublicPeering", "secondaryPeerAddressPrefix": "101.0.0.0/30"},
+      "etag": "W/\"2c76a970-6713-4bad-abb1-1ef44b659c27\"", "name": "AzurePublicPeering"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['682']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [608e914f-fd17-11e6-925e-a0b3ccf7272a]
+      x-ms-client-request-id: [ebe19b4c-09db-11e7-91ad-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"0e439e89-f927-49bb-95cf-d578bbc27c4c\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"1145d082-0369-4ec2-9914-611488097d49\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1828,19 +1953,19 @@ interactions:
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 200,\r\n    \"gatewayManagerEtag\"\
         : \"\",\r\n    \"lastModifiedBy\": \"Customer\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/2aa2c20a-a6ae-45ad-9acf-5a152fcc03c6?api-version=2016-09-01']
-      cache-control: [no-cache]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/29393b77-af7c-4e32-9a43-ed76261d5b1b?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['761']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:05:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1849,26 +1974,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [608e914f-fd17-11e6-925e-a0b3ccf7272a]
+      x-ms-client-request-id: [ebe19b4c-09db-11e7-91ad-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2aa2c20a-a6ae-45ad-9acf-5a152fcc03c6?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/29393b77-af7c-4e32-9a43-ed76261d5b1b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1877,25 +2002,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [608e914f-fd17-11e6-925e-a0b3ccf7272a]
+      x-ms-client-request-id: [ebe19b4c-09db-11e7-91ad-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/2aa2c20a-a6ae-45ad-9acf-5a152fcc03c6?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/29393b77-af7c-4e32-9a43-ed76261d5b1b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1904,16 +2029,15 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [608e914f-fd17-11e6-925e-a0b3ccf7272a]
+      x-ms-client-request-id: [ebe19b4c-09db-11e7-91ad-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"9e8ee29b-8653-4bec-8e6f-ceb62ea54b69\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"2d22f58e-5fd1-44d7-966c-491c29b6e8ca\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1922,16 +2046,16 @@ interactions:
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 200,\r\n    \"gatewayManagerEtag\"\
         : \"\",\r\n    \"lastModifiedBy\": \"Customer\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['762']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:14 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1941,25 +2065,193 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6e3bb261-fd17-11e6-9e07-a0b3ccf7272a]
+      x-ms-client-request-id: [f967959c-09db-11e7-b4fd-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/azureprivatepeering/arpTables/primary?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: 'null'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:15 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/56052b53-7ceb-4d64-b7aa-f32d871cf974?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:24 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/fc55156a-a4c2-4da7-9dbf-57d30cdfdae9?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f967959c-09db-11e7-b4fd-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/fc55156a-a4c2-4da7-9dbf-57d30cdfdae9?api-version=2016-09-01
+  response:
+    body: {string: 'null'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:34 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/fc55156a-a4c2-4da7-9dbf-57d30cdfdae9?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f967959c-09db-11e7-b4fd-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/fc55156a-a4c2-4da7-9dbf-57d30cdfdae9?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"value\": []\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:44 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/fc55156a-a4c2-4da7-9dbf-57d30cdfdae9?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['19']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0643e506-09dc-11e7-ad03-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/azureprivatepeering/routeTables/primary?api-version=2016-09-01
+  response:
+    body: {string: 'null'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:45 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/0f930afe-16bf-4cb9-b964-776af6d89d3f?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0643e506-09dc-11e7-ad03-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/0f930afe-16bf-4cb9-b964-776af6d89d3f?api-version=2016-09-01
+  response:
+    body: {string: 'null'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:03:55 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/0f930afe-16bf-4cb9-b964-776af6d89d3f?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0643e506-09dc-11e7-ad03-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/0f930afe-16bf-4cb9-b964-776af6d89d3f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"value\": []\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:04:05 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/0f930afe-16bf-4cb9-b964-776af6d89d3f?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['19']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 16 Mar 2017 00:04:07 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
@@ -1969,194 +2261,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6e3bb261-fd17-11e6-9e07-a0b3ccf7272a]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/56052b53-7ceb-4d64-b7aa-f32d871cf974?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:25 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/56052b53-7ceb-4d64-b7aa-f32d871cf974?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
+      Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6e3bb261-fd17-11e6-9e07-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/56052b53-7ceb-4d64-b7aa-f32d871cf974?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:37 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/56052b53-7ceb-4d64-b7aa-f32d871cf974?api-version=2016-09-01']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7ba11c0f-fd17-11e6-823f-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/azureprivatepeering/routeTables/primary?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode 'null'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:38 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/69dcc138-a93d-4481-8fb8-eae176a74fae?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7ba11c0f-fd17-11e6-823f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/69dcc138-a93d-4481-8fb8-eae176a74fae?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode 'null'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:48 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/69dcc138-a93d-4481-8fb8-eae176a74fae?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7ba11c0f-fd17-11e6-823f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/69dcc138-a93d-4481-8fb8-eae176a74fae?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:06:58 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/69dcc138-a93d-4481-8fb8-eae176a74fae?api-version=2016-09-01']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Mon, 27 Feb 2017 18:07:00 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      cache-control: [no-cache]
+      Date: ['Thu, 16 Mar 2017 00:04:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2165,26 +2289,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:04:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2193,26 +2317,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:04:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2221,26 +2345,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:04:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2249,25 +2373,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [890f3851-fd17-11e6-bdcc-a0b3ccf7272a]
+      x-ms-client-request-id: [132213ee-09dc-11e7-b549-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/91d093ec-391a-42ce-96f2-6e60c682dfbf?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ca01797e-e6b6-4eaf-8b79-71cf38c7391b?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:05:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2276,24 +2400,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.2rc2+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a8fce540-fd17-11e6-8563-a0b3ccf7272a]
+      x-ms-client-request-id: [33ad7664-09dc-11e7-b833-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 16 Mar 2017 00:05:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Mon, 27 Feb 2017 18:07:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/tests/test_network_commands.py
@@ -8,6 +8,7 @@
 #pylint: disable=bad-continuation
 #pylint: disable=too-many-lines
 import os
+import unittest
 
 from azure.cli.core._util import CLIError
 from azure.cli.core.commands.arm import resource_id
@@ -1295,3 +1296,6 @@ class NetworkZoneImportExportTest(ResourceGroupVCRTestBase):
         self.cmd('network dns zone import -n {} -g {} --file-name "{}"'
                  .format(zone_name, self.resource_group, zone_file_path))
         self.cmd('network dns zone export -n {} -g {}'.format(zone_name, self.resource_group))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -84,20 +84,20 @@ def transform_av_set_collection_output(av_sets):
 
 op_var = 'virtual_machines_operations'
 op_class = 'VirtualMachinesOperations'
-cli_command(__name__, 'vm create', custom_path.format('create_vm'), transform=transform_vm_create_output)
-cli_command(__name__, 'vm delete', mgmt_path.format(op_var, op_class, 'delete'), cf_vm, confirmation=True)
-cli_command(__name__, 'vm deallocate', mgmt_path.format(op_var, op_class, 'deallocate'), cf_vm)
-cli_command(__name__, 'vm generalize', mgmt_path.format(op_var, op_class, 'generalize'), cf_vm)
+cli_command(__name__, 'vm create', custom_path.format('create_vm'), transform=transform_vm_create_output, no_wait_param='no_wait')
+cli_command(__name__, 'vm delete', mgmt_path.format(op_var, op_class, 'delete'), cf_vm, confirmation=True, no_wait_param='raw')
+cli_command(__name__, 'vm deallocate', mgmt_path.format(op_var, op_class, 'deallocate'), cf_vm, no_wait_param='raw')
+cli_command(__name__, 'vm generalize', mgmt_path.format(op_var, op_class, 'generalize'), cf_vm, no_wait_param='raw')
 cli_command(__name__, 'vm show', custom_path.format('show_vm'), table_transformer=transform_vm, exception_handler=empty_on_404)
 cli_command(__name__, 'vm list-vm-resize-options', mgmt_path.format(op_var, op_class, 'list_available_sizes'), cf_vm)
-cli_command(__name__, 'vm stop', mgmt_path.format(op_var, op_class, 'power_off'), cf_vm)
-cli_command(__name__, 'vm restart', mgmt_path.format(op_var, op_class, 'restart'), cf_vm)
-cli_command(__name__, 'vm start', mgmt_path.format(op_var, op_class, 'start'), cf_vm)
-cli_command(__name__, 'vm redeploy', mgmt_path.format(op_var, op_class, 'redeploy'), cf_vm)
+cli_command(__name__, 'vm stop', mgmt_path.format(op_var, op_class, 'power_off'), cf_vm, no_wait_param='raw')
+cli_command(__name__, 'vm restart', mgmt_path.format(op_var, op_class, 'restart'), cf_vm, no_wait_param='raw')
+cli_command(__name__, 'vm start', mgmt_path.format(op_var, op_class, 'start'), cf_vm, no_wait_param='raw')
+cli_command(__name__, 'vm redeploy', mgmt_path.format(op_var, op_class, 'redeploy'), cf_vm, no_wait_param='raw')
 cli_command(__name__, 'vm list-ip-addresses', custom_path.format('list_ip_addresses'), table_transformer=transform_ip_addresses)
 cli_command(__name__, 'vm get-instance-view', custom_path.format('get_instance_view'))
 cli_command(__name__, 'vm list', custom_path.format('list_vm'), table_transformer=transform_vm_list)
-cli_command(__name__, 'vm resize', custom_path.format('resize_vm'))
+cli_command(__name__, 'vm resize', custom_path.format('resize_vm'), no_wait_param='no_wait')
 cli_command(__name__, 'vm capture', custom_path.format('capture_vm'))
 cli_command(__name__, 'vm open-port', custom_path.format('vm_open_port'))
 cli_command(__name__, 'vm format-secret', custom_path.format('get_vm_format_secret'))
@@ -108,6 +108,7 @@ cli_generic_update_command(__name__, 'vm update',
                            no_wait_param='raw')
 cli_generic_wait_command(__name__, 'vm wait', 'azure.cli.command_modules.vm.custom#get_instance_view')
 cli_command(__name__, 'vm convert', mgmt_path.format(op_var, op_class, 'convert_to_managed_disks'), cf_vm)
+
 cli_command(__name__, 'vm encryption enable', 'azure.cli.command_modules.vm.disk_encryption#enable')
 cli_command(__name__, 'vm encryption disable', 'azure.cli.command_modules.vm.disk_encryption#disable')
 cli_command(__name__, 'vm encryption show', 'azure.cli.command_modules.vm.disk_encryption#show', exception_handler=empty_on_404)
@@ -125,9 +126,9 @@ cli_command(__name__, 'vmss nic list-vm-nics', 'azure.mgmt.network.operations.ne
 cli_command(__name__, 'vmss nic show', 'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.get_virtual_machine_scale_set_network_interface', cf_ni, exception_handler=empty_on_404)
 
 # VM Access
-cli_command(__name__, 'vm user update', custom_path.format('set_user'))
-cli_command(__name__, 'vm user delete', custom_path.format('delete_user'))
-cli_command(__name__, 'vm user reset-ssh', custom_path.format('reset_linux_ssh'))
+cli_command(__name__, 'vm user update', custom_path.format('set_user'), no_wait_param='no_wait')
+cli_command(__name__, 'vm user delete', custom_path.format('delete_user'), no_wait_param='no_wait')
+cli_command(__name__, 'vm user reset-ssh', custom_path.format('reset_linux_ssh'), no_wait_param='no_wait')
 
 # # VM Availability Set
 cli_command(__name__, 'vm availability-set create', custom_path.format('create_av_set'), transform=transform_av_set_output)
@@ -143,9 +144,12 @@ cli_command(__name__, 'vm availability-set convert', custom_path.format('convert
 cli_generic_update_command(__name__, 'vm availability-set update',
                            custom_path.format('availset_get'),
                            custom_path.format('availset_set'))
+
 cli_generic_update_command(__name__, 'vmss update',
                            custom_path.format('vmss_get'),
-                           custom_path.format('vmss_set'))
+                           custom_path.format('vmss_set'),
+                           no_wait_param='no_wait')
+cli_generic_wait_command(__name__, 'vmss wait', custom_path.format('vmss_get'))
 
 # VM Boot Diagnostics
 cli_command(__name__, 'vm boot-diagnostics disable', custom_path.format('disable_boot_diagnostics'))
@@ -211,23 +215,23 @@ cli_command(__name__, 'vm image list', custom_path.format('list_vm_images'))
 cli_command(__name__, 'vm list-usage', mgmt_path.format('usage_operations', 'UsageOperations', 'list'), cf_usage)
 
 # VMSS
-cli_command(__name__, 'vmss delete', mgmt_path.format('virtual_machine_scale_sets_operations', 'VirtualMachineScaleSetsOperations', 'delete'), cf_vmss)
+cli_command(__name__, 'vmss delete', mgmt_path.format('virtual_machine_scale_sets_operations', 'VirtualMachineScaleSetsOperations', 'delete'), cf_vmss, no_wait_param='raw')
 cli_command(__name__, 'vmss list-skus', mgmt_path.format('virtual_machine_scale_sets_operations', 'VirtualMachineScaleSetsOperations', 'list_skus'), cf_vmss)
 
 cli_command(__name__, 'vmss list-instances', mgmt_path.format('virtual_machine_scale_set_vms_operations', 'VirtualMachineScaleSetVMsOperations', 'list'), cf_vmss_vm)
 
-cli_command(__name__, 'vmss create', custom_path.format('create_vmss'), transform=DeploymentOutputLongRunningOperation('Starting vmss create'))
-cli_command(__name__, 'vmss deallocate', custom_path.format('deallocate_vmss'))
-cli_command(__name__, 'vmss delete-instances', custom_path.format('delete_vmss_instances'))
+cli_command(__name__, 'vmss create', custom_path.format('create_vmss'), transform=DeploymentOutputLongRunningOperation('Starting vmss create'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss deallocate', custom_path.format('deallocate_vmss'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss delete-instances', custom_path.format('delete_vmss_instances'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss get-instance-view', custom_path.format('get_vmss_instance_view'))
 cli_command(__name__, 'vmss show', custom_path.format('show_vmss'), exception_handler=empty_on_404)
 cli_command(__name__, 'vmss list', custom_path.format('list_vmss'))
-cli_command(__name__, 'vmss stop', custom_path.format('stop_vmss'))
-cli_command(__name__, 'vmss restart', custom_path.format('restart_vmss'))
-cli_command(__name__, 'vmss start', custom_path.format('start_vmss'))
-cli_command(__name__, 'vmss update-instances', custom_path.format('update_vmss_instances'))
-cli_command(__name__, 'vmss reimage', custom_path.format('reimage_vmss'))
-cli_command(__name__, 'vmss scale', custom_path.format('scale_vmss'))
+cli_command(__name__, 'vmss stop', custom_path.format('stop_vmss'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss restart', custom_path.format('restart_vmss'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss start', custom_path.format('start_vmss'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss update-instances', custom_path.format('update_vmss_instances'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss reimage', custom_path.format('reimage_vmss'), no_wait_param='no_wait')
+cli_command(__name__, 'vmss scale', custom_path.format('scale_vmss'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss list-instance-connection-info', custom_path.format('list_vmss_instance_connection_info'))
 
 # VM Size

--- a/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
@@ -259,8 +259,8 @@ class VMGeneralizeScenarioTest(ResourceGroupVCRTestBase):
                      self.resource_group, self.location, self.vm_name))
         self.cmd('vm stop -g {} -n {}'.format(self.resource_group, self.vm_name))
         # Should be able to generalize the VM after it has been stopped
-        self.cmd('vm generalize -g {} --n {}'.format(self.resource_group, self.vm_name), checks=NoneCheck())
-        vm = self.cmd('vm show -g {} --n {}'.format(self.resource_group, self.vm_name))
+        self.cmd('vm generalize -g {} -n {}'.format(self.resource_group, self.vm_name), checks=NoneCheck())
+        vm = self.cmd('vm show -g {} -n {}'.format(self.resource_group, self.vm_name))
         self.cmd('vm capture -g {} -n {} --vhd-name-prefix vmtest'.format(self.resource_group, self.vm_name),
                  checks=NoneCheck())
 


### PR DESCRIPTION
Adds `wait` command for the following: `express-route, local-gateway, vnet-gateway, vmss`

Add `--no-wait` parameters to the following: 
  **vm**: `create, delete, deallocate, generalize, stop, start, restart, redeploy, resize`
  **vm user**: `update, delete, reset-ssh`
  **vmss**: `create, delete, update, deallocate, delete-instances, stop, restart, start, update-instances, reimage, scale`
  **vnet-gateway**: `delete`
  **local-gateway**: `create, delete, update`
  **express-route**: `create, delete, update`