### PR TITLE
Fixed test failure in test_sql_db_mgmt.

### DIFF
--- a/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
@@ -253,10 +253,9 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                  .format(rg, server),
                  checks=[
                      JMESPathCheck('length(@)', 2),
-                     JMESPathCheck('[1].name', 'master'),
-                     JMESPathCheck('[1].resourceGroup', rg),
-                     JMESPathCheck('[0].name', database_name),
-                     JMESPathCheck('[0].resourceGroup', rg)])
+                     JMESPathCheck('sort([].name)', sorted([database_name, 'master'])),
+                     JMESPathCheck('[0].resourceGroup', rg),
+                     JMESPathCheck('[1].resourceGroup', rg)])
 
         self.cmd('sql db show -g {} --server {} --name {}'
                  .format(rg, server, database_name),


### PR DESCRIPTION
The assertion error is:
JMESPathCheckAssertionError: Query '[1].name' doesn't yield expected value 'master', instead the actual value is 'cliautomationdb01'.

The fix is to sort the database names returned from the service so that it's guaranteed they are in order.