### PR TITLE
[Configure] Adding short name alias for the --defaults flag

### DIFF
--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_params.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_params.py
@@ -6,5 +6,5 @@
 from azure.cli.core.commands import register_cli_argument
 
 # pylint: disable=line-too-long
-register_cli_argument('configure', 'defaults', nargs='+',
+register_cli_argument('configure', 'defaults', nargs='+', options_list=('--defaults', '-d'),
                       help="space separated 'name=value' pairs for common arguments defaults, e.g. '--defaults group=myRG web=myweb vm=myvm'. Use '' to clear the defaults, e.g. --defaults vm='' web=''")


### PR DESCRIPTION
This PR simply adds a short name option for the recently added `az configure --defaults` flag. As I've been using it recently, I've just found it helpful to have the alias.