### PR TITLE
[ACS] Provide a short name alias for the orchestrator type flag

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -58,7 +58,7 @@ name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 register_cli_argument('acs', 'name', arg_type=name_arg_type, help='ACS cluster name', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
-register_cli_argument('acs', 'orchestrator_type', options_list=('--orchestrator_type', '-t'), **enum_choice_list(ContainerServiceOchestratorTypes))
+register_cli_argument('acs', 'orchestrator_type', options_list=('--orchestrator-type', '-t'), **enum_choice_list(ContainerServiceOchestratorTypes))
 # some admin names are prohibited in acs, such as root, admin, etc. Because we have no control on the orchestrators, so default to a safe name.
 register_cli_argument('acs', 'admin_username', options_list=('--admin-username',), default='azureuser', required=False)
 register_cli_argument('acs', 'dns_name_prefix', options_list=('--dns-prefix', '-d'))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -58,7 +58,7 @@ name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 register_cli_argument('acs', 'name', arg_type=name_arg_type, help='ACS cluster name', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
-register_cli_argument('acs', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))
+register_cli_argument('acs', 'orchestrator_type', options_list=('--orchestrator_type', '-t'), **enum_choice_list(ContainerServiceOchestratorTypes))
 # some admin names are prohibited in acs, such as root, admin, etc. Because we have no control on the orchestrators, so default to a safe name.
 register_cli_argument('acs', 'admin_username', options_list=('--admin-username',), default='azureuser', required=False)
 register_cli_argument('acs', 'dns_name_prefix', options_list=('--dns-prefix', '-d'))


### PR DESCRIPTION
This PR simply adds a short name alias to the `--orchestrator-type` flag (on the `az acs create` command), since it is very common to set.