### PR TITLE
[ACS] Adding support for configuring a default ACS cluster

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -55,7 +55,7 @@ def _get_default_install_location(exe_name):
 
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-register_cli_argument('acs', 'name', arg_type=name_arg_type, help='ACS cluster name', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
+register_cli_argument('acs', 'name', arg_type=name_arg_type, configured_default=‘acs’, help="ACS cluster name. You can configure the default using 'az configure --defaults acs=<name>'", completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
 register_cli_argument('acs', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -55,7 +55,10 @@ def _get_default_install_location(exe_name):
 
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-register_cli_argument('acs', 'name', arg_type=name_arg_type, configured_default='acs', help="ACS cluster name. You can configure the default using 'az configure --defaults acs=<name>'", completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
+register_cli_argument('acs', 'name', arg_type=name_arg_type, configured_default='acs',
+                      help="ACS cluster name. You can configure the default using 'az configure --defaults acs=<name>'",
+                      completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
+
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
 register_cli_argument('acs', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -55,7 +55,7 @@ def _get_default_install_location(exe_name):
 
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-register_cli_argument('acs', 'name', arg_type=name_arg_type, configured_default=‘acs’, help="ACS cluster name. You can configure the default using 'az configure --defaults acs=<name>'", completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
+register_cli_argument('acs', 'name', arg_type=name_arg_type, configured_default='acs', help="ACS cluster name. You can configure the default using 'az configure --defaults acs=<name>'", completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
 register_cli_argument('acs', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))


### PR DESCRIPTION
This PR simply allows calling `az configure --defaults acs=<name>` in order to specify the default ACS cluster name. This allows calling `az acs` commands without needing to explicitly specify the `-n` flag, which can be really nice when working with the same cluster frequently.

<image src="https://cloud.githubusercontent.com/assets/116461/24076700/9d490a58-0bf4-11e7-94c4-2486eb8d88d2.png" width="400px" />