### PR TITLE
Add blank line after each example.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -243,6 +243,8 @@ def _print_examples(help_file):
         indent = 2
         _print_indent('{0}'.format(e.text), indent)
 
+        print('')
+
 
 class HelpObject(object):  # pylint: disable=too-few-public-methods
 


### PR DESCRIPTION
This is intended to improve readability of examples. #2535