### PR TITLE
Refactoring SDK reflection utils into azure.cli.core.sdk

### DIFF
--- a/src/azure-cli-core/azure/cli/core/sdk/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/src/azure-cli-core/azure/cli/core/sdk/util.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/util.py
@@ -38,11 +38,13 @@ class ServiceGroup(object):
 
 
 class CommandGroup(object):
-    def __init__(self, scope, group_name, client_factory, service_adapter=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, scope, group_name, client_factory, service_adapter=None, custom_path=None):
         self._scope = scope
         self._group_name = group_name
         self._client_factory = client_factory
         self._service_adapter = service_adapter or (lambda name: name)
+        self._custom_path = custom_path
 
     def __enter__(self):
         return self
@@ -56,13 +58,29 @@ class CommandGroup(object):
                     self._service_adapter(method_name),
                     client_factory=self._client_factory)
 
-    def generic_update_command(self, name, getter_op, setter_op):
+    def custom_command(self, name, custom_func_name, confirmation=None):
+        cli_command(self._scope,
+                    '{} {}'.format(self._group_name, name),
+                    self._custom_path.format(custom_func_name),
+                    client_factory=self._client_factory,
+                    confirmation=confirmation)
+
+    # pylint: disable=too-many-arguments
+    def generic_update_command(self, name, getter_op, setter_op, custom_func_name=None,
+                               setter_arg_name='parameters'):
+        if custom_func_name:
+            custom_function_op = self._custom_path.format(custom_func_name)
+        else:
+            custom_function_op = None
+
         cli_generic_update_command(
             self._scope,
             '{} {}'.format(self._group_name, name),
             self._service_adapter(getter_op),
             self._service_adapter(setter_op),
-            factory=self._client_factory)
+            factory=self._client_factory,
+            custom_function_op=custom_function_op,
+            setter_arg_name=setter_arg_name)
 
 
 # PARAMETERS UTILITIES
@@ -108,7 +126,7 @@ class ParametersContext(object):
         from azure.cli.core.commands._introspection import \
             (extract_args_from_signature, _option_descriptions)
 
-        from azure.cli.command_modules.monitor.validators import get_complex_argument_processor
+        from azure.cli.core.sdk.validators import get_complex_argument_processor
 
         if not patches:
             patches = dict()

--- a/src/azure-cli-core/azure/cli/core/sdk/validators.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/validators.py
@@ -1,0 +1,23 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def get_complex_argument_processor(expanded_arguments, assigned_arg, model_type):
+    """
+    Return a validator which will aggregate multiple arguments to one complex argument.
+    """
+    def _expansion_validator_impl(namespace):
+        """
+        The validator create a argument of a given type from a specific set of arguments from CLI
+        command.
+        :param namespace: The argparse namespace represents the CLI arguments.
+        :return: The argument of specific type.
+        """
+        ns = vars(namespace)
+        kwargs = dict((k, ns[k]) for k in ns if k in set(expanded_arguments))
+
+        setattr(namespace, assigned_arg, model_type(**kwargs))
+
+    return _expansion_validator_impl

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -94,6 +94,7 @@ setup(
         'azure.cli.core',
         'azure.cli.core.commands',
         'azure.cli.core.extensions',
+        'azure.cli.core.sdk',
     ],
     install_requires=DEPENDENCIES
 )

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -11,7 +11,7 @@ from ._client_factory import (get_monitor_alert_rules_operation,
                               get_monitor_activity_log_operation,
                               get_monitor_metric_definitions_operation,
                               get_monitor_metrics_operation)
-from ._util import (ServiceGroup, create_service_adapter)
+from azure.cli.core.sdk.util import (ServiceGroup, create_service_adapter)
 
 
 # MANAGEMENT COMMANDS

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -4,8 +4,9 @@
 # --------------------------------------------------------------------------------------------
 
 import json
-from ._util import ParametersContext
+from azure.cli.core.sdk.util import ParametersContext
 from azure.cli.command_modules.monitor.validators import (validate_diagnostic_settings)
+
 
 with ParametersContext(command='monitor alert-rules') as c:
     c.register_alias('name', ('--azure-resource-name',))

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -7,25 +7,6 @@ from azure.cli.core.commands.arm import is_valid_resource_id, resource_id, parse
 from azure.cli.core._util import CLIError
 
 
-def get_complex_argument_processor(expanded_arguments, assigned_arg, model_type):
-    """
-    Return a validator which will aggregate multiple arguments to one complex argument.
-    """
-    def _expansion_validator_impl(namespace):
-        """
-        The validator create a argument of a given type from a specific set of arguments from CLI
-        command.
-        :param namespace: The argparse namespace represents the CLI arguments.
-        :return: The argument of specific type.
-        """
-        ns = vars(namespace)
-        kwargs = dict((k, ns[k]) for k in ns if k in set(expanded_arguments))
-
-        setattr(namespace, assigned_arg, model_type(**kwargs))
-
-    return _expansion_validator_impl
-
-
 # pylint: disable=line-too-long
 def validate_diagnostic_settings(namespace):
     from azure.cli.core.commands.client_factory import get_subscription_id


### PR DESCRIPTION
Moving the common utility commands related to sdk reflection to be used in devtestlabs. 

Feel free to suggest better command module name then `sdk` :)

Haven't moved sql utils as [it's been changed heavily](https://github.com/Azure/azure-cli/blame/master/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py) and may require more time to understand and move them.