### PR TITLE
[Monitor] Refactoring diagnostic-settings create parameters

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_util.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_util.py
@@ -94,8 +94,8 @@ class ParametersContext(object):
     def argument(self, argument_name, arg_type=None, **kwargs):
         register_cli_argument(self._commmand, argument_name, arg_type=arg_type, **kwargs)
 
-    def register_alias(self, argument_name, options_list):
-        register_cli_argument(self._commmand, argument_name, options_list=options_list)
+    def register_alias(self, argument_name, options_list, **kwargs):
+        register_cli_argument(self._commmand, argument_name, options_list=options_list, **kwargs)
 
     def register(self, argument_name, options_list, **kwargs):
         register_cli_argument(self._commmand, argument_name, options_list=options_list, **kwargs)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -15,6 +15,8 @@ from ._util import (ServiceGroup, create_service_adapter)
 
 
 # MANAGEMENT COMMANDS
+custom_operations = create_service_adapter('azure.cli.command_modules.monitor.custom')
+
 alert_rules_operations = create_service_adapter(
     'azure.mgmt.monitor.operations.alert_rules_operations',
     'AlertRulesOperations')
@@ -57,9 +59,12 @@ diagnostic_settings_operations = create_service_adapter(
 with ServiceGroup(__name__, get_monitor_diagnostic_settings_operation,
                   diagnostic_settings_operations) as s:
     with s.group('monitor diagnostic-settings') as c:
-        c.command('create', 'create_or_update')
         c.command('show', 'get')
         c.generic_update_command('update', 'get', 'create_or_update')
+
+with ServiceGroup(__name__, get_monitor_diagnostic_settings_operation, custom_operations) as s:
+    with s.group('monitor diagnostic-settings') as c:
+        c.command('create', 'create_diagnostics_settings')
 
 autoscale_settings_operations = create_service_adapter(
     'azure.mgmt.monitor.operations.autoscale_settings_operations',
@@ -74,35 +79,23 @@ with ServiceGroup(__name__, get_monitor_autoscale_settings_operation,
         c.command('list', 'list_by_resource_group')
         c.generic_update_command('update', 'get', 'create_or_update')
 
-autoscale_settings_scaffold = create_service_adapter(
-    'azure.cli.command_modules.monitor.custom')
-
 with ServiceGroup(__name__, get_monitor_autoscale_settings_operation,
-                  autoscale_settings_scaffold) as s:
+                  custom_operations) as s:
     with s.group('monitor autoscale-settings') as c:
         c.command('get-parameters-template', 'scaffold_autoscale_settings_parameters')
 
 
 # DATA COMMANDS
-activity_logs_operations = create_service_adapter(
-    'azure.cli.command_modules.monitor.custom')
-
 with ServiceGroup(__name__, get_monitor_activity_log_operation,
-                  activity_logs_operations) as s:
+                  custom_operations) as s:
     with s.group('monitor activity-log') as c:
         c.command('list', 'list_activity_log')
 
-metric_definitions_operations = create_service_adapter(
-    'azure.cli.command_modules.monitor.custom')
-
 with ServiceGroup(__name__, get_monitor_metric_definitions_operation,
-                  metric_definitions_operations) as s:
+                  custom_operations) as s:
     with s.group('monitor metric-definitions') as c:
         c.command('list', 'list_metric_definitions')
 
-metrics_operations = create_service_adapter(
-    'azure.cli.command_modules.monitor.custom')
-
-with ServiceGroup(__name__, get_monitor_metrics_operation, metrics_operations) as s:
+with ServiceGroup(__name__, get_monitor_metrics_operation, custom_operations) as s:
     with s.group('monitor metrics') as c:
         c.command('list', 'list_metrics')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -7,7 +7,6 @@ import datetime
 import os
 from azure.cli.core._util import get_file_json, CLIError
 
-
 # 1 hour in milliseconds
 DEFAULT_QUERY_TIME_RANGE = 3600000
 
@@ -241,3 +240,24 @@ def _load_autoscale_settings_parameters(file_path):
         raise CLIError('File {} not found.'.format(file_path))
 
     return get_file_json(file_path)
+
+
+# pylint: disable=unused-argument
+def create_diagnostics_settings(client, target_resource_id, resource_group=None, logs=None,
+                                metrics=None, namespace=None, rule_name=None, tags=None,
+                                service_bus_rule_id=None, storage_account=None, workspace=None):
+    from azure.mgmt.monitor.models.service_diagnostic_settings_resource import \
+        ServiceDiagnosticSettingsResource
+
+    # https://github.com/Azure/azure-rest-api-specs/issues/1058
+    # https://github.com/Azure/azure-rest-api-specs/issues/1059
+    parameters = ServiceDiagnosticSettingsResource(location='',
+                                                   name='',
+                                                   storage_account_id=storage_account,
+                                                   service_bus_rule_id=service_bus_rule_id,
+                                                   metrics=metrics,
+                                                   logs=logs,
+                                                   workspace_id=workspace,
+                                                   tags=tags)
+
+    return client.create_or_update(target_resource_id, parameters)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/help.py
@@ -5,6 +5,7 @@
 
 from azure.cli.core.help_files import helps
 
+# pylint: disable=line-too-long, too-many-lines
 
 helps['monitor'] = """
             type: group
@@ -34,6 +35,37 @@ helps['monitor log-profiles update'] = """
 helps['monitor diagnostic-settings'] = """
             type: group
             short-summary: Commands to manage service diagnostic settings.
+            """
+helps['monitor diagnostic-settings create'] = """
+            type: command
+            short-summary: Creates diagnostic settings for the specified resource.
+            parameters:
+                - name: --resource-id
+                  type: string
+                  short-summary: The identifier of the resource
+                - name: --resource-group -g
+                  type: string
+                  short-summary: Name of the resource group
+                - name: --logs
+                  type: string
+                  short-summary: JSON encoded list of logs settings. Use @{file} to load from a file.
+                - name: --metrics
+                  type: string
+                  short-summary: JSON encoded list of metric settings. Use @{file} to load from a file.
+                - name: --storage-account
+                  type: string
+                  short-summary: Name or ID of the storage account to which you would like to send Diagnostic Logs
+                - name: --namespace
+                  type: string
+                  short-summary: Name or ID of the Service Bus namespace
+                - name: --rule-name
+                  type: string
+                  short-summary: Name of the Service Bus authorization rule
+                - name: --workspace
+                  type: string
+                  short-summary: Name or ID of the Log Analytics workspace to which you would like to send Diagnostic Logs
+                - name: --tags
+                  short-summary: Space separated tags in 'key[=value]' format. Use '' to clear existing tags
             """
 helps['monitor diagnostic-settings update'] = """
             type: command

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -5,6 +5,7 @@
 
 import json
 from ._util import ParametersContext
+from azure.cli.command_modules.monitor.validators import (validate_diagnostic_settings)
 
 with ParametersContext(command='monitor alert-rules') as c:
     c.register_alias('name', ('--azure-resource-name',))
@@ -55,18 +56,17 @@ with ParametersContext(command='monitor diagnostic-settings') as c:
     c.register_alias('resource_uri', ('--resource-id',))
 
 with ParametersContext(command='monitor diagnostic-settings create') as c:
-    from azure.mgmt.monitor.models.service_diagnostic_settings_resource import \
-        (ServiceDiagnosticSettingsResource)
+    c.register_alias('resource_group', ('--resource-group', '-g'))
+    c.register_alias('target_resource_id', ('--resource-id',),
+                     validator=validate_diagnostic_settings)
+    c.register('logs', ('--logs',), type=json.loads)
+    c.register('metrics', ('--metrics',), type=json.loads)
+    c.argument('tags', nargs='*')
 
-    c.expand('parameters', ServiceDiagnosticSettingsResource)
-    c.register_alias('resource_uri', ('--resource-id',))
-    c.register('logs', ('--logs',),
-               type=json.loads,
-               help='JSON encoded list of logs settings. Use @{file} to load from a file.')
-    c.register('metrics', ('--metrics',),
-               type=json.loads,
-               help='JSON encoded list of metric settings. Use @{file} to load from a file.')
-
+    # Service Bus argument group
+    c.ignore('service_bus_rule_id')
+    c.argument('namespace', arg_group='Service Bus')
+    c.argument('rule_name', arg_group='Service Bus')
 
 with ParametersContext(command='monitor log-profiles') as c:
     c.register_alias('log_profile_name', ('--name', '-n'))

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -3,6 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from azure.cli.core.commands.arm import is_valid_resource_id, resource_id, parse_resource_id
+from azure.cli.core._util import CLIError
+
 
 def get_complex_argument_processor(expanded_arguments, assigned_arg, model_type):
     """
@@ -21,3 +24,72 @@ def get_complex_argument_processor(expanded_arguments, assigned_arg, model_type)
         setattr(namespace, assigned_arg, model_type(**kwargs))
 
     return _expansion_validator_impl
+
+
+# pylint: disable=line-too-long
+def validate_diagnostic_settings(namespace):
+    from azure.cli.core.commands.client_factory import get_subscription_id
+    resource_group_error = "--resource-group is required when name is provided for "\
+                           "storage account or workspace or service bus namespace and rule. "
+
+    if namespace.namespace or namespace.rule_name:
+        if namespace.namespace is None:
+            raise CLIError(resource_group_error)
+        if namespace.rule_name is None:
+            raise CLIError(resource_group_error)
+        if namespace.resource_group is None:
+            raise CLIError(resource_group_error)
+
+        if not is_valid_resource_id(namespace.namespace):
+            namespace.service_bus_rule_id = resource_id(subscription=get_subscription_id(),
+                                                        resource_group=namespace.resource_group,
+                                                        namespace='microsoft.ServiceBus',
+                                                        type='namespaces',
+                                                        name=namespace.namespace,
+                                                        child_type='AuthorizationRules',
+                                                        child_name=namespace.rule_name)
+        else:
+            resource_dict = parse_resource_id(namespace.namespace)
+            namespace.service_bus_rule_id = resource_id(subscription=resource_dict['subscription'],
+                                                        resource_group=resource_dict['resource_group'],
+                                                        namespace=resource_dict['namespace'],
+                                                        type=resource_dict['type'],
+                                                        name=resource_dict['name'],
+                                                        child_type='AuthorizationRules',
+                                                        child_name=namespace.rule_name)
+
+    if namespace.storage_account and not is_valid_resource_id(namespace.storage_account):
+        if namespace.resource_group is None:
+            raise CLIError(resource_group_error)
+        namespace.storage_account = resource_id(subscription=get_subscription_id(),
+                                                resource_group=namespace.resource_group,
+                                                namespace='microsoft.Storage',
+                                                type='storageAccounts',
+                                                name=namespace.storage_account)
+
+    if namespace.workspace and not is_valid_resource_id(namespace.workspace):
+        if namespace.resource_group is None:
+            raise CLIError(resource_group_error)
+        namespace.workspace = resource_id(subscription=get_subscription_id(),
+                                          resource_group=namespace.resource_group,
+                                          namespace='microsoft.OperationalInsights',
+                                          type='workspaces', name=namespace.workspace)
+    _validate_tags(namespace)
+
+
+def _validate_tags(namespace):
+    """ Extracts multiple space-separated tags in key[=value] format """
+    if isinstance(namespace.tags, list):
+        tags_dict = {}
+        for item in namespace.tags:
+            tags_dict.update(_validate_tag(item))
+        namespace.tags = tags_dict
+
+
+def _validate_tag(string):
+    """ Extracts a single tag in key[=value] format """
+    result = {}
+    if string:
+        comps = string.split('=', 1)
+        result = {comps[0]: comps[1]} if len(comps) > 1 else {string: ''}
+    return result


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/2582

```
(env) vishrut@mac azure-cli (monitor-2582) $ az monitor diagnostic-settings create -h

Command
    az monitor diagnostic-settings create: Creates diagnostic settings for the specified resource.

Arguments
    --resource-id [Required]: The identifier of the resource.
    --logs                  : JSON encoded list of logs settings. Use @{file} to load from a file.
    --metrics               : JSON encoded list of metric settings. Use @{file} to load from a file.
    --resource-group -g     : Name of the resource group.
    --storage-account       : Name or ID of the storage account to which you would like to send
                              Diagnostic Logs.
    --tags                  : Space separated tags in 'key[=value]' format. Use '' to clear existing
                              tags.
    --workspace             : Name or ID of the Log Analytics workspace to which you would like to
                              send Diagnostic Logs.

Service Bus Arguments
    --namespace             : Name or ID of the Service Bus namespace.
    --rule-name             : Name of the Service Bus authorization rule.

Global Arguments
    --debug                 : Increase logging verbosity to show all debug logs.
    --help -h               : Show this help message and exit.
    --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
    --query                 : JMESPath query string. See http://jmespath.org/ for more information
                              and examples.
    --verbose               : Increase logging verbosity. Use --debug for full debug logs.
```