### PR TITLE
[Do not merge]Modify "appservice SC config" to allow VSTS as the deployment engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ setuptools==30.4.0
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
+vsts-cd-manager==0.115.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ setuptools==30.4.0
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
-vsts-cd-manager==0.115.3

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -149,6 +149,10 @@ register_cli_argument('appservice web config backup restore', 'ignore_hostname_c
 register_cli_argument('appservice web source-control', 'manual_integration', action='store_true', help='disable automatic sync between source control and web')
 register_cli_argument('appservice web source-control', 'repo_url', help='repository url to pull the latest source from, e.g. https://github.com/foo/foo-web')
 register_cli_argument('appservice web source-control', 'branch', help='the branch name of the repository')
+register_cli_argument('appservice web source-control', 'cd_provider', help='type of CI/CD provider', default='kudu', **enum_choice_list(['kudu', 'vsts']))
+register_cli_argument('appservice web source-control', 'cd_app_type', help='VSTS Only: web application framework you used to develop your app', default='AspNetWap', **enum_choice_list(['AspNetWap', 'AspNetCore', 'NodeJSWithGulp', 'NodeJSWithGrunt']))
+register_cli_argument('appservice web source-control', 'cd_account', help='VSTS Only: name of the VSTS account to create/use for continuous delivery', default='')
+register_cli_argument('appservice web source-control', 'cd_create_account', help='VSTS Only: specifies that the account should be created if it does not already exist (existing accounts are updated)', default=True)
 register_cli_argument('appservice web source-control', 'repository_type', help='repository type', default='git', **enum_choice_list(['git', 'mercurial']))
 register_cli_argument('appservice web source-control', 'git_token', help='git access token required for auto sync')
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -150,9 +150,9 @@ register_cli_argument('appservice web source-control', 'manual_integration', act
 register_cli_argument('appservice web source-control', 'repo_url', help='repository url to pull the latest source from, e.g. https://github.com/foo/foo-web')
 register_cli_argument('appservice web source-control', 'branch', help='the branch name of the repository')
 register_cli_argument('appservice web source-control', 'cd_provider', help='type of CI/CD provider', default='kudu', **enum_choice_list(['kudu', 'vsts']))
-register_cli_argument('appservice web source-control', 'cd_app_type', help='VSTS Only: web application framework you used to develop your app', default='AspNetWap', **enum_choice_list(['AspNetWap', 'AspNetCore', 'NodeJSWithGulp', 'NodeJSWithGrunt']))
-register_cli_argument('appservice web source-control', 'cd_account', help='VSTS Only: name of the VSTS account to create/use for continuous delivery', default='')
-register_cli_argument('appservice web source-control', 'cd_create_account', help='VSTS Only: specifies that the account should be created if it does not already exist (existing accounts are updated)', default=True)
+register_cli_argument('appservice web source-control', 'cd_app_type', arg_group='VSTS CD Provider', help='web application framework you used to develop your app', default='AspNetWap', **enum_choice_list(['AspNetWap', 'AspNetCore', 'NodeJSWithGulp', 'NodeJSWithGrunt']))
+register_cli_argument('appservice web source-control', 'cd_account', arg_group='VSTS CD Provider', help='name of the VSTS account to create/use for continuous delivery', default='')
+register_cli_argument('appservice web source-control', 'cd_account_must_exist', arg_group='VSTS CD Provider', help='specifies that the account must already exist. If not specified, the account will be created if it does not already exist (existing accounts are updated)', action='store_true')
 register_cli_argument('appservice web source-control', 'repository_type', help='repository type', default='git', **enum_choice_list(['git', 'mercurial']))
 register_cli_argument('appservice web source-control', 'git_token', help='git access token required for auto sync')
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -28,6 +28,7 @@ from azure.cli.core.prompting import prompt_pass, NoTTYException
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core._util import CLIError
 from ._params import web_client_factory, _generic_site_operation
+from .vsts_cd_provider import VstsContinuousDeliveryProvider
 
 logger = azlogging.get_az_logger(__name__)
 
@@ -290,21 +291,29 @@ def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=N
 
 
 def config_source_control(resource_group_name, name, repo_url, repository_type=None, branch=None,
-                          git_token=None, manual_integration=None, slot=None):
-    from azure.mgmt.web.models import SiteSourceControl, SourceControl
+                          git_token=None, manual_integration=None, slot=None, cd_provider=None,
+                          cd_app_type=None, cd_account=None, cd_create_account=None):
     client = web_client_factory()
     location = _get_location_from_webapp(client, resource_group_name, name)
-    if git_token:
-        sc = SourceControl(location, name='GitHub', token=git_token)
-        client.update_source_control('GitHub', sc)
 
-    source_control = SiteSourceControl(location, repo_url=repo_url, branch=branch,
-                                       is_manual_integration=manual_integration,
-                                       is_mercurial=(repository_type != 'git'))
-    poller = _generic_site_operation(resource_group_name, name,
-                                     'create_or_update_source_control',
-                                     slot, source_control)
-    return AppServiceLongRunningOperation()(poller)
+    if cd_provider == 'vsts':
+        vsts_provider = VstsContinuousDeliveryProvider()
+        vsts_provider.setup_continuous_delivery(resource_group_name, name, repo_url, branch, git_token, slot,
+                                                cd_app_type, cd_account, cd_create_account, location)
+        return None
+    else:
+        from azure.mgmt.web.models import SiteSourceControl, SourceControl
+        if git_token:
+            sc = SourceControl(location, name='GitHub', token=git_token)
+            client.update_source_control('GitHub', sc)
+
+        source_control = SiteSourceControl(location, repo_url=repo_url, branch=branch,
+                                           is_manual_integration=manual_integration,
+                                           is_mercurial=(repository_type != 'git'))
+        poller = _generic_site_operation(resource_group_name, name,
+                                         'create_or_update_source_control',
+                                         slot, source_control)
+        return AppServiceLongRunningOperation()(poller)
 
 def update_git_token(git_token=None):
     '''

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -292,15 +292,17 @@ def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=N
 
 def config_source_control(resource_group_name, name, repo_url, repository_type=None, branch=None,
                           git_token=None, manual_integration=None, slot=None, cd_provider=None,
-                          cd_app_type=None, cd_account=None, cd_create_account=None):
+                          cd_app_type=None, cd_account=None, cd_account_must_exist=None):
     client = web_client_factory()
     location = _get_location_from_webapp(client, resource_group_name, name)
 
     if cd_provider == 'vsts':
+        create_account = False if cd_account_must_exist else True
         vsts_provider = VstsContinuousDeliveryProvider()
-        vsts_provider.setup_continuous_delivery(resource_group_name, name, repo_url, branch, git_token, slot,
-                                                cd_app_type, cd_account, cd_create_account, location)
-        return None
+        status = vsts_provider.setup_continuous_delivery(resource_group_name, name, repo_url, branch, git_token, slot,
+                                                         cd_app_type, cd_account, create_account, location)
+        print(status.status_message)
+        return status.status
     else:
         from azure.mgmt.web.models import SiteSourceControl, SourceControl
         if git_token:

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
@@ -45,7 +45,7 @@ class VstsContinuousDeliveryProvider(object):
         cd_manager.set_azure_web_info(resource_group_name, name, cred, subscription['id'],
                                       subscription['name'], subscription['tenantId'], location)
         summary = cd_manager.setup_continuous_delivery(slot, cd_app_type, cd_account, cd_create_account, auth_token)
-        print(summary)
+        return vsts_cd_status("SUCCESS", summary)
 
     def remove_continuous_delivery(self):
         """
@@ -75,3 +75,8 @@ class VstsContinuousDeliveryProvider(object):
 
     def _authentication_context_factory(self, authority, cache):
         return adal.AuthenticationContext(authority, cache=cache, api_version=None)
+
+class vsts_cd_status(object):
+    def __init__(self, status, status_message):
+        self.status = status
+        self.status_message = status_message

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
@@ -1,0 +1,77 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import print_function
+from sys import stderr
+from azure.cli.core._profile import Profile, CredsCache
+from vsts_cd_manager.continuous_delivery_manager import ContinuousDeliveryManager
+import adal
+
+
+class VstsContinuousDeliveryProvider(object):
+    def __init__(self):
+        self._progress_last_message = ''
+
+    def setup_continuous_delivery(self, resource_group_name, name, repo_url, branch, git_token, slot,
+                                  cd_app_type, cd_account, cd_create_account, location):
+        """
+        This method sets up CD for an Azure Website thru VSTS
+        :param resource_group_name:
+        :param name:
+        :param repo_url:
+        :param branch:
+        :param git_token:
+        :param slot:
+        :param cd_app_type:
+        :param cd_account:
+        :param cd_create_account:
+        :param location:
+        :return:
+        """
+        # Gather information about the Azure connection
+        profile = Profile()
+        subscription = profile.get_subscription()
+        user = profile.get_current_account_user()
+        cred, subscription_id, _ = profile.get_login_credentials(subscription_id=None)
+
+        cd_manager = ContinuousDeliveryManager(self._update_progress)
+
+        # Generate an Azure token with the VSTS resource app id
+        auth_token = self._get_vsts_azure_auth_token(user, None, cd_manager.get_vsts_app_id())
+
+        cd_manager.set_repository_info(repo_url, branch, git_token)
+        cd_manager.set_azure_web_info(resource_group_name, name, cred, subscription['id'],
+                                      subscription['name'], subscription['tenantId'], location)
+        summary = cd_manager.setup_continuous_delivery(slot, cd_app_type, cd_account, cd_create_account, auth_token)
+        print(summary)
+
+    def remove_continuous_delivery(self):
+        """
+        To be Implemented
+        :return:
+        """
+        # TODO: this would be called by appservice web source-control delete
+
+    def _update_progress(self, current, total, status):
+        if total:
+            percent_done = current * 100 / total
+            message = '{: >3.0f}% complete: {}'.format(percent_done, status)
+            # Erase the previous message (backspace to beginning, space over the text and backspace again)
+            l = len(self._progress_last_message)
+            print('\b' * l + ' ' * l + '\b' * l, end='', file=stderr)
+            print(message, end='', file=stderr)
+            self._progress_last_message = message
+            stderr.flush()
+            if current == total:
+                print('', file=stderr)
+
+    def _get_vsts_azure_auth_token(self, username, tenant, resource):
+        tenant = tenant or 'common'
+        creds_cache = CredsCache(self._authentication_context_factory)
+        token_entry_type, access_token = creds_cache.retrieve_token_for_user(username, tenant, resource)
+        return access_token
+
+    def _authentication_context_factory(self, authority, cache):
+        return adal.AuthenticationContext(authority, cache=cache, api_version=None)

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -31,6 +31,7 @@ DEPENDENCIES = [
     'urllib3[secure]==1.16',
     'xmltodict',
     'pyOpenSSL',
+    'vsts-cd-manager',
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
(attempt 2)
- Adding dependency on vsts-cd-manager to do CD flow in VSTS
- Created a vsts_cd_provider class to wrap all the logic around inputs and outputs to the VSTS CD flow
- Added 4 new parameters to "az appservice web source-control config" all optional
- cd-provider tells the command line to use kudu or vsts (kudu is still currently the default)
- cd-account is required if vsts is chosen but a non-vsts repo-url is used
- cd_create_account and cd_app_type are passed on to the CD flow for VSTS