### PR TITLE
appservice: support binding wildcard certificates

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -900,15 +900,15 @@ def _update_ssl_binding(resource_group_name, name, certificate_thumbprint, ssl_t
 
 
 def bind_ssl_cert(resource_group_name, name, certificate_thumbprint, ssl_type, slot=None):
-    return _update_ssl_binding(resource_group_name, name,
-                               certificate_thumbprint,
-                               SslState.sni_enabled if ssl_type == 'SNI' else SslState.ip_based_enabled,
-                               slot)
+    return _update_ssl_binding(
+        resource_group_name, name, certificate_thumbprint,
+        SslState.sni_enabled if ssl_type == 'SNI' else SslState.ip_based_enabled, slot)
 
 
 def unbind_ssl_cert(resource_group_name, name, certificate_thumbprint, slot=None):
     return _update_ssl_binding(resource_group_name, name,
                                certificate_thumbprint, SslState.disabled, slot)
+
 
 def _match_host_names_from_cert(hostnames_from_cert, hostnames_in_webapp):
     matched = set()

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -883,9 +883,9 @@ def _update_ssl_binding(resource_group_name, name, certificate_thumbprint, ssl_t
     for webapp_cert in webapp_certs:
         if webapp_cert.thumbprint == certificate_thumbprint:
             if len(webapp_cert.host_names) == 1 and not webapp_cert.host_names[0].startswith('*'):
-                _update_host_name_ssl_state(resource_group_name, name, webapp.location,
-                                            webapp_cert.host_names[0], ssl_type,
-                                            certificate_thumbprint, slot)
+                return _update_host_name_ssl_state(resource_group_name, name, webapp.location,
+                                                   webapp_cert.host_names[0], ssl_type,
+                                                   certificate_thumbprint, slot)
             else:
                 query_result = list_hostnames(resource_group_name, name, slot)
                 hostnames_in_webapp = [x.name.split('/')[-1] for x in query_result]
@@ -894,7 +894,7 @@ def _update_ssl_binding(resource_group_name, name, certificate_thumbprint, ssl_t
                     _update_host_name_ssl_state(resource_group_name, name, webapp.location,
                                                 h, ssl_type, certificate_thumbprint, slot)
 
-            return show_webapp(resource_group_name, name, slot)
+                return show_webapp(resource_group_name, name, slot)
 
     raise CLIError("Certificate for thumbprint '{}' not found.".format(certificate_thumbprint))
 
@@ -911,6 +911,7 @@ def unbind_ssl_cert(resource_group_name, name, certificate_thumbprint, slot=None
 
 
 def _match_host_names_from_cert(hostnames_from_cert, hostnames_in_webapp):
+    # the goal is to match '*.foo.com' with host name like 'admin.foo.com', 'logs.foo.com', etc
     matched = set()
     for hostname in hostnames_from_cert:
         if hostname.startswith('*'):

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -855,19 +855,13 @@ def list_ssl_certs(resource_group_name):
     return client.certificates.list_by_resource_group(resource_group_name)
 
 
-def delete_ssl_cert(resource_group_name, name, certificate_thumbprint):
+def delete_ssl_cert(resource_group_name, certificate_thumbprint):
     client = web_client_factory()
-    error_str_1 = "Certificate for thumbprint '{}' found, but not for webapp '{}'"
-    error_str_2 = "Certificate for thumbprint '{}' not found"
     webapp_certs = client.certificates.list_by_resource_group(resource_group_name)
     for webapp_cert in webapp_certs:
         if webapp_cert.thumbprint == certificate_thumbprint:
-            for hostname in webapp_cert.host_names:
-                if name in hostname:
-                    return client.certificates.delete(resource_group_name,
-                                                      webapp_cert.name)
-                raise CLIError(error_str_1.format(certificate_thumbprint, name))
-            raise CLIError(error_str_2.format(certificate_thumbprint))
+            return client.certificates.delete(resource_group_name, webapp_cert.name)
+    raise CLIError("Certificate for thumbprint '{}' not found".format(certificate_thumbprint))
 
 
 def _update_host_name_ssl_state(resource_group_name, webapp_name, location,
@@ -884,25 +878,45 @@ def _update_host_name_ssl_state(resource_group_name, webapp_name, location,
 
 def _update_ssl_binding(resource_group_name, name, certificate_thumbprint, ssl_type, slot=None):
     client = web_client_factory()
-    webapp = _generic_site_operation(resource_group_name, name, 'get')
+    webapp = client.web_apps.get(resource_group_name, name)
     webapp_certs = client.certificates.list_by_resource_group(resource_group_name)
     for webapp_cert in webapp_certs:
         if webapp_cert.thumbprint == certificate_thumbprint:
-            return _update_host_name_ssl_state(resource_group_name, name, webapp.location,
-                                               webapp_cert.host_names[0], ssl_type,
-                                               certificate_thumbprint, slot)
+            if len(webapp_cert.host_names) == 1 and not webapp_cert.host_names[0].startswith('*'):
+                _update_host_name_ssl_state(resource_group_name, name, webapp.location,
+                                            webapp_cert.host_names[0], ssl_type,
+                                            certificate_thumbprint, slot)
+            else:
+                query_result = list_hostnames(resource_group_name, name, slot)
+                hostnames_in_webapp = [x.name.split('/')[-1] for x in query_result]
+                to_update = _match_host_names_from_cert(webapp_cert.host_names, hostnames_in_webapp)
+                for h in to_update:
+                    _update_host_name_ssl_state(resource_group_name, name, webapp.location,
+                                                h, ssl_type, certificate_thumbprint, slot)
+
+            return show_webapp(resource_group_name, name, slot)
+
     raise CLIError("Certificate for thumbprint '{}' not found.".format(certificate_thumbprint))
 
 
 def bind_ssl_cert(resource_group_name, name, certificate_thumbprint, ssl_type, slot=None):
-    if ssl_type == 'SNI':
-        return _update_ssl_binding(resource_group_name, name,
-                                   certificate_thumbprint, SslState.sni_enabled, slot)
-    else:
-        return _update_ssl_binding(resource_group_name, name,
-                                   certificate_thumbprint, SslState.ip_based_enabled, slot)
+    return _update_ssl_binding(resource_group_name, name,
+                               certificate_thumbprint,
+                               SslState.sni_enabled if ssl_type == 'SNI' else SslState.ip_based_enabled,
+                               slot)
 
 
 def unbind_ssl_cert(resource_group_name, name, certificate_thumbprint, slot=None):
     return _update_ssl_binding(resource_group_name, name,
                                certificate_thumbprint, SslState.disabled, slot)
+
+def _match_host_names_from_cert(hostnames_from_cert, hostnames_in_webapp):
+    matched = set()
+    for hostname in hostnames_from_cert:
+        if hostname.startswith('*'):
+            for h in hostnames_in_webapp:
+                if hostname[hostname.find('.'):] == h[h.find('.'):]:
+                    matched.add(h)
+        elif hostname in hostnames_in_webapp:
+            matched.add(hostname)
+    return matched

--- a/src/command_modules/azure-cli-appservice/tests/recordings/test_webapp_ssl.yaml
+++ b/src/command_modules/azure-cli-appservice/tests/recordings/test_webapp_ssl.yaml
@@ -6,11 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+          AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d79e7a4-05c8-11e7-8d18-480fcf502758]
+      x-ms-client-request-id: [6cf60914-10c8-11e7-93de-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_cli_webapp_ssl?api-version=2016-09-01
   response:
@@ -18,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 10 Mar 2017 19:30:42 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -27,27 +27,28 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "properties": {"perSiteScaling": false, "name":
-      "webapp-ssl-test-plan"}, "sku": {"name": "B1", "capacity": 1, "tier": "BASIC"}}'
+      "webapp-ssl-test-plan"}, "sku": {"tier": "BASIC", "name": "B1", "capacity":
+      1}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['150']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d86540c-05c8-11e7-bf27-480fcf502758]
+      x-ms-client-request-id: [6d07cd08-10c8-11e7-b0b2-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan?api-version=2016-09-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","name":"webapp-ssl-test-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-ssl-test-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"test_cli_webapp_ssl-WestUSwebspace","subscription":"8d57ddbd-c779-40ea-b660-1015f4bf027d","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"test_cli_webapp_ssl","reserved":false,"mdmId":"waws-prod-bay-075_2633","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
+        US","properties":{"serverFarmId":0,"name":"webapp-ssl-test-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"test_cli_webapp_ssl-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"test_cli_webapp_ssl","reserved":false,"mdmId":"waws-prod-bay-075_4456","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:30:54 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -56,95 +57,32 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1183']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [14df9e08-05c8-11e7-9291-480fcf502758]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan?api-version=2016-09-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","name":"webapp-ssl-test-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-ssl-test-plan","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"test_cli_webapp_ssl-WestUSwebspace","subscription":"8d57ddbd-c779-40ea-b660-1015f4bf027d","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Shared","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"test_cli_webapp_ssl","reserved":false,"mdmId":"waws-prod-bay-075_2633","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:30:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['1183']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "West US", "properties": {"microService": "false", "scmSiteAlsoStopped":
-      false, "serverFarmId": "webapp-ssl-test-plan", "reserved": false}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['152']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1537d5ba-05c8-11e7-bb92-480fcf502758]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:00.03","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:02 GMT']
-      ETag: ['"1D299D4D93E7D35"']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      content-length: ['2720']
+      content-length: ['1171']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
-    body: null
+    body: '{"location": "westus", "properties": {"reserved": false, "microService":
+      "false", "serverFarmId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan",
+      "scmSiteAlsoStopped": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
+      Content-Length: ['280']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [19a063e6-05c8-11e7-9d54-480fcf502758]
-    method: GET
+      x-ms-client-request-id: [79d20ab4-10c8-11e7-b0d3-64510658e3b3]
+    method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:00.4033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"westus","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:28.4566667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:04 GMT']
-      ETag: ['"1D299D4D93E7D35"']
+      Date: ['Fri, 24 Mar 2017 19:31:31 GMT']
+      ETag: ['"1D2A4D53BD26840"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -153,31 +91,64 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2725']
+      content-length: ['2712']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"password": "test", "pfxBlob": "MIIJ0QIBAzCCCZcGCSqGSIb3DQEHAaCCCYgEggmEMIIJgDCCBDcGCSqGSIb3DQEHBqCCBCgwggQkAgEAMIIEHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQINlblqlYslJgCAggAgIID8F0H+UkIxP3wD9FDn9tzt9ATQWlSKZAp7MQWwVxfr3b6Nn+OarlLGDReRoHgYhJelZAyPFPAOlA+DXh8Cr6+g/Skp9KBQf7nqDR6tnQ4VOcEqNfoj5O7LmvjQ9KY8I7CmTr0+ZpWRWoCPZ6WTw3BK9lQhbOuEU0I/5+sIveGuIlC0qITO8WyUDM+Q0GtqlEs9Yv/jtyclhzX4oNCM0RrhQrFNdVSTksV0Oxnldf9SPeMsFCJ3l1VMWj3o3/E8AnR9QJsE7PTLRpSouJZHweQP1WRlQxNwLogOkJuI4ddrqacKo6SC3myMspt0uARPIlpI9IFxCRUGooJV9ZtFziGkA2ey7X0yVYJ0MuZNQcsOFSw4uyx1jmLR9uRvYBBEr+xxwbC/+lDIRbjJBQ32hRKDcWWM7JYbkeFw/3tMtE7Sc1hSFLVwIcoVUqV/02gCgCwYbwXGA0eYo5X88jZxxsoTjkeeMGmw+PGzo1EC3dCxseCrsXXSVaVr/CDeUOJBtIQofnd4E8UdtpuwoTa0cwXAbZmBghzA6J6puQuyN+yf+6RLExzVZPACXna3BHgWGiHGRgc3tF8ua1KnT/dhNu5+CVPajklO4MhrBLIF9JQ7br4vFGFKIy1kV04A0SxLU9JurYCNhPM8/LEXlzAbLpHhlqAAz25yBaYrC4GfAbv6afnd0arbNc40JWaSHmsDjcCDqewh/f7oUsn27/4pDzBgmvOX3lUXe2wkRk7QS/9kdq0cu5mhgyDD+D9MeMRu/gjJRrbtioc8IuQgMO9Y6mmouEpu2cHX70X1mpMORRgNxWfB4nNSfrYC8LngeFjivh2Imu9LKS/7HtxdQ0n1KpVkGGKwOu3pXs1o9cwDpNXK8iQ/IhMF21w6cI7biGxHAsJUas10ApC6e54MGewrjgCMSej8z0Z/Wp+tc7pKxfdlun7H2e0Ou8L5QjjR2ilGrhvuQuXU2DWgprjm7ivYGe+1Yi300L9jvqEXgyCZslfW0PEQyZkdpX6AJSU/EFsay57cSNF3t41GCdD38RbRPvr8A0J4Y5JSuSBux7twrDXQAfZ33y9SyJ8zwzMN9dYc2WG39u0IT7aQ0U6xBS9j7eaMGIRdGq+VBLtAgB22iyTK+FQJFE1aVjmsp+os5SZkfgWEYA7p8AGLd1lVg69kgWu5E0EqaHk4yuoA/X6kDzNLCiV5Q5MODylkTBq9Qdpau/8FZiO8tZ0dbGcELIoGlRVIRIfkUi7Nbk6W9F1719BDYr61KzsB/JElReR0uC9qW52Z+I3Es7mKMmhi3wQJY/+FIraGVD0xMAbE36LTu0RQ01+TD++Z35mvinvZIn1rEjX5DCCBUEGCSqGSIb3DQEHAaCCBTIEggUuMIIFKjCCBSYGCyqGSIb3DQEMCgECoIIE7jCCBOowHAYKKoZIhvcNAQwBAzAOBAhZn41qm5xQYQICCAAEggTI8BsnZxqfxgWTlDSpWzu0G1KF/t3Bi9DPTg0nDdX4PMc8RCCLNOJkQhYZh2Dkog6A0tv0/yElusd08giS86fBCE8MWeeZ0BNRJt7wr8UNa8er3U1unz47hwx1eGF8OhhbF3cRlvR3c2H9BT+kn6j5JaFuCglqzutfJ3oIcJvITi8AtU1c4/+Q4/zLIPbnPAcj2/WJDbvmjxQdYa+v7UZlosRTR93hyxIiY4O942JprBQ4C0ZlKU4i1QKC+57eB/qibxn76fmS/DqCQMooTNNschlXV+I+lAqS6axBW/kCW0QkPp60LcZ79atZLceBcMew452/aR1noj3fPdao4Vv5x6RjZBjm+P2y3XBF68zwd9qrS3cZgyxMuzoyQl9pP7HNaZVG03KZwwDzyOyP1v5EUCON91rKgcAVA+Xw8XKM2+pThE4j0DneqwT+JAPZceOAWIXvt7pPZLYxu8Sd04K6FdE8yRmjDRS20y+j9tArZJyyHRmckS6Tb0G07xQ+wSRnLYLqEhCfMQZS0RXzGPvN82Kd9kqtGkse+ku3ct5pQUowgkrSbfHj9OCyLftvrOc0FL+nXcuJ+VWg0Ui0M3/CHdGxgH5d7uRNAduegS1g+Y4R/W8AXyK4xvyGOkI9LyMV1Ote17F2/qqNqctxDmsH2TjGOLX8FJqpI5L0/gNkmH+kWWIq8N0W9I4lkzRHOE13rC7Rm3HkaUNgwMmiTEs9hmyWO4q5iJuYG3tOLsxrInkj7uZDEf4yyRq6FyauXafiaUs7Qzzg39coIERvkhnqF3nx9kspNviBE9bhP4XsUsxGCdhg4y0TsPxdMeZl7pWSOhX479ZLMtZZmOfm3uUogNyS+BB8A/0AXF8YK6Th2YozpyaKj7o/ghTeAbvhLAn/1BA8YPfy/ynCH2eVOVFkPMeACnZt1/cOua38/1PKrCmN5ZhI7tFmqEiLYWwo78ZuI58LMqpo/urGX6dGz6wxD6Ljmw4MVkQQhu+s/Vor5fNSHl/yj+7nrkw0FMgxlTZbHPbbuBm78LU+B/stBq9MuTjMZAQustV+f8UmJNmlljHdIo103ZtQ6MaxTsq7KQXW4Pjt0w3bw4eF4i/VAn7f9hcT3eRJ2rdIa/A04TDXqYlb0U7Iw4ZfdhxNTwfHGgU25D9z14uupkfOXJfAe/N5YU5+w1J9xcv393gEbYz3z8ALBx5Oiwnak5M/6m20FypRG4OSW9MZZ3g5ppR71JlKZtfaVkrFSVUPCP19ZJvWapVwBnwxcFzsS11klWMLupAAwLOJZ/TA7S8eczd0u2cfKhL5oxAiGvWcnWhd7pmcBWMOYPuq5FlXR8wDTRihtXp3Wt67y+mTNWNADMurbXoamMvx9yR+fBg4FAKuV+TrjhVJP/iSRsoJsmgXPRlKS+DciI3RUh6Pg++MPS+u9lL3STZjEws2oBf6zjzjTiPrVsqMjgrfZfdwZJZAKltalHmiZRaQI6H1wC2wsoCQGc+PUtSMCGq92k8AfOXvvd8uVqC0f+9DoT/HjKqFyvzO1MLqydIKTgu+IAhWdMQIra6GHQDqpNk+NsGhMbcgbjFQ1tzYC0CyNY3o+ThcnoiqL7NICpsWFpIwE0wb+sEhzxrOMAgbAyCMPjK/MSUwIwYJKoZIhvcNAQkVMRYEFNsrpomNCzMKk+f2n/UFxh7zmSG2MDEwITAJBgUrDgMCGgUABBTzbsBu11reT+Sadb94N2t+155P4QQImFXG2dTQ71ACAggA"}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [7d11a8a2-10c8-11e7-b449-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:28.58","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Fri, 24 Mar 2017 19:31:32 GMT']
+      ETag: ['"1D2A4D53BD26840"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2708']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "West US", "properties": {"pfxBlob": "MIIJ0QIBAzCCCZcGCSqGSIb3DQEHAaCCCYgEggmEMIIJgDCCBDcGCSqGSIb3DQEHBqCCBCgwggQkAgEAMIIEHQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQINlblqlYslJgCAggAgIID8F0H+UkIxP3wD9FDn9tzt9ATQWlSKZAp7MQWwVxfr3b6Nn+OarlLGDReRoHgYhJelZAyPFPAOlA+DXh8Cr6+g/Skp9KBQf7nqDR6tnQ4VOcEqNfoj5O7LmvjQ9KY8I7CmTr0+ZpWRWoCPZ6WTw3BK9lQhbOuEU0I/5+sIveGuIlC0qITO8WyUDM+Q0GtqlEs9Yv/jtyclhzX4oNCM0RrhQrFNdVSTksV0Oxnldf9SPeMsFCJ3l1VMWj3o3/E8AnR9QJsE7PTLRpSouJZHweQP1WRlQxNwLogOkJuI4ddrqacKo6SC3myMspt0uARPIlpI9IFxCRUGooJV9ZtFziGkA2ey7X0yVYJ0MuZNQcsOFSw4uyx1jmLR9uRvYBBEr+xxwbC/+lDIRbjJBQ32hRKDcWWM7JYbkeFw/3tMtE7Sc1hSFLVwIcoVUqV/02gCgCwYbwXGA0eYo5X88jZxxsoTjkeeMGmw+PGzo1EC3dCxseCrsXXSVaVr/CDeUOJBtIQofnd4E8UdtpuwoTa0cwXAbZmBghzA6J6puQuyN+yf+6RLExzVZPACXna3BHgWGiHGRgc3tF8ua1KnT/dhNu5+CVPajklO4MhrBLIF9JQ7br4vFGFKIy1kV04A0SxLU9JurYCNhPM8/LEXlzAbLpHhlqAAz25yBaYrC4GfAbv6afnd0arbNc40JWaSHmsDjcCDqewh/f7oUsn27/4pDzBgmvOX3lUXe2wkRk7QS/9kdq0cu5mhgyDD+D9MeMRu/gjJRrbtioc8IuQgMO9Y6mmouEpu2cHX70X1mpMORRgNxWfB4nNSfrYC8LngeFjivh2Imu9LKS/7HtxdQ0n1KpVkGGKwOu3pXs1o9cwDpNXK8iQ/IhMF21w6cI7biGxHAsJUas10ApC6e54MGewrjgCMSej8z0Z/Wp+tc7pKxfdlun7H2e0Ou8L5QjjR2ilGrhvuQuXU2DWgprjm7ivYGe+1Yi300L9jvqEXgyCZslfW0PEQyZkdpX6AJSU/EFsay57cSNF3t41GCdD38RbRPvr8A0J4Y5JSuSBux7twrDXQAfZ33y9SyJ8zwzMN9dYc2WG39u0IT7aQ0U6xBS9j7eaMGIRdGq+VBLtAgB22iyTK+FQJFE1aVjmsp+os5SZkfgWEYA7p8AGLd1lVg69kgWu5E0EqaHk4yuoA/X6kDzNLCiV5Q5MODylkTBq9Qdpau/8FZiO8tZ0dbGcELIoGlRVIRIfkUi7Nbk6W9F1719BDYr61KzsB/JElReR0uC9qW52Z+I3Es7mKMmhi3wQJY/+FIraGVD0xMAbE36LTu0RQ01+TD++Z35mvinvZIn1rEjX5DCCBUEGCSqGSIb3DQEHAaCCBTIEggUuMIIFKjCCBSYGCyqGSIb3DQEMCgECoIIE7jCCBOowHAYKKoZIhvcNAQwBAzAOBAhZn41qm5xQYQICCAAEggTI8BsnZxqfxgWTlDSpWzu0G1KF/t3Bi9DPTg0nDdX4PMc8RCCLNOJkQhYZh2Dkog6A0tv0/yElusd08giS86fBCE8MWeeZ0BNRJt7wr8UNa8er3U1unz47hwx1eGF8OhhbF3cRlvR3c2H9BT+kn6j5JaFuCglqzutfJ3oIcJvITi8AtU1c4/+Q4/zLIPbnPAcj2/WJDbvmjxQdYa+v7UZlosRTR93hyxIiY4O942JprBQ4C0ZlKU4i1QKC+57eB/qibxn76fmS/DqCQMooTNNschlXV+I+lAqS6axBW/kCW0QkPp60LcZ79atZLceBcMew452/aR1noj3fPdao4Vv5x6RjZBjm+P2y3XBF68zwd9qrS3cZgyxMuzoyQl9pP7HNaZVG03KZwwDzyOyP1v5EUCON91rKgcAVA+Xw8XKM2+pThE4j0DneqwT+JAPZceOAWIXvt7pPZLYxu8Sd04K6FdE8yRmjDRS20y+j9tArZJyyHRmckS6Tb0G07xQ+wSRnLYLqEhCfMQZS0RXzGPvN82Kd9kqtGkse+ku3ct5pQUowgkrSbfHj9OCyLftvrOc0FL+nXcuJ+VWg0Ui0M3/CHdGxgH5d7uRNAduegS1g+Y4R/W8AXyK4xvyGOkI9LyMV1Ote17F2/qqNqctxDmsH2TjGOLX8FJqpI5L0/gNkmH+kWWIq8N0W9I4lkzRHOE13rC7Rm3HkaUNgwMmiTEs9hmyWO4q5iJuYG3tOLsxrInkj7uZDEf4yyRq6FyauXafiaUs7Qzzg39coIERvkhnqF3nx9kspNviBE9bhP4XsUsxGCdhg4y0TsPxdMeZl7pWSOhX479ZLMtZZmOfm3uUogNyS+BB8A/0AXF8YK6Th2YozpyaKj7o/ghTeAbvhLAn/1BA8YPfy/ynCH2eVOVFkPMeACnZt1/cOua38/1PKrCmN5ZhI7tFmqEiLYWwo78ZuI58LMqpo/urGX6dGz6wxD6Ljmw4MVkQQhu+s/Vor5fNSHl/yj+7nrkw0FMgxlTZbHPbbuBm78LU+B/stBq9MuTjMZAQustV+f8UmJNmlljHdIo103ZtQ6MaxTsq7KQXW4Pjt0w3bw4eF4i/VAn7f9hcT3eRJ2rdIa/A04TDXqYlb0U7Iw4ZfdhxNTwfHGgU25D9z14uupkfOXJfAe/N5YU5+w1J9xcv393gEbYz3z8ALBx5Oiwnak5M/6m20FypRG4OSW9MZZ3g5ppR71JlKZtfaVkrFSVUPCP19ZJvWapVwBnwxcFzsS11klWMLupAAwLOJZ/TA7S8eczd0u2cfKhL5oxAiGvWcnWhd7pmcBWMOYPuq5FlXR8wDTRihtXp3Wt67y+mTNWNADMurbXoamMvx9yR+fBg4FAKuV+TrjhVJP/iSRsoJsmgXPRlKS+DciI3RUh6Pg++MPS+u9lL3STZjEws2oBf6zjzjTiPrVsqMjgrfZfdwZJZAKltalHmiZRaQI6H1wC2wsoCQGc+PUtSMCGq92k8AfOXvvd8uVqC0f+9DoT/HjKqFyvzO1MLqydIKTgu+IAhWdMQIra6GHQDqpNk+NsGhMbcgbjFQ1tzYC0CyNY3o+ThcnoiqL7NICpsWFpIwE0wb+sEhzxrOMAgbAyCMPjK/MSUwIwYJKoZIhvcNAQkVMRYEFNsrpomNCzMKk+f2n/UFxh7zmSG2MDEwITAJBgUrDgMCGgUABBTzbsBu11reT+Sadb94N2t+155P4QQImFXG2dTQ71ACAggA",
+      "password": "test"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3430']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [19fd1790-05c8-11e7-a4b7-480fcf502758]
+      x-ms-client-request-id: [7d3f0be2-10c8-11e7-8f97-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West%20US_test_cli_webapp_ssl?api-version=2016-03-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","name":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","type":"Microsoft.Web/certificates","location":"West
-        US","tags":null,"properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}'}
+        US","properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:06 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -188,8 +159,8 @@ interactions:
           Some of the uploaded certificates cannot be validated to a trusted CA']
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1006']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['994']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -198,20 +169,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b91d340-05c8-11e7-b847-480fcf502758]
+      x-ms-client-request-id: [7e9cfab4-10c8-11e7-b78c-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:00.4033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:28.58","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:06 GMT']
-      ETag: ['"1D299D4D93E7D35"']
+      Date: ['Fri, 24 Mar 2017 19:31:36 GMT']
+      ETag: ['"1D2A4D53BD26840"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -220,7 +191,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2725']
+      content-length: ['2708']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -229,21 +200,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1bba379e-05c8-11e7-9697-480fcf502758]
+      x-ms-client-request-id: [7eee82ec-10c8-11e7-a83e-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates?api-version=2016-03-01
   response:
     body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","name":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","type":"Microsoft.Web/certificates","location":"West
-        US","tags":null,"properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
+        US","properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:07 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -252,32 +223,33 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1044']
+      content-length: ['1032']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "scmSiteAlsoStopped":
-      false, "reserved": false, "hostNameSslStates": [{"toUpdate": true, "name": "webapp-ssl-test123.azurewebsites.net",
-      "thumbprint": "DB2BA6898D0B330A93E7F69FF505C61EF39921B6", "sslState": "SniEnabled"}]}}'
+    body: '{"location": "West US", "properties": {"reserved": false, "hostNameSslStates":
+      [{"sslState": "SniEnabled", "toUpdate": true, "name": "webapp-ssl-test123.azurewebsites.net",
+      "thumbprint": "DB2BA6898D0B330A93E7F69FF505C61EF39921B6"}], "microService":
+      "false", "scmSiteAlsoStopped": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['287']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c0b9a88-05c8-11e7-95e4-480fcf502758]
+      x-ms-client-request-id: [7f4c3574-10c8-11e7-abf2-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:09.3266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:36.94","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:09 GMT']
-      ETag: ['"1D299D4DE9014EB"']
+      Date: ['Fri, 24 Mar 2017 19:31:38 GMT']
+      ETag: ['"1D2A4D540CE0AC0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -286,7 +258,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2765']
+      content-length: ['2748']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
@@ -296,20 +268,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1e076fec-05c8-11e7-950a-480fcf502758]
+      x-ms-client-request-id: [80c14f68-10c8-11e7-93ff-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:09.3266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:36.94","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:11 GMT']
-      ETag: ['"1D299D4DE9014EB"']
+      Date: ['Fri, 24 Mar 2017 19:31:39 GMT']
+      ETag: ['"1D2A4D540CE0AC0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -318,7 +290,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2765']
+      content-length: ['2748']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -327,21 +299,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1e47209c-05c8-11e7-b908-480fcf502758]
+      x-ms-client-request-id: [812ebd3a-10c8-11e7-ae56-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates?api-version=2016-03-01
   response:
     body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","name":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","type":"Microsoft.Web/certificates","location":"West
-        US","tags":null,"properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
+        US","properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:12 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -350,32 +322,33 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1044']
+      content-length: ['1032']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"microService": "false", "scmSiteAlsoStopped":
-      false, "reserved": false, "hostNameSslStates": [{"toUpdate": true, "name": "webapp-ssl-test123.azurewebsites.net",
-      "thumbprint": "DB2BA6898D0B330A93E7F69FF505C61EF39921B6", "sslState": "Disabled"}]}}'
+    body: '{"location": "West US", "properties": {"reserved": false, "hostNameSslStates":
+      [{"sslState": "Disabled", "toUpdate": true, "name": "webapp-ssl-test123.azurewebsites.net",
+      "thumbprint": "DB2BA6898D0B330A93E7F69FF505C61EF39921B6"}], "microService":
+      "false", "scmSiteAlsoStopped": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['285']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1eac4940-05c8-11e7-9baf-480fcf502758]
+      x-ms-client-request-id: [81a08d26-10c8-11e7-8799-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123","name":"webapp-ssl-test123","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","tags":null,"properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-10T19:31:14.28","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
+        US","properties":{"name":"webapp-ssl-test123","state":"Running","hostNames":["webapp-ssl-test123.azurewebsites.net"],"webSpace":"test_cli_webapp_ssl-WestUSwebspace","selfLink":"https://waws-prod-bay-075.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/test_cli_webapp_ssl-WestUSwebspace/sites/webapp-ssl-test123","repositorySiteName":"webapp-ssl-test123","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-ssl-test123.azurewebsites.net","webapp-ssl-test123.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-ssl-test123.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-ssl-test123.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/serverfarms/webapp-ssl-test-plan","reserved":false,"lastModifiedTimeUtc":"2017-03-24T19:31:41.2233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"webapp-ssl-test123","trafficManagerHostNames":null,"sku":"Basic","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"false","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"104.40.3.53,104.40.18.224,104.40.21.79,104.40.21.56,104.40.23.196","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-075","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"test_cli_webapp_ssl","defaultHostName":"webapp-ssl-test123.azurewebsites.net","slotSwapStatus":null}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:16 GMT']
-      ETag: ['"1D299D4E183E680"']
+      Date: ['Fri, 24 Mar 2017 19:31:43 GMT']
+      ETag: ['"1D2A4D5435BA075"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -384,8 +357,8 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['2720']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      content-length: ['2713']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -394,21 +367,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [21e1e686-05c8-11e7-9841-480fcf502758]
+      x-ms-client-request-id: [83a5ace6-10c8-11e7-b90c-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates?api-version=2016-03-01
   response:
     body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","name":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West
         US_test_cli_webapp_ssl","type":"Microsoft.Web/certificates","location":"West
-        US","tags":null,"properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
+        US","properties":{"friendlyName":"","subjectName":"webapp-ssl-test123.azurewebsites.net","hostNames":["webapp-ssl-test123.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"webapp-ssl-test123.azurewebsites.net","issueDate":"2017-02-08T23:14:36+00:00","expirationDate":"2018-02-08T23:14:36+00:00","password":null,"thumbprint":"DB2BA6898D0B330A93E7F69FF505C61EF39921B6","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultSecretStatus":"Initialized","webSpace":"test_cli_webapp_ssl-WestUSwebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json]
-      Date: ['Fri, 10 Mar 2017 19:31:18 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -417,7 +390,7 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      content-length: ['1044']
+      content-length: ['1032']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -427,10 +400,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [22334576-05c8-11e7-a9a3-480fcf502758]
+      x-ms-client-request-id: [852a7f4c-10c8-11e7-849c-64510658e3b3]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/certificates/DB2BA6898D0B330A93E7F69FF505C61EF39921B6__West%20US_test_cli_webapp_ssl?api-version=2016-03-01
   response:
@@ -438,14 +411,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Fri, 10 Mar 2017 19:31:18 GMT']
+      Date: ['Fri, 24 Mar 2017 19:31:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -455,10 +428,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+          msrest_azure/0.4.7 websitemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [22e0b0fe-05c8-11e7-8ac3-480fcf502758]
+      x-ms-client-request-id: [864508c6-10c8-11e7-9264-64510658e3b3]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_cli_webapp_ssl/providers/Microsoft.Web/sites/webapp-ssl-test123?api-version=2016-08-01
   response:
@@ -466,14 +439,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Fri, 10 Mar 2017 19:31:23 GMT']
-      ETag: ['"1D299D4E183E680"']
+      Date: ['Fri, 24 Mar 2017 19:31:54 GMT']
+      ETag: ['"1D2A4D5435BA075"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands.py
@@ -445,13 +445,13 @@ class WebappSSLCertTest(ResourceGroupVCRTestBase):
             JMESPathCheck('thumbprint', cert_thumbprint)
         ])
         self.cmd('appservice web config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(self.resource_group, self.webapp_name, cert_thumbprint, 'SNI'), checks=[
-            JMESPathCheck('hostNameSslStates[0].sslState', 'SniEnabled'),
-            JMESPathCheck('hostNameSslStates[0].thumbprint', cert_thumbprint)
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(self.webapp_name), 'SniEnabled'),
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(self.webapp_name), cert_thumbprint)
         ])
         self.cmd('appservice web config ssl unbind -g {} -n {} --certificate-thumbprint {}'.format(self.resource_group, self.webapp_name, cert_thumbprint), checks=[
-            JMESPathCheck('hostNameSslStates[0].sslState', 'Disabled')
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(self.webapp_name), 'Disabled'),
         ])
-        self.cmd('appservice web config ssl delete -g {} -n {} --certificate-thumbprint {}'.format(self.resource_group, self.webapp_name, cert_thumbprint))
+        self.cmd('appservice web config ssl delete -g {} --certificate-thumbprint {}'.format(self.resource_group, cert_thumbprint))
         self.cmd('appservice web delete -g {} -n {}'.format(self.resource_group, self.webapp_name))
 
 

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -161,8 +161,8 @@ class Test_Webapp_Mocked(unittest.TestCase):
 
         # assert
         self.assertEqual(len(host_ssl_update_mock.call_args_list), 2)
-        self.assertEqual(host_ssl_update_mock.call_args_list[0][0][3], 'logs.foo.com')
-        self.assertEqual(host_ssl_update_mock.call_args_list[1][0][3], 'admin.foo.com')
+        host_names_updated = set([x[0][3] for x in host_ssl_update_mock.call_args_list])
+        self.assertEqual(host_names_updated, set(['logs.foo.com', 'admin.foo.com']))
 
 
 class FakedResponse(object):  # pylint: disable=too-few-public-methods

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -7,7 +7,7 @@ import mock
 
 from msrestazure.azure_exceptions import CloudError
 from azure.mgmt.web.models import (SourceControl, HostNameBinding, Site, SiteConfig,
-                                   HostNameSslState, SslState, Certificate, HostNameBinding)
+                                   HostNameSslState, SslState, Certificate)
 from azure.mgmt.web import WebSiteManagementClient
 from azure.cli.core.adal_authentication import AdalAuthentication
 from azure.cli.core._util import CLIError
@@ -155,14 +155,14 @@ class Test_Webapp_Mocked(unittest.TestCase):
         hostname_binding1 = HostNameBinding('antarctica', name='web1/admin.foo.com',)
         hostname_binding2 = HostNameBinding('antarctica', name='web1/logs.foo.com')
         site_op_mock.return_value = [hostname_binding1, hostname_binding2]
+
+        # action
         bind_ssl_cert('rg1', 'web1', 't1', SslState.sni_enabled)
 
-        expected = [('rg1', 'web1', 'antarctica', 'logs.foo.com', SslState.sni_enabled, 't1', None), ('rg1', 'web1', 'antarctica', 'admin.foo.com', SslState.sni_enabled, 't1', None)]
-        #host_ssl_update_mock.assert_called_with('rg1', 'web1', 'antarctica', 'admin.foo.com', SslState.sni_enabled, 't1', None)
+        # assert
         self.assertEqual(len(host_ssl_update_mock.call_args_list), 2)
-
-        #self.assertEqual(host_ssl_update_mock.call_args_list[0][3], 'logs.foo.com')
-        #self.assertEqual(host_ssl_update_mock.call_args_list[1][3], 'admin.foo.com')
+        self.assertEqual(host_ssl_update_mock.call_args_list[0][0][3], 'logs.foo.com')
+        self.assertEqual(host_ssl_update_mock.call_args_list[1][0][3], 'admin.foo.com')
 
 
 class FakedResponse(object):  # pylint: disable=too-few-public-methods

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -7,7 +7,7 @@ import mock
 
 from msrestazure.azure_exceptions import CloudError
 from azure.mgmt.web.models import (SourceControl, HostNameBinding, Site, SiteConfig,
-                                   HostNameSslState, SslState)
+                                   HostNameSslState, SslState, Certificate, HostNameBinding)
 from azure.mgmt.web import WebSiteManagementClient
 from azure.cli.core.adal_authentication import AdalAuthentication
 from azure.cli.core._util import CLIError
@@ -16,7 +16,9 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          update_site_configs,
                                                          view_in_browser,
                                                          sync_site_repo,
-                                                         list_publish_profiles)
+                                                         list_publish_profiles,
+                                                         _match_host_names_from_cert,
+                                                         bind_ssl_cert)
 
 # pylint: disable=line-too-long
 
@@ -129,6 +131,38 @@ class Test_Webapp_Mocked(unittest.TestCase):
             sync_site_repo('myRG', 'myweb')
         # assert
         self.assertEqual("nice error", str(ex.exception))
+
+    def test_match_host_names_from_cert(self):
+        result = _match_host_names_from_cert(['*.mysite.com'], ['admin.mysite.com', 'log.mysite.com', 'mysite.com'])
+        self.assertEqual(set(['admin.mysite.com', 'log.mysite.com']), result)
+
+        result = _match_host_names_from_cert(['*.mysite.com', 'mysite.com'], ['admin.mysite.com', 'log.mysite.com', 'mysite.com'])
+        self.assertEqual(set(['admin.mysite.com', 'log.mysite.com', 'mysite.com']), result)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._update_host_name_ssl_state', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom.show_webapp', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
+    def test_update_host_certs(self, client_mock, show_webapp_mock, host_ssl_update_mock, site_op_mock):
+        faked_web_client = mock.MagicMock()
+        client_mock.return_value = faked_web_client
+        faked_site = Site('antarctica', server_farm_id='big_plan')
+        faked_web_client.web_apps.get.side_effect = [faked_site, faked_site]
+        test_hostname = '*.foo.com'
+        cert1 = Certificate('antarctica', host_names=[test_hostname])
+        cert1.thumbprint = 't1'
+        faked_web_client.certificates.list_by_resource_group.return_value = [cert1]
+        hostname_binding1 = HostNameBinding('antarctica', name='web1/admin.foo.com',)
+        hostname_binding2 = HostNameBinding('antarctica', name='web1/logs.foo.com')
+        site_op_mock.return_value = [hostname_binding1, hostname_binding2]
+        bind_ssl_cert('rg1', 'web1', 't1', SslState.sni_enabled)
+
+        expected = [('rg1', 'web1', 'antarctica', 'logs.foo.com', SslState.sni_enabled, 't1', None), ('rg1', 'web1', 'antarctica', 'admin.foo.com', SslState.sni_enabled, 't1', None)]
+        #host_ssl_update_mock.assert_called_with('rg1', 'web1', 'antarctica', 'admin.foo.com', SslState.sni_enabled, 't1', None)
+        self.assertEqual(len(host_ssl_update_mock.call_args_list), 2)
+
+        #self.assertEqual(host_ssl_update_mock.call_args_list[0][3], 'logs.foo.com')
+        #self.assertEqual(host_ssl_update_mock.call_args_list[1][3], 'admin.foo.com')
 
 
 class FakedResponse(object):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
fix #2561
(per standard, wildcard only covers one level of subdomains)