### PR TITLE
Adding lab and monitor previews as default cli install

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -58,6 +58,8 @@ DEPENDENCIES = [
     'azure-cli-find',
     'azure-cli-iot',
     'azure-cli-keyvault',
+    'azure-cli-lab',
+    'azure-cli-monitor',
     'azure-cli-network',
     'azure-cli-nspkg',
     'azure-cli-profile',


### PR DESCRIPTION
- [x] Default install for `az lab` command module
- [x] Default install for `az monitor` command module