### PR TITLE
Avoid loading azure.storage simply to getting an internal string to b…

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -10,7 +10,6 @@ import azure.cli.core._debug as _debug
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core._util import CLIError
 from azure.cli.core.application import APPLICATION
-from azure.storage._error import _ERROR_STORAGE_MISSING_INFO
 
 logger = azlogging.get_az_logger(__name__)
 
@@ -80,6 +79,7 @@ def get_data_service_client(service_type, account_name, account_key, connection_
             client_kwargs['endpoint_suffix'] = endpoint_suffix
         client = service_type(**client_kwargs)
     except ValueError as exc:
+        from azure.storage._error import _ERROR_STORAGE_MISSING_INFO
         if _ERROR_STORAGE_MISSING_INFO in str(exc):
             raise ValueError(exc)
         else:


### PR DESCRIPTION
…e used in exceptional cases when trying to instantiate a storage data plane client.  Loading modules slows down startup of the command. 
