### PR TITLE
[DevTestLab] Verify existence of inbound nat rules before defaulting to Shared IP configuration

### DIFF
--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -159,7 +159,8 @@ def _validate_ip_configuration(namespace, lab_vnet=None):
     elif namespace.ip_configuration is None:
         # case 5: lab virtual network was selected from user's option / formula default then use it for look-up
         if lab_vnet:
-            if lab_vnet.subnet_overrides and lab_vnet.subnet_overrides[0].shared_public_ip_address_configuration:
+            if lab_vnet.subnet_overrides and lab_vnet.subnet_overrides[0].shared_public_ip_address_configuration and \
+                    lab_vnet.subnet_overrides[0].shared_public_ip_address_configuration.inbound_nat_rules:
                 rule = _inbound_rule_from_os(namespace)
                 public_ip_config = SharedPublicIpAddressConfiguration(inbound_nat_rules=[rule])
                 nic_properties = NetworkInterfaceProperties(shared_public_ip_address_configuration=public_ip_config)

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -159,6 +159,8 @@ def _validate_ip_configuration(namespace, lab_vnet=None):
     elif namespace.ip_configuration is None:
         # case 5: lab virtual network was selected from user's option / formula default then use it for look-up
         if lab_vnet:
+            # Default to shared ip configuration based on os type only if inbound nat rules exist on the
+            # shared configuration of the selected lab's virtual network
             if lab_vnet.subnet_overrides and lab_vnet.subnet_overrides[0].shared_public_ip_address_configuration and \
                     lab_vnet.subnet_overrides[0].shared_public_ip_address_configuration.inbound_nat_rules:
                 rule = _inbound_rule_from_os(namespace)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/2674

@ericame Can you please see whether this would be the right defaulting logic for the "Shared IP configuration" ?