### PR TITLE
[DevTestLab] Explicitly enable usage of saved secrets while lab vm creation

### DIFF
--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
@@ -13,7 +13,7 @@ def create_lab_vm(client, resource_group, lab_name, name, notes=None, image=None
                   location=None, tags=None, custom_image_id=None, lab_virtual_network_id=None,
                   gallery_image_reference=None, generate_ssh_keys=None, allow_claim=False,
                   disk_type=None, expiration_date=None, formula=None, ip_configuration=None,
-                  network_interface=None, os_type=None):
+                  network_interface=None, os_type=None, saved_secret=None):
     """ Command to create vm of in the Azure DevTest Lab """
     from .sdk.devtestlabs.models.lab_virtual_machine_creation_parameter import \
         LabVirtualMachineCreationParameter

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/help.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/help.py
@@ -45,6 +45,10 @@ helps['lab vm create'] = """
                   short-summary: The SSH public key or public key file path. Use --generate-ssh-keys to regen ssh keys
                 - name: --authentication-type
                   short-summary: Type of authentication to use with the VM. Allowed values are password, ssh
+                - name: --saved-secret
+                  short-summary: Name of the saved secret to be used for authentication. When provided,
+                                 we'll use it inplace of --admin-password for password based authentication or
+                                 inplace of --ssh-key for ssh based authentication
                 - name: --vnet-name
                   short-summary: Name of the virtual network to reference an existing one in lab. If omitted, lab's existing one
                                  VNet and subnet will be selected automatically

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/params.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/params.py
@@ -26,6 +26,7 @@ with ParametersContext(command='lab vm create') as c:
     c.argument('authentication_type', arg_group=authentication_group_name)
     c.argument('ssh_key', arg_group=authentication_group_name)
     c.argument('generate_ssh_keys', action='store_true', arg_group=authentication_group_name)
+    c.argument('saved_secret', arg_group=authentication_group_name)
 
     # Add Artifacts from json object
     c.argument('artifacts', type=json.loads)

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -307,6 +307,10 @@ def validate_authentication_type(namespace, formula=None):
                 "incorrect usage for authentication-type 'password': "
                 "[--admin-username USERNAME] --admin-password PASSWORD")
 
+        # Respect user's provided saved secret name for password authentication
+        if namespace.saved_secret:
+            namespace.admin_password = "[[{}]]".format(namespace.saved_secret)
+
         if not namespace.admin_password:
             # prompt for admin password if not supplied
             from azure.cli.core.prompting import prompt_pass, NoTTYException
@@ -322,7 +326,11 @@ def validate_authentication_type(namespace, formula=None):
         if namespace.admin_password:
             raise ValueError('Admin password cannot be used with SSH authentication type')
 
-        validate_ssh_key(namespace)
+        # Respect user's provided saved secret name for ssh authentication
+        if namespace.saved_secret:
+            namespace.ssh_key = "[[{}]]".format(namespace.saved_secret)
+        else:
+            validate_ssh_key(namespace)
     else:
         raise CLIError("incorrect value for authentication-type: {}".format(namespace.authentication_type))
 

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -302,10 +302,11 @@ def validate_authentication_type(namespace, formula=None):
 
     # validate proper arguments supplied based on the authentication type
     if namespace.authentication_type == 'password':
-        if namespace.ssh_key or namespace.generate_ssh_keys:
-            raise ValueError(
-                "incorrect usage for authentication-type 'password': "
-                "[--admin-username USERNAME] --admin-password PASSWORD")
+        password_usage_error = "incorrect usage for authentication-type 'password': " \
+                               "[--admin-username USERNAME] --admin-password PASSWORD | " \
+                               "[--admin-username USERNAME] --saved-secret SECRETNAME"
+        if namespace.ssh_key or namespace.generate_ssh_keys or (namespace.saved_secret and namespace.admin_password):
+            raise ValueError(password_usage_error)
 
         # Respect user's provided saved secret name for password authentication
         if namespace.saved_secret:
@@ -323,8 +324,14 @@ def validate_authentication_type(namespace, formula=None):
         if namespace.os_type != 'Linux':
             raise CLIError("incorrect authentication-type '{}' for os type '{}'".format(
                 namespace.authentication_type, namespace.os_type))
-        if namespace.admin_password:
-            raise ValueError('Admin password cannot be used with SSH authentication type')
+
+        ssh_usage_error = "incorrect usage for authentication-type 'ssh': " \
+                          "[--admin-username USERNAME] | " \
+                          "[--admin-username USERNAME] --ssh-key KEY | " \
+                          "[--admin-username USERNAME] --generate-ssh-keys | " \
+                          "[--admin-username USERNAME] --saved-secret SECRETNAME"
+        if namespace.admin_password or (namespace.saved_secret and (namespace.ssh_key or namespace.generate_ssh_keys)):
+            raise ValueError(ssh_usage_error)
 
         # Respect user's provided saved secret name for ssh authentication
         if namespace.saved_secret:


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/2687

- [x] Users should be able to use saved secret for `password` based auth
- [x] Users should be able to use saved secret for `ssh` based auth

Until now user were allowed to use them but not explicitly. This enables supplying the name of the secrets to be used from the lab's secret store itself. 

Reference: https://azure.microsoft.com/en-us/updates/azure-devtest-labs-keep-your-secrets-safe-and-easy-to-use-with-the-new-personal-secret-store/

**NOTE**: I'll be sending new PRs on DTL work but it's not necessary for us to ship them with this release so feel free to label it as team prefers 