### PR TITLE
Fix msi path to include msbuild in path

### DIFF
--- a/packaged_releases/windows/build.cmd
+++ b/packaged_releases/windows/build.cmd
@@ -3,7 +3,7 @@ echo Building the Windows Installer...
 echo.
 :: Add Git to the path as this should be run through a .NET command prompt
 :: and not a Git bash shell... We also need the gnu toolchain (for curl & unzip)
-set PATH=%PATH%;"C:\Program Files (x86)\Git\bin;C:\Program Files (x86)\MSBuild\14.0\Bin"
+set "PATH=%PATH%;C:\Program Files (x86)\Git\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;"
 
 pushd %~dp0
 


### PR DESCRIPTION
msbuild was not added to the path correctly due to the spaces in the path.
Now fixed.