### PR TITLE
Fix TypeError on a release script

### DIFF
--- a/scripts/automation/release/packaged.py
+++ b/scripts/automation/release/packaged.py
@@ -91,7 +91,7 @@ def create_packaged_archive(version, components, archive_dest=None, use_version_
         patch.apply(working_dir)
     # Build archive
     archive_filename = ARCHIVE_FILE_TMPL.format(version)
-    archive_dest = os.path.expanduser(archive_dest) or os.getcwd()
+    archive_dest = os.path.expanduser(archive_dest) if archive_dest else os.getcwd()
     archive_path = os.path.join(archive_dest, archive_filename+'.tar.gz')
     with tarfile.open(archive_path, 'w:gz') as tar:
         tar.add(working_dir, arcname=archive_filename)


### PR DESCRIPTION
Fix None Type error on os.path.expanduser(…)

If archive_dest was None, the call to expanduser would fail.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change.

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
