### PR TITLE
Fix doc references to azure.cli.commands

### DIFF
--- a/doc/authoring_command_modules/README.md
+++ b/doc/authoring_command_modules/README.md
@@ -88,7 +88,7 @@ def load_commands():
 ```
 
 ```python
-from azure.cli.commands import cli_command
+from azure.cli.core.commands import cli_command
 
 def example(my_required_arg, my_optional_arg='MyDefault'):
     '''Returns the params you passed in.
@@ -101,7 +101,7 @@ cli_command('example', example)
 ```
 
 The snippet above shows what it takes to author a basic command.
-1. Import `cli_command` from `azure.cli.commands`  
+1. Import `cli_command` from `azure.cli.core.commands`  
     This holds the core logic for creating commands.
 2. Use `cli_command` to create your command  
     The only required parameters to this method are:  

--- a/doc/authoring_command_modules/authoring_commands.md
+++ b/doc/authoring_command_modules/authoring_commands.md
@@ -30,7 +30,7 @@ If you specify a default value in your function signature, this will flag the ar
 Before your command can be used in the CLI, it must be registered. Insert the following statement in your file:
 
 ```Python
-from azure.cli.commands import cli_command
+from azure.cli.core.commands import cli_command
 ```
 
 The signature of this method is 
@@ -53,7 +53,7 @@ See the following for guidance on writing a help entry: https://github.com/Azure
 
 **Customizing Arguments**
 
-There are a number of customizations that you can make to the arguments of a command that alter their behavior within the CLI. To modify/enhance your command arguments, use the `register_cli_argument` method from the `azure.cli.commands` package. For the standard modules, these entries are contained within a file called `_params.py`. 
+There are a number of customizations that you can make to the arguments of a command that alter their behavior within the CLI. To modify/enhance your command arguments, use the `register_cli_argument` method from the `azure.cli.core.commands` package. For the standard modules, these entries are contained within a file called `_params.py`. 
 
 The signature of this method is
 ```Python
@@ -75,7 +75,7 @@ Like CSS rules, modifications are applied in order from generic to specific.
 register_cli_argument('mypackage', 'my_param', ...)  # applies to both command1 and command2
 register_cli_argument('mypackage command2', 'my_param', ...)  # command2 inherits and build upon the previous changes
 ```
-- `arg_type` - An instance of the `azure.cli.commands.CliArgumentType` class. This essentially serves as a named, reusable packaging of the `kwargs` that modify your command's argument. It is useful when you want to reuse an argument definition, but is generally not required. It is most commonly used for name type parameters.
+- `arg_type` - An instance of the `azure.cli.core.commands.CliArgumentType` class. This essentially serves as a named, reusable packaging of the `kwargs` that modify your command's argument. It is useful when you want to reuse an argument definition, but is generally not required. It is most commonly used for name type parameters.
 - `kwargs` - Most likely, you will simply specify keyword arguments in `register_cli_argument` that will accomplish what you need.  Any `kwargs` specified will override or extended the definition in `arg_type`, if provided.
 
 The follow keyword arguments are supported:

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
@@ -35,7 +35,7 @@ server_param_type = CliArgumentType(
     help='Name of the Azure SQL server.')
 
 #####
-#           SizeWithUnitConverter - consider moving to common code (azure.cli.commands.parameters)
+#           SizeWithUnitConverter - consider moving to common code (azure.cli.core.commands.parameters)
 #####
 
 

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
@@ -35,7 +35,7 @@ server_param_type = CliArgumentType(
     help='Name of the Azure SQL server.')
 
 #####
-#           SizeWithUnitConverter - consider moving to common code (azure.cli.core.commands.parameters)
+#        SizeWithUnitConverter - consider moving to common code (azure.cli.core.commands.parameters)
 #####
 
 


### PR DESCRIPTION
This module has moved to azure.cli.core.commands
