### PR TITLE
Enable better certificate importing for Key Vault

### DIFF
--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -91,6 +91,32 @@ helps['keyvault certificate create'] = """
               --image debian --secrets "$vm_secrets"
 """
 
+helps['keyvault certificate import'] = """
+    type: command
+    long-summary: >
+        Import a certificate into Key Vault. Certificates can also be used as a secrets in provisioned virtual machines.
+    examples:
+        - name: Create a service principal with a certificate, add the certificate to Key Vault and provision a VM with that certificate.
+          text: >
+            az group create -g my-group -l westus \n
+
+            service_principal=$(az ad sp create-for-rbac --create-cert) \n
+
+            cert_file=$(echo $service_principal | jq .fileWithCertAndPrivateKey -r) \n
+
+            az keyvault create -g my-group -n vaultname \n
+
+            az keyvault certificate import --vault-name vaultname -n cert_file \n
+
+            secrets=$(az keyvault secret list-versions --vault-name vaultname \\
+              -n cert1 --query "[?attributes.enabled].id" -o tsv)
+
+            vm_secrets=$(az vm format-secret -s "$secrets") \n
+
+            az vm create -g group-name -n vm-name --admin-username deploy  \\
+              --image debian --secrets "$vm_secrets"
+"""
+
 helps['keyvault certificate pending'] = """
     type: group
     short-summary: Manage pending certificate creation operations.

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -24,7 +24,7 @@ from azure.keyvault.generated.models.key_vault_client_enums import \
 from azure.keyvault.generated.models import \
     (KeyAttributes, SecretAttributes, CertificateAttributes)
 from azure.cli.command_modules.keyvault._validators import \
-    (datetime_type, base64_encoded_certificate_type,
+    (datetime_type, certificate_type,
      get_attribute_validator,
      vault_base_url_type, validate_key_import_source,
      validate_key_type, validate_key_ops, validate_policy_permissions,
@@ -155,7 +155,6 @@ register_cli_argument('keyvault secret download', 'encoding', options_list=('--e
 
 register_cli_argument('keyvault certificate', 'certificate_version', options_list=('--version', '-v'), help='The certificate version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('certificate'))
 register_attributes_argument('keyvault certificate create', 'certificate', CertificateAttributes, True)
-register_attributes_argument('keyvault certificate import', 'certificate', CertificateAttributes, True)
 register_attributes_argument('keyvault certificate set-attributes', 'certificate', CertificateAttributes)
 register_cli_argument('keyvault certificate set-attributes', 'expires', ignore_type)
 register_cli_argument('keyvault certificate set-attributes', 'not_before', ignore_type)
@@ -163,7 +162,9 @@ register_cli_argument('keyvault certificate set-attributes', 'not_before', ignor
 for item in ['create', 'set-attributes', 'import']:
     register_cli_argument('keyvault certificate {}'.format(item), 'certificate_policy', options_list=('--policy', '-p'), help='JSON encoded policy defintion. Use @{file} to load from a file.', type=get_json_object)
 
-register_cli_argument('keyvault certificate import', 'base64_encoded_certificate', options_list=('--file', '-f'), completer=FilesCompleter(), help='PKCS12 file or PEM file containing the certificate and private key.', type=base64_encoded_certificate_type)
+register_cli_argument('keyvault certificate import', 'certificate_data', options_list=('--file', '-f'), completer=FilesCompleter(), help='PKCS12 file or PEM file containing the certificate and private key.', type=certificate_type)
+register_cli_argument('keyvault certificate import', 'password', help="If the private key in certificate is encrypted, the password used for encryption.")
+register_extra_cli_argument('keyvault certificate import', 'disabled', help='Import the certificate in disabled state.', **three_state_flag())
 
 register_cli_argument('keyvault certificate download', 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='File to receive the binary certificate contents.')
 register_cli_argument('keyvault certificate download', 'encoding', options_list=('--encoding', '-e'), help='How to store base64 certificate contents in file.', **enum_choice_list(certificate_file_encoding_values))

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
@@ -210,15 +210,11 @@ def validate_x509_certificate_chain(ns):
 # ARGUMENT TYPES
 
 
-def base64_encoded_certificate_type(string):
+def certificate_type(string):
     """ Loads file and outputs contents as base64 encoded string. """
-    with open(string, 'rb') as f:
+    import os
+    with open(os.path.expanduser(string), 'rb') as f:
         cert_data = f.read()
-    try:
-        # for PEM files (including automatic endline conversion for Windows)
-        cert_data = cert_data.decode('utf-8').replace('\r\n', '\n')
-    except UnicodeDecodeError:
-        cert_data = binascii.b2a_base64(cert_data).decode('utf-8')
     return cert_data
 
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -28,6 +28,7 @@ cli_command(__name__, 'keyvault set-policy', custom_path.format('set_policy'), f
 cli_command(__name__, 'keyvault delete-policy', custom_path.format('delete_policy'), factory)
 
 
+
 cli_generic_update_command(__name__,
                            'keyvault update',
                            mgmt_path.format('VaultsOperations.get'),
@@ -61,7 +62,7 @@ cli_keyvault_data_plane_command('keyvault certificate list-versions', convenienc
 cli_keyvault_data_plane_command('keyvault certificate show', base_client_path.format('KeyVaultClient.get_certificate'))
 cli_keyvault_data_plane_command('keyvault certificate delete', convenience_path.format('KeyVaultClient.delete_certificate'))
 cli_keyvault_data_plane_command('keyvault certificate set-attributes', base_client_path.format('KeyVaultClient.update_certificate'))
-cli_keyvault_data_plane_command('keyvault certificate import', convenience_path.format('KeyVaultClient.import_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate import', custom_path.format('import_certificate'))
 cli_keyvault_data_plane_command('keyvault certificate download', custom_path.format('download_certificate'))
 
 cli_keyvault_data_plane_command('keyvault key list', convenience_path.format('KeyVaultClient.get_keys'))


### PR DESCRIPTION
This pull request provides better documentation for Key Vault certificate importing showing the path for creating a service principal, importing the cert into key vault, and using it to provision a vm via secrets.

This pull request also fixes an issue where we `az keyvault certificate import` was not sniffing the type of certificate and properly specifying the content type. Now, we sniff out either PEM or PFX and properly encode the payload for the server.