### PR TITLE
Use the app service plan's resource group for cert operations

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.3 (2017-04-04)
+++++++++++++++++++++
+
+* Use the app service plan's resource group for cert operations (#2750)
+
 0.1.2 (2017-04-03)
 ++++++++++++++++++++
 

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -209,7 +209,7 @@ class Test_Webapp_Mocked(unittest.TestCase):
     def test_update_host_certs(self, client_mock, show_webapp_mock, host_ssl_update_mock, site_op_mock):
         faked_web_client = mock.MagicMock()
         client_mock.return_value = faked_web_client
-        faked_site = Site('antarctica', server_farm_id='big_plan')
+        faked_site = Site('antarctica', server_farm_id='/subscriptions/foo/resourceGroups/foo/providers/Microsoft.Web/serverfarms/big_plan')
         faked_web_client.web_apps.get.side_effect = [faked_site, faked_site]
         test_hostname = '*.foo.com'
         cert1 = Certificate('antarctica', host_names=[test_hostname])


### PR DESCRIPTION
SSL certificates are associated with the the app service plan/server farm in Azure, so use the web app's `server_farm_id` to extract the associated resource group for any `bind`, `unbind`, or `upload` actions. Fixes #2750

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change.

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
