### PR TITLE
Performance: Allow delay-loading of command descriptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -187,7 +187,7 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
         self.name = name
         self.handler = handler
         self.help = None
-        self.description = description_loader() \
+        self.description = description_loader \
             if description_loader and CliCommand._should_load_description() \
             else description
         self.arguments = {}

--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_gather_commands.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_gather_commands.py
@@ -20,7 +20,9 @@ def build_command_table():
     for cmd in cmd_table:
         com_descip = {}
         param_descrip = {}
-        com_descip['short-summary'] = cmd_table[cmd].description or ''
+        com_descip['short-summary'] = cmd_table[cmd].description() \
+            if callable(cmd_table[cmd].description) \
+            else cmd_table[cmd].description or ''
         com_descip['examples'] = ''
 
         for key in cmd_table[cmd].arguments:


### PR DESCRIPTION

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a ] The PR has modified HISTORY.rst with an appropriate description of the change.

This change is infrastructure only, no az cli facing functionality has been changed.

### Command Guidelines

- [ n/a] Each command and parameter has a meaningful description.
- [ n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))

Loading descriptions for commands can be expensive (inspecting/parsing doc strings for handlers). This change allows for a caller to provide a callable for the description parameter. The az parser overrides the default argparse description handling to delay load the description if callable was passed. 

The PR also makes sure that the `az find` command correctly deals with callable descriptions when building the search index. 
