### PR TITLE
Support multi-versioned mgmt network compute resources SDK packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
 -e git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-storage&subdirectory=azure-mgmt-storage
+-e git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-compute&subdirectory=azure-mgmt-compute
+-e git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-resource&subdirectory=azure-mgmt-resource
+-e git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-network&subdirectory=azure-mgmt-network

--- a/scripts/automation/tests/verify_packages.py
+++ b/scripts/automation/tests/verify_packages.py
@@ -77,6 +77,9 @@ def verify_packages():
 
     # TODO Remove this when package released and merging to master
     exec_command('python -m pip install git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-storage&subdirectory=azure-mgmt-storage')
+    exec_command('python -m pip install git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-compute&subdirectory=azure-mgmt-compute')
+    exec_command('python -m pip install git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-resource&subdirectory=azure-mgmt-resource')
+    exec_command('python -m pip install git+https://github.com/Azure/azure-sdk-for-python.git@azurestack#egg=azure-mgmt-network&subdirectory=azure-mgmt-network')
 
     # STEP 2:: Install the CLI and dependencies
     azure_cli_modules_path = next(path for name, path in all_modules if name == 'azure-cli')

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -322,7 +322,7 @@ class SubscriptionFinder(object):
     '''finds all subscriptions for a user or service principal'''
 
     def __init__(self, auth_context_factory, adal_token_cache, arm_client_factory=None):
-        from azure.mgmt.resource.subscriptions import SubscriptionClient
+        from azure.mgmt.resource import SubscriptionClient
         from azure.cli.core._debug import allow_debug_connection
 
         self._adal_token_cache = adal_token_cache

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -334,9 +334,10 @@ def _patch_mgmt_operation(operation):
                       azure.mgmt.storage.v2016_12_01.operations.storage_accounts_operations
     """
     for rt in ResourceType:
-        if operation.startswith(rt.sdk_module):
-            return operation.replace(rt.sdk_module,
-                                     rt.sdk_module + '.v' + get_api_version(rt).replace('-', '_'))
+        if operation.startswith(rt.operations_path):
+            return operation.replace(rt.operations_path,
+                                     rt.operations_path + '.v' +
+                                     get_api_version(rt).replace('-', '_'))
     return operation
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -95,7 +95,7 @@ class ResourceId(str):
 def resource_exists(resource_group, name, namespace, type, **_):  # pylint: disable=redefined-builtin
     '''Checks if the given resource exists.
     '''
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
 
     odata_filter = "resourceGroup eq '{}' and name eq '{}'" \
         " and resourceType eq '{}/{}'".format(resource_group, name, namespace, type)

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -16,7 +16,7 @@ from azure.cli.core.profiles import get_versioned_models
 
 def get_subscription_locations():
     from azure.cli.core.commands.client_factory import get_subscription_service_client
-    from azure.mgmt.resource.subscriptions import SubscriptionClient
+    from azure.mgmt.resource import SubscriptionClient
     subscription_client, subscription_id = get_subscription_service_client(SubscriptionClient)
     return list(subscription_client.subscriptions.list_locations(subscription_id))
 
@@ -49,7 +49,8 @@ def get_one_of_subscription_locations():
 
 def get_resource_groups():
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    # TODO Find usages of ResourceManagementClient and version those also.
+    from azure.mgmt.resource import ResourceManagementClient
     rcf = get_mgmt_service_client(ResourceManagementClient)
     return list(rcf.resource_groups.list())
 
@@ -61,7 +62,7 @@ def get_resource_group_completion_list(prefix, **kwargs):  # pylint: disable=unu
 
 def get_resources_in_resource_group(resource_group_name, resource_type=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     rcf = get_mgmt_service_client(ResourceManagementClient)
     filter_str = "resourceType eq '{}'".format(resource_type) if resource_type else None
     return list(rcf.resource_groups.list_resources(resource_group_name, filter=filter_str))
@@ -69,7 +70,7 @@ def get_resources_in_resource_group(resource_group_name, resource_type=None):
 
 def get_resources_in_subscription(resource_type=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     rcf = get_mgmt_service_client(ResourceManagementClient)
     filter_str = "resourceType eq '{}'".format(resource_type) if resource_type else None
     return list(rcf.resources.list(filter=filter_str))

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -43,7 +43,7 @@ def generate_deployment_name(namespace):
 
 def get_default_location_from_resource_group(namespace):
     if not namespace.location:
-        from azure.mgmt.resource.resources import ResourceManagementClient
+        from azure.mgmt.resource import ResourceManagementClient
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
         resource_client = get_mgmt_service_client(ResourceManagementClient)
         rg = resource_client.resource_groups.get(namespace.resource_group_name)

--- a/src/azure-cli-core/azure/cli/core/profiles/shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/shared.py
@@ -24,8 +24,8 @@ class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
     # TODO Thinking of removing the RP/RT format due to swagger/sdk format
     MGMT_STORAGE = ('Microsoft.Storage/storageAccounts',
-                                     'azure.mgmt.storage',
-                                     'azure.mgmt.storage#StorageManagementClient')
+                    'azure.mgmt.storage',
+                    'azure.mgmt.storage#StorageManagementClient')
     MGMT_COMPUTE = ('Microsoft.Compute/all',
                     'azure.mgmt.compute.compute',
                     'azure.mgmt.compute#ComputeManagementClient')

--- a/src/azure-cli-core/azure/cli/core/profiles/shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/shared.py
@@ -23,7 +23,7 @@ class APIVersionException(Exception):
 class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
     # TODO Thinking of removing the RP/RT format due to swagger/sdk format
-    MGMT_STORAGE_STORAGE_ACCOUNTS = ('Microsoft.Storage/storageAccounts',
+    MGMT_STORAGE = ('Microsoft.Storage/storageAccounts',
                                      'azure.mgmt.storage',
                                      'azure.mgmt.storage#StorageManagementClient')
     MGMT_COMPUTE = ('Microsoft.Compute/all',
@@ -71,7 +71,7 @@ class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
 AZURE_API_PROFILES = {
     'latest': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01',
+        ResourceType.MGMT_STORAGE: '2016-12-01',
         ResourceType.MGMT_NETWORK: '2016-09-01',
         ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
         ResourceType.MGMT_COMPUTE: '2016-04-30-preview',
@@ -83,7 +83,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS: '2016-06-01'
     },
     '2016-example': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01',
+        ResourceType.MGMT_STORAGE: '2016-12-01',
         ResourceType.MGMT_NETWORK: '2016-09-01',
         ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
         ResourceType.MGMT_COMPUTE: '2016-04-30-preview',
@@ -95,7 +95,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS: '2016-06-01'
     },
     '2015-example': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2015-06-15',
+        ResourceType.MGMT_STORAGE: '2015-06-15',
         ResourceType.MGMT_NETWORK: '2015-06-15',
         ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
         ResourceType.MGMT_COMPUTE: '2015-06-15',

--- a/src/azure-cli-core/azure/cli/core/profiles/shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/shared.py
@@ -22,34 +22,89 @@ class APIVersionException(Exception):
 
 class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
+    # TODO Thinking of removing the RP/RT format due to swagger/sdk format
     MGMT_STORAGE_STORAGE_ACCOUNTS = ('Microsoft.Storage/storageAccounts',
                                      'azure.mgmt.storage',
-                                     'StorageManagementClient')
+                                     'azure.mgmt.storage#StorageManagementClient')
+    MGMT_COMPUTE = ('Microsoft.Compute/all',
+                    'azure.mgmt.compute.compute',
+                    'azure.mgmt.compute#ComputeManagementClient')
+    MGMT_CONTAINER_SERVICE = ('Microsoft.ContainerService/all',
+                              'azure.mgmt.compute.containerservice',
+                              'azure.mgmt.compute#ContainerServiceClient')
+    MGMT_NETWORK = ('Microsoft.Network/all',
+                    'azure.mgmt.network',
+                    'azure.mgmt.network#NetworkManagementClient')
+    MGMT_RESOURCE_FEATURES = ('Microsoft.Features/features',
+                              'azure.mgmt.resource.features',
+                              'azure.mgmt.resource#FeatureClient')
+    MGMT_RESOURCE_LINKS = ('Microsoft.Resources/links',
+                           'azure.mgmt.resource.links',
+                           'azure.mgmt.resource#ManagementLinkClient')
+    MGMT_RESOURCE_LOCKS = ('Microsoft.Authorization/locks',
+                           'azure.mgmt.resource.locks',
+                           'azure.mgmt.resource#ManagementLockClient')
+    MGMT_RESOURCE_POLICY = ('Microsoft.Authorization/policyassignments',
+                            'azure.mgmt.resource.policy',
+                            'azure.mgmt.resource#PolicyClient')
+    MGMT_RESOURCE_RESOURCES = ('Microsoft.Resources/deployments',
+                               'azure.mgmt.resource.resources',
+                               'azure.mgmt.resource#ResourceManagementClient')
+    MGMT_RESOURCE_SUBSCRIPTIONS = ('Microsoft.Resources/subscriptions',
+                                   'azure.mgmt.resource.subscriptions',
+                                   'azure.mgmt.resource#SubscriptionClient')
 
-    def __init__(self, type_name, sdk_module, client_name):
+    def __init__(self, type_name, operations_path, client_path):
         """Constructor.
 
         :param type_name: The full resource type name (e.g. Provider/ResourceType).
         :type type_name: str.
-        :param sdk_module: Path to the sdk module.
-        :type sdk_module: str.
-        :param client_name: The name of the client for this resource type.
-        :type client_name: str.
+        :param operations_path: Path to the (unversioned) operations module.
+        :type operations_path: str.
+        :param client_path: The path to the client for this resource type.
+        :type client_path: str.
         """
         self.type_name = type_name
-        self.sdk_module = sdk_module
-        self.client_name = client_name
+        self.operations_path = operations_path
+        self.client_path = client_path
 
 
 AZURE_API_PROFILES = {
     'latest': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01'
+        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01',
+        ResourceType.MGMT_NETWORK: '2016-09-01',
+        ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
+        ResourceType.MGMT_COMPUTE: '2016-04-30-preview',
+        ResourceType.MGMT_RESOURCE_FEATURES: '2015-12-01',
+        ResourceType.MGMT_RESOURCE_LINKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_LOCKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_POLICY: '2016-04-01',
+        ResourceType.MGMT_RESOURCE_RESOURCES: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS: '2016-06-01'
     },
     '2016-example': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01'
+        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2016-12-01',
+        ResourceType.MGMT_NETWORK: '2016-09-01',
+        ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
+        ResourceType.MGMT_COMPUTE: '2016-04-30-preview',
+        ResourceType.MGMT_RESOURCE_FEATURES: '2015-12-01',
+        ResourceType.MGMT_RESOURCE_LINKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_LOCKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_POLICY: '2016-12-01',
+        ResourceType.MGMT_RESOURCE_RESOURCES: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS: '2016-06-01'
     },
     '2015-example': {
-        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2015-06-15'
+        ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS: '2015-06-15',
+        ResourceType.MGMT_NETWORK: '2015-06-15',
+        ResourceType.MGMT_CONTAINER_SERVICE: '2017-01-31',
+        ResourceType.MGMT_COMPUTE: '2015-06-15',
+        ResourceType.MGMT_RESOURCE_FEATURES: '2015-12-01',
+        ResourceType.MGMT_RESOURCE_LINKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_LOCKS: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_POLICY: '2016-12-01',
+        ResourceType.MGMT_RESOURCE_RESOURCES: '2016-09-01',
+        ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS: '2016-06-01'
     }
 }
 
@@ -78,7 +133,15 @@ def get_client_class(resource_type):
     :raises: ImportError, AttributeError
     :returns:  class -- the Client class.
     """
-    return getattr(import_module(resource_type.sdk_module), resource_type.client_name)
+    cp = resource_type.client_path
+    try:
+        mod_to_import, attr_path = cp.split('#')
+        op = import_module(mod_to_import)
+        for part in attr_path.split('.'):
+            op = getattr(op, part)
+        return op
+    except (ValueError, AttributeError):
+        return None
 
 
 def get_versioned_models(api_profile, resource_type, *model_args, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/profiles/shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/shared.py
@@ -130,18 +130,14 @@ def get_client_class(resource_type):
 
     :param resource_type: The resource type.
     :type resource_type: ResourceType.
-    :raises: ImportError, AttributeError
     :returns:  class -- the Client class.
     """
     cp = resource_type.client_path
-    try:
-        mod_to_import, attr_path = cp.split('#')
-        op = import_module(mod_to_import)
-        for part in attr_path.split('.'):
-            op = getattr(op, part)
-        return op
-    except (ValueError, AttributeError):
-        return None
+    mod_to_import, attr_path = cp.split('#')
+    op = import_module(mod_to_import)
+    for part in attr_path.split('.'):
+        op = getattr(op, part)
+    return op
 
 
 def get_versioned_models(api_profile, resource_type, *model_args, **kwargs):

--- a/src/azure-cli-core/tests/test_cloud.py
+++ b/src/azure-cli-core/tests/test_cloud.py
@@ -65,7 +65,7 @@ class TestCloud(unittest.TestCase):
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as\
                 config_file:
             add_cloud(c)
-            config = configparser.SafeConfigParser()
+            config = get_config_parser()
             config.read(config_file)
             self.assertTrue(c.name in config.sections())
             self.assertEqual(config.get(c.name, 'endpoint_resource_manager'), endpoint_rm)

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -11,7 +11,7 @@ import mock
 
 from adal import AdalError
 from azure.mgmt.resource.subscriptions.models import (SubscriptionState, Subscription,
-                                                      SubscriptionPolicies, spendingLimit)
+                                                      SubscriptionPolicies, SpendingLimit)
 from azure.cli.core._profile import (Profile, CredsCache, SubscriptionFinder,
                                      ServicePrincipalAuth, CLOUD)
 from azure.cli.core.util import CLIError
@@ -687,7 +687,7 @@ class SubscriptionStub(Subscription):  # pylint: disable=too-few-public-methods
 
     def __init__(self, id, display_name, state, tenant_id):  # pylint: disable=redefined-builtin,
         policies = SubscriptionPolicies()
-        policies.spending_limit = spendingLimit.current_period_off
+        policies.spending_limit = SpendingLimit.current_period_off
         policies.quota_id = 'some quota'
         super(SubscriptionStub, self).__init__(policies, 'some_authorization_source')
         self.id = id

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_factory.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_factory.py
@@ -12,14 +12,14 @@ logger = azlogging.get_az_logger(__name__)
 def get_arm_service_client():
     '''Returns the client for managing ARM resources.
     '''
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     return get_mgmt_service_client(ResourceManagementClient)
 
 def get_storage_service_client():
     '''Returns the client for managing storage accounts.
     '''
-    from azure.mgmt.storage import StorageManagementClient
-    return get_mgmt_service_client(StorageManagementClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
 
 def get_acr_service_client():
     '''Returns the client for managing container registries.

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_factory.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_factory.py
@@ -19,7 +19,7 @@ def get_storage_service_client():
     '''Returns the client for managing storage accounts.
     '''
     from azure.cli.core.profiles.shared import ResourceType
-    return get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
+    return get_mgmt_service_client(ResourceType.MGMT_STORAGE)
 
 def get_acr_service_client():
     '''Returns the client for managing container registries.

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-cli-core',
-    'azure-mgmt-resource==0.30.2',
+    'azure-mgmt-resource==0.40.0',
     'azure-mgmt-storage==0.40.0',
     'azure-mgmt-containerregistry==0.2.0',
 ]

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
@@ -31,6 +31,6 @@ def _graph_client_factory(**_):
 
 
 def _acs_client_factory(_):
-    from azure.mgmt.compute import ComputeManagementClient
+    from azure.cli.core.profiles.shared import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(ComputeManagementClient).container_services
+    return get_mgmt_service_client(ResourceType.MGMT_CONTAINER_SERVICE).container_services

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -16,14 +16,14 @@ from azure.cli.core.commands.parameters import (
     resource_group_name_type,
     get_one_of_subscription_locations,
     get_resource_name_completion_list)
-from azure.mgmt.compute.models import ContainerServiceOchestratorTypes
+from azure.mgmt.compute.containerservice.models import ContainerServiceOchestratorTypes
 from azure.cli.command_modules.vm._validators import validate_ssh_key
 
 
 def _compute_client_factory(**_):
-    from azure.mgmt.compute import ComputeManagementClient
+    from azure.cli.core.profiles.shared import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(ComputeManagementClient)
+    return get_mgmt_service_client(ResourceType.MGMT_COMPUTE)
 
 
 def get_vm_sizes(location):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -9,8 +9,9 @@ from azure.cli.core.commands import cli_command
 from ._client_factory import _acs_client_factory
 from azure.cli.core.util import empty_on_404
 
-cli_command(__name__, 'acs show', 'azure.mgmt.compute.operations.container_services_operations#ContainerServicesOperations.get', _acs_client_factory, exception_handler=empty_on_404)
-cli_command(__name__, 'acs delete', 'azure.mgmt.compute.operations.container_services_operations#ContainerServicesOperations.delete', _acs_client_factory)
+
+cli_command(__name__, 'acs show', 'azure.mgmt.compute.containerservice.operations.container_services_operations#ContainerServicesOperations.get', _acs_client_factory, exception_handler=empty_on_404)
+cli_command(__name__, 'acs delete', 'azure.mgmt.compute.containerservice.operations.container_services_operations#ContainerServicesOperations.delete', _acs_client_factory)
 
 # Per conversation with ACS team, hide the update till we have something meaningful to tweak
 # from azure.cli.command_modules.acs.custom import update_acs

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -38,8 +38,8 @@ from azure.cli.core.util import CLIError, shell_safe_json_parse
 from azure.cli.core._profile import Profile
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core._environment import get_config_dir
-from azure.mgmt.compute import ComputeManagementClient
-from azure.mgmt.compute.models import ContainerServiceOchestratorTypes
+from azure.cli.core.profiles.shared import ResourceType
+from azure.mgmt.compute.containerservice.models import ContainerServiceOchestratorTypes
 from azure.graphrbac.models import (ApplicationCreateParameters,
                                     PasswordCredential,
                                     KeyCredential,
@@ -68,7 +68,7 @@ def which(binary):
 
 
 def _resource_client_factory():
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     return get_mgmt_service_client(ResourceManagementClient)
 
 
@@ -733,7 +733,7 @@ def _get_acs_info(name, resource_group_name):
     :param resource_group_name: Resource group name
     :type resource_group_name: String
     """
-    mgmt_client = get_mgmt_service_client(ComputeManagementClient)
+    mgmt_client = get_mgmt_service_client(ResourceType.MGMT_CONTAINER_SERVICE)
     return mgmt_client.container_services.get(resource_group_name, name)
 
 

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-mgmt-authorization==0.30.0rc6',
-    'azure-mgmt-compute==0.33.1rc1',
+    'azure-mgmt-compute==0.40.0',
     'azure-graphrbac==0.30.0rc6',
     'azure-cli-core',
     'paramiko',

--- a/src/command_modules/azure-cli-acs/tests/test_custom.py
+++ b/src/command_modules/azure-cli-acs/tests/test_custom.py
@@ -15,8 +15,9 @@ from msrestazure.azure_exceptions import CloudError
 
 from azure.cli.command_modules.acs.custom import (merge_kubernetes_configurations,
                                                   _acs_browse_internal, _add_role_assignment)
-from azure.mgmt.compute.models import (ContainerServiceOchestratorTypes, ContainerService,
-                                       ContainerServiceOrchestratorProfile)
+from azure.mgmt.compute.containerservice.models import (ContainerServiceOchestratorTypes,
+                                                        ContainerService,
+                                                        ContainerServiceOrchestratorProfile)
 from azure.cli.core.util import CLIError
 
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -614,7 +614,7 @@ def _get_sku_name(tier):
 
 
 def _get_location_from_resource_group(resource_group_name):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     client = get_mgmt_service_client(ResourceManagementClient)
     group = client.resource_groups.get(resource_group_name)
     return group.location

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
@@ -131,12 +131,13 @@ def validate_required_parameter(ns, parser):
 def storage_account_id(namespace):
     """Validate storage account name"""
     from azure.mgmt.storage import StorageManagementClient
+    from azure.cli.core.profiles.shared import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
     if (namespace.storage_account and not
             ('/providers/Microsoft.ClassicStorage/storageAccounts/' in namespace.storage_account or
              '/providers/Microsoft.Storage/storageAccounts/' in namespace.storage_account)):
-        storage_client = get_mgmt_service_client(StorageManagementClient)
+        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
         acc = storage_client.storage_accounts.get_properties(namespace.resource_group_name,
                                                              namespace.storage_account)
         if not acc:

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_validators.py
@@ -137,7 +137,7 @@ def storage_account_id(namespace):
     if (namespace.storage_account and not
             ('/providers/Microsoft.ClassicStorage/storageAccounts/' in namespace.storage_account or
              '/providers/Microsoft.Storage/storageAccounts/' in namespace.storage_account)):
-        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
+        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE)
         acc = storage_client.storage_accounts.get_properties(namespace.resource_group_name,
                                                              namespace.storage_account)
         if not acc:

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/custom.py
@@ -50,7 +50,7 @@ def _print_cur_configuration(file_config):
 
 def _config_env_public_azure(_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core._profile import Profile
     # Determine if user logged in
     try:

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/custom.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/custom.py
@@ -259,7 +259,7 @@ def _get_uuid_str():
 
 
 def _get_resource_group_location(resource_group_name):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     client = get_mgmt_service_client(ResourceManagementClient)
     # pylint: disable=no-member
     return client.resource_groups.get(resource_group_name).location

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
@@ -325,7 +325,7 @@ def set_adls_item_permissions(account_name,
 
 # helpers
 def _get_resource_group_location(resource_group_name):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     client = get_mgmt_service_client(ResourceManagementClient)
     # pylint: disable=no-member
     return client.resource_groups.get(resource_group_name).location

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
@@ -29,7 +29,7 @@ def cli_documentdb_create(client,
     if default_consistency_level is not None:
         consistency_policy = ConsistencyPolicy(default_consistency_level, max_staleness_prefix, max_interval)
 
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     resource_client = get_mgmt_service_client(ResourceManagementClient)
     rg = resource_client.resource_groups.get(resource_group_name)

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_factory.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_factory.py
@@ -9,6 +9,6 @@ def iot_hub_service_factory(_):
     return get_mgmt_service_client(IotHubClient).iot_hub_resource
 
 def resource_service_factory(**_):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(ResourceManagementClient)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_client_factory.py
@@ -6,9 +6,9 @@
 #pylint: disable=line-too-long
 
 def _network_client_factory(**_):
-    from azure.mgmt.network import NetworkManagementClient
+    from azure.cli.core.profiles.shared import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(NetworkManagementClient)
+    return get_mgmt_service_client(ResourceType.MGMT_NETWORK)
 
 
 def resource_client_factory(**_):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -9,7 +9,7 @@ from argcomplete.completers import FilesCompleter
 
 from azure.mgmt.network.models import \
     (IPAllocationMethod, RouteNextHopType)
-from azure.mgmt.network.models.network_management_client_enums import \
+from azure.mgmt.network.models import \
     (ApplicationGatewaySkuName, ApplicationGatewayCookieBasedAffinity,
      ApplicationGatewayFirewallMode, ApplicationGatewayProtocol,
      ApplicationGatewayRequestRoutingRuleType, ExpressRouteCircuitSkuFamily,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -111,7 +111,7 @@ def create_application_gateway(application_gateway_name, resource_group_name, lo
                                subnet='default', subnet_address_prefix='10.0.0.0/24',
                                virtual_network_name=None, vnet_address_prefix='10.0.0.0/16',
                                public_ip_address_type=None, subnet_type=None, validate=False):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties, TemplateLink
     from azure.cli.core.util import random_string
     from azure.cli.command_modules.network._template_builder import \
@@ -519,7 +519,7 @@ def create_load_balancer(load_balancer_name, resource_group_name, location=None,
                          virtual_network_name=None, vnet_address_prefix='10.0.0.0/16',
                          public_ip_address_type=None, subnet_type=None, validate=False,
                          no_wait=False):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties, TemplateLink
     from azure.cli.core.util import random_string
     from azure.cli.command_modules.network._template_builder import \
@@ -1171,7 +1171,7 @@ def create_vpn_connection(client, resource_group_name, connection_name, vnet_gat
     :param bool no_wait: Do not wait for the long running operation to finish.
     :param bool validate: Display and validate the ARM template but do not create any resources.
     """
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties, TemplateLink
     from azure.cli.core.util import random_string
     from azure.cli.command_modules.network._template_builder import \

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -25,10 +25,10 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-network==0.30.0',
+    'azure-mgmt-network==0.40.0',
     'azure-mgmt-trafficmanager==0.30.0rc6',
     'azure-mgmt-dns==1.0.0',
-    'azure-mgmt-resource==0.30.2',
+    'azure-mgmt-resource==0.40.0',
     'azure-cli-core'
 ]
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
@@ -5,28 +5,28 @@
 
 def _resource_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.resources import ResourceManagementClient
-    return get_mgmt_service_client(ResourceManagementClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_RESOURCES)
 
 def _resource_feature_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.features  import FeatureClient
-    return get_mgmt_service_client(FeatureClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_FEATURES)
 
 def _resource_policy_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.policy import PolicyClient
-    return get_mgmt_service_client(PolicyClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_POLICY)
 
 def _resource_lock_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.locks import ManagementLockClient
-    return get_mgmt_service_client(ManagementLockClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_LOCKS)
 
 def _resource_links_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.mgmt.resource.links import ManagementLinkClient
-    return get_mgmt_service_client(ManagementLinkClient)
+    from azure.cli.core.profiles.shared import ResourceType
+    return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_LINKS)
 
 def cf_resource_groups(_):
     return _resource_client_factory().resource_groups

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -86,7 +86,7 @@ cli_command(__name__, 'group deployment validate', 'azure.cli.command_modules.re
 cli_command(__name__, 'group deployment export', 'azure.cli.command_modules.resource.custom#export_deployment_as_template')
 
 # Resource group deployment operations commands
-cli_command(__name__, 'group deployment operation list', 'azure.mgmt.resource.resources.operations.deployment_operations_operations#DeploymentOperationsOperations.list', cf_deployment_operations)
+cli_command(__name__, 'group deployment operation list', 'azure.mgmt.resource.resources.operations.deployment_operations#DeploymentOperations.list', cf_deployment_operations)
 cli_command(__name__, 'group deployment operation show', 'azure.cli.command_modules.resource.custom#get_deployment_operations', cf_deployment_operations, exception_handler=empty_on_404)
 
 cli_generic_update_command(__name__, 'resource update',

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -11,11 +11,9 @@ import os
 import re
 import uuid
 
-from azure.mgmt.resource.resources import ResourceManagementClient
-from azure.mgmt.resource.resources.models.resource_group import ResourceGroup
+from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import GenericResource
 
-from azure.mgmt.resource.policy.models import (PolicyAssignment, PolicyDefinition)
 from azure.mgmt.resource.locks.models import ManagementLockObject
 from azure.mgmt.resource.links.models import ResourceLinkProperties
 
@@ -25,6 +23,8 @@ from azure.cli.core.util import CLIError, get_file_json, shell_safe_json_parse
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.arm import is_valid_resource_id, parse_resource_id
+from azure.cli.core.profiles import get_versioned_models
+from azure.cli.core.profiles.shared import ResourceType
 
 from ._client_factory import (_resource_client_factory,
                               _resource_policy_client_factory,
@@ -58,6 +58,7 @@ def create_resource_group(rg_name, location, tags=None):
     '''
     rcf = _resource_client_factory()
 
+    ResourceGroup = get_versioned_models(ResourceType.MGMT_RESOURCE_RESOURCES, 'ResourceGroup')
     parameters = ResourceGroup(
         location=location,
         tags=tags
@@ -378,6 +379,7 @@ def create_policy_assignment(policy, name=None, display_name=None,
     scope = _build_policy_scope(policy_client.config.subscription_id,
                                 resource_group_name, scope)
     policy_id = _resolve_policy_id(policy, policy_client)
+    PolicyAssignment = get_versioned_models(ResourceType.MGMT_RESOURCE_POLICY, 'PolicyAssignment')
     assignment = PolicyAssignment(display_name, policy_id, scope)
     return policy_client.policy_assignments.create(scope,
                                                    name or uuid.uuid4(),
@@ -457,6 +459,7 @@ def create_policy_definition(name, rules, display_name=None, description=None):
         rules = shell_safe_json_parse(rules)
 
     policy_client = _resource_policy_client_factory()
+    PolicyDefinition = get_versioned_models(ResourceType.MGMT_RESOURCE_POLICY, 'PolicyDefinition')
     parameters = PolicyDefinition(policy_rule=rules, description=description,
                                   display_name=display_name)
     return policy_client.policy_definitions.create_or_update(name, parameters)
@@ -472,6 +475,7 @@ def update_policy_definition(policy_definition_name, rules=None,
     policy_client = _resource_policy_client_factory()
     definition = policy_client.policy_definitions.get(policy_definition_name)
     #pylint: disable=line-too-long,no-member
+    PolicyDefinition = get_versioned_models(ResourceType.MGMT_RESOURCE_POLICY, 'PolicyDefinition')
     parameters = PolicyDefinition(policy_rule=rules if rules is not None else definition.policy_rule,
                                   description=description if description is not None else definition.description,
                                   display_name=display_name if display_name is not None else definition.display_name)
@@ -523,7 +527,7 @@ def get_lock(name, resource_group_name=None):
     '''
     lock_client = _resource_lock_client_factory()
     if resource_group_name is None:
-        return lock_client.management_locks.get(name)
+        return lock_client.management_locks.get_at_subscription_level(name)
     return lock_client.management_locks.get_at_resource_group_level(resource_group_name, name)
 
 def delete_lock(name, resource_group_name=None, resource_provider_namespace=None,
@@ -603,7 +607,7 @@ def update_lock(name, resource_group_name=None,
                 level=None, notes=None, lock_id=None, lock_type=None):
     lock_client = _resource_lock_client_factory()
     if resource_group_name is None:
-        params = lock_client.management_locks.get(name)
+        params = lock_client.management_locks.get_at_subscription_level(name)
         _update_lock_parameters(params, level, notes, lock_id, lock_type)
         return lock_client.management_locks.create_or_update_at_subscription_level(name, params)
     params = lock_client.management_locks.get_at_resource_group_level(resource_group_name, name)

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -25,7 +25,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-resource==0.30.2',
+    'azure-mgmt-resource==0.40.0',
     'azure-cli-core',
 ]
 

--- a/src/command_modules/azure-cli-resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/tests/test_resource.py
@@ -5,6 +5,7 @@
 
 import os
 import time
+import unittest
 # AZURE CLI RESOURCE TEST DEFINITIONS
 from azure.cli.core.test_utils.vcr_test_base import (VCRTestBase, JMESPathCheck, NoneCheck,
                                                      BooleanCheck,
@@ -194,7 +195,7 @@ class TagScenarioTest(VCRTestBase): # Not RG test base because it operates only 
         s.cmd('tag create -n {}'.format(tn), checks=[
             JMESPathCheck('tagName', tn),
             JMESPathCheck('values', []),
-            JMESPathCheck('count.value', '0')
+            JMESPathCheck('count.value', 0)
         ])
         s.cmd('tag add-value -n {} --value test'.format(tn))
         s.cmd('tag add-value -n {} --value test2'.format(tn))
@@ -448,3 +449,6 @@ class PolicyScenarioTest(ResourceGroupVCRTestBase):
         time.sleep(10) # ensure the policy is gone when run live.
         self.cmd('policy definition list', checks=[
             JMESPathCheck("length([?name=='{}'])".format(policy_name), 0)])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -21,7 +21,7 @@ from azure.mgmt.sql.models.sql_management_client_enums import (
     ServiceObjectiveName,
     StorageKeyType
 )
-from azure.mgmt.resource.resources import ResourceManagementClient
+from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.storage import StorageManagementClient
 
 # url parse package has different names in Python 2 and 3. 'six' package works cross-version.

--- a/src/command_modules/azure-cli-sql/setup.py
+++ b/src/command_modules/azure-cli-sql/setup.py
@@ -25,7 +25,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-sql==0.4.0',
-    'azure-mgmt-storage==0.31.0',
+    'azure-mgmt-storage==0.40.0',
     'six'
 ]
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
@@ -48,7 +48,7 @@ def generic_data_service_factory(service, name=None, key=None, connection_string
 
 
 def storage_client_factory(**_):
-    return get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
+    return get_mgmt_service_client(ResourceType.MGMT_STORAGE)
 
 
 def file_data_service_factory(kwargs):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -241,21 +241,21 @@ register_cli_argument('storage account show-connection-string', 'key_name', opti
 for item in ['blob', 'file', 'queue', 'table']:
     register_cli_argument('storage account show-connection-string', '{}_endpoint'.format(item), help='Custom endpoint for {}s.'.format(item))
 
-register_cli_argument('storage account create', 'account_type', help='The storage account type', **model_choice_list(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'AccountType'))
+register_cli_argument('storage account create', 'account_type', help='The storage account type', **model_choice_list(ResourceType.MGMT_STORAGE, 'AccountType'))
 
 register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None)
 
-register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account.', **model_choice_list(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'Kind'))
+register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account.', **model_choice_list(ResourceType.MGMT_STORAGE, 'Kind'))
 register_cli_argument('storage account create', 'tags', tags_type)
 
 for item in ['create', 'update']:
-    register_cli_argument('storage account {}'.format(item), 'sku', help='The storage account SKU.', **model_choice_list(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'SkuName'))
-    es_model = get_versioned_models(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'EncryptionServices')
+    register_cli_argument('storage account {}'.format(item), 'sku', help='The storage account SKU.', **model_choice_list(ResourceType.MGMT_STORAGE, 'SkuName'))
+    es_model = get_versioned_models(ResourceType.MGMT_STORAGE, 'EncryptionServices')
     if es_model:
         register_cli_argument('storage account {}'.format(item), 'encryption', nargs='+', help='Specifies which service(s) to encrypt.', validator=validate_encryption, **enum_choice_list(list(es_model._attribute_map.keys())))  # pylint: disable=protected-access
 
-register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **model_choice_list(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'AccessTier'))
-register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **model_choice_list(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'AccessTier'))
+register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **model_choice_list(ResourceType.MGMT_STORAGE, 'AccessTier'))
+register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **model_choice_list(ResourceType.MGMT_STORAGE, 'AccessTier'))
 register_cli_argument('storage account create', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.')
 register_cli_argument('storage account update', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source. Use "" to clear existing value.', validator=validate_custom_domain)
 register_cli_argument('storage account update', 'use_subdomain', help='Specify whether to use indirect CNAME validation.', **enum_choice_list(['true', 'false']))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -34,7 +34,7 @@ storage_account_key_options = {'primary': 'key1', 'secondary': 'key2'}
 # Utilities
 
 def _query_account_key(account_name):
-    scf = get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
+    scf = get_mgmt_service_client(ResourceType.MGMT_STORAGE)
     acc = next((x for x in scf.storage_accounts.list() if x.name == account_name), None)
     if acc:
         from azure.cli.core.commands.arm import parse_resource_id
@@ -283,7 +283,7 @@ def validate_encryption(namespace):
     ''' Builds up the encryption object for storage account operations based on the
     list of services passed in. '''
     if namespace.encryption:
-        rt = ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS
+        rt = ResourceType.MGMT_STORAGE
         Encryption, EncryptionServices, EncryptionService = get_versioned_models(rt, 'Encryption', 'EncryptionServices', 'EncryptionService')  # pylint: disable=line-too-long
         services = {service: EncryptionService(True) for service in namespace.encryption}
         namespace.encryption = Encryption(EncryptionServices(**services))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -59,7 +59,7 @@ cli_command(__name__, 'storage account keys renew', mgmt_path + 'regenerate_key'
 cli_command(__name__, 'storage account keys list', mgmt_path + 'list_keys', factory, transform=lambda x: getattr(x, 'keys', x))
 
 cli_command(__name__, 'storage account create', custom_nonce_path + 'create_storage_account')
-if get_api_version(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS) in ['2016-12-01']:
+if get_api_version(ResourceType.MGMT_STORAGE) in ['2016-12-01']:
     cli_generic_update_command(__name__, 'storage account update',
                                mgmt_path + 'get_properties',
                                mgmt_path + 'update', factory,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom_nonce.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom_nonce.py
@@ -11,12 +11,12 @@ from azure.cli.core.profiles.shared import ResourceType
 from azure.cli.command_modules.storage._factory import storage_client_factory
 
 
-if get_api_version(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS) in ['2016-12-01']:
+if get_api_version(ResourceType.MGMT_STORAGE) in ['2016-12-01']:
 
     def create_storage_account(resource_group_name, account_name, sku, location,
-                               kind=get_versioned_models(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'Kind').storage.value, tags=None, custom_domain=None,
+                               kind=get_versioned_models(ResourceType.MGMT_STORAGE, 'Kind').storage.value, tags=None, custom_domain=None,
                                encryption=None, access_tier=None):
-        StorageAccountCreateParameters, Kind, Sku, CustomDomain, AccessTier = get_versioned_models(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'StorageAccountCreateParameters', 'Kind', 'Sku', 'CustomDomain', 'AccessTier')
+        StorageAccountCreateParameters, Kind, Sku, CustomDomain, AccessTier = get_versioned_models(ResourceType.MGMT_STORAGE, 'StorageAccountCreateParameters', 'Kind', 'Sku', 'CustomDomain', 'AccessTier')
         scf = storage_client_factory()
         params = StorageAccountCreateParameters(
             sku=Sku(sku),
@@ -30,7 +30,7 @@ if get_api_version(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS) in ['2016-12-01']
 
     def update_storage_account(instance, sku=None, tags=None, custom_domain=None,
                                use_subdomain=None, encryption=None, access_tier=None):
-        StorageAccountUpdateParameters, Sku, CustomDomain, AccessTier = get_versioned_models(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'StorageAccountUpdateParameters', 'Sku', 'CustomDomain', 'AccessTier')
+        StorageAccountUpdateParameters, Sku, CustomDomain, AccessTier = get_versioned_models(ResourceType.MGMT_STORAGE, 'StorageAccountUpdateParameters', 'Sku', 'CustomDomain', 'AccessTier')
         domain = instance.custom_domain
         if custom_domain is not None:
             domain = CustomDomain(custom_domain)
@@ -46,10 +46,10 @@ if get_api_version(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS) in ['2016-12-01']
         )
         return params
 
-elif get_api_version(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS) in ['2015-06-15']:
+elif get_api_version(ResourceType.MGMT_STORAGE) in ['2015-06-15']:
 
     def create_storage_account(resource_group_name, account_name, location, account_type, tags=None):
-        StorageAccountCreateParameters, AccountType = get_versioned_models(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS, 'StorageAccountCreateParameters', 'AccountType')
+        StorageAccountCreateParameters, AccountType = get_versioned_models(ResourceType.MGMT_STORAGE, 'StorageAccountCreateParameters', 'AccountType')
         scf = storage_client_factory()
         params = StorageAccountCreateParameters(location, AccountType(account_type), tags)
         return scf.storage_accounts.create(resource_group_name, account_name, params)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_client_factory.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_client_factory.py
@@ -5,13 +5,14 @@
 
 
 def _compute_client_factory(**_):
-    from azure.mgmt.compute import ComputeManagementClient
+    from azure.cli.core.profiles.shared import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(ComputeManagementClient)
+    return get_mgmt_service_client(ResourceType.MGMT_COMPUTE)
 
 
 def _subscription_client_factory(**_):
-    from azure.mgmt.resource.subscriptions import SubscriptionClient
+    # TODO Check usages of SubscriptionClient as they may need to be versioned.
+    from azure.mgmt.resource import SubscriptionClient
     from azure.cli.core.commands.client_factory import get_subscription_service_client
     return get_subscription_service_client(SubscriptionClient)
 
@@ -22,7 +23,9 @@ def cf_ni(_):
     # TODO: Remove hard coded api-version once
     # https://github.com/Azure/azure-rest-api-specs/issues/570
     # is fixed.
-    return get_mgmt_service_client(NetworkManagementClient, api_version='2016-03-30').network_interfaces  # pylint: disable=line-too-long
+    ni = get_mgmt_service_client(NetworkManagementClient).network_interfaces
+    ni.api_version = '2016-03-30'
+    return ni
 
 
 def cf_avail_set(_):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -394,7 +394,7 @@ def _validate_vm_create_storage_account(namespace):
     else:
         from azure.cli.core.profiles.shared import ResourceType
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS).storage_accounts  # pylint: disable=line-too-long
+        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE).storage_accounts  # pylint: disable=line-too-long
 
         # find storage account in target resource group that matches the VM's location
         sku_tier = 'Premium' if 'Premium' in namespace.storage_sku else 'Standard'

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -392,9 +392,9 @@ def _validate_vm_create_storage_account(namespace):
             # 2 - params for new storage account specified
             namespace.storage_account_type = 'new'
     else:
-        from azure.mgmt.storage import StorageManagementClient
+        from azure.cli.core.profiles.shared import ResourceType
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        storage_client = get_mgmt_service_client(StorageManagementClient).storage_accounts
+        storage_client = get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS).storage_accounts  # pylint: disable=line-too-long
 
         # find storage account in target resource group that matches the VM's location
         sku_tier = 'Premium' if 'Premium' in namespace.storage_sku else 'Standard'
@@ -439,9 +439,9 @@ def _validate_vm_create_vnet(namespace, for_scale_set=False):
 
     if not vnet and not subnet and not nics:  # pylint: disable=too-many-nested-blocks
         # if nothing specified, try to find an existing vnet and subnet in the target resource group
-        from azure.mgmt.network import NetworkManagementClient
+        from azure.cli.core.profiles.shared import ResourceType
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        client = get_mgmt_service_client(NetworkManagementClient).virtual_networks
+        client = get_mgmt_service_client(ResourceType.MGMT_NETWORK).virtual_networks
 
         # find VNET in target resource group that matches the VM's location with a matching subnet
         for vnet_match in (v for v in client.list(rg) if v.location == location and v.subnets):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -18,7 +18,7 @@ def read_content_if_is_file(string_or_file):
 
 
 def _resolve_api_version(provider_namespace, resource_type, parent_path):
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     client = get_mgmt_service_client(ResourceManagementClient)
     provider = client.providers.get(provider_namespace)
@@ -52,7 +52,7 @@ def log_pprint_template(template):
 def check_existence(value, resource_group, provider_namespace, resource_type,
                     parent_name=None, parent_type=None):
     # check for name or ID and set the type flags
-    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from msrestazure.azure_exceptions import CloudError
     resource_client = get_mgmt_service_client(ResourceManagementClient).resources

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -17,7 +17,7 @@ from azure.cli.core.util import empty_on_404
 # pylint: disable=line-too-long
 
 custom_path = 'azure.cli.command_modules.vm.custom#{}'
-mgmt_path = 'azure.mgmt.compute.operations.{}#{}.{}'
+mgmt_path = 'azure.mgmt.compute.compute.operations.{}#{}.{}'
 
 # VM
 
@@ -246,8 +246,8 @@ cli_command(__name__, 'disk show', mgmt_path.format(op_var, op_class, 'get'), cf
 cli_command(__name__, 'disk delete', mgmt_path.format(op_var, op_class, 'delete'), cf_disks)
 cli_command(__name__, 'disk grant-access', custom_path.format('grant_disk_access'))
 cli_command(__name__, 'disk revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_disks)
-cli_generic_update_command(__name__, 'disk update', 'azure.mgmt.compute.operations.{}#{}.get'.format(op_var, op_class),
-                           'azure.mgmt.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
+cli_generic_update_command(__name__, 'disk update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
+                           'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
                            custom_function_op=custom_path.format('update_managed_disk'),
                            setter_arg_name='disk', factory=cf_disks)
 
@@ -259,8 +259,8 @@ cli_command(__name__, 'snapshot show', mgmt_path.format(op_var, op_class, 'get')
 cli_command(__name__, 'snapshot delete', mgmt_path.format(op_var, op_class, 'delete'), cf_snapshots)
 cli_command(__name__, 'snapshot grant-access', custom_path.format('grant_snapshot_access'))
 cli_command(__name__, 'snapshot revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_snapshots)
-cli_generic_update_command(__name__, 'snapshot update', 'azure.mgmt.compute.operations.{}#{}.get'.format(op_var, op_class),
-                           'azure.mgmt.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
+cli_generic_update_command(__name__, 'snapshot update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
+                           'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
                            custom_function_op=custom_path.format('update_snapshot'),
                            setter_arg_name='snapshot', factory=cf_snapshots)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -125,7 +125,7 @@ def _get_access_extension_upgrade_info(extensions, name):
 
 def _get_storage_management_client():
     from azure.cli.core.profiles.shared import ResourceType
-    return get_mgmt_service_client(ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS)
+    return get_mgmt_service_client(ResourceType.MGMT_STORAGE)
 
 
 def _trim_away_build_number(version):

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -25,11 +25,11 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-compute==0.33.1rc1',
+    'azure-mgmt-compute==0.40.0',
     'azure-mgmt-keyvault==0.30.0',
     'azure-keyvault==0.1.0',
-    'azure-mgmt-network==0.30.0',
-    'azure-mgmt-resource==0.30.2',
+    'azure-mgmt-network==0.40.0',
+    'azure-mgmt-resource==0.40.0',
     'azure-storage==0.34.0',
     'azure-cli-core',
     'paramiko'

--- a/src/command_modules/azure-cli-vm/tests/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_custom_vm_commands.py
@@ -16,13 +16,14 @@ from azure.cli.command_modules.vm.custom import (_get_access_extension_upgrade_i
                                                  _get_extension_instance_name)
 from azure.cli.command_modules.vm.custom import \
     (attach_unmanaged_data_disk, detach_data_disk, get_vmss_instance_view)
-from azure.cli.command_modules.vm.disk_encryption import enable, disable, _check_encrypt_is_supported
+from azure.cli.command_modules.vm.disk_encryption import (enable,
+                                                          disable,
+                                                          _check_encrypt_is_supported)
 from azure.mgmt.compute.models import (NetworkProfile, StorageProfile, DataDisk, OSDisk,
                                        OperatingSystemTypes, InstanceViewStatus,
                                        VirtualMachineExtensionInstanceView,
-                                       VirtualMachineExtension, ImageReference)
-from azure.mgmt.compute.models.compute_management_client_enums import (DiskCreateOptionTypes,
-                                                                       CachingTypes)
+                                       VirtualMachineExtension, ImageReference,
+                                       DiskCreateOptionTypes, CachingTypes)
 
 
 class Test_Vm_Custom(unittest.TestCase):

--- a/src/command_modules/azure-cli-vm/tests/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_defaults.py
@@ -12,7 +12,9 @@ except ImportError:
 
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.resource.resources import ResourceManagementClient
+from azure.mgmt.resource import ResourceManagementClient
+
+from azure.cli.core.profiles.shared import ResourceType
 
 from azure.cli.command_modules.vm._validators import (_validate_vm_create_vnet,
                                                       _validate_vmss_create_subnet,
@@ -25,9 +27,9 @@ from azure.cli.command_modules.vm._validators import (_validate_vm_create_vnet,
 # pylint: disable=too-many-lines
 
 
-def _mock_resource_client(client_class):
+def _mock_resource_client(client_type):
     client = mock.MagicMock()
-    if client_class is NetworkManagementClient:
+    if client_type is ResourceType.MGMT_NETWORK:
         def _mock_list(rg):
 
             def _get_mock_vnet(name, rg, location):
@@ -47,7 +49,7 @@ def _mock_resource_client(client_class):
             ]
             return [x for x in all_mocks if x.rg == rg]
         client.virtual_networks.list = _mock_list
-    elif client_class is ResourceManagementClient:
+    elif client_type is ResourceType.MGMT_RESOURCE_RESOURCES:
         def _mock_get(rg):
             def _get_mock_rg(name, location):
                 mock_rg = mock.MagicMock()
@@ -60,7 +62,7 @@ def _mock_resource_client(client_class):
             ]
             return next((x for x in all_mocks if x.name == rg), _get_mock_rg(rg, 'unknown'))
         client.resource_groups.get = _mock_get
-    elif client_class is StorageManagementClient:
+    elif client_type is ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS:
         def _mock_list_by_resource_group(rg):
             def _get_mock_sa(name, rg, location, tier):
                 mock_sa = mock.MagicMock()

--- a/src/command_modules/azure-cli-vm/tests/test_vm_defaults.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_defaults.py
@@ -62,7 +62,7 @@ def _mock_resource_client(client_type):
             ]
             return next((x for x in all_mocks if x.name == rg), _get_mock_rg(rg, 'unknown'))
         client.resource_groups.get = _mock_get
-    elif client_type is ResourceType.MGMT_STORAGE_STORAGE_ACCOUNTS:
+    elif client_type is ResourceType.MGMT_STORAGE:
         def _mock_list_by_resource_group(rg):
             def _get_mock_sa(name, rg, location, tier):
                 mock_sa = mock.MagicMock()


### PR DESCRIPTION
It still only works with the api versions for public Azure.
The required changes haven’t been made to support other API versions.