### PR TITLE
Improve UX for Management Lock delete

### DIFF
--- a/src/azure-cli-core/tests/test_arm.py
+++ b/src/azure-cli-core/tests/test_arm.py
@@ -7,7 +7,10 @@ import unittest
 
 from azure.cli.core.commands.arm import parse_resource_id
 
+<<<<<<< 9735c8a016cdcc8a36b19fefe2a7ac7d60632714
 
+=======
+>>>>>>> Fix ARM resource id parsing.
 class TestARM(unittest.TestCase):
     def test_resource_parse(self):
         tests = [{
@@ -92,7 +95,6 @@ class TestARM(unittest.TestCase):
         for test in tests:
             resource = parse_resource_id(test['resource_id'])
             self.assertDictEqual(resource, test['expected'])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/azure-cli-core/tests/test_arm.py
+++ b/src/azure-cli-core/tests/test_arm.py
@@ -7,10 +7,7 @@ import unittest
 
 from azure.cli.core.commands.arm import parse_resource_id
 
-<<<<<<< 9735c8a016cdcc8a36b19fefe2a7ac7d60632714
 
-=======
->>>>>>> Fix ARM resource id parsing.
 class TestARM(unittest.TestCase):
     def test_resource_parse(self):
         tests = [{
@@ -95,6 +92,7 @@ class TestARM(unittest.TestCase):
         for test in tests:
             resource = parse_resource_id(test['resource_id'])
             self.assertDictEqual(resource, test['expected'])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This isn't strictly necessary, but it improves the user UX.

If the user asks us to delete a lock that we can find in a different scope, print better error messages to help the user do the right thing.

Addresses:

https://github.com/Azure/azure-cli/issues/2688