### PR TITLE
[Network] VPN-connection shared key fixes

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -7,6 +7,8 @@ unreleased
 ++++++++++++++++++
 * Add support for active-active VNet gateways
 * Remove nulls values from output of `network vpn-connection list/show` commands.
+* BC: Fix bug in the output of `vpn-connection create` 
+* Fix bug where '--key-length' argument of 'vpn-connection create' was not parsed correctly.
 
 2.0.2 (2017-04-03)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -85,17 +85,23 @@ def transform_vpn_connection_list(result):
 
 def transform_vpn_connection(result):
 
-    properties_to_strip = \
-        ['virtual_network_gateway1', 'virtual_network_gateway2', 'local_network_gateway2', 'peer']
-    for prop in properties_to_strip:
-        prop_val = getattr(result, prop, None)
-        if not prop_val:
-            delattr(result, prop)
-        else:
-            null_props = [key for key in prop_val.__dict__ if not prop_val.__dict__[key]]
-            for prop in null_props:
-                delattr(prop_val, prop)
+    if result:
+        properties_to_strip = \
+            ['virtual_network_gateway1', 'virtual_network_gateway2', 'local_network_gateway2', 'peer']
+        for prop in properties_to_strip:
+            prop_val = getattr(result, prop, None)
+            if not prop_val:
+                delattr(result, prop)
+            else:
+                null_props = [key for key in prop_val.__dict__ if not prop_val.__dict__[key]]
+                for prop in null_props:
+                    delattr(prop_val, prop)
     return result
+
+def transform_vpn_connection_create_output(result):
+    from azure.cli.core.commands import DeploymentOutputLongRunningOperation
+    result = DeploymentOutputLongRunningOperation('Starting network vpn-connection create')(result)
+    return result['resource']
 
 
 def transform_vnet_create_output(result):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -516,6 +516,7 @@ register_cli_argument('network vpn-connection update', 'enable_bgp', help='Enabl
 # VPN connection shared key
 register_cli_argument('network vpn-connection shared-key', 'connection_shared_key_name', options_list=('--name', '-n'), id_part='name')
 register_cli_argument('network vpn-connection shared-key', 'virtual_network_gateway_connection_name', options_list=('--connection-name',), metavar='NAME', id_part='name')
+register_cli_argument('network vpn-connection shared-key', 'key_length', type=int)
 
 # Traffic manager profiles
 register_cli_argument('network traffic-manager profile', 'traffic_manager_profile_name', name_arg_type, id_part='name', help='Traffic manager profile name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -19,7 +19,8 @@ from ._format import \
      transform_vnet_create_output, transform_public_ip_create_output,
      transform_traffic_manager_create_output, transform_nic_create_output,
      transform_nsg_create_output, transform_vnet_gateway_create_output,
-     transform_vpn_connection, transform_vpn_connection_list)
+     transform_vpn_connection, transform_vpn_connection_list,
+     transform_vpn_connection_create_output)
 
 custom_path = 'azure.cli.command_modules.network.custom#{}'
 
@@ -292,7 +293,7 @@ cli_generic_update_command(__name__, 'network vnet subnet update',
 cli_command(__name__, 'network list-usages', 'azure.mgmt.network.operations.usages_operations#UsagesOperations.list', cf_usages)
 
 # VirtualNetworkGatewayConnectionsOperations
-cli_command(__name__, 'network vpn-connection create', custom_path.format('create_vpn_connection'), cf_virtual_network_gateway_connections)
+cli_command(__name__, 'network vpn-connection create', custom_path.format('create_vpn_connection'), cf_virtual_network_gateway_connections, transform=transform_vpn_connection_create_output)
 cli_command(__name__, 'network vpn-connection delete', 'azure.mgmt.network.operations.virtual_network_gateway_connections_operations#VirtualNetworkGatewayConnectionsOperations.delete', cf_virtual_network_gateway_connections)
 cli_command(__name__, 'network vpn-connection show', 'azure.mgmt.network.operations.virtual_network_gateway_connections_operations#VirtualNetworkGatewayConnectionsOperations.get', cf_virtual_network_gateway_connections, exception_handler=empty_on_404, transform=transform_vpn_connection)
 cli_command(__name__, 'network vpn-connection list', 'azure.mgmt.network.operations.virtual_network_gateway_connections_operations#VirtualNetworkGatewayConnectionsOperations.list', cf_virtual_network_gateway_connections, transform=transform_vpn_connection_list)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -19,7 +19,6 @@ from azure.mgmt.network.models import \
      VirtualNetworkGatewayType, VirtualNetworkGatewaySkuName, VpnType, ApplicationGatewaySkuName)
 
 import azure.cli.core.azlogging as azlogging
-from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.commands.arm import parse_resource_id, is_valid_resource_id, resource_id
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.util import CLIError
@@ -1198,8 +1197,8 @@ def create_vpn_connection(client, resource_group_name, connection_name, vnet_gat
         _log_pprint_template(template)
         return client.validate(resource_group_name, deployment_name, properties)
 
-    return LongRunningOperation()(client.create_or_update(
-        resource_group_name, deployment_name, properties, raw=no_wait))
+    return client.create_or_update(
+        resource_group_name, deployment_name, properties, raw=no_wait)
 
 
 def update_vpn_connection(instance, routing_weight=None, shared_key=None, tags=None,

--- a/src/command_modules/azure-cli-network/tests/recordings/test_network_active_active_cross_premise_connection.yaml
+++ b/src/command_modules/azure-cli-network/tests/recordings/test_network_active_active_cross_premise_connection.yaml
@@ -6,11 +6,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b1d450c-1643-11e7-b555-a0b3ccf7272a]
+      x-ms-client-request-id: [6085bda2-1bb1-11e7-b3fa-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection?api-version=2016-09-01
   response:
@@ -18,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:52:19 GMT']
+      Date: ['Fri, 07 Apr 2017 16:43:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -26,44 +26,43 @@ interactions:
       content-length: ['284']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"ipConfigurations": [{"properties":
-      {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet"},
-      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip1"},
-      "privateIPAllocationMethod": "Dynamic"}, "name": "vnetGatewayConfig0"}, {"properties":
-      {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet"},
+    body: '{"location": "westus", "properties": {"vpnType": "RouteBased", "ipConfigurations":
+      [{"name": "vnetGatewayConfig0", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip1"},
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet"}}},
+      {"name": "vnetGatewayConfig1", "properties": {"privateIPAllocationMethod": "Dynamic",
       "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip2"},
-      "privateIPAllocationMethod": "Dynamic"}, "name": "vnetGatewayConfig1"}], "vpnType":
-      "RouteBased", "bgpSettings": {"asn": 65010}, "activeActive": true, "sku": {"tier":
-      "HighPerformance", "name": "HighPerformance"}, "enableBgp": true, "gatewayType":
-      "Vpn"}}'
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet"}}}],
+      "activeActive": true, "enableBgp": true, "bgpSettings": {"asn": 65010}, "gatewayType":
+      "Vpn", "sku": {"name": "HighPerformance", "tier": "HighPerformance"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1252']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"510c3035-8b86-4416-8536-1d93ffce512b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"19e885b5-439f-4bb3-b46d-8672fbe212cc\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworkGateways\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"resourceGuid\": \"15632be1-08e9-4994-93d3-4072c5ffce4f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"5c728d4d-52d3-478e-ac7c-8ef2b2dceb0b\",\r\n \
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"vnetGatewayConfig0\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig0\"\
-        ,\r\n        \"etag\": \"W/\\\"510c3035-8b86-4416-8536-1d93ffce512b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"19e885b5-439f-4bb3-b46d-8672fbe212cc\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
         publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip1\"\
         \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet\"\
         \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         vnetGatewayConfig1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig1\"\
-        ,\r\n        \"etag\": \"W/\\\"510c3035-8b86-4416-8536-1d93ffce512b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"19e885b5-439f-4bb3-b46d-8672fbe212cc\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
         publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip2\"\
@@ -77,11 +76,11 @@ interactions:
         : {\r\n      \"asn\": 65010,\r\n      \"peerWeight\": 0\r\n    }\r\n  }\r\n\
         }"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01']
       Cache-Control: [no-cache]
       Content-Length: ['2863']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:52:20 GMT']
+      Date: ['Fri, 07 Apr 2017 16:43:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -96,18 +95,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:52:31 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -124,18 +123,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:52:41 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -152,18 +151,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:52:51 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -180,18 +179,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:01 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:32 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -208,18 +207,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:12 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -236,18 +235,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:21 GMT']
+      Date: ['Fri, 07 Apr 2017 16:44:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -264,18 +263,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:32 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -292,18 +291,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:43 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -320,18 +319,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:53:52 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -348,18 +347,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:03 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -376,18 +375,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:14 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -404,18 +403,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:23 GMT']
+      Date: ['Fri, 07 Apr 2017 16:45:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -432,18 +431,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:34 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -460,18 +459,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:44 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -488,18 +487,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:54:54 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -516,18 +515,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:05 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -544,18 +543,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:16 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -572,18 +571,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:26 GMT']
+      Date: ['Fri, 07 Apr 2017 16:46:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -600,18 +599,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:36 GMT']
+      Date: ['Fri, 07 Apr 2017 16:47:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -628,18 +627,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:48 GMT']
+      Date: ['Fri, 07 Apr 2017 16:47:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -656,18 +655,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:55:58 GMT']
+      Date: ['Fri, 07 Apr 2017 16:47:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -684,18 +683,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:08 GMT']
+      Date: ['Fri, 07 Apr 2017 16:47:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -712,18 +711,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:18 GMT']
+      Date: ['Fri, 07 Apr 2017 16:47:49 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -740,18 +739,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:28 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -768,18 +767,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:38 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -796,18 +795,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:48 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -824,18 +823,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:56:59 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -852,18 +851,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:57:09 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -880,18 +879,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:57:19 GMT']
+      Date: ['Fri, 07 Apr 2017 16:48:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -908,18 +907,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:57:31 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -936,18 +935,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:57:41 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -964,18 +963,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:57:50 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -992,18 +991,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:01 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1020,18 +1019,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:12 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1048,18 +1047,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:23 GMT']
+      Date: ['Fri, 07 Apr 2017 16:49:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1076,18 +1075,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:33 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1104,18 +1103,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:43 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1132,18 +1131,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:58:55 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1160,18 +1159,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:05 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1188,18 +1187,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:15 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1216,18 +1215,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:26 GMT']
+      Date: ['Fri, 07 Apr 2017 16:50:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1244,18 +1243,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:36 GMT']
+      Date: ['Fri, 07 Apr 2017 16:51:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1272,18 +1271,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:46 GMT']
+      Date: ['Fri, 07 Apr 2017 16:51:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1300,18 +1299,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 18:59:57 GMT']
+      Date: ['Fri, 07 Apr 2017 16:51:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1328,18 +1327,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:07 GMT']
+      Date: ['Fri, 07 Apr 2017 16:51:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1356,18 +1355,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:16 GMT']
+      Date: ['Fri, 07 Apr 2017 16:51:49 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1384,18 +1383,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:27 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1412,18 +1411,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:37 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1440,18 +1439,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:47 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1468,18 +1467,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:00:58 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1496,18 +1495,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:01:08 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1524,18 +1523,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:01:18 GMT']
+      Date: ['Fri, 07 Apr 2017 16:52:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1552,18 +1551,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:01:28 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1580,18 +1579,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:01:38 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1608,18 +1607,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:01:49 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1636,18 +1635,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:00 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1664,18 +1663,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:10 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1692,18 +1691,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:20 GMT']
+      Date: ['Fri, 07 Apr 2017 16:53:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1720,18 +1719,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:31 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1748,18 +1747,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:42 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1776,18 +1775,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:02:52 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1804,18 +1803,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:03 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1832,18 +1831,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:13 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1860,18 +1859,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:24 GMT']
+      Date: ['Fri, 07 Apr 2017 16:54:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1888,18 +1887,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:34 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1916,18 +1915,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:46 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1944,18 +1943,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:03:56 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -1972,18 +1971,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:07 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2000,18 +1999,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:17 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2028,18 +2027,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:27 GMT']
+      Date: ['Fri, 07 Apr 2017 16:55:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2056,18 +2055,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:38 GMT']
+      Date: ['Fri, 07 Apr 2017 16:56:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2084,18 +2083,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:47 GMT']
+      Date: ['Fri, 07 Apr 2017 16:56:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2112,18 +2111,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:04:58 GMT']
+      Date: ['Fri, 07 Apr 2017 16:56:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2140,18 +2139,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:08 GMT']
+      Date: ['Fri, 07 Apr 2017 16:56:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2168,18 +2167,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:18 GMT']
+      Date: ['Fri, 07 Apr 2017 16:56:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2196,18 +2195,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:29 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2224,18 +2223,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:40 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2252,18 +2251,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:49 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2280,18 +2279,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:05:59 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2308,18 +2307,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:06:10 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2336,18 +2335,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:06:21 GMT']
+      Date: ['Fri, 07 Apr 2017 16:57:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2364,18 +2363,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:06:32 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2392,18 +2391,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:06:42 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2420,18 +2419,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:06:53 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2448,18 +2447,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:03 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2476,18 +2475,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:14 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2504,18 +2503,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:24 GMT']
+      Date: ['Fri, 07 Apr 2017 16:58:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2532,18 +2531,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:35 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2560,18 +2559,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:45 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2588,18 +2587,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:07:55 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2616,18 +2615,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:05 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2644,18 +2643,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:16 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2672,18 +2671,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:26 GMT']
+      Date: ['Fri, 07 Apr 2017 16:59:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2700,18 +2699,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:36 GMT']
+      Date: ['Fri, 07 Apr 2017 17:00:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2728,18 +2727,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:47 GMT']
+      Date: ['Fri, 07 Apr 2017 17:00:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2756,18 +2755,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:08:57 GMT']
+      Date: ['Fri, 07 Apr 2017 17:00:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2784,18 +2783,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:07 GMT']
+      Date: ['Fri, 07 Apr 2017 17:00:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2812,18 +2811,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:17 GMT']
+      Date: ['Fri, 07 Apr 2017 17:00:49 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2840,18 +2839,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:27 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2868,18 +2867,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:38 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2896,18 +2895,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:48 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:21 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2924,18 +2923,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:09:58 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:32 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2952,18 +2951,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:10:09 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -2980,18 +2979,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:10:18 GMT']
+      Date: ['Fri, 07 Apr 2017 17:01:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3008,18 +3007,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:10:29 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3036,18 +3035,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:10:39 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3064,18 +3063,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:10:50 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3092,18 +3091,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:00 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3120,18 +3119,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:10 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3148,18 +3147,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:21 GMT']
+      Date: ['Fri, 07 Apr 2017 17:02:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3176,18 +3175,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:31 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3204,18 +3203,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:41 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3232,18 +3231,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:11:52 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3260,18 +3259,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:01 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3288,18 +3287,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:12 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3316,18 +3315,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:22 GMT']
+      Date: ['Fri, 07 Apr 2017 17:03:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3344,18 +3343,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:33 GMT']
+      Date: ['Fri, 07 Apr 2017 17:04:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3372,18 +3371,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:43 GMT']
+      Date: ['Fri, 07 Apr 2017 17:04:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3400,18 +3399,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:12:54 GMT']
+      Date: ['Fri, 07 Apr 2017 17:04:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3428,18 +3427,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:04 GMT']
+      Date: ['Fri, 07 Apr 2017 17:04:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3456,18 +3455,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:15 GMT']
+      Date: ['Fri, 07 Apr 2017 17:04:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3484,18 +3483,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:25 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3512,18 +3511,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:36 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3540,18 +3539,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:47 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3568,18 +3567,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:13:58 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3596,18 +3595,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:14:08 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3624,18 +3623,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:14:19 GMT']
+      Date: ['Fri, 07 Apr 2017 17:05:54 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3652,18 +3651,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:14:29 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3680,18 +3679,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:14:40 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3708,18 +3707,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:14:50 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3736,18 +3735,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:01 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3764,74 +3763,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['30']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
-  response:
-    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['30']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/941ce25e-3871-4045-801b-2d998751f41c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/26b1f3bb-2122-46f2-85bf-c2e2960e06cc?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:35 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3847,28 +3790,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b2e9d8a-1643-11e7-b51e-a0b3ccf7272a]
+      x-ms-client-request-id: [609825b0-1bb1-11e7-9d66-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"gw1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1\"\
-        ,\r\n  \"etag\": \"W/\\\"6bf49958-ad54-44fc-876d-3dcf789e525b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"59c838c1-3f23-4d7a-8c38-3a9c4f4a15a9\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworkGateways\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"15632be1-08e9-4994-93d3-4072c5ffce4f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"5c728d4d-52d3-478e-ac7c-8ef2b2dceb0b\",\r\n \
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"vnetGatewayConfig0\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig0\"\
-        ,\r\n        \"etag\": \"W/\\\"6bf49958-ad54-44fc-876d-3dcf789e525b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"59c838c1-3f23-4d7a-8c38-3a9c4f4a15a9\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
         publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip1\"\
         \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/GatewaySubnet\"\
         \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         vnetGatewayConfig1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/vnetGatewayConfig1\"\
-        ,\r\n        \"etag\": \"W/\\\"6bf49958-ad54-44fc-876d-3dcf789e525b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"59c838c1-3f23-4d7a-8c38-3a9c4f4a15a9\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
         publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/publicIPAddresses/gwip2\"\
@@ -3883,7 +3826,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:35 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3894,37 +3837,37 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "eastus", "properties": {"gatewayIpAddress": "131.107.72.22",
-      "localNetworkAddressSpace": {"addressPrefixes": ["10.52.255.253/32"]}, "bgpSettings":
-      {"asn": 65050, "bgpPeeringAddress": "10.52.255.253"}}}'
+      "bgpSettings": {"asn": 65050, "bgpPeeringAddress": "10.52.255.253"}, "localNetworkAddressSpace":
+      {"addressPrefixes": ["10.52.255.253/32"]}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['215']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6b591ed2-1646-11e7-993b-a0b3ccf7272a]
+      x-ms-client-request-id: [9667f1c8-1bb4-11e7-aea5-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"lgw2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2\"\
-        ,\r\n  \"etag\": \"W/\\\"e3d668f5-a20e-44b7-b7fa-38cfbe24ecb2\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"191e6e26-997c-4947-9569-446cb30beb14\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/localNetworkGateways\",\r\n  \"location\"\
         : \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"resourceGuid\": \"424519dd-2add-4dde-a6f5-e2347b51dfe9\",\r\n \
+        ,\r\n    \"resourceGuid\": \"66b9c1cb-c0e2-4bf2-8b12-787b009513c1\",\r\n \
         \   \"localNetworkAddressSpace\": {\r\n      \"addressPrefixes\": [\r\n  \
         \      \"10.52.255.253/32\"\r\n      ]\r\n    },\r\n    \"gatewayIpAddress\"\
         : \"131.107.72.22\",\r\n    \"bgpSettings\": {\r\n      \"asn\": 65050,\r\n\
         \      \"bgpPeeringAddress\": \"10.52.255.253\",\r\n      \"peerWeight\":\
         \ 0\r\n    }\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/eastus/operations/c000c2be-3bef-497c-873b-4189a9b6c4ad?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/eastus/operations/a1504d88-dc2d-40df-bccc-e8f31fdb9877?api-version=2016-09-01']
       Cache-Control: [no-cache]
       Content-Length: ['736']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:37 GMT']
+      Date: ['Fri, 07 Apr 2017 17:06:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
@@ -3939,18 +3882,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6b591ed2-1646-11e7-993b-a0b3ccf7272a]
+      x-ms-client-request-id: [9667f1c8-1bb4-11e7-aea5-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/c000c2be-3bef-497c-873b-4189a9b6c4ad?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a1504d88-dc2d-40df-bccc-e8f31fdb9877?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:47 GMT']
+      Date: ['Fri, 07 Apr 2017 17:07:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3966,18 +3909,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6b591ed2-1646-11e7-993b-a0b3ccf7272a]
+      x-ms-client-request-id: [9667f1c8-1bb4-11e7-aea5-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"lgw2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2\"\
-        ,\r\n  \"etag\": \"W/\\\"0454970d-6377-4438-8279-562aa7e18fbe\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4bed76a5-4154-42b4-8e8c-62e330576a34\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/localNetworkGateways\",\r\n  \"location\"\
         : \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"424519dd-2add-4dde-a6f5-e2347b51dfe9\",\r\n \
+        ,\r\n    \"resourceGuid\": \"66b9c1cb-c0e2-4bf2-8b12-787b009513c1\",\r\n \
         \   \"localNetworkAddressSpace\": {\r\n      \"addressPrefixes\": [\r\n  \
         \      \"10.52.255.253/32\"\r\n      ]\r\n    },\r\n    \"gatewayIpAddress\"\
         : \"131.107.72.22\",\r\n    \"bgpSettings\": {\r\n      \"asn\": 65050,\r\n\
@@ -3986,8 +3929,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:48 GMT']
-      ETag: [W/"0454970d-6377-4438-8279-562aa7e18fbe"]
+      Date: ['Fri, 07 Apr 2017 17:07:01 GMT']
+      ETag: [W/"4bed76a5-4154-42b4-8e8c-62e330576a34"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4003,11 +3946,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [73750026-1646-11e7-a7a4-a0b3ccf7272a]
+      x-ms-client-request-id: [9e9fb1c6-1bb4-11e7-8c8c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection?api-version=2016-09-01
   response:
@@ -4015,7 +3958,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:49 GMT']
+      Date: ['Fri, 07 Apr 2017 17:07:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -4023,41 +3966,40 @@ interactions:
       content-length: ['284']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"mode": "Incremental", "template": {"outputs": {"resource":
-      {"value": "[reference(''Vnet1toSite5_1'')]", "type": "object"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "resources": [{"location": "westus", "properties":
-      {"virtualNetworkGateway1": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},
-      "routingWeight": 10, "connectionType": "IPSec", "authorizationKey": null, "localNetworkGateway2":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2"},
-      "enableBgp": true, "sharedKey": "abc123"}, "apiVersion": "2015-06-15", "tags":
-      {}, "dependsOn": [], "type": "Microsoft.Network/connections", "name": "Vnet1toSite5_1"}],
-      "variables": {}, "parameters": {}}, "parameters": {}}}'
+    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {}, "variables": {}, "outputs": {"resource":
+      {"type": "object", "value": "[reference(''Vnet1toSite5_1'')]"}}, "resources":
+      [{"dependsOn": [], "properties": {"routingWeight": 10, "enableBgp": true, "sharedKey":
+      "abc123", "localNetworkGateway2": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2"},
+      "virtualNetworkGateway1": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},
+      "authorizationKey": null, "connectionType": "IPSec"}, "type": "Microsoft.Network/connections",
+      "name": "Vnet1toSite5_1", "location": "westus", "apiVersion": "2015-06-15",
+      "tags": {}}]}, "parameters": {}, "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1034']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [738aab4a-1646-11e7-9c76-a0b3ccf7272a]
+      x-ms-client-request-id: [9ecc238a-1bb4-11e7-ad42-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_ggIDURKxCVkgx93JBNCfeNzIzqHwyArL","name":"vpn_connection_deploy_ggIDURKxCVkgx93JBNCfeNzIzqHwyArL","properties":{"templateHash":"17600274930576475001","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-03-31T19:15:51.1136755Z","duration":"PT0.4825926S","correlationId":"73a2916e-424e-4a47-a67a-a5279c1ecaf0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_oaotL9h9FNfOsMOMe9udYayDdMrVsxx5","name":"vpn_connection_deploy_oaotL9h9FNfOsMOMe9udYayDdMrVsxx5","properties":{"templateHash":"2432247413714289770","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-04-07T17:07:04.7505487Z","duration":"PT0.9882197S","correlationId":"c128883a-21d8-498b-8097-7da46fdef72d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_ggIDURKxCVkgx93JBNCfeNzIzqHwyArL/operationStatuses/08587106191348465278?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_oaotL9h9FNfOsMOMe9udYayDdMrVsxx5/operationStatuses/08587100220617152839?api-version=2016-09-01']
       Cache-Control: [no-cache]
-      Content-Length: ['673']
+      Content-Length: ['672']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:15:50 GMT']
+      Date: ['Fri, 07 Apr 2017 17:07:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -4066,19 +4008,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [738aab4a-1646-11e7-9c76-a0b3ccf7272a]
+      x-ms-client-request-id: [9ecc238a-1bb4-11e7-ad42-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587106191348465278?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587100220617152839?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:20 GMT']
+      Date: ['Fri, 07 Apr 2017 17:07:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -4092,65 +4034,574 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [738aab4a-1646-11e7-9c76-a0b3ccf7272a]
+      x-ms-client-request-id: [9ecc238a-1bb4-11e7-ad42-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_ggIDURKxCVkgx93JBNCfeNzIzqHwyArL","name":"vpn_connection_deploy_ggIDURKxCVkgx93JBNCfeNzIzqHwyArL","properties":{"templateHash":"17600274930576475001","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-03-31T19:16:18.5897816Z","duration":"PT27.9586987S","correlationId":"73a2916e-424e-4a47-a67a-a5279c1ecaf0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[],"outputs":{"resource":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"f3e63a38-9d31-4242-bd5c-ba5af1ac1873","virtualNetworkGateway1":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},"localNetworkGateway2":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2"},"connectionType":"IPsec","routingWeight":10,"sharedKey":"abc123","enableBgp":true,"connectionStatus":"Unknown","ingressBytesTransferred":0,"egressBytesTransferred":0}}},"outputResources":[{"id":"Microsoft.Network/connections/Vnet1toSite5_1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_oaotL9h9FNfOsMOMe9udYayDdMrVsxx5","name":"vpn_connection_deploy_oaotL9h9FNfOsMOMe9udYayDdMrVsxx5","properties":{"templateHash":"2432247413714289770","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-04-07T17:07:31.8901855Z","duration":"PT28.1278565S","correlationId":"c128883a-21d8-498b-8097-7da46fdef72d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[],"outputs":{"resource":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"36744744-b005-41bb-8f32-518de1e8586a","virtualNetworkGateway1":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},"localNetworkGateway2":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2"},"connectionType":"IPsec","routingWeight":10,"sharedKey":"abc123","enableBgp":true,"connectionStatus":"Unknown","ingressBytesTransferred":0,"egressBytesTransferred":0}}},"outputResources":[{"id":"Microsoft.Network/connections/Vnet1toSite5_1"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:21 GMT']
+      Date: ['Fri, 07 Apr 2017 17:07:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['1469']
+      content-length: ['1468']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "eastus", "properties": {"gatewayIpAddress": "131.107.72.23",
-      "localNetworkAddressSpace": {"addressPrefixes": ["10.52.255.254/32"]}, "bgpSettings":
-      {"asn": 65050, "bgpPeeringAddress": "10.52.255.254"}}}'
+    body: '{"keyLength": 128}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['215']
+      Content-Length: ['18']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [86fbd8ae-1646-11e7-bb9a-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3?api-version=2016-09-01
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1/sharedkey/reset?api-version=2016-09-01
   response:
-    body: {string: "{\r\n  \"name\": \"lgw3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3\"\
-        ,\r\n  \"etag\": \"W/\\\"9ff7983f-b829-40e6-8f85-f936134395e6\\\"\",\r\n \
-        \ \"type\": \"Microsoft.Network/localNetworkGateways\",\r\n  \"location\"\
-        : \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"resourceGuid\": \"68b9dccc-9f89-4313-8b7c-bfb2bc47cc7f\",\r\n \
-        \   \"localNetworkAddressSpace\": {\r\n      \"addressPrefixes\": [\r\n  \
-        \      \"10.52.255.254/32\"\r\n      ]\r\n    },\r\n    \"gatewayIpAddress\"\
-        : \"131.107.72.23\",\r\n    \"bgpSettings\": {\r\n      \"asn\": 65050,\r\n\
-        \      \"bgpPeeringAddress\": \"10.52.255.254\",\r\n      \"peerWeight\":\
-        \ 0\r\n    }\r\n  }\r\n}"}
+    body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/eastus/operations/0237915f-68ad-452e-b7cc-22b9b0ac0d02?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01']
       Cache-Control: [no-cache]
-      Content-Length: ['736']
+      Content-Length: ['0']
+      Date: ['Fri, 07 Apr 2017 17:07:38 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:23 GMT']
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:07:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:07:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:08:59 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:09:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:09:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:09:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:09:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:09:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3853f08-1bb4-11e7-8343-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/974483b1-35b2-4978-80aa-5d16e6e5748f?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10fb4c64-1bb5-11e7-8375-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1/sharedkey?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"value\": \"wxBjjq5qIWQmCbwaiSgKkpQOWAoo3KF0WqmvWLHqwTKNqJgKcj2HN8malxEdN00n5dwQhbWksE0RtbFBs54iBd4uj0xrSIHL9gNDnj7eh2rtaWWQwtu4OhnWiJy2zO10\"\
+        \r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['147']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [11f469a4-1bb5-11e7-a9b0-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"Vnet1toSite5_1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1\"\
+        ,\r\n  \"etag\": \"W/\\\"5865dae4-3b4e-4a24-a34e-e9897e8c191c\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/connections\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"36744744-b005-41bb-8f32-518de1e8586a\"\
+        ,\r\n    \"virtualNetworkGateway1\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1\"\
+        \r\n    },\r\n    \"localNetworkGateway2\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw2\"\
+        \r\n    },\r\n    \"connectionType\": \"IPsec\",\r\n    \"routingWeight\"\
+        : 10,\r\n    \"sharedKey\": \"wxBjjq5qIWQmCbwaiSgKkpQOWAoo3KF0WqmvWLHqwTKNqJgKcj2HN8malxEdN00n5dwQhbWksE0RtbFBs54iBd4uj0xrSIHL9gNDnj7eh2rtaWWQwtu4OhnWiJy2zO10\"\
+        ,\r\n    \"enableBgp\": true,\r\n    \"connectionStatus\": \"Connecting\"\
+        ,\r\n    \"ingressBytesTransferred\": 0,\r\n    \"egressBytesTransferred\"\
+        : 0,\r\n    \"tunnelConnectionStatus\": [\r\n      {\r\n        \"tunnel\"\
+        : \"Vnet1toSite5_1_138.91.249.226\",\r\n        \"connectionStatus\": \"Connecting\"\
+        ,\r\n        \"ingressBytesTransferred\": 0,\r\n        \"egressBytesTransferred\"\
+        : 0,\r\n        \"lastConnectionEstablishedUtcTime\": \"1601-01-01T00:00:00Z\"\
+        \r\n      },\r\n      {\r\n        \"tunnel\": \"Vnet1toSite5_1_138.91.251.28\"\
+        ,\r\n        \"connectionStatus\": \"Connecting\",\r\n        \"ingressBytesTransferred\"\
+        : 0,\r\n        \"egressBytesTransferred\": 0,\r\n        \"lastConnectionEstablishedUtcTime\"\
+        : \"1601-01-01T00:00:00Z\"\r\n      }\r\n    ]\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1843']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"value": "a1b2c3"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['19']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1/sharedkey?api-version=2016-09-01
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Fri, 07 Apr 2017 17:10:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 201, message: Created}
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
@@ -4158,18 +4609,130 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [86fbd8ae-1646-11e7-bb9a-a0b3ccf7272a]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/0237915f-68ad-452e-b7cc-22b9b0ac0d02?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:10:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:11:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/868fb86b-43d7-4e29-82a9-48970bac29c9?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:33 GMT']
+      Date: ['Fri, 07 Apr 2017 17:11:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4185,18 +4748,139 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 networkmanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [86fbd8ae-1646-11e7-bb9a-a0b3ccf7272a]
+      x-ms-client-request-id: [1282c70c-1bb5-11e7-8964-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1/sharedkey?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"value\": \"a1b2c3\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:11:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['25']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3359916e-1bb5-11e7-8f9b-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/connections/Vnet1toSite5_1/sharedkey?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"value\": \"a1b2c3\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:11:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['25']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "eastus", "properties": {"gatewayIpAddress": "131.107.72.23",
+      "bgpSettings": {"asn": 65050, "bgpPeeringAddress": "10.52.255.254"}, "localNetworkAddressSpace":
+      {"addressPrefixes": ["10.52.255.254/32"]}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['215']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3415efc6-1bb5-11e7-bb85-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"lgw3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3\"\
+        ,\r\n  \"etag\": \"W/\\\"3a800155-997f-43b5-8bf3-13c3065088aa\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/localNetworkGateways\",\r\n  \"location\"\
+        : \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
+        ,\r\n    \"resourceGuid\": \"d171d273-cef6-428d-a015-9aeccb1e6338\",\r\n \
+        \   \"localNetworkAddressSpace\": {\r\n      \"addressPrefixes\": [\r\n  \
+        \      \"10.52.255.254/32\"\r\n      ]\r\n    },\r\n    \"gatewayIpAddress\"\
+        : \"131.107.72.23\",\r\n    \"bgpSettings\": {\r\n      \"asn\": 65050,\r\n\
+        \      \"bgpPeeringAddress\": \"10.52.255.254\",\r\n      \"peerWeight\":\
+        \ 0\r\n    }\r\n  }\r\n}"}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/eastus/operations/784061d0-dfff-456f-b427-153bfcfdb5a7?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['736']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:11:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3415efc6-1bb5-11e7-bb85-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/784061d0-dfff-456f-b427-153bfcfdb5a7?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 07 Apr 2017 17:11:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3415efc6-1bb5-11e7-bb85-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3?api-version=2016-09-01
   response:
     body: {string: "{\r\n  \"name\": \"lgw3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3\"\
-        ,\r\n  \"etag\": \"W/\\\"5177222f-cf52-4fd7-94b4-c65554668cbf\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a6163d2d-9c57-4040-a5ab-3acffc9e993a\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/localNetworkGateways\",\r\n  \"location\"\
         : \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"68b9dccc-9f89-4313-8b7c-bfb2bc47cc7f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"d171d273-cef6-428d-a015-9aeccb1e6338\",\r\n \
         \   \"localNetworkAddressSpace\": {\r\n      \"addressPrefixes\": [\r\n  \
         \      \"10.52.255.254/32\"\r\n      ]\r\n    },\r\n    \"gatewayIpAddress\"\
         : \"131.107.72.23\",\r\n    \"bgpSettings\": {\r\n      \"asn\": 65050,\r\n\
@@ -4205,8 +4889,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:34 GMT']
-      ETag: [W/"5177222f-cf52-4fd7-94b4-c65554668cbf"]
+      Date: ['Fri, 07 Apr 2017 17:11:25 GMT']
+      ETag: [W/"a6163d2d-9c57-4040-a5ab-3acffc9e993a"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4222,11 +4906,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f19d912-1646-11e7-b148-a0b3ccf7272a]
+      x-ms-client-request-id: [3c4d5a40-1bb5-11e7-ae90-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection?api-version=2016-09-01
   response:
@@ -4234,7 +4918,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:36 GMT']
+      Date: ['Fri, 07 Apr 2017 17:11:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -4242,37 +4926,36 @@ interactions:
       content-length: ['284']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"mode": "Incremental", "template": {"outputs": {"resource":
-      {"value": "[reference(''Vnet1toSite5_2'')]", "type": "object"}}, "$schema":
-      "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "resources": [{"location": "westus", "properties":
-      {"virtualNetworkGateway1": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},
-      "routingWeight": 10, "connectionType": "IPSec", "authorizationKey": null, "localNetworkGateway2":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3"},
-      "enableBgp": true, "sharedKey": "abc123"}, "apiVersion": "2015-06-15", "tags":
-      {}, "dependsOn": [], "type": "Microsoft.Network/connections", "name": "Vnet1toSite5_2"}],
-      "variables": {}, "parameters": {}}, "parameters": {}}}'
+    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {}, "variables": {}, "outputs": {"resource":
+      {"type": "object", "value": "[reference(''Vnet1toSite5_2'')]"}}, "resources":
+      [{"dependsOn": [], "properties": {"routingWeight": 10, "enableBgp": true, "sharedKey":
+      "abc123", "localNetworkGateway2": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3"},
+      "virtualNetworkGateway1": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},
+      "authorizationKey": null, "connectionType": "IPSec"}, "type": "Microsoft.Network/connections",
+      "name": "Vnet1toSite5_2", "location": "westus", "apiVersion": "2015-06-15",
+      "tags": {}}]}, "parameters": {}, "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1034']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f4ae37a-1646-11e7-a4bb-a0b3ccf7272a]
+      x-ms-client-request-id: [3c641568-1bb5-11e7-bb8a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_xXBbcjdOc5ia5NtxottD6l9vsakCw1j4","name":"vpn_connection_deploy_xXBbcjdOc5ia5NtxottD6l9vsakCw1j4","properties":{"templateHash":"14690740186505567652","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-03-31T19:16:38.095127Z","duration":"PT0.7400646S","correlationId":"15cf548c-6484-4013-ac87-9e300bf2757f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_AJVbrlcNiRPvcXhiBSssVOrHlXNOSBES","name":"vpn_connection_deploy_AJVbrlcNiRPvcXhiBSssVOrHlXNOSBES","properties":{"templateHash":"12874660932771935754","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-04-07T17:11:29.0306999Z","duration":"PT0.7441379S","correlationId":"68a2a554-c4d7-4d1a-8cbe-8db37bcf0994","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_xXBbcjdOc5ia5NtxottD6l9vsakCw1j4/operationStatuses/08587106190881225560?api-version=2016-09-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_AJVbrlcNiRPvcXhiBSssVOrHlXNOSBES/operationStatuses/08587100217971910583?api-version=2016-09-01']
       Cache-Control: [no-cache]
-      Content-Length: ['672']
+      Content-Length: ['673']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:16:37 GMT']
+      Date: ['Fri, 07 Apr 2017 17:11:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -4285,45 +4968,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f4ae37a-1646-11e7-a4bb-a0b3ccf7272a]
+      x-ms-client-request-id: [3c641568-1bb5-11e7-bb8a-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587106190881225560?api-version=2016-09-01
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:17:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8f4ae37a-1646-11e7-a4bb-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587106190881225560?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587100217971910583?api-version=2016-09-01
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:17:38 GMT']
+      Date: ['Fri, 07 Apr 2017 17:11:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -4337,19 +4994,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.6
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.1+dev]
+          AZURECLI/TEST/2.0.2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f4ae37a-1646-11e7-a4bb-a0b3ccf7272a]
+      x-ms-client-request-id: [3c641568-1bb5-11e7-bb8a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2016-09-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_xXBbcjdOc5ia5NtxottD6l9vsakCw1j4","name":"vpn_connection_deploy_xXBbcjdOc5ia5NtxottD6l9vsakCw1j4","properties":{"templateHash":"14690740186505567652","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-03-31T19:17:09.4950858Z","duration":"PT32.1400234S","correlationId":"15cf548c-6484-4013-ac87-9e300bf2757f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[],"outputs":{"resource":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"bb903a0e-e341-4f3b-824e-86c2f4e63abb","virtualNetworkGateway1":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},"localNetworkGateway2":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3"},"connectionType":"IPsec","routingWeight":10,"sharedKey":"abc123","enableBgp":true,"connectionStatus":"Unknown","ingressBytesTransferred":0,"egressBytesTransferred":0}}},"outputResources":[{"id":"Microsoft.Network/connections/Vnet1toSite5_2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Resources/deployments/vpn_connection_deploy_AJVbrlcNiRPvcXhiBSssVOrHlXNOSBES","name":"vpn_connection_deploy_AJVbrlcNiRPvcXhiBSssVOrHlXNOSBES","properties":{"templateHash":"12874660932771935754","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-04-07T17:11:59.3805203Z","duration":"PT31.0939583S","correlationId":"68a2a554-c4d7-4d1a-8cbe-8db37bcf0994","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"connections","locations":["westus"]}]}],"dependencies":[],"outputs":{"resource":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"4f6caa22-1df3-4525-84c0-212c0d6ed1f5","virtualNetworkGateway1":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/virtualNetworkGateways/gw1"},"localNetworkGateway2":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_active_active_cross_premise_connection/providers/Microsoft.Network/localNetworkGateways/lgw3"},"connectionType":"IPsec","routingWeight":10,"sharedKey":"abc123","enableBgp":true,"connectionStatus":"Unknown","ingressBytesTransferred":0,"egressBytesTransferred":0}}},"outputResources":[{"id":"Microsoft.Network/connections/Vnet1toSite5_2"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 31 Mar 2017 19:17:39 GMT']
+      Date: ['Fri, 07 Apr 2017 17:11:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]

--- a/src/command_modules/azure-cli-network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/tests/test_network_commands.py
@@ -1128,6 +1128,7 @@ class NetworkActiveActiveCrossPremiseScenarioTest(ResourceGroupVCRTestBase): # p
         conn_151 = 'Vnet1toSite5_1'
         conn_152 = 'Vnet1toSite5_2'
         shared_key = 'abc123'
+        shared_key2 = 'a1b2c3'
 
         # create the vnet gateway with active-active feature
         self.cmd('network vnet-gateway create -g {} -n {} --vnet {} --sku HighPerformance --asn {} --public-ip-addresses {} {}'.format(rg, gw1, vnet1, vnet1_asn, self.gw_ip1, self.gw_ip2))
@@ -1135,6 +1136,12 @@ class NetworkActiveActiveCrossPremiseScenarioTest(ResourceGroupVCRTestBase): # p
         # create and connect first local-gateway
         self.cmd('network local-gateway create -g {} -n {} -l {} --gateway-ip-address {} --local-address-prefixes {} --asn {} --bgp-peering-address {}'.format(rg, lgw2, lgw_loc, lgw_ip, lgw_prefix, lgw_asn, bgp_peer1))
         self.cmd('network vpn-connection create -g {} -n {} --vnet-gateway1 {} --local-gateway2 {} --shared-key {} --enable-bgp'.format(rg, conn_151, gw1, lgw2, shared_key))
+        self.cmd('network vpn-connection shared-key reset -g {} --connection-name {} --key-length 128'.format(rg, conn_151))
+        sk1 = self.cmd('network vpn-connection shared-key show -g {} --connection-name {}'.format(rg, conn_151))
+        self.cmd('network vpn-connection shared-key update -g {} --connection-name {} --value {}'.format(rg, conn_151, shared_key2))
+        sk2 = self.cmd('network vpn-connection shared-key show -g {} --connection-name {}'.format(rg, conn_151),
+            checks=JMESPathCheck('value', shared_key2))
+        self.assertNotEqual(sk1, sk2)
 
         lgw3 = 'lgw3'
         lgw3_ip = '131.107.72.23'


### PR DESCRIPTION
Closes #1602. 

Adds test coverage for the previously not covered `vpn-connection shared-key` commands. Fixes the output of the vpn-connection create command, which previously exposed the deployment "wrapping". This is technically a breaking change (and called out as such in the HISTORY). 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
