### PR TITLE
Improve `az find` search results

### DIFF
--- a/src/command_modules/azure-cli-find/HISTORY.rst
+++ b/src/command_modules/azure-cli-find/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* improve search results and allow for versioning of the search index
+
 0.0.1b1 (2017-03-13)
 ++++++++++++++++++++
 

--- a/src/command_modules/azure-cli-find/tests/test_find.py
+++ b/src/command_modules/azure-cli-find/tests/test_find.py
@@ -15,7 +15,7 @@ from nose import with_setup
 from six import StringIO
 
 from azure.cli.main import main as cli_main
-from azure.cli.command_modules.find.custom import _remove_index
+from azure.cli.command_modules.find.custom import _purge
 
 
 @contextlib.contextmanager
@@ -46,16 +46,16 @@ def exec_json(cmd):
 class SearchIndexTest(unittest.TestCase):
 
     def setUp(self):
-        _remove_index()
+        _purge()
 
     def test_search_index(self):
         six.assertRegex(
             self,
             execute('find -q keyvault list'),
-            'az keyvault certificate list-versions')
+            'az keyvault list')
 
     def test_search_reindex(self):
         six.assertRegex(
             self,
             execute('find -q keyvault list --reindex'),
-            'az keyvault certificate list-versions')
+            'az keyvault list')


### PR DESCRIPTION
Fixes #2805

```
$ az find -q keyvault list
`az keyvault list`
    List key vaults.

`az keyvault key list`
    List keys in the specified vault.

`az keyvault certificate list`
    List certificates in the specified vault.

`az keyvault secret list`
    List secrets in the specified vault.

`az keyvault certificate list-versions`
    List the versions of a certificate.

`az keyvault secret list-versions`
    List the versions of the specified secret.

`az keyvault key list-versions`
    List the versions of the specified key.

`az keyvault certificate issuer list`
    List certificate issuers for the specified vault.

`az keyvault certificate issuer admin list`
    List admins for a specified certificate issuer.

`az keyvault certificate contact list`
    Gets the certificate contacts for the specified vault.
```