### PR TITLE
SQL - ability to connect directly to resource provider

### DIFF
--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+
 def get_sql_management_client(_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from azure.mgmt.sql import SqlManagementClient

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
@@ -5,18 +5,21 @@
 
 def get_sql_management_client(_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    from azure.cli.core._profile import Profile, CLOUD
     from azure.mgmt.sql import SqlManagementClient
     from msrest.authentication import Authentication
     from os import getenv
 
+    # Allow overriding SQL resource manager URI using environment variable
+    # for testing purposes. Subscription id is also determined by environment
+    # variable.
     sql_rm_override = getenv('_AZURE_CLI_SQL_RM_URI')
     if sql_rm_override:
         return SqlManagementClient(
             subscription_id=getenv('_AZURE_CLI_SQL_SUB_ID'),
             base_url=sql_rm_override,
-            credentials=Authentication())
+            credentials=Authentication())  # No authentication
     else:
+        # Normal production scenario.
         return get_mgmt_service_client(SqlManagementClient)
 
 

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_util.py
@@ -3,11 +3,21 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-
 def get_sql_management_client(_):
-    from azure.mgmt.sql import SqlManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(SqlManagementClient)
+    from azure.cli.core._profile import Profile, CLOUD
+    from azure.mgmt.sql import SqlManagementClient
+    from msrest.authentication import Authentication
+    from os import getenv
+
+    sql_rm_override = getenv('_AZURE_CLI_SQL_RM_URI')
+    if sql_rm_override:
+        return SqlManagementClient(
+            subscription_id=getenv('_AZURE_CLI_SQL_SUB_ID'),
+            base_url=sql_rm_override,
+            credentials=Authentication())
+    else:
+        return get_mgmt_service_client(SqlManagementClient)
 
 
 def get_sql_servers_operations(kwargs):


### PR DESCRIPTION
Use SQL RP URI and subscription id from environment variables in order to skip AAD and connect directly to the resource provider. This is used for SQL internal testing where there is no AAD/ARM frontend so the user has authority to use any subscription id.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
