### PR TITLE
Fix #2830 - subgroups incorrectly shows as commands in help

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -89,7 +89,7 @@ class Configuration(object):  # pylint: disable=too-few-public-methods
                     yield (cmd.name, cmd)
                 else:
                     dummy_cmdname = ' '.join((command_so_far, part))
-                    yield (dummy_cmdname, CliCommand(dummy_cmdname, lambda **kwargs: None))
+                    yield (dummy_cmdname, CliCommand(dummy_cmdname, None))
 
 
 class Application(object):

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -178,7 +178,11 @@ class AzCliCommandParser(argparse.ArgumentParser):
         self.exit()
 
     def is_group(self):
-        return getattr(self, '_subparsers', None) is not None
+        """ Determine if this parser instance represents a group
+            or a command. Anything that has a func default is considered
+            a group. This includes any dummy commands served up by the
+            "filter out irrelevant commands based on argv" command filter """
+        return not self._defaults.get('func', None)
 
     def __getattribute__(self, name):
         """ Since getting the description can be expensive (require module loads), we defer


### PR DESCRIPTION
Fixed regression introduced by the performance work that made the help subsystem confused about commands vs. command groups (we now replace command groups we know won't match the arguments passed in with a dummy command). 

Fixes #2830 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a ] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
