### PR TITLE
login: fix a failure when login twice using the same sp

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 2.0.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
+*core: fix a failure when login using a service principal twice (#2800)
 *core: Allow file path of accessTokens.json to be configurable through an env var(#2605)
 *core: Allow configured defaults to apply on optional args(#2703)
 *core: Improved performance

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -499,7 +499,7 @@ class CredsCache(object):
             # pylint: disable=line-too-long
             if (sp_entry.get(_ACCESS_TOKEN, None) != getattr(matched[0], _ACCESS_TOKEN, None) or
                     sp_entry.get(_SERVICE_PRINCIPAL_CERT_FILE, None) != getattr(matched[0], _SERVICE_PRINCIPAL_CERT_FILE, None)):
-                self._service_principal_creds.pop(matched[0])
+                self._service_principal_creds.remove(matched[0])
                 self._service_principal_creds.append(matched[0])
                 state_changed = True
         else:

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -584,7 +584,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     @mock.patch('os.fdopen', autospec=True)
     @mock.patch('os.open', autospec=True)
-    def test_credscache_add_pre_existing_sp_creds(self, _, mock_open_for_write, mock_read_file):
+    def test_credscache_add_preexisting_sp_creds(self, _, mock_open_for_write, mock_read_file):
         test_sp = {
             "servicePrincipalId": "myapp",
             "servicePrincipalTenant": "mytenant",

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -584,6 +584,25 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     @mock.patch('os.fdopen', autospec=True)
     @mock.patch('os.open', autospec=True)
+    def test_credscache_add_pre_existing_sp_creds(self, _, mock_open_for_write, mock_read_file):
+        test_sp = {
+            "servicePrincipalId": "myapp",
+            "servicePrincipalTenant": "mytenant",
+            "accessToken": "Secret"
+        }
+        mock_open_for_write.return_value = FileHandleStub()
+        mock_read_file.return_value = [test_sp]
+        creds_cache = CredsCache()
+
+        # action
+        creds_cache.save_service_principal_cred(test_sp)
+
+        # assert
+        self.assertEqual(creds_cache._service_principal_creds, [test_sp])
+
+    @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
+    @mock.patch('os.fdopen', autospec=True)
+    @mock.patch('os.open', autospec=True)
     def test_credscache_remove_creds(self, _, mock_open_for_write, mock_read_file):
         test_sp = {
             "servicePrincipalId": "myapp",


### PR DESCRIPTION
fix #2800 

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
