### PR TITLE
Performance: avoid loading adal/requests in order to get current subscription/user name

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -97,7 +97,7 @@ class CredentialType(Enum):  # pylint: disable=too-few-public-methods
 
 class ReadOnlyProfile(object):
 
-    def __init__(self, storage):
+    def __init__(self, storage=None):
         self._storage = storage or ACCOUNT
 
     def get_subscription(self, subscription=None):  # take id or name

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -127,7 +127,7 @@ class ReadOnlyProfile(object):
         except CLIError:
             raise CLIError('There are no active accounts.')
 
-        return active_account[_USER_ENTITY][_SUBSCRIPTION_ID]
+        return active_account[_SUBSCRIPTION_ID]
 
     def load_cached_subscriptions(self, all_clouds=False):
         subscriptions = self._storage.get(_SUBSCRIPTIONS) or []

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -285,8 +285,8 @@ def _get_installation_id():
 @decorators.call_once
 @decorators.suppress_all_exceptions(fallback_return=None)
 def _get_profile():
-    from azure.cli.core._profile import Profile
-    return Profile()
+    from azure.cli.core._profile import ReadOnlyProfile
+    return ReadOnlyProfile()
 
 
 @decorators.suppress_all_exceptions(fallback_return='')

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -322,7 +322,7 @@ def _get_env_string():
 
 @decorators.suppress_all_exceptions(fallback_return=None)
 def _get_azure_subscription_id():
-    return _get_profile().get_login_credentials()[1]
+    return _get_profile().get_current_subscription_id()
 
 
 def _get_shell_type():


### PR DESCRIPTION
Loading adal brings in requests. We don't need either if we are just going to read the current subscription/installationid. 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
