### PR TITLE
Performance: avoid loading adal and friends for telemetry purposes

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -9,7 +9,6 @@ import collections
 import errno
 import json
 import os.path
-from pprint import pformat
 from copy import deepcopy
 from enum import Enum
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -132,7 +132,7 @@ class Profile(object):
             self._creds_cache.save_service_principal_cred(sp_auth.get_entry_to_persist(username,
                                                                                        tenant))
 
-        if self._creds_cache.load_adal_token_cache().has_state_changed:
+        if self._creds_cache.adal_token_cache.has_state_changed:
             self._creds_cache.persist_cached_creds()
         consolidated = Profile._normalize_properties(self.subscription_finder.user_id,
                                                      subscriptions,
@@ -532,7 +532,7 @@ class CredsCache(object):
     def remove_cached_creds(self, user_or_sp):
         state_changed = False
         # clear AAD tokens
-        tokens = self.load_adal_token_cache().find({_TOKEN_ENTRY_USER_ID: user_or_sp})
+        tokens = self.adal_token_cache.find({_TOKEN_ENTRY_USER_ID: user_or_sp})
         if tokens:
             state_changed = True
             self.adal_token_cache.remove(tokens)

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -322,7 +322,7 @@ def _get_env_string():
 
 @decorators.suppress_all_exceptions(fallback_return=None)
 def _get_azure_subscription_id():
-    return _get_profile().get_login_credentials()[1]
+    return _get_profile().get_subscription_id()
 
 
 def _get_shell_type():

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -310,7 +310,6 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         token_type, token = cred._token_retriever()
         self.assertEqual(token, self.raw_token1)
         self.assertEqual(some_token_type, token_type)
-        self.assertEqual(mock_read_cred_file.call_count, 1)
         mock_get_token.assert_called_once_with(mock.ANY, self.user1, self.tenant_id,
                                                'https://management.core.windows.net/')
         self.assertEqual(mock_get_token.call_count, 1)
@@ -535,7 +534,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         creds_cache = CredsCache()
 
         # assert
-        token_entries = [entry for _, entry in creds_cache.adal_token_cache.read_items()]
+        token_entries = [entry for _, entry in creds_cache.load_adal_token_cache().read_items()]
         self.assertEqual(token_entries, [self.token_entry1])
         self.assertEqual(creds_cache._service_principal_creds, [test_sp])
 
@@ -550,6 +549,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
 
         # action
         creds_cache = CredsCache()
+        creds_cache.load_adal_token_cache()
 
         # assert
         self.assertEqual(creds_cache._service_principal_creds, [test_sp])

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -238,7 +238,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         storage_mock = {'subscriptions': []}
         profile = Profile(storage_mock)
         profile._management_resource_uri = 'https://management.core.windows.net/'
-        profile._subscription_finder = finder
+        profile._subscription_finder_attr = finder
         profile.find_subscriptions_on_login(False, '1234', 'my-secret', True, self.tenant_id)
         # action
         extended_info = profile.get_expanded_subscription_info()


### PR DESCRIPTION
We loaded adal modules even though we didn't need any credentials et.al. Refactored the Profile class a bit so we don't load them until they are actually needed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
