### PR TITLE
Support 'provider operation' commands

### DIFF
--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -2,8 +2,8 @@
 
 Release History
 ===============
-2.0.3 (unreleased)
-
+2.0.4 (unreleased)
+* Support 'provider operation' commands (#2908)
 * Support generic resource create (#2606)
 
 2.0.3 (2017-04-17)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
@@ -31,7 +31,7 @@ def _resource_links_client_factory(**_):
 def _authorization_management_client(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from azure.mgmt.authorization import AuthorizationManagementClient
-    return get_mgmt_service_client(AuthorizationManagementClient) # .provider_operations_metadata
+    return get_mgmt_service_client(AuthorizationManagementClient)
 
 
 def cf_resource_groups(_):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_client_factory.py
@@ -28,6 +28,12 @@ def _resource_links_client_factory(**_):
     from azure.cli.core.profiles import ResourceType
     return get_mgmt_service_client(ResourceType.MGMT_RESOURCE_LINKS)
 
+def _authorization_management_client(**_):
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    from azure.mgmt.authorization import AuthorizationManagementClient
+    return get_mgmt_service_client(AuthorizationManagementClient) # .provider_operations_metadata
+
+
 def cf_resource_groups(_):
     return _resource_client_factory().resource_groups
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -274,6 +274,18 @@ helps['provider unregister'] = """
     type: command
     short-summary: Unregister a provider.
 """
+helps['provider operation'] = """
+    type: group
+    short-summary: get provider operations.
+"""
+helps['provider operation show'] = """
+    type: command
+    short-summary: Get an individual provider's operations.
+"""
+helps['provider operation list'] = """
+    type: command
+    short-summary: Get operations from all providers.
+"""
 helps['tag'] = """
     type: group
     short-summary: Manage resource tags.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -276,7 +276,7 @@ helps['provider unregister'] = """
 """
 helps['provider operation'] = """
     type: group
-    short-summary: get provider operations.
+    short-summary: Get provider operations metadatas.
 """
 helps['provider operation show'] = """
     type: command

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -46,6 +46,8 @@ register_cli_argument('resource create', 'is_full_object', action='store_true',
 register_cli_argument('provider', 'top', ignore_type)
 register_cli_argument('provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), completer=get_providers_completion_list,
                       help=_PROVIDER_HELP_TEXT)
+register_cli_argument('provider operation', 'api_version', help="The api version of the 'Microsoft.Authorization/providerOperations' resource (omit for latest)")
+
 
 register_cli_argument('feature', 'resource_provider_namespace', options_list=('--namespace',), required=True, help=_PROVIDER_HELP_TEXT)
 register_cli_argument('feature list', 'resource_provider_namespace', options_list=('--namespace',), required=False, help=_PROVIDER_HELP_TEXT)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -59,7 +59,8 @@ cli_command(__name__, 'provider list', 'azure.mgmt.resource.resources.operations
 cli_command(__name__, 'provider show', 'azure.mgmt.resource.resources.operations.providers_operations#ProvidersOperations.get', cf_providers, exception_handler=empty_on_404)
 cli_command(__name__, 'provider register', 'azure.cli.command_modules.resource.custom#register_provider')
 cli_command(__name__, 'provider unregister', 'azure.cli.command_modules.resource.custom#unregister_provider')
-
+cli_command(__name__, 'provider operation list', 'azure.cli.command_modules.resource.custom#list_provider_operations')
+cli_command(__name__, 'provider operation show', 'azure.cli.command_modules.resource.custom#show_provider_operations')
 # Resource feature commands
 cli_command(__name__, 'feature list', 'azure.cli.command_modules.resource.custom#list_features', cf_features)
 cli_command(__name__, 'feature show', 'azure.mgmt.resource.features.operations.features_operations#FeaturesOperations.get', cf_features, exception_handler=empty_on_404)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -27,7 +27,8 @@ from azure.cli.core.profiles import get_sdk, ResourceType
 from ._client_factory import (_resource_client_factory,
                               _resource_policy_client_factory,
                               _resource_lock_client_factory,
-                              _resource_links_client_factory)
+                              _resource_links_client_factory,
+                              _authorization_management_client)
 
 logger = azlogging.get_az_logger(__name__)
 
@@ -351,6 +352,26 @@ def _update_provider(namespace, registering):
     action = 'Registering' if registering else 'Unregistering'
     msg_template = '%s is still on-going. You can monitor using \'az provider show -n %s\''
     logger.warning(msg_template, action, namespace)
+
+
+def list_provider_operations(api_version=None):
+    api_version = api_version or _get_auth_provider_latest_api_version()
+    auth_client = _authorization_management_client()
+    return auth_client.provider_operations_metadata.list(api_version)
+
+
+def show_provider_operations(resource_provider_namespace, api_version=None):
+    api_version = api_version or _get_auth_provider_latest_api_version()
+    auth_client = _authorization_management_client()
+    return auth_client.provider_operations_metadata.get(resource_provider_namespace, api_version)
+
+
+def _get_auth_provider_latest_api_version():
+    rcf = _resource_client_factory()
+    api_version = _ResourceUtils.resolve_api_version(rcf, 'Microsoft.Authorization',
+                                                     None, 'providerOperations')
+    return api_version
+
 
 def move_resource(ids, destination_group, destination_subscription_id=None):
     '''Moves resources from one resource group to another(can be under different subscription)
@@ -742,10 +763,10 @@ class _ResourceUtils(object): #pylint: disable=too-many-instance-attributes
             else:
                 _validate_resource_inputs(resource_group_name, resource_provider_namespace,
                                           resource_type, resource_name)
-                api_version = _ResourceUtils._resolve_api_version(self.rcf,
-                                                                  resource_provider_namespace,
-                                                                  parent_resource_path,
-                                                                  resource_type)
+                api_version = _ResourceUtils.resolve_api_version(self.rcf,
+                                                                 resource_provider_namespace,
+                                                                 parent_resource_path,
+                                                                 resource_type)
 
         self.resource_group_name = resource_group_name
         self.resource_provider_namespace = resource_provider_namespace
@@ -847,7 +868,7 @@ class _ResourceUtils(object): #pylint: disable=too-many-instance-attributes
                 parameters)
 
     @staticmethod
-    def _resolve_api_version(rcf, resource_provider_namespace, parent_resource_path, resource_type):
+    def resolve_api_version(rcf, resource_provider_namespace, parent_resource_path, resource_type):
         provider = rcf.providers.get(resource_provider_namespace)
 
         #If available, we will use parent resource's api-version
@@ -887,4 +908,4 @@ class _ResourceUtils(object): #pylint: disable=too-many-instance-attributes
             parent = None
             resource_type = parts['type']
 
-        return _ResourceUtils._resolve_api_version(rcf, namespace, parent, resource_type)
+        return _ResourceUtils.resolve_api_version(rcf, namespace, parent, resource_type)

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -27,6 +27,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-resource==1.0.0rc1',
     'azure-cli-core',
+    'azure-mgmt-authorization'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -27,7 +27,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-mgmt-resource==1.0.0rc1',
     'azure-cli-core',
-    'azure-mgmt-authorization'
+    'azure-mgmt-authorization==0.30.0rc6'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/command_modules/azure-cli-resource/tests/recordings/test_provider_operation.yaml
+++ b/src/command_modules/azure-cli-resource/tests/recordings/test_provider_operation.yaml
@@ -1,0 +1,428 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b0b09c36-24ae-11e7-b378-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization?api-version=2016-09-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 19 Apr 2017 03:17:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['1711']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b11a8248-24ae-11e7-a4df-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Authorization/providerOperations/microsoft.compute?api-version=2016-07-01&$expand=resourceTypes
+  response:
+    body: {string: '{"displayName":"Microsoft Compute","operations":[{"name":"Microsoft.Compute/register/action","displayName":"Register
+        Subscription for Compute","description":"Registers Subscription with Microsoft.Compute
+        resource provider","origin":"user,system","properties":null}],"resourceTypes":[{"name":"restorePointCollections","displayName":"Restore
+        Point Collections","operations":[{"name":"Microsoft.Compute/restorePointCollections/read","displayName":"Get
+        Restore Point Collection","description":"Get the properties of a restore point
+        collection","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/write","displayName":"Create
+        or Update Restore Point Collection","description":"Creates a new restore point
+        collection or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/delete","displayName":"Delete
+        Restore Point Collection","description":"Deletes the restore point collection
+        and contained restore points","origin":"user,system","properties":null}]},{"name":"restorePointCollections/restorePoints","displayName":"Restore
+        Points","operations":[{"name":"Microsoft.Compute/restorePointCollections/restorePoints/read","displayName":"Get
+        Restore Point","description":"Get the properties of a restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/write","displayName":"Create
+        Restore Point","description":"Creates a new restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/delete","displayName":"Delete
+        Restore Point","description":"Deletes the restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/retrieveSasUris/action","displayName":"Get
+        Restore Point along with blob SAS URIs","description":"Get the properties
+        of a restore point along with blob SAS URIs","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets","displayName":"Virtual
+        Machine Scale Sets","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/read","displayName":"Get
+        Virtual Machine Scale Set","description":"Get the properties of a virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/write","displayName":"Create
+        or Update Virtual Machine Scale Set","description":"Creates a new virtual
+        machine scale set or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/delete","displayName":"Delete
+        Virtual Machine Scale Set","description":"Deletes the virtual machine scale
+        set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/start/action","displayName":"Start
+        Virtual Machine Scale Set","description":"Starts the instances of the virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/powerOff/action","displayName":"Power
+        Off Virtual Machine Scale Set","description":"Powers off the instances of
+        the virtual machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/restart/action","displayName":"Restart
+        Virtual Machine Scale Set","description":"Restarts the instances of the virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/deallocate/action","displayName":"Deallocate
+        Virtual Machine Scale Set","description":"Powers off and releases the compute
+        resources for the instances of the virtual machine scale set ","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/manualUpgrade/action","displayName":"Manual
+        Upgrade Virtual Machine Scale Set","description":"Manually updates instances
+        to latest model of the virtual machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/scale/action","displayName":"Scale
+        Virtual Machine Scale Set","description":"Scale In/Scale Out instance count
+        of an existing virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine Scalet Set Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine Scalet Set Metric Definitions","description":"Reads Virtual
+        Machine Scalet Set Metric Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachineScaleSets/instanceView","displayName":"Virtual
+        Machine Scale Set Instance View","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/instanceView/read","displayName":"Get
+        Virtual Machine Scale Set Instance View","description":"Gets the instance
+        view of the virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/skus","displayName":"Virtual
+        Machine Scale Set SKU","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/skus/read","displayName":"List
+        SKUs for Virtual Machine Scale Set","description":"Lists the valid SKUs for
+        an existing virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/virtualMachines","displayName":"Virtual
+        Machine in Scale Set","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read","displayName":"Gets
+        the properties of a Virtual Machine in a Virtual Machine Scale Set","description":"Retrieves
+        the properties of a Virtual Machine in a VM Scale Set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/delete","displayName":"Delete
+        Virtual Machine in a Virtual Machine Scale Set","description":"Delete a specific
+        Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/start/action","displayName":"Start
+        Virtual Machine in a Virtual Machine Scale Set","description":"Starts a Virtual
+        Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/powerOff/action","displayName":"Power
+        off Virtual Machine in a Virtual Machine Scale Set","description":"Powers
+        Off a Virtual Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/restart/action","displayName":"Restart
+        Virtual Machine instance in a Virtual Machine Scale Set","description":"Restarts
+        a Virtual Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/deallocate/action","displayName":"Deallocate
+        Virtual Machine in a Virtual Machine Scale Set","description":"Powers off
+        and releases the compute resources for a Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/virtualMachines/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine in Scale Set Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine in Scale Set Metric Definitions","description":"Reads Virtual
+        Machine in Scale Set Metric Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachineScaleSets/virtualMachines/instanceView","displayName":"Instance
+        View of Virtual Machine in Scale Set","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/instanceView/read","displayName":"Gets
+        Instance View of a Virtual Machine in a Virtual Machine Scale Set","description":"Retrieves
+        the instance view of a Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null}]},{"name":"images","displayName":"Images","operations":[{"name":"Microsoft.Compute/images/read","displayName":"Get
+        Image","description":"Get the properties of the Image","origin":"user,system","properties":null},{"name":"Microsoft.Compute/images/write","displayName":"Create
+        or Update Image","description":"Creates a new Image or updates an existing
+        one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/images/delete","displayName":"Delete
+        Image","description":"Deletes the image","origin":"user,system","properties":null}]},{"name":"operations","displayName":"Available
+        Compute Operations","operations":[{"name":"Microsoft.Compute/operations/read","displayName":"List
+        Available Compute Operations","description":"Lists operations available on
+        Microsoft.Compute resource provider","origin":"user,system","properties":null}]},{"name":"disks","displayName":"Disks","operations":[{"name":"Microsoft.Compute/disks/read","displayName":"Get
+        Disk","description":"Get the properties of a Disk","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/write","displayName":"Create
+        or Update Disk","description":"Creates a new Disk or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/delete","displayName":"Delete
+        Disk","description":"Deletes the Disk","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/beginGetAccess/action","displayName":"Get
+        Disk SAS URI","description":"Get the SAS URI of the Disk for blob access","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/endGetAccess/action","displayName":"Revoke
+        Disk SAS URI","description":"Revoke the SAS URI of the Disk","origin":"user,system","properties":null}]},{"name":"snapshots","displayName":"Snapshots","operations":[{"name":"Microsoft.Compute/snapshots/read","displayName":"Get
+        Snapshot","description":"Get the properties of a Snapshot","origin":"user,system","properties":null},{"name":"Microsoft.Compute/snapshots/write","displayName":"Create
+        or Update Snapshot","description":"Create a new Snapshot or update an existing
+        one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/snapshots/delete","displayName":"Delete
+        Snapshot","description":"Delete a Snapshot","origin":"user,system","properties":null}]},{"name":"availabilitySets","displayName":"Availability
+        Sets","operations":[{"name":"Microsoft.Compute/availabilitySets/read","displayName":"Get
+        Availablity Set","description":"Get the properties of an availability set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/availabilitySets/write","displayName":"Create
+        or Update Availability Set","description":"Creates a new availability set
+        or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/availabilitySets/delete","displayName":"Delete
+        Availability Set","description":"Deletes the availability set","origin":"user,system","properties":null}]},{"name":"availabilitySets/vmSizes","displayName":"Virtual
+        Machine Size for Availability set","operations":[{"name":"Microsoft.Compute/availabilitySets/vmSizes/read","displayName":"List
+        Virtual Machine Sizes for Availability Set","description":"List available
+        sizes for creating or updating a virtual machine in the availability set","origin":"user,system","properties":null}]},{"name":"virtualMachines","displayName":"Virtual
+        Machines","operations":[{"name":"Microsoft.Compute/virtualMachines/read","displayName":"Get
+        Virtual Machine","description":"Get the properties of a virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/write","displayName":"Create
+        or Update Virtual Machine","description":"Creates a new virtual machine or
+        updates an existing virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/delete","displayName":"Delete
+        Virtual Machine","description":"Deletes the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/start/action","displayName":"Start
+        Virtual Machine","description":"Starts the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/powerOff/action","displayName":"Power
+        Off Virtual Machine","description":"Powers off the virtual machine. Note that
+        the virtual machine will continue to be billed.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/redeploy/action","displayName":"Redeploy
+        Virtual Machine","description":"Redeploys virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/restart/action","displayName":"Restart
+        Virtual Machine","description":"Restarts the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/deallocate/action","displayName":"Deallocate
+        Virtual Machine","description":"Powers off the virtual machine and releases
+        the compute resources","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/generalize/action","displayName":"Generalize
+        Virtual Machine","description":"Sets the virtual machine state to Generalized
+        and prepares the virtual machine for capture","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/capture/action","displayName":"Capture
+        Virtual Machine","description":"Captures the virtual machine by copying virtual
+        hard disks and generates a template that can be used to create similar virtual
+        machines","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/convertToManagedDisks/action","displayName":"Convert
+        Virtual Machine disks to Managed Disks","description":"Converts the blob based
+        disks of the virtual machine to managed disks","origin":"user,system","properties":null}]},{"name":"virtualMachines/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine Metric Definitions","description":"Reads Virtual Machine Metric
+        Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachines/vmSizes","displayName":"Virtual
+        Machine Size","operations":[{"name":"Microsoft.Compute/virtualMachines/vmSizes/read","displayName":"Lists
+        Available Virtual Machine Sizes","description":"Lists available sizes the
+        virtual machine can be updated to","origin":"user,system","properties":null}]},{"name":"virtualMachines/instanceView","displayName":"Virtual
+        Machine Instance View","operations":[{"name":"Microsoft.Compute/virtualMachines/instanceView/read","displayName":"Get
+        Virtual Machine Instance View","description":"Gets the detailed runtime status
+        of the virtual machine and its resources","origin":"user,system","properties":null}]},{"name":"virtualMachines/extensions","displayName":"Virtual
+        Machine Extensions","operations":[{"name":"Microsoft.Compute/virtualMachines/extensions/read","displayName":"Get
+        Virtual Machine Extension","description":"Get the properties of a virtual
+        machine extension","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/extensions/write","displayName":"Create
+        or Update Virtual Machine Extension","description":"Creates a new virtual
+        machine extension or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/extensions/delete","displayName":"Delete
+        Virtual Machine Extension","description":"Deletes the virtual machine extension","origin":"user,system","properties":null}]},{"name":"locations/vmSizes","displayName":"Virtual
+        Machine Sizes","operations":[{"name":"Microsoft.Compute/locations/vmSizes/read","displayName":"List
+        Available Virtual Machine Sizes in Location","description":"Lists available
+        virtual machine sizes in a location","origin":"user,system","properties":null}]},{"name":"locations/usages","displayName":"Usage
+        Metrics","operations":[{"name":"Microsoft.Compute/locations/usages/read","displayName":"Get
+        Usage Metrics","description":"Gets service limits and current usage quantities
+        for the subscription''s compute resources in a location","origin":"user,system","properties":null}]},{"name":"locations/operations","displayName":"Operation","operations":[{"name":"Microsoft.Compute/locations/operations/read","displayName":"Get
+        Operation","description":"Gets the status of an asynchronous operation","origin":"user,system","properties":null}]}],"id":"/providers/Microsoft.Authorization/providerOperations/Microsoft.Compute","type":"Microsoft.Authorization/providerOperations","name":"Microsoft.Compute"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 19 Apr 2017 03:17:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['20896']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b1821cb8-24ae-11e7-a4ab-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Authorization/providerOperations/microsoft.compute?api-version=2015-07-01&$expand=resourceTypes
+  response:
+    body: {string: '{"displayName":"Microsoft Compute","operations":[{"name":"Microsoft.Compute/register/action","displayName":"Register
+        Subscription for Compute","description":"Registers Subscription with Microsoft.Compute
+        resource provider","origin":"user,system","properties":null}],"resourceTypes":[{"name":"restorePointCollections","displayName":"Restore
+        Point Collections","operations":[{"name":"Microsoft.Compute/restorePointCollections/read","displayName":"Get
+        Restore Point Collection","description":"Get the properties of a restore point
+        collection","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/write","displayName":"Create
+        or Update Restore Point Collection","description":"Creates a new restore point
+        collection or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/delete","displayName":"Delete
+        Restore Point Collection","description":"Deletes the restore point collection
+        and contained restore points","origin":"user,system","properties":null}]},{"name":"restorePointCollections/restorePoints","displayName":"Restore
+        Points","operations":[{"name":"Microsoft.Compute/restorePointCollections/restorePoints/read","displayName":"Get
+        Restore Point","description":"Get the properties of a restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/write","displayName":"Create
+        Restore Point","description":"Creates a new restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/delete","displayName":"Delete
+        Restore Point","description":"Deletes the restore point","origin":"user,system","properties":null},{"name":"Microsoft.Compute/restorePointCollections/restorePoints/retrieveSasUris/action","displayName":"Get
+        Restore Point along with blob SAS URIs","description":"Get the properties
+        of a restore point along with blob SAS URIs","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets","displayName":"Virtual
+        Machine Scale Sets","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/read","displayName":"Get
+        Virtual Machine Scale Set","description":"Get the properties of a virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/write","displayName":"Create
+        or Update Virtual Machine Scale Set","description":"Creates a new virtual
+        machine scale set or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/delete","displayName":"Delete
+        Virtual Machine Scale Set","description":"Deletes the virtual machine scale
+        set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/start/action","displayName":"Start
+        Virtual Machine Scale Set","description":"Starts the instances of the virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/powerOff/action","displayName":"Power
+        Off Virtual Machine Scale Set","description":"Powers off the instances of
+        the virtual machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/restart/action","displayName":"Restart
+        Virtual Machine Scale Set","description":"Restarts the instances of the virtual
+        machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/deallocate/action","displayName":"Deallocate
+        Virtual Machine Scale Set","description":"Powers off and releases the compute
+        resources for the instances of the virtual machine scale set ","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/manualUpgrade/action","displayName":"Manual
+        Upgrade Virtual Machine Scale Set","description":"Manually updates instances
+        to latest model of the virtual machine scale set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/scale/action","displayName":"Scale
+        Virtual Machine Scale Set","description":"Scale In/Scale Out instance count
+        of an existing virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine Scalet Set Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine Scalet Set Metric Definitions","description":"Reads Virtual
+        Machine Scalet Set Metric Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachineScaleSets/instanceView","displayName":"Virtual
+        Machine Scale Set Instance View","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/instanceView/read","displayName":"Get
+        Virtual Machine Scale Set Instance View","description":"Gets the instance
+        view of the virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/skus","displayName":"Virtual
+        Machine Scale Set SKU","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/skus/read","displayName":"List
+        SKUs for Virtual Machine Scale Set","description":"Lists the valid SKUs for
+        an existing virtual machine scale set","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/virtualMachines","displayName":"Virtual
+        Machine in Scale Set","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read","displayName":"Gets
+        the properties of a Virtual Machine in a Virtual Machine Scale Set","description":"Retrieves
+        the properties of a Virtual Machine in a VM Scale Set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/delete","displayName":"Delete
+        Virtual Machine in a Virtual Machine Scale Set","description":"Delete a specific
+        Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/start/action","displayName":"Start
+        Virtual Machine in a Virtual Machine Scale Set","description":"Starts a Virtual
+        Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/powerOff/action","displayName":"Power
+        off Virtual Machine in a Virtual Machine Scale Set","description":"Powers
+        Off a Virtual Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/restart/action","displayName":"Restart
+        Virtual Machine instance in a Virtual Machine Scale Set","description":"Restarts
+        a Virtual Machine instance in a VM Scale Set.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/deallocate/action","displayName":"Deallocate
+        Virtual Machine in a Virtual Machine Scale Set","description":"Powers off
+        and releases the compute resources for a Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null}]},{"name":"virtualMachineScaleSets/virtualMachines/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine in Scale Set Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine in Scale Set Metric Definitions","description":"Reads Virtual
+        Machine in Scale Set Metric Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachineScaleSets/virtualMachines/instanceView","displayName":"Instance
+        View of Virtual Machine in Scale Set","operations":[{"name":"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/instanceView/read","displayName":"Gets
+        Instance View of a Virtual Machine in a Virtual Machine Scale Set","description":"Retrieves
+        the instance view of a Virtual Machine in a VM Scale Set.","origin":"user,system","properties":null}]},{"name":"images","displayName":"Images","operations":[{"name":"Microsoft.Compute/images/read","displayName":"Get
+        Image","description":"Get the properties of the Image","origin":"user,system","properties":null},{"name":"Microsoft.Compute/images/write","displayName":"Create
+        or Update Image","description":"Creates a new Image or updates an existing
+        one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/images/delete","displayName":"Delete
+        Image","description":"Deletes the image","origin":"user,system","properties":null}]},{"name":"operations","displayName":"Available
+        Compute Operations","operations":[{"name":"Microsoft.Compute/operations/read","displayName":"List
+        Available Compute Operations","description":"Lists operations available on
+        Microsoft.Compute resource provider","origin":"user,system","properties":null}]},{"name":"disks","displayName":"Disks","operations":[{"name":"Microsoft.Compute/disks/read","displayName":"Get
+        Disk","description":"Get the properties of a Disk","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/write","displayName":"Create
+        or Update Disk","description":"Creates a new Disk or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/delete","displayName":"Delete
+        Disk","description":"Deletes the Disk","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/beginGetAccess/action","displayName":"Get
+        Disk SAS URI","description":"Get the SAS URI of the Disk for blob access","origin":"user,system","properties":null},{"name":"Microsoft.Compute/disks/endGetAccess/action","displayName":"Revoke
+        Disk SAS URI","description":"Revoke the SAS URI of the Disk","origin":"user,system","properties":null}]},{"name":"snapshots","displayName":"Snapshots","operations":[{"name":"Microsoft.Compute/snapshots/read","displayName":"Get
+        Snapshot","description":"Get the properties of a Snapshot","origin":"user,system","properties":null},{"name":"Microsoft.Compute/snapshots/write","displayName":"Create
+        or Update Snapshot","description":"Create a new Snapshot or update an existing
+        one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/snapshots/delete","displayName":"Delete
+        Snapshot","description":"Delete a Snapshot","origin":"user,system","properties":null}]},{"name":"availabilitySets","displayName":"Availability
+        Sets","operations":[{"name":"Microsoft.Compute/availabilitySets/read","displayName":"Get
+        Availablity Set","description":"Get the properties of an availability set","origin":"user,system","properties":null},{"name":"Microsoft.Compute/availabilitySets/write","displayName":"Create
+        or Update Availability Set","description":"Creates a new availability set
+        or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/availabilitySets/delete","displayName":"Delete
+        Availability Set","description":"Deletes the availability set","origin":"user,system","properties":null}]},{"name":"availabilitySets/vmSizes","displayName":"Virtual
+        Machine Size for Availability set","operations":[{"name":"Microsoft.Compute/availabilitySets/vmSizes/read","displayName":"List
+        Virtual Machine Sizes for Availability Set","description":"List available
+        sizes for creating or updating a virtual machine in the availability set","origin":"user,system","properties":null}]},{"name":"virtualMachines","displayName":"Virtual
+        Machines","operations":[{"name":"Microsoft.Compute/virtualMachines/read","displayName":"Get
+        Virtual Machine","description":"Get the properties of a virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/write","displayName":"Create
+        or Update Virtual Machine","description":"Creates a new virtual machine or
+        updates an existing virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/delete","displayName":"Delete
+        Virtual Machine","description":"Deletes the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/start/action","displayName":"Start
+        Virtual Machine","description":"Starts the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/powerOff/action","displayName":"Power
+        Off Virtual Machine","description":"Powers off the virtual machine. Note that
+        the virtual machine will continue to be billed.","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/redeploy/action","displayName":"Redeploy
+        Virtual Machine","description":"Redeploys virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/restart/action","displayName":"Restart
+        Virtual Machine","description":"Restarts the virtual machine","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/deallocate/action","displayName":"Deallocate
+        Virtual Machine","description":"Powers off the virtual machine and releases
+        the compute resources","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/generalize/action","displayName":"Generalize
+        Virtual Machine","description":"Sets the virtual machine state to Generalized
+        and prepares the virtual machine for capture","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/capture/action","displayName":"Capture
+        Virtual Machine","description":"Captures the virtual machine by copying virtual
+        hard disks and generates a template that can be used to create similar virtual
+        machines","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/convertToManagedDisks/action","displayName":"Convert
+        Virtual Machine disks to Managed Disks","description":"Converts the blob based
+        disks of the virtual machine to managed disks","origin":"user,system","properties":null}]},{"name":"virtualMachines/providers/Microsoft.Insights/metricDefinitions","displayName":"Virtual
+        Machine Metric Definitions","operations":[{"name":"Microsoft.Compute/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read","displayName":"Get
+        Virtual Machine Metric Definitions","description":"Reads Virtual Machine Metric
+        Definitions","origin":"system","properties":{"serviceSpecification":{"metricSpecifications":[{"name":"Percentage
+        CPU","displayName":"Percentage CPU","displayDescription":"The percentage of
+        allocated compute units that are currently in use by the Virtual Machine(s)","unit":"Percent","aggregationType":"Average"},{"name":"Network
+        In","displayName":"Network In","displayDescription":"The number of bytes received
+        on all network interfaces by the Virtual Machine(s) (Incoming Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Network
+        Out","displayName":"Network Out","displayDescription":"The number of bytes
+        out on all network interfaces by the Virtual Machine(s) (Outgoing Traffic)","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Bytes","displayName":"Disk Read Bytes","displayDescription":"Total bytes
+        read from disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Write Bytes","displayName":"Disk Write Bytes","displayDescription":"Total
+        bytes written to disk during monitoring period","unit":"Bytes","aggregationType":"Total"},{"name":"Disk
+        Read Operations/Sec","displayName":"Disk Read Operations/Sec","displayDescription":"Disk
+        Read IOPS","unit":"CountPerSecond","aggregationType":"Average"},{"name":"Disk
+        Write Operations/Sec","displayName":"Disk Write Operations/Sec","displayDescription":"Disk
+        Write IOPS","unit":"CountPerSecond","aggregationType":"Average"}]}}}]},{"name":"virtualMachines/vmSizes","displayName":"Virtual
+        Machine Size","operations":[{"name":"Microsoft.Compute/virtualMachines/vmSizes/read","displayName":"Lists
+        Available Virtual Machine Sizes","description":"Lists available sizes the
+        virtual machine can be updated to","origin":"user,system","properties":null}]},{"name":"virtualMachines/instanceView","displayName":"Virtual
+        Machine Instance View","operations":[{"name":"Microsoft.Compute/virtualMachines/instanceView/read","displayName":"Get
+        Virtual Machine Instance View","description":"Gets the detailed runtime status
+        of the virtual machine and its resources","origin":"user,system","properties":null}]},{"name":"virtualMachines/extensions","displayName":"Virtual
+        Machine Extensions","operations":[{"name":"Microsoft.Compute/virtualMachines/extensions/read","displayName":"Get
+        Virtual Machine Extension","description":"Get the properties of a virtual
+        machine extension","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/extensions/write","displayName":"Create
+        or Update Virtual Machine Extension","description":"Creates a new virtual
+        machine extension or updates an existing one","origin":"user,system","properties":null},{"name":"Microsoft.Compute/virtualMachines/extensions/delete","displayName":"Delete
+        Virtual Machine Extension","description":"Deletes the virtual machine extension","origin":"user,system","properties":null}]},{"name":"locations/vmSizes","displayName":"Virtual
+        Machine Sizes","operations":[{"name":"Microsoft.Compute/locations/vmSizes/read","displayName":"List
+        Available Virtual Machine Sizes in Location","description":"Lists available
+        virtual machine sizes in a location","origin":"user,system","properties":null}]},{"name":"locations/usages","displayName":"Usage
+        Metrics","operations":[{"name":"Microsoft.Compute/locations/usages/read","displayName":"Get
+        Usage Metrics","description":"Gets service limits and current usage quantities
+        for the subscription''s compute resources in a location","origin":"user,system","properties":null}]},{"name":"locations/operations","displayName":"Operation","operations":[{"name":"Microsoft.Compute/locations/operations/read","displayName":"Get
+        Operation","description":"Gets the status of an asynchronous operation","origin":"user,system","properties":null}]}],"id":"/providers/Microsoft.Authorization/providerOperations/Microsoft.Compute","type":"Microsoft.Authorization/providerOperations","name":"Microsoft.Compute"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 19 Apr 2017 03:17:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['20896']
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/tests/test_resource.py
@@ -262,6 +262,25 @@ class ProviderRegistrationTest(VCRTestBase): # Not RG test base because it opera
             result = self.cmd('provider show -n {}'.format(provider))
             self.assertTrue(result['registrationState'] in ['Registering', 'Registered'])
 
+
+class ProviderOperationTest(VCRTestBase): # Not RG test base because it operates only on the subscription
+    def __init__(self, test_method):
+        super(ProviderOperationTest, self).__init__(__file__, test_method)
+
+    def test_provider_operation(self):
+        self.execute()
+
+    def body(self):
+        self.cmd('provider operation show --namespace microsoft.compute', checks=[
+            JMESPathCheck('id', '/providers/Microsoft.Authorization/providerOperations/Microsoft.Compute'),
+            JMESPathCheck('type', 'Microsoft.Authorization/providerOperations')
+        ]) 
+        self.cmd('provider operation show --namespace microsoft.compute --api-version 2015-07-01', checks=[
+            JMESPathCheck('id', '/providers/Microsoft.Authorization/providerOperations/Microsoft.Compute'),
+            JMESPathCheck('type', 'Microsoft.Authorization/providerOperations')
+        ])
+
+
 class DeploymentTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
         super(DeploymentTest, self).__init__(__file__, test_method, resource_group='azure-cli-deployment-test')


### PR DESCRIPTION
Fix #2908 
I thought for a while and felt the `azure-cli-resource` command module is a better place  than the `azure-cli-role` module because other `provider` commands are already there. Having a command module depend on multiple SDK packages is not a new thing and we have done it on other command modules as well.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
