### PR TITLE
Help examples can specify the profiles they belong to

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -11,6 +11,7 @@ import azure.cli.core.azlogging as azlogging
 from azure.cli.core._config import \
     (GLOBAL_CONFIG_DIR, GLOBAL_CONFIG_PATH, set_global_config_value, get_config_parser)
 from azure.cli.core.util import CLIError
+from azure.cli.core.profiles import API_PROFILES
 
 CLOUD_CONFIG_FILE = os.path.join(GLOBAL_CONFIG_DIR, 'clouds.config')
 
@@ -256,6 +257,10 @@ def get_clouds():
                 setattr(c.suffixes, option.replace('suffix_', ''), config.get(section, option))
         if c.profile is None:
             # If profile isn't set, use latest
+            setattr(c, 'profile', 'latest')
+        if c.profile not in API_PROFILES:
+            # The profile doesn't exist. Maybe it was renamed or is user error.
+            logger.info('Profile %s does not exist, using latest.', c.profile)
             setattr(c, 'profile', 'latest')
         if not c.endpoints.has_endpoint_set('management') and \
                 c.endpoints.has_endpoint_set('resource_manager'):

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -259,9 +259,7 @@ def get_clouds():
             # If profile isn't set, use latest
             setattr(c, 'profile', 'latest')
         if c.profile not in API_PROFILES:
-            # The profile doesn't exist. Maybe it was renamed or is user error.
-            logger.info('Profile %s does not exist, using latest.', c.profile)
-            setattr(c, 'profile', 'latest')
+            raise CLIError('Profile {} does not exist or is not supported.'.format(c.profile))
         if not c.endpoints.has_endpoint_set('management') and \
                 c.endpoints.has_endpoint_set('resource_manager'):
             # If management endpoint not set, use resource manager endpoint

--- a/src/azure-cli-core/azure/cli/core/profiles/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/__init__.py
@@ -13,8 +13,8 @@ from azure.cli.core.profiles._shared import (AZURE_API_PROFILES,
 # API Profiles currently supported in the CLI.
 API_PROFILES = {
     'latest': AZURE_API_PROFILES['latest'],
-    '2016-sample': AZURE_API_PROFILES['2016-sample'],
-    '2015-sample': AZURE_API_PROFILES['2015-sample']
+    '2016-00-00-preview': AZURE_API_PROFILES['2016-00-00-preview'],
+    '2015-00-00-preview': AZURE_API_PROFILES['2015-00-00-preview']
 }
 
 
@@ -31,6 +31,8 @@ def get_api_version(resource_type):
 
 def supported_api_version(resource_type, min_api=None, max_api=None):
     """ Method to check if the current API version for a given resource_type is supported.
+        If resource_type is set to None, the current profile version will be used as the basis of
+        the comparison.
 
     :param resource_type: The resource type.
     :type resource_type: ResourceType.

--- a/src/azure-cli-core/tests/test_cloud.py
+++ b/src/azure-cli-core/tests/test_cloud.py
@@ -19,6 +19,7 @@ from azure.cli.core.cloud import (Cloud,
                                   CloudEndpointNotSetException)
 from azure.cli.core._config import get_config_parser
 from azure.cli.core._profile import Profile
+from azure.cli.core.util import CLIError
 
 
 class TestCloud(unittest.TestCase):
@@ -79,9 +80,8 @@ class TestCloud(unittest.TestCase):
                              c.profile)
 
     def test_add_get_cloud_with_invalid_profile(self):
-        ''' Cloud has profile that doesn't exist so we default to latest '''
+        ''' Cloud has profile that doesn't exist so an exception should be raised '''
         profile = 'none-existent-profile'
-        default_profile = 'latest'
         c = Cloud('MyOwnCloud', profile=profile)
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as\
                 config_file:
@@ -90,10 +90,8 @@ class TestCloud(unittest.TestCase):
             config.read(config_file)
             self.assertTrue(c.name in config.sections())
             self.assertEqual(config.get(c.name, 'profile'), profile)
-            custom_clouds = get_custom_clouds()
-            self.assertEqual(len(custom_clouds), 1)
-            self.assertEqual(custom_clouds[0].name, c.name)
-            self.assertEqual(custom_clouds[0].profile, default_profile)
+            with self.assertRaises(CLIError):
+                get_custom_clouds()
 
     def test_get_default_latest_profile(self):
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]):
@@ -106,7 +104,7 @@ class TestCloud(unittest.TestCase):
         endpoint_rm = 'http://management.contoso.com'
         endpoint_mgmt = 'http://management.core.contoso.com'
         endpoints = CloudEndpoints(resource_manager=endpoint_rm, management=endpoint_mgmt)
-        profile = '2017-01-01-test'
+        profile = '2016-00-00-preview'
         c = Cloud('MyOwnCloud', endpoints=endpoints, profile=profile)
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]):
             add_cloud(c)
@@ -123,7 +121,7 @@ class TestCloud(unittest.TestCase):
             if only ARM endpoint is set '''
         endpoint_rm = 'http://management.contoso.com'
         endpoints = CloudEndpoints(resource_manager=endpoint_rm)
-        profile = '2017-01-01-test'
+        profile = '2016-00-00-preview'
         c = Cloud('MyOwnCloud', endpoints=endpoints, profile=profile)
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]):
             add_cloud(c)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -65,10 +65,12 @@ helps['storage account create'] = """
     type: command
     short-summary: Creates a storage account.
     examples:
-        - name: Create a storage account with minimal options.
+        - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
-        - name: Create a storage account saccount1 in resource group rg1 in the West US region with locally redundant storage.
-          text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
+          min_profile: 2016-00-00-preview
+        - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
+          text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
+          max_profile: 2015-00-00-preview
 """
 
 helps['storage container create'] = """
@@ -79,11 +81,6 @@ helps['storage container create'] = """
           text: az storage container create -n MyStorageContainer
         - name: Create a storage container in a storage account and return an error if the container already exists.
           text: az storage container create -n MyStorageContainer --fail-on-exist
-"""
-
-helps['storage account create'] = """
-    type: command
-    short-summary: Create a storage account.
 """
 
 helps['storage account list'] = """


### PR DESCRIPTION
- Specify `min_profile` and/or `max_profile` on any help examples you want to only appear for given profiles.
- Currently implemented for `storage account create -h`

Other changes:
- Change sample profiles to be dates instead of just YYYY-sample.
- API version comparison function supports 'latest'
- Default to 'latest' if a given profile version is not valid.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
