### PR TITLE
Declarative api versions for cli_command

### DIFF
--- a/doc/authoring_command_modules/authoring_commands.md
+++ b/doc/authoring_command_modules/authoring_commands.md
@@ -44,6 +44,7 @@ You will generally only specify `name`, `operation` and possibly `table_transfor
       - For example if `operation='azure.mgmt.compute.operations.virtual_machines_operations#VirtualMachinesOperations.get'`, the CLI will import `azure.mgmt.compute.operations.virtual_machines_operations`, get the `VirtualMachinesOperations` attribute and then the `get` attribute of `VirtualMachinesOperations`.
   - `table_transformer` (optional) - Supply a callable that takes, transforms and returns a result for table output.
   - `confirmation` (optional) - Supply True to enable default confirmation. Alternatively, supply a callable that takes the command arguments as a dict and returning a boolean. Alternatively, supply a string for the prompt.
+  - `version_constraint` (optional) - Supply a VersionConstraint object if this command only applies for a range of API versions.
 
 At this point, you should be able to access your command using `az [name]` and access the built-in help with `az [name] -h/--help`. Your command will automatically be 'wired up' with the global parameters.
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -6,7 +6,7 @@
 # pylint: disable=line-too-long
 
 from azure.cli.core.commands.arm import cli_generic_update_command, cli_generic_wait_command
-from azure.cli.core.commands import DeploymentOutputLongRunningOperation, cli_command
+from azure.cli.core.commands import DeploymentOutputLongRunningOperation, cli_command, VersionConstraint
 from ._client_factory import * # pylint: disable=wildcard-import, unused-wildcard-import
 from azure.cli.core.util import empty_on_404
 
@@ -22,7 +22,7 @@ from ._format import \
      transform_vpn_connection, transform_vpn_connection_list,
      transform_vpn_connection_create_output)
 
-from azure.cli.core.profiles import supported_api_version, ResourceType
+from azure.cli.core.profiles import ResourceType
 
 custom_path = 'azure.cli.command_modules.network.custom#{}'
 
@@ -34,8 +34,7 @@ cli_command(__name__, 'network application-gateway list', custom_path.format('li
 cli_command(__name__, 'network application-gateway start', 'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.start', cf_application_gateways)
 cli_command(__name__, 'network application-gateway stop', 'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.stop', cf_application_gateways)
 
-if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-    cli_command(__name__, 'network application-gateway show-backend-health', 'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.backend_health', cf_application_gateways)
+cli_command(__name__, 'network application-gateway show-backend-health', 'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.backend_health', cf_application_gateways, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 
 cli_generic_update_command(__name__, 'network application-gateway update',
                            'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.get',
@@ -102,25 +101,24 @@ cli_generic_update_command(__name__, 'network express-route peering update',
                            custom_function_op=custom_path.format('update_express_route_peering'))
 cli_command(__name__, 'network express-route peering create', custom_path.format('create_express_route_peering'), cf_express_route_circuit_peerings)
 
-if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-    # ExpressRouteCircuitsOperations
-    cli_command(__name__, 'network express-route delete', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.delete', cf_express_route_circuits, no_wait_param='raw')
-    cli_command(__name__, 'network express-route show', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits, exception_handler=empty_on_404)
-    cli_command(__name__, 'network express-route get-stats', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get_stats', cf_express_route_circuits)
-    cli_command(__name__, 'network express-route list-arp-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_arp_table', cf_express_route_circuits)
-    cli_command(__name__, 'network express-route list-route-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_routes_table', cf_express_route_circuits)
-    cli_command(__name__, 'network express-route create', custom_path.format('create_express_route'), no_wait_param='no_wait')
-    cli_command(__name__, 'network express-route list', custom_path.format('list_express_route_circuits'))
-    cli_generic_update_command(__name__, 'network express-route update',
-                               'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get',
-                               'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.create_or_update',
-                               cf_express_route_circuits,
-                               custom_function_op=custom_path.format('update_express_route'),
-                               no_wait_param='raw')
-    cli_generic_wait_command(__name__, 'network express-route wait', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits)
+# ExpressRouteCircuitsOperations
+cli_command(__name__, 'network express-route delete', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.delete', cf_express_route_circuits, no_wait_param='raw', version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route show', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits, exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route get-stats', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get_stats', cf_express_route_circuits, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route list-arp-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_arp_table', cf_express_route_circuits, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route list-route-tables', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.list_routes_table', cf_express_route_circuits, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route create', custom_path.format('create_express_route'), no_wait_param='no_wait', version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network express-route list', custom_path.format('list_express_route_circuits'), version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_generic_update_command(__name__, 'network express-route update',
+                           'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get',
+                           'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.create_or_update',
+                           cf_express_route_circuits,
+                           custom_function_op=custom_path.format('update_express_route'),
+                           no_wait_param='raw', version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_generic_wait_command(__name__, 'network express-route wait', 'azure.mgmt.network.operations.express_route_circuits_operations#ExpressRouteCircuitsOperations.get', cf_express_route_circuits, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 
-    # ExpressRouteServiceProvidersOperations
-    cli_command(__name__, 'network express-route list-service-providers', 'azure.mgmt.network.operations.express_route_service_providers_operations#ExpressRouteServiceProvidersOperations.list', cf_express_route_service_providers)
+# ExpressRouteServiceProvidersOperations
+cli_command(__name__, 'network express-route list-service-providers', 'azure.mgmt.network.operations.express_route_service_providers_operations#ExpressRouteServiceProvidersOperations.list', cf_express_route_service_providers, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 
 # LoadBalancersOperations
 cli_command(__name__, 'network lb create', custom_path.format('create_load_balancer'), transform=DeploymentOutputLongRunningOperation('Starting network lb create'), no_wait_param='no_wait')
@@ -205,9 +203,9 @@ cli_generic_update_command(__name__, 'network nic update',
                            'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.create_or_update',
                            cf_network_interfaces,
                            custom_function_op=custom_path.format('update_nic'))
-if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-    cli_command(__name__, 'network nic show-effective-route-table', 'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.get_effective_route_table', cf_network_interfaces)
-    cli_command(__name__, 'network nic list-effective-nsg', 'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.list_effective_network_security_groups', cf_network_interfaces)
+
+cli_command(__name__, 'network nic show-effective-route-table', 'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.get_effective_route_table', cf_network_interfaces, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network nic list-effective-nsg', 'azure.mgmt.network.operations.network_interfaces_operations#NetworkInterfacesOperations.list_effective_network_security_groups', cf_network_interfaces, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 
 resource = 'network_interfaces'
 subresource = 'ip_configurations'
@@ -339,8 +337,8 @@ cli_command(__name__, 'network vnet-gateway revoked-cert delete', custom_path.fo
 cli_command(__name__, 'network vnet delete', 'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.delete', cf_virtual_networks)
 cli_command(__name__, 'network vnet show', 'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.get', cf_virtual_networks, exception_handler=empty_on_404)
 cli_command(__name__, 'network vnet list', custom_path.format('list_vnet'))
-if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-    cli_command(__name__, 'network vnet check-ip-address', 'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.check_ip_address_availability', cf_virtual_networks)
+
+cli_command(__name__, 'network vnet check-ip-address', 'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.check_ip_address_availability', cf_virtual_networks, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 cli_command(__name__, 'network vnet create', custom_path.format('create_vnet'), transform=transform_vnet_create_output)
 cli_generic_update_command(__name__, 'network vnet update',
                            'azure.mgmt.network.operations.virtual_networks_operations#VirtualNetworksOperations.get',
@@ -348,17 +346,16 @@ cli_generic_update_command(__name__, 'network vnet update',
                            cf_virtual_networks,
                            custom_function_op=custom_path.format('update_vnet'))
 
-if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-    # VNET Peering Operations
-    cli_command(__name__, 'network vnet peering create', custom_path.format('create_vnet_peering'))
-    cli_command(__name__, 'network vnet peering show', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.get', cf_virtual_network_peerings, exception_handler=empty_on_404)
-    cli_command(__name__, 'network vnet peering list', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.list', cf_virtual_network_peerings)
-    cli_command(__name__, 'network vnet peering delete', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.delete', cf_virtual_network_peerings)
-    cli_generic_update_command(__name__, 'network vnet peering update',
-                               'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.get',
-                               'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.create_or_update',
-                               cf_virtual_network_peerings,
-                               setter_arg_name='virtual_network_peering_parameters')
+# VNET Peering Operations
+cli_command(__name__, 'network vnet peering create', custom_path.format('create_vnet_peering'), version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network vnet peering show', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.get', cf_virtual_network_peerings, exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network vnet peering list', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.list', cf_virtual_network_peerings, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_command(__name__, 'network vnet peering delete', 'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.delete', cf_virtual_network_peerings, version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
+cli_generic_update_command(__name__, 'network vnet peering update',
+                           'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.get',
+                           'azure.mgmt.network.operations.virtual_network_peerings_operations#VirtualNetworkPeeringsOperations.create_or_update',
+                           cf_virtual_network_peerings,
+                           setter_arg_name='virtual_network_peering_parameters', version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
 
 # Traffic Manager ProfileOperations
 cli_command(__name__, 'network traffic-manager profile check-dns', 'azure.mgmt.trafficmanager.operations.profiles_operations#ProfilesOperations.check_traffic_manager_relative_dns_name_availability', cf_traffic_manager_mgmt_profiles)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
@@ -4,14 +4,21 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands import create_command, command_table
+from azure.cli.core.profiles import supported_api_version
 from ._validators import validate_client_parameters
 
 
 def cli_storage_data_plane_command(name, operation, client_factory,  # pylint: disable=too-many-arguments
-                                   transform=None, table_transformer=None, exception_handler=None):
+                                   transform=None, table_transformer=None, exception_handler=None,
+                                   version_constraint=None):
     """ Registers an Azure CLI Storage Data Plane command. These commands always include the
     four parameters which can be used to obtain a storage client: account-name, account-key,
     connection-string, and sas-token. """
+    if version_constraint and not supported_api_version(version_constraint.resource_type,
+                                                        min_api=version_constraint.min_api,
+                                                        max_api=version_constraint.max_api):
+        return
+
     command = create_command(__name__, name, operation, transform, table_transformer,
                              client_factory, exception_handler=exception_handler)
     # add parameters required to create a storage client

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -24,10 +24,10 @@ from azure.cli.command_modules.storage._transformers import \
      transform_logging_list_output, transform_metrics_list_output,
      transform_url, transform_storage_list_output, transform_container_permission_output,
      create_boolean_result_output_transformer)
-from azure.cli.core.commands import cli_command
+from azure.cli.core.commands import cli_command, VersionConstraint
 from azure.cli.core.commands.arm import cli_generic_update_command
 from azure.cli.core.util import empty_on_404
-from azure.cli.core.profiles import supported_api_version, get_sdk, ResourceType
+from azure.cli.core.profiles import get_sdk, ResourceType
 
 mgmt_path = 'azure.mgmt.storage.operations.storage_accounts_operations#StorageAccountsOperations.'
 custom_path = 'azure.cli.command_modules.storage.custom#'
@@ -59,16 +59,13 @@ cli_command(__name__, 'storage account show-connection-string', custom_path + 's
 cli_command(__name__, 'storage account keys renew', mgmt_path + 'regenerate_key', factory, transform=lambda x: getattr(x, 'keys', x))
 cli_command(__name__, 'storage account keys list', mgmt_path + 'list_keys', factory, transform=lambda x: getattr(x, 'keys', x))
 
-if supported_api_version(ResourceType.MGMT_STORAGE, max_api='2015-06-15'):
-    cli_command(__name__, 'storage account create', custom_path + 'create_storage_account_with_account_type')
-else:
-    cli_command(__name__, 'storage account create', custom_path + 'create_storage_account')
+cli_command(__name__, 'storage account create', custom_path + 'create_storage_account_with_account_type', version_constraint=VersionConstraint(ResourceType.MGMT_STORAGE, max_api='2015-06-15'))
+cli_command(__name__, 'storage account create', custom_path + 'create_storage_account', version_constraint=VersionConstraint(ResourceType.MGMT_STORAGE, min_api='2016-12-01'))
 
-if supported_api_version(ResourceType.MGMT_STORAGE, min_api='2016-12-01'):
-    cli_generic_update_command(__name__, 'storage account update',
-                               mgmt_path + 'get_properties',
-                               mgmt_path + 'update', factory,
-                               custom_function_op=custom_path + 'update_storage_account')
+cli_generic_update_command(__name__, 'storage account update',
+                           mgmt_path + 'get_properties',
+                           mgmt_path + 'update', factory,
+                           custom_function_op=custom_path + 'update_storage_account', version_constraint=VersionConstraint(ResourceType.MGMT_STORAGE, min_api='2016-12-01'))
 
 cli_storage_data_plane_command('storage account generate-sas', 'azure.multiapi.storage.cloudstorageaccount#CloudStorageAccount.generate_shared_access_signature', cloud_storage_account_service_factory)
 
@@ -198,8 +195,7 @@ cli_storage_data_plane_command('storage entity delete', table_path + 'delete_ent
 factory = queue_data_service_factory
 cli_storage_data_plane_command('storage queue generate-sas', queue_path + 'generate_queue_shared_access_signature', factory)
 
-if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
-    cli_storage_data_plane_command('storage queue stats', queue_path + 'get_queue_service_stats', factory)
+cli_storage_data_plane_command('storage queue stats', queue_path + 'get_queue_service_stats', factory, version_constraint=VersionConstraint(ResourceType.DATA_STORAGE, min_api='2016-05-31'))
 
 cli_storage_data_plane_command('storage queue list', queue_path + 'list_queues', factory, transform=transform_storage_list_output)
 cli_storage_data_plane_command('storage queue create', queue_path + 'create_queue', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -11,10 +11,12 @@ from azure.cli.command_modules.vm._client_factory import (cf_vm, cf_avail_set, c
                                                           cf_vmss, cf_vmss_vm,
                                                           cf_vm_sizes, cf_disks, cf_snapshots,
                                                           cf_images)
-from azure.cli.core.commands import DeploymentOutputLongRunningOperation, cli_command
+from azure.cli.core.commands import (DeploymentOutputLongRunningOperation,
+                                     VersionConstraint,
+                                     cli_command)
 from azure.cli.core.commands.arm import cli_generic_update_command, cli_generic_wait_command
 from azure.cli.core.util import empty_on_404
-from azure.cli.core.profiles import supported_api_version, ResourceType
+from azure.cli.core.profiles import ResourceType
 
 # pylint: disable=line-too-long
 
@@ -110,11 +112,10 @@ cli_generic_update_command(__name__, 'vm update',
                            no_wait_param='raw')
 cli_generic_wait_command(__name__, 'vm wait', 'azure.cli.command_modules.vm.custom#get_instance_view')
 
-if supported_api_version(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'):
-    cli_command(__name__, 'vm convert', mgmt_path.format(op_var, op_class, 'convert_to_managed_disks'), cf_vm)
-    cli_command(__name__, 'vm encryption enable', 'azure.cli.command_modules.vm.disk_encryption#enable')
-    cli_command(__name__, 'vm encryption disable', 'azure.cli.command_modules.vm.disk_encryption#disable')
-    cli_command(__name__, 'vm encryption show', 'azure.cli.command_modules.vm.disk_encryption#show', exception_handler=empty_on_404)
+cli_command(__name__, 'vm convert', mgmt_path.format(op_var, op_class, 'convert_to_managed_disks'), cf_vm, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'vm encryption enable', 'azure.cli.command_modules.vm.disk_encryption#enable', version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'vm encryption disable', 'azure.cli.command_modules.vm.disk_encryption#disable', version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'vm encryption show', 'azure.cli.command_modules.vm.disk_encryption#show', exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
 
 # VM NIC
 cli_command(__name__, 'vm nic add', custom_path.format('vm_add_nics'))
@@ -242,36 +243,35 @@ cli_command(__name__, 'vmss list-instance-connection-info', custom_path.format('
 cli_command(__name__, 'vm list-sizes', mgmt_path.format('virtual_machine_sizes_operations', 'VirtualMachineSizesOperations', 'list'), cf_vm_sizes)
 
 
-if supported_api_version(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'):
-    # VM Disk
-    op_var = 'disks_operations'
-    op_class = 'DisksOperations'
-    cli_command(__name__, 'disk create', custom_path.format('create_managed_disk'))
-    cli_command(__name__, 'disk list', custom_path.format('list_managed_disks'))
-    cli_command(__name__, 'disk show', mgmt_path.format(op_var, op_class, 'get'), cf_disks, exception_handler=empty_on_404)
-    cli_command(__name__, 'disk delete', mgmt_path.format(op_var, op_class, 'delete'), cf_disks)
-    cli_command(__name__, 'disk grant-access', custom_path.format('grant_disk_access'))
-    cli_command(__name__, 'disk revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_disks)
-    cli_generic_update_command(__name__, 'disk update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
-                               'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
-                               custom_function_op=custom_path.format('update_managed_disk'),
-                               setter_arg_name='disk', factory=cf_disks)
-    op_var = 'snapshots_operations'
-    op_class = 'SnapshotsOperations'
-    cli_command(__name__, 'snapshot create', custom_path.format('create_snapshot'))
-    cli_command(__name__, 'snapshot list', custom_path.format('list_snapshots'))
-    cli_command(__name__, 'snapshot show', mgmt_path.format(op_var, op_class, 'get'), cf_snapshots, exception_handler=empty_on_404)
-    cli_command(__name__, 'snapshot delete', mgmt_path.format(op_var, op_class, 'delete'), cf_snapshots)
-    cli_command(__name__, 'snapshot grant-access', custom_path.format('grant_snapshot_access'))
-    cli_command(__name__, 'snapshot revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_snapshots)
-    cli_generic_update_command(__name__, 'snapshot update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
-                               'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
-                               custom_function_op=custom_path.format('update_snapshot'),
-                               setter_arg_name='snapshot', factory=cf_snapshots)
+# VM Disk
+op_var = 'disks_operations'
+op_class = 'DisksOperations'
+cli_command(__name__, 'disk create', custom_path.format('create_managed_disk'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'disk list', custom_path.format('list_managed_disks'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'disk show', mgmt_path.format(op_var, op_class, 'get'), cf_disks, exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'disk delete', mgmt_path.format(op_var, op_class, 'delete'), cf_disks, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'disk grant-access', custom_path.format('grant_disk_access'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'disk revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_disks, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_generic_update_command(__name__, 'disk update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
+                           'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
+                           custom_function_op=custom_path.format('update_managed_disk'),
+                           setter_arg_name='disk', factory=cf_disks, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+op_var = 'snapshots_operations'
+op_class = 'SnapshotsOperations'
+cli_command(__name__, 'snapshot create', custom_path.format('create_snapshot'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'snapshot list', custom_path.format('list_snapshots', version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview')))
+cli_command(__name__, 'snapshot show', mgmt_path.format(op_var, op_class, 'get'), cf_snapshots, exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'snapshot delete', mgmt_path.format(op_var, op_class, 'delete'), cf_snapshots, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'snapshot grant-access', custom_path.format('grant_snapshot_access'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'snapshot revoke-access', mgmt_path.format(op_var, op_class, 'revoke_access'), cf_snapshots, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_generic_update_command(__name__, 'snapshot update', 'azure.mgmt.compute.compute.operations.{}#{}.get'.format(op_var, op_class),
+                           'azure.mgmt.compute.compute.operations.{}#{}.create_or_update'.format(op_var, op_class),
+                           custom_function_op=custom_path.format('update_snapshot'),
+                           setter_arg_name='snapshot', factory=cf_snapshots, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
 
-    op_var = 'images_operations'
-    op_class = 'ImagesOperations'
-    cli_command(__name__, 'image create', custom_path.format('create_image'))
-    cli_command(__name__, 'image list', custom_path.format('list_images'))
-    cli_command(__name__, 'image show', mgmt_path.format(op_var, op_class, 'get'), cf_images, exception_handler=empty_on_404)
-    cli_command(__name__, 'image delete', mgmt_path.format(op_var, op_class, 'delete'), cf_images)
+op_var = 'images_operations'
+op_class = 'ImagesOperations'
+cli_command(__name__, 'image create', custom_path.format('create_image'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'image list', custom_path.format('list_images'), version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'image show', mgmt_path.format(op_var, op_class, 'get'), cf_images, exception_handler=empty_on_404, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))
+cli_command(__name__, 'image delete', mgmt_path.format(op_var, op_class, 'delete'), cf_images, version_constraint=VersionConstraint(ResourceType.MGMT_COMPUTE, min_api='2016-04-30-preview'))


### PR DESCRIPTION
Moved from doing:
```
if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
    cli_command(...)
```

To:
```
cli_command(..., version_constraint=VersionConstraint(ResourceType.MGMT_NETWORK, min_api='2016-09-01'))
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [n/a] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
