### PR TITLE
login: support login when there are no subscriptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -106,7 +106,7 @@ class Profile(object):
                                     password,
                                     is_service_principal,
                                     tenant,
-                                    include_bare_tenants=False,
+                                    allow_no_subscriptions=False,
                                     subscription_finder=None):
         from azure.cli.core._debug import allow_debug_adal_connection
         allow_debug_adal_connection()
@@ -129,9 +129,10 @@ class Profile(object):
                 subscriptions = subscription_finder.find_from_user_account(
                     username, password, tenant, self._ad_resource_uri)
 
-        if not include_bare_tenants and not subscriptions:
+        if not allow_no_subscriptions and not subscriptions:
             raise CLIError("No subscriptions were found for '{}'. If this is expected, use "
-                           "'--all' to have a tenant level account".format(username))
+                           "'--allow-no-subscriptions' to have a tenant level account".format(
+                               username))
 
         if is_service_principal:
             self._creds_cache.save_service_principal_cred(sp_auth.get_entry_to_persist(username,
@@ -139,7 +140,7 @@ class Profile(object):
         if self._creds_cache.adal_token_cache.has_state_changed:
             self._creds_cache.persist_cached_creds()
 
-        if include_bare_tenants:
+        if allow_no_subscriptions:
             t_list = [s.tenant_id for s in subscriptions]
             bare_tenants = [t for t in subscription_finder.tenants if t not in t_list]
             subscriptions = Profile._build_tenant_level_accounts(bare_tenants)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -131,7 +131,7 @@ class Profile(object):
 
         if not allow_no_subscriptions and not subscriptions:
             raise CLIError("No subscriptions were found for '{}'. If this is expected, use "
-                           "'--allow-no-subscriptions' to have a tenant level account".format(
+                           "'--allow-no-subscriptions' to have tenant level accesses".format(
                                username))
 
         if is_service_principal:

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -243,6 +243,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                                             'my-secret',
                                             True,
                                             self.tenant_id,
+                                            False,
                                             finder)
         # action
         extended_info = profile.get_expanded_subscription_info()
@@ -254,7 +255,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                          extended_info['endpoints'].active_directory)
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
-    def test_create_account_without_subscription(self, mock_auth_context):
+    def test_create_account_without_subscriptions(self, mock_auth_context):
         mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
         mock_arm_client.subscriptions.list.return_value = []
@@ -272,13 +273,13 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                                                      'my-secret',
                                                      True,
                                                      self.tenant_id,
-                                                     no_subscriptions=True,
+                                                     include_bare_tenants=True,
                                                      subscription_finder=finder)
 
         # assert
         self.assertTrue(1, len(result))
         self.assertEqual(result[0]['id'], self.tenant_id)
-        self.assertEqual(result[0]['state'], 'N/A')
+        self.assertEqual(result[0]['state'], 'Enabled')
         self.assertEqual(result[0]['tenantId'], self.tenant_id)
         self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
 

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -273,7 +273,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                                                      'my-secret',
                                                      True,
                                                      self.tenant_id,
-                                                     include_bare_tenants=True,
+                                                     allow_no_subscriptions=True,
                                                      subscription_finder=finder)
 
         # assert

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -253,6 +253,35 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertEqual('https://login.microsoftonline.com',
                          extended_info['endpoints'].active_directory)
 
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_create_account_without_subscription(self, mock_auth_context):
+        mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.subscriptions.list.return_value = []
+        finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
+                                    None,
+                                    lambda _: mock_arm_client)
+
+        storage_mock = {'subscriptions': []}
+        profile = Profile(storage_mock)
+        profile._management_resource_uri = 'https://management.core.windows.net/'
+
+        # action
+        result = profile.find_subscriptions_on_login(False,
+                                                     '1234',
+                                                     'my-secret',
+                                                     True,
+                                                     self.tenant_id,
+                                                     no_subscriptions=True,
+                                                     subscription_finder=finder)
+
+        # assert
+        self.assertTrue(1, len(result))
+        self.assertEqual(result[0]['id'], self.tenant_id)
+        self.assertEqual(result[0]['state'], 'N/A')
+        self.assertEqual(result[0]['tenantId'], self.tenant_id)
+        self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
+
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     def test_get_current_account_user(self, mock_read_cred_file):
         # setup

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.4 (unreleased)
+++++++++++++++++++
+* Support login when there are no subscriptions found (#2560)
 
 2.0.3 (2017-04-17)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -21,6 +21,7 @@ register_cli_argument('login', 'password', options_list=('--password', '-p'), he
 register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
+register_cli_argument('login', 'no_subscriptions', action='store_true', help='Continue the login process even though the account has no subscriptions. It is uncommon')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -21,7 +21,7 @@ register_cli_argument('login', 'password', options_list=('--password', '-p'), he
 register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
-register_cli_argument('login', 'all', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
+register_cli_argument('login', 'allow_no_subscriptions', options_list='--all', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -21,7 +21,7 @@ register_cli_argument('login', 'password', options_list=('--password', '-p'), he
 register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
-register_cli_argument('login', 'allow_no_subscriptions', options_list='--all', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
+register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -21,7 +21,7 @@ register_cli_argument('login', 'password', options_list=('--password', '-p'), he
 register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
-register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
+register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -21,7 +21,7 @@ register_cli_argument('login', 'password', options_list=('--password', '-p'), he
 register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
-register_cli_argument('login', 'no_subscriptions', action='store_true', help='Continue the login process even though the account has no subscriptions. It is uncommon')
+register_cli_argument('login', 'all', action='store_true', help='Support login for tenants without subscriptions. This is uncommon')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -54,7 +54,8 @@ def account_clear():
     profile.logout_all()
 
 
-def login(username=None, password=None, service_principal=None, tenant=None, no_subscriptions=False):
+def login(username=None, password=None, service_principal=None, tenant=None,
+          all=False):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -77,7 +78,7 @@ def login(username=None, password=None, service_principal=None, tenant=None, no_
             password,
             service_principal,
             tenant,
-            no_subscriptions=no_subscriptions)
+            include_bare_tenants=all)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -54,7 +54,7 @@ def account_clear():
     profile.logout_all()
 
 
-def login(username=None, password=None, service_principal=None, tenant=None):
+def login(username=None, password=None, service_principal=None, tenant=None, no_subscriptions=False):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -76,7 +76,8 @@ def login(username=None, password=None, service_principal=None, tenant=None):
             username,
             password,
             service_principal,
-            tenant)
+            tenant,
+            no_subscriptions=no_subscriptions)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -55,7 +55,7 @@ def account_clear():
 
 
 def login(username=None, password=None, service_principal=None, tenant=None,
-          all=False):
+          allow_no_subscriptions=False):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -78,7 +78,7 @@ def login(username=None, password=None, service_principal=None, tenant=None,
             password,
             service_principal,
             tenant,
-            include_bare_tenants=all)
+            allow_no_subscriptions=allow_no_subscriptions)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:


### PR DESCRIPTION
This is not a common thing, so users should use a flag of `--allow-no-subscriptions` to opt-in
Fix #2560 

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
