### PR TITLE
[Storage] Make 'location' optional in storage account create

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unreleased
+++++++++++++++++++
+
+* Default location to resource group location for `storage account create`.
+
 2.0.3 (2017-04-17)
 ++++++++++++++++++
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -11,7 +11,8 @@ from six import u as unicode_string
 from azure.cli.core._config import az_config
 from azure.cli.core.commands.parameters import \
     (ignore_type, tags_type, file_type, get_resource_name_completion_list, enum_choice_list,
-     model_choice_list, enum_default)
+     model_choice_list, enum_default, location_type)
+from azure.cli.core.commands.validators import get_default_location_from_resource_group
 import azure.cli.core.commands.arm  # pylint: disable=unused-import
 from azure.cli.core.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 
@@ -283,6 +284,7 @@ register_cli_argument('storage account show-connection-string', 'key_name', opti
 for item in ['blob', 'file', 'queue', 'table']:
     register_cli_argument('storage account show-connection-string', '{}_endpoint'.format(item), help='Custom endpoint for {}s.'.format(item))
 
+register_cli_argument('storage account create', 'location', location_type, validator=get_default_location_from_resource_group)
 register_cli_argument('storage account create', 'account_type', help='The storage account type', **model_choice_list(ResourceType.MGMT_STORAGE, 'AccountType'))
 
 register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -52,7 +52,7 @@ def _update_progress(current, total):
 
 # CUSTOM METHODS
 
-def create_storage_account(resource_group_name, account_name, sku, location,
+def create_storage_account(resource_group_name, account_name, sku, location=None,
                            kind=None, tags=None, custom_domain=None,
                            encryption=None, access_tier=None):
     StorageAccountCreateParameters, Kind, Sku, CustomDomain, AccessTier = get_sdk(
@@ -75,7 +75,8 @@ def create_storage_account(resource_group_name, account_name, sku, location,
     return scf.storage_accounts.create(resource_group_name, account_name, params)
 
 
-def create_storage_account_with_account_type(resource_group_name, account_name, location, account_type, tags=None):
+def create_storage_account_with_account_type(resource_group_name, account_name, account_type,
+                                             location=None, tags=None):
     StorageAccountCreateParameters, AccountType = get_sdk(
         ResourceType.MGMT_STORAGE,
         'StorageAccountCreateParameters',


### PR DESCRIPTION
Closes #2928.  Uses the resource group location as the default for storage account create--consistent with other create commands. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
[N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
