### PR TITLE
reraise rather than raise

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -8,12 +8,13 @@ from __future__ import print_function
 import json
 import pkgutil
 import re
+import sys
 import time
 import timeit
 import traceback
 from collections import OrderedDict, defaultdict
 from importlib import import_module
-from six import string_types
+from six import string_types, reraise
 
 import azure.cli.core.azlogging as azlogging
 import azure.cli.core.telemetry as telemetry
@@ -400,7 +401,7 @@ def create_command(module_name, name, operation,
                 if exception_handler:
                     result = exception_handler(ex)
                 else:
-                    raise ex
+                    reraise(*sys.exc_info())
 
             if no_wait_param and kwargs.get(no_wait_param, None):
                 return None  # return None for 'no-wait'


### PR DESCRIPTION
fixes #2941
Within a command an exception will now cause the error to bubble up with trace. This will help in cases like this issue: #2939
```python
raise Exception("hello world") 
```

```
hello world
Traceback (most recent call last):
  File "/Users/david/code/azure/azure-cli/src/azure-cli/azure/cli/main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "/Users/david/code/azure/azure-cli/src/azure-cli-core/azure/cli/core/application.py", line 201, in execute
    result = expanded_arg.func(params)
  File "/Users/david/code/azure/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 404, in _execute_command
    reraise(*sys.exc_info())
  File "/Users/david/code/azure/azure-cli/src/azure-cli-core/azure/cli/core/commands/__init__.py", line 399, in _execute_command
    result = op(client, **kwargs) if client else op(**kwargs)
  File "/Users/david/code/azure/azure-cli/src/command_modules/azure-cli-find/azure/cli/command_modules/find/custom.py", line 107, in find
    raise Exception("hello world")
Exception: hello world
```