### PR TITLE
Added sql server/db list-usages.

### DIFF
--- a/src/command_modules/azure-cli-sql/HISTORY.rst
+++ b/src/command_modules/azure-cli-sql/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unreleased
+++++++++++
+
+* Added az sql server list-usages and az sql db list-usages commands.
+
 2.0.1 (2017-04-17)
 ++++++++++++++++++
 

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
@@ -28,8 +28,7 @@ with ServiceGroup(__name__, get_sql_databases_operations, database_operations, c
         c.custom_command('restore', 'db_restore')
         c.command('show', 'get')
         c.custom_command('list', 'db_list')
-        # # Usages will not be included in the first batch of GA commands
-        # c.command('show-usage', 'list_usages')
+        c.command('list-usages', 'list_usages')
         c.command('delete', 'delete', confirmation=True)
         c.generic_update_command('update', 'get', 'create_or_update', custom_func_name='db_update')
         c.custom_command('import', 'db_import')
@@ -125,8 +124,7 @@ with ServiceGroup(__name__, get_sql_servers_operations, servers_operations, cust
         c.command('create', 'create_or_update')
         c.command('delete', 'delete', confirmation=True)
         c.command('show', 'get')
-        # Usages will not be included in the first batch of GA commands
-        # c.command('show-usage', 'list_usages')
+        c.command('list-usages', 'list_usages')
         c.command('list', 'list_by_resource_group')
         c.generic_update_command('update', 'get', 'create_or_update',
                                  custom_func_name='server_update')

--- a/src/command_modules/azure-cli-sql/tests/recordings/test_sql_db_mgmt.yaml
+++ b/src/command_modules/azure-cli-sql/tests/recordings/test_sql_db_mgmt.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2016-09-01
@@ -20,7 +20,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['326']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 12 Mar 2017 01:41:39 GMT']
+      date: ['Fri, 21 Apr 2017 17:22:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -36,8 +36,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2014-04-01
@@ -49,12 +49,12 @@ interactions:
       content-length: ['695']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:08 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:13 GMT']
       preference-applied: [return-content]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -64,8 +64,8 @@ interactions:
       CommandName: [sql db create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2014-04-01
@@ -77,7 +77,7 @@ interactions:
       content-length: ['680']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:09 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:14 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -93,21 +93,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['23']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"CreateLogicalDatabase","startTime":"\/Date(1489282932626+0000)\/"}'}
+    body: {string: '{"operation":"CreateLogicalDatabase","startTime":"\/Date(1492795396786+0000)\/"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b74e1406-320c-4667-88af-785bd4a24fe4?api-version=2014-04-01-Preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/f323ddf4-2de7-4fd0-b2bb-4389e0cc0f03?api-version=2014-04-01-Preview']
       cache-control: ['no-store, no-cache']
       content-length: ['80']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:11 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/operationResults/b74e1406-320c-4667-88af-785bd4a24fe4?api-version=2014-04-01-Preview']
+      date: ['Fri, 21 Apr 2017 17:23:14 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/operationResults/f323ddf4-2de7-4fd0-b2bb-4389e0cc0f03?api-version=2014-04-01-Preview']
       preference-applied: [return-content]
       retry-after: ['30']
       server: [Microsoft-HTTPAPI/2.0]
@@ -123,20 +123,20 @@ interactions:
       CommandName: [sql db create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b74e1406-320c-4667-88af-785bd4a24fe4?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/f323ddf4-2de7-4fd0-b2bb-4389e0cc0f03?api-version=2014-04-01-Preview
   response:
-    body: {string: '{"operationId":"b74e1406-320c-4667-88af-785bd4a24fe4","status":"Succeeded","error":null}'}
+    body: {string: '{"operationId":"f323ddf4-2de7-4fd0-b2bb-4389e0cc0f03","status":"Succeeded","error":null}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b74e1406-320c-4667-88af-785bd4a24fe4?api-version=2014-04-01-Preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/f323ddf4-2de7-4fd0-b2bb-4389e0cc0f03?api-version=2014-04-01-Preview']
       cache-control: ['no-store, no-cache']
       content-length: ['88']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:41 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:46 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -151,21 +151,21 @@ interactions:
       CommandName: [sql db create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"fb1929a3-e9a8-4a22-bdb1-0b4bc3ccf6a4","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-03-12T01:42:12.847Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-03-12T01:52:42.123Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
+        US","kind":"v12.0,user","properties":{"databaseId":"cf7581cc-a728-4fb7-a65b-c31f58415e95","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-04-21T17:23:17.067Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-04-21T17:33:40.79Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1000']
+      content-length: ['999']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:43 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:48 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -180,23 +180,23 @@ interactions:
       CommandName: [sql db list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases?api-version=2014-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"fb1929a3-e9a8-4a22-bdb1-0b4bc3ccf6a4","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-03-12T01:42:12.847Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-03-12T01:52:42.123Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/master","name":"master","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,system","properties":{"databaseId":"41d431b4-2180-4964-b22a-6af10a83b917","edition":"System","status":"Online","serviceLevelObjective":"System2","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"32212254720","creationDate":"2017-03-12T01:41:43.297Z","currentServiceObjectiveId":"620323bf-2879-4807-b30d-c2e6d7b3b3aa","requestedServiceObjectiveId":"620323bf-2879-4807-b30d-c2e6d7b3b3aa","requestedServiceObjectiveName":"System2","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":null,"elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/master","name":"master","type":"Microsoft.Sql/servers/databases","location":"West
+        US","kind":"v12.0,system","properties":{"databaseId":"5e0c1f1b-de7e-40de-a1b6-763337505c4f","edition":"System","status":"Online","serviceLevelObjective":"System2","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"32212254720","creationDate":"2017-04-21T17:22:49.523Z","currentServiceObjectiveId":"620323bf-2879-4807-b30d-c2e6d7b3b3aa","requestedServiceObjectiveId":"620323bf-2879-4807-b30d-c2e6d7b3b3aa","requestedServiceObjectiveName":"System2","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":null,"elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
+        US","kind":"v12.0,user","properties":{"databaseId":"cf7581cc-a728-4fb7-a65b-c31f58415e95","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-04-21T17:23:17.067Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-04-21T17:33:40.79Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}]}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1978']
+      content-length: ['1977']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:45 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:49 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -211,21 +211,49 @@ interactions:
       CommandName: [sql db show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"fb1929a3-e9a8-4a22-bdb1-0b4bc3ccf6a4","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-03-12T01:42:12.847Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-03-12T01:52:42.123Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
+        US","kind":"v12.0,user","properties":{"databaseId":"cf7581cc-a728-4fb7-a65b-c31f58415e95","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-04-21T17:23:17.067Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-04-21T17:33:40.79Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1000']
+      content-length: ['999']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:47 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:51 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [sql db list-usages]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/usages?api-version=2014-04-01
+  response:
+    body: {string: '{"value":[{"name":"database_size","resourceName":"cliautomationdb01","displayName":"Database
+        Size","currentValue":4194304.0,"limit":268435456000.0,"unit":"Bytes","nextResetTime":null}]}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['185']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Fri, 21 Apr 2017 17:23:51 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -240,21 +268,21 @@ interactions:
       CommandName: [sql db update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"fb1929a3-e9a8-4a22-bdb1-0b4bc3ccf6a4","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-03-12T01:42:12.847Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-03-12T01:52:42.123Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
+        US","kind":"v12.0,user","properties":{"databaseId":"cf7581cc-a728-4fb7-a65b-c31f58415e95","edition":"Standard","status":"Online","serviceLevelObjective":"S0","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-04-21T17:23:17.067Z","currentServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveId":"f1173c43-91bd-4aaa-973c-54e79e15235b","requestedServiceObjectiveName":"S0","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-04-21T17:33:40.79Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1000']
+      content-length: ['999']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:48 GMT']
+      date: ['Fri, 21 Apr 2017 17:23:52 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -262,9 +290,9 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"requestedServiceObjectiveName":
-      "S1", "maxSizeBytes": "10737418240", "collation": "SQL_Latin1_General_CP1_CI_AS",
-      "readScale": "Disabled"}, "tags": {"key1": "value1"}}'
+    body: '{"tags": {"key1": "value1"}, "location": "West US", "properties": {"readScale":
+      "Disabled", "maxSizeBytes": "10737418240", "requestedServiceObjectiveName":
+      "S1", "collation": "SQL_Latin1_General_CP1_CI_AS"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -272,21 +300,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['207']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"AlterDatabaseOperation","startTime":"\/Date(1489282972706+0000)\/"}'}
+    body: {string: '{"operation":"AlterDatabaseOperation","startTime":"\/Date(1492795435908+0000)\/"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview']
       cache-control: ['no-store, no-cache']
       content-length: ['81']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:42:51 GMT']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/operationResults/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview']
+      date: ['Fri, 21 Apr 2017 17:23:54 GMT']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/operationResults/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview']
       preference-applied: [return-content]
       retry-after: ['30']
       server: [Microsoft-HTTPAPI/2.0]
@@ -302,20 +330,20 @@ interactions:
       CommandName: [sql db update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview
   response:
-    body: {string: '{"operationId":"b27d03f3-0031-4413-91ec-5ee844c6a3a8","status":"InProgress","error":null}'}
+    body: {string: '{"operationId":"9864311a-abdf-4f4b-a32e-14b25c7b12d4","status":"InProgress","error":null}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview']
       cache-control: ['no-store, no-cache']
       content-length: ['89']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:43:22 GMT']
+      date: ['Fri, 21 Apr 2017 17:24:25 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -330,48 +358,20 @@ interactions:
       CommandName: [sql db update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview
   response:
-    body: {string: '{"operationId":"b27d03f3-0031-4413-91ec-5ee844c6a3a8","status":"InProgress","error":null}'}
+    body: {string: '{"operationId":"9864311a-abdf-4f4b-a32e-14b25c7b12d4","status":"Succeeded","error":null}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview']
-      cache-control: ['no-store, no-cache']
-      content-length: ['89']
-      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
-      dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:43:53 GMT']
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [sql db update]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview
-  response:
-    body: {string: '{"operationId":"b27d03f3-0031-4413-91ec-5ee844c6a3a8","status":"Succeeded","error":null}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/b27d03f3-0031-4413-91ec-5ee844c6a3a8?api-version=2014-04-01-Preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01/azureAsyncOperation/9864311a-abdf-4f4b-a32e-14b25c7b12d4?api-version=2014-04-01-Preview']
       cache-control: ['no-store, no-cache']
       content-length: ['88']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:44:24 GMT']
+      date: ['Fri, 21 Apr 2017 17:24:55 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -386,21 +386,21 @@ interactions:
       CommandName: [sql db update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
   response:
     body: {string: '{"tags":{"key1":"value1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01","name":"cliautomationdb01","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"fb1929a3-e9a8-4a22-bdb1-0b4bc3ccf6a4","edition":"Standard","status":"Online","serviceLevelObjective":"S1","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"10737418240","creationDate":"2017-03-12T01:42:12.847Z","currentServiceObjectiveId":"1b1ebd4d-d903-4baa-97f9-4ea675f5e928","requestedServiceObjectiveId":"1b1ebd4d-d903-4baa-97f9-4ea675f5e928","requestedServiceObjectiveName":"S1","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-03-12T01:52:42.123Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
+        US","kind":"v12.0,user","properties":{"databaseId":"cf7581cc-a728-4fb7-a65b-c31f58415e95","edition":"Standard","status":"Online","serviceLevelObjective":"S1","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"10737418240","creationDate":"2017-04-21T17:23:17.067Z","currentServiceObjectiveId":"1b1ebd4d-d903-4baa-97f9-4ea675f5e928","requestedServiceObjectiveId":"1b1ebd4d-d903-4baa-97f9-4ea675f5e928","requestedServiceObjectiveName":"S1","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-04-21T17:33:40.79Z","elasticPoolName":null,"containmentState":2,"readScale":"Disabled","failoverGroupId":null}}'}
     headers:
       cache-control: ['no-store, no-cache']
-      content-length: ['1024']
+      content-length: ['1023']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Sun, 12 Mar 2017 01:44:25 GMT']
+      date: ['Fri, 21 Apr 2017 17:24:56 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -416,8 +416,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/databases/cliautomationdb01?api-version=2014-04-01
@@ -428,7 +428,7 @@ interactions:
       content-length: ['0']
       content-type: [application/xml; charset=utf-8]
       dataserviceversion: [1.0;]
-      date: ['Sun, 12 Mar 2017 01:44:28 GMT']
+      date: ['Fri, 21 Apr 2017 17:24:58 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -443,9 +443,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2016-09-01
@@ -454,9 +454,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Sun, 12 Mar 2017 01:44:30 GMT']
+      date: ['Fri, 21 Apr 2017 17:24:59 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdEOEFBQkM4MDU2ODE0RTdCN0NDQzg2NDgxNjFERjIzNjFGNnxCODM5RkZEM0NGNjM1RUU3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2016-09-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdDNzMwNTBDNTlEQTFFNkI4M0E5MkFENzBCREJBNzlCRTAyNXxBQ0NBMjM5RDE5NTA0QUNGLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2016-09-01']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]

--- a/src/command_modules/azure-cli-sql/tests/recordings/test_sql_server_mgmt.yaml
+++ b/src/command_modules/azure-cli-sql/tests/recordings/test_sql_server_mgmt.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2016-09-01
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['326']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 10 Mar 2017 00:46:41 GMT']
+      date: ['Fri, 21 Apr 2017 17:43:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: '{"location": "westus", "properties": {"administratorLoginPassword": "SecretPassword123",
@@ -36,25 +36,25 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53?api-version=2014-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword123","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword123","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['551']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:18 GMT']
+      date: ['Fri, 21 Apr 2017 17:43:49 GMT']
       preference-applied: [return-content]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -64,20 +64,20 @@ interactions:
       CommandName: [sql server list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers?api-version=2014-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}]}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['548']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:21 GMT']
+      date: ['Fri, 21 Apr 2017 17:43:51 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -92,20 +92,20 @@ interactions:
       CommandName: [sql server update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53?api-version=2014-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['536']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:22 GMT']
+      date: ['Fri, 21 Apr 2017 17:43:51 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -113,8 +113,8 @@ interactions:
       x-content-type-options: [nosniff]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "West US", "properties": {"version": "12.0", "administratorLoginPassword":
-      "SecretPassword456", "administratorLogin": "admin123"}}'
+    body: '{"location": "West US", "properties": {"administratorLoginPassword": "SecretPassword456",
+      "version": "12.0", "administratorLogin": "admin123"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -122,27 +122,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['143']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53?api-version=2014-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword456","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword456","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['551']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:24 GMT']
+      date: ['Fri, 21 Apr 2017 17:43:52 GMT']
       preference-applied: [return-content]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: '{"location": "westus", "properties": {"administratorLoginPassword": "SecretPassword123",
@@ -154,25 +154,25 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation52?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation54?api-version=2014-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation52","name":"cliautomation52","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation52.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword123","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation54","name":"cliautomation54","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation54.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":"SecretPassword123","externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['551']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:51 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:22 GMT']
       preference-applied: [return-content]
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -182,21 +182,21 @@ interactions:
       CommandName: [sql server list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers?api-version=2014-04-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation52","name":"cliautomation52","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation52.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation54","name":"cliautomation54","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation54.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}]}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['1085']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:54 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:25 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -211,20 +211,49 @@ interactions:
       CommandName: [sql server show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53?api-version=2014-04-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51","name":"cliautomation51","type":"Microsoft.Sql/servers","location":"West
-        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation51.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53","name":"cliautomation53","type":"Microsoft.Sql/servers","location":"West
+        US","kind":"v12.0","properties":{"fullyQualifiedDomainName":"cliautomation53.database.windows.net","administratorLogin":"admin123","administratorLoginPassword":null,"externalAdministratorLogin":null,"externalAdministratorSid":null,"version":"12.0","state":"Ready"}}'}
     headers:
       cache-control: ['no-store, no-cache']
       content-length: ['536']
       content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Fri, 10 Mar 2017 00:47:54 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:26 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [sql server list-usages]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53/usages?api-version=2014-04-01
+  response:
+    body: {string: '{"value":[{"name":"server_dtu_quota","resourceName":"cliautomation53","displayName":"Database
+        Throughput Unit Quota","currentValue":0.0,"limit":45000.0,"unit":"DTUs","nextResetTime":null},{"name":"server_dtu_quota_current","resourceName":"cliautomation53","displayName":"Database
+        Throughput Unit Quota","currentValue":0.0,"limit":45000.0,"unit":"DTUs","nextResetTime":null}]}'}
+    headers:
+      cache-control: ['no-store, no-cache']
+      content-length: ['375']
+      content-type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Fri, 21 Apr 2017 17:44:26 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
@@ -240,11 +269,11 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation51?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation53?api-version=2014-04-01
   response:
     body: {string: ''}
     headers:
@@ -252,11 +281,11 @@ interactions:
       content-length: ['0']
       content-type: [application/xml; charset=utf-8]
       dataserviceversion: [1.0;]
-      date: ['Fri, 10 Mar 2017 00:47:57 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:29 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -267,11 +296,11 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation52?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/cliautomation54?api-version=2014-04-01
   response:
     body: {string: ''}
     headers:
@@ -279,7 +308,7 @@ interactions:
       content-length: ['0']
       content-type: [application/xml; charset=utf-8]
       dataserviceversion: [1.0;]
-      date: ['Fri, 10 Mar 2017 00:48:01 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:31 GMT']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
@@ -293,8 +322,8 @@ interactions:
       CommandName: [sql server list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 sqlmanagementclient/0.3.1 Azure-SDK-For-Python AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 sqlmanagementclient/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers?api-version=2014-04-01
@@ -304,7 +333,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 10 Mar 2017 00:48:01 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -319,9 +348,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.3+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2016-09-01
@@ -330,12 +359,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 10 Mar 2017 00:48:03 GMT']
+      date: ['Fri, 21 Apr 2017 17:44:32 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdDM0EwQjYzMjJFNjA4ODRENENFNjkyMTNCRDlDMTI5RDdBNHw0NUJCMkY1Q0UzNDA3RDUwLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2016-09-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkc4MzMzMUVFMEU3Qjc4N0U3QTZGRDk4MzA4MTc1RTZEMzdDRXw5MkU5RkYzNzMyQjg1QUJCLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2016-09-01']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
@@ -111,7 +111,7 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('administratorLogin', user)])
 
         self.cmd('sql server list-usages -g {} -n {}'
-                 .format(rg, servers[0]), 
+                 .format(rg, servers[0]),
                  checks=[JMESPathCheck('[0].resourceName', servers[0])])
 
         # test delete sql server
@@ -269,7 +269,7 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('resourceGroup', rg)])
 
         self.cmd('sql db list-usages -g {} --server {} --name {}'
-                 .format(rg, server, database_name), 
+                 .format(rg, server, database_name),
                  checks=[JMESPathCheck('[0].resourceName', database_name)])
 
         self.cmd('sql db update -g {} -s {} -n {} --service-objective {} --max-size {}'

--- a/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
@@ -59,7 +59,7 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer()
     def test_sql_server_mgmt(self, resource_group, resource_group_location):
-        servers = ['cliautomation51', 'cliautomation52']  # TODO: Server names should be randomized
+        servers = ['cliautomation53', 'cliautomation54']  # TODO: Server names should be randomized
         admin_login = 'admin123'
         admin_passwords = ['SecretPassword123', 'SecretPassword456']
 
@@ -109,6 +109,10 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('name', servers[0]),
                      JMESPathCheck('resourceGroup', rg),
                      JMESPathCheck('administratorLogin', user)])
+
+        self.cmd('sql server list-usages -g {} -n {}'
+                 .format(rg, servers[0]), 
+                 checks=[JMESPathCheck('[0].resourceName', servers[0])])
 
         # test delete sql server
         self.cmd('sql server delete -g {} --name {} --yes'
@@ -264,10 +268,9 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('name', database_name),
                      JMESPathCheck('resourceGroup', rg)])
 
-        # # Usages will not be included in the first batch of GA commands
-        # self.cmd('sql db show-usage -g {} --server {} --name {}'
-        #          .format(rg, server, database_name), checks=[
-        #              JMESPathCheck('[0].resourceName', database_name)])
+        self.cmd('sql db list-usages -g {} --server {} --name {}'
+                 .format(rg, server, database_name), 
+                 checks=[JMESPathCheck('[0].resourceName', database_name)])
 
         self.cmd('sql db update -g {} -s {} -n {} --service-objective {} --max-size {}'
                  ' --set tags.key1=value1'


### PR DESCRIPTION
These commands were originally called show-usage. I had removed these
commands before GA in order to scope down the design work. Re-adding these
now.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))

```
(env) D:\git\azure-cli [usages ≡]> az sql db list-usages -h

Command
    az sql db list-usages: Returns database usages.

Arguments
    --name -n           [Required]: Name of the Azure SQL Database.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using 'az configure --defaults group=<name>'.
    --server -s         [Required]: Name of the Azure SQL server.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

```
(env) D:\git\azure-cli [usages ≡]> az sql server list-usages -h

Command
    az sql server list-usages: Returns server usages.

Arguments
    --name -n           [Required]: The name of the server.
    --resource-group -g [Required]: Name of resource group. You can configure the default group
                                    using 'az configure --defaults group=<name>'.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```