### PR TITLE
Performance: avoid loading msrest and azure.mgmt.redis modules as part of redis command package load

### DIFF
--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/commands.py
@@ -11,7 +11,8 @@ from azure.cli.command_modules.redis._client_factory import (cf_redis, cf_patch_
 
 from azure.cli.command_modules.redis.custom import wrong_vmsize_argument_exception_handler
 
-cli_command(__name__, 'redis create', 'azure.cli.command_modules.redis.custom#cli_redis_create', cf_redis)
+cli_command(__name__, 'redis create', 'azure.cli.command_modules.redis.custom#cli_redis_create', cf_redis,
+            exception_handler=wrong_vmsize_argument_exception_handler)
 cli_command(__name__, 'redis delete', 'azure.mgmt.redis.operations.redis_operations#RedisOperations.delete', cf_redis)
 cli_command(__name__, 'redis export', 'azure.cli.command_modules.redis.custom#cli_redis_export', cf_redis)
 cli_command(__name__, 'redis force-reboot', 'azure.mgmt.redis.operations.redis_operations#RedisOperations.force_reboot', cf_redis)

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
@@ -43,6 +43,7 @@ def cli_redis_update_settings(client, resource_group_name, name, redis_configura
     return client.create_or_update(resource_group_name, name, parameters=update_params)
 
 def cli_redis_update(instance, sku=None, vm_size=None):
+    from azure.mgmt.redis.models import RedisCreateOrUpdateParameters
     if sku != None:
         instance.sku.name = sku
 
@@ -91,6 +92,7 @@ def cli_redis_create(client, resource_group_name, name, location, sku, # pylint:
     :param subnet_id: The full resource ID of a subnet in a virtual network to deploy the redis cache in. Example format /subscriptions/{subid}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1
     :param static_ip: Required when deploying a redis cache inside an existing Azure Virtual Network.
     """
+    from azure.mgmt.redis.models import RedisCreateOrUpdateParameters, Sku
     params = RedisCreateOrUpdateParameters(
         location,
         Sku(sku, vm_size[0], vm_size[1:]),


### PR DESCRIPTION
Fixes #2952

- Don't load azure.mgmt.redis or msrest modules as part of redis command module load (performance)
- Standardize on exception handling between commands (register exception handler instead of handling the exception in the custom redis create command)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N.A] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
