### PR TITLE
fix asn1 date parse

### DIFF
--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -543,8 +543,10 @@ create_certificate.__doc__ = KeyVaultClient.create_certificate.__doc__
 
 
 def _asn1_to_iso8601(asn1_date):
-    import dateutil
-    return dateutil.parser.parse(asn1_date.decode('utf-8'))
+    import dateutil.parser
+    if isinstance(asn1_date, bytes):
+        asn1_date = asn1_date.decode('utf-8')
+    return dateutil.parser.parse(asn1_date)
 
 
 def import_certificate(client, vault_base_url, certificate_name, certificate_data,

--- a/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
@@ -11,6 +11,10 @@ from __future__ import print_function
 import os
 import time
 import unittest
+from datetime import datetime
+from dateutil import tz
+
+from azure.cli.command_modules.keyvault.custom import _asn1_to_iso8601
 
 from azure.cli.core.util import CLIError
 from azure.cli.core.test_utils.vcr_test_base import (ResourceGroupVCRTestBase, JMESPathCheck,
@@ -44,6 +48,20 @@ def _create_keyvault(test, vault_name, resource_group, location, retry_wait=30, 
                 time.sleep(retry_wait)
             else:
                 raise ex
+
+
+class DateTimeParseTest(unittest.TestCase):
+
+    def test_parse_asn1_date(self):
+        expected = datetime(year=2017,
+                            month=4,
+                            day=24,
+                            hour=16,
+                            minute=37,
+                            second=20,
+                            tzinfo=tz.tzutc())
+        self.assertEqual(_asn1_to_iso8601("20170424163720Z"), expected)
+
 
 
 class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):


### PR DESCRIPTION
Ran into an issue with ASN1 not parsing correctly due to lack of import of datetime.parser. This should fix this. Also added a unit test to ensure no regression.

```
module 'dateutil' has no attribute 'parser'
Traceback (most recent call last):
  File "/Users/david/code/azure/azure-cli/src/azure-cli/azure/cli/main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "/Users/david/code/azure/azure-cli/src/azure-cli-core/azure/cli/core/application.py", line 201, in execute
    result = expanded_arg.func(params)
  File "/Users/david/code/azure/azure-cli/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_command_type.py", line 76, in _execute_command
    result = op(client, **kwargs)
  File "/Users/david/code/azure/azure-cli/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py", line 582, in import_certificate
    not_before = _asn1_to_iso8601(x509.get_notBefore())
  File "/Users/david/code/azure/azure-cli/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py", line 547, in _asn1_to_iso8601
    return dateutil.parser.parse(asn1_date.decode('utf-8'))
AttributeError: module 'dateutil' has no attribute 'parser'
```