### PR TITLE
[KeyVault] Fix issues with KeyVault create and get-default-policy

### DIFF
--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+unreleased
+++++++++++++++++++++
+
+* BC: Remove --expires and --not-before from `keyvault certificate create` as these parameters are not supported by the service.
+* Adds the --validity parameter to `keyvault certificate create` to selectively override the value in --policy
+* Fixes issue in `keyvault certificate get-default-policy` where 'expires' and 'not_before' were exposed but 'validity_in_months' was not.
+
 2.0.1 (2017-04-17)
 ++++++++++++++++++++
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -93,8 +93,8 @@ helps['keyvault certificate create'] = """
 
 helps['keyvault certificate import'] = """
     type: command
-    long-summary: >
-        Import a certificate into Key Vault. Certificates can also be used as a secrets in provisioned virtual machines.
+    short-summary: Import a certificate into KeyVault.
+    long-summary: Certificates can also be used as a secrets in provisioned virtual machines.
     examples:
         - name: Create a service principal with a certificate, add the certificate to Key Vault and provision a VM with that certificate.
           text: >

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
@@ -111,8 +111,8 @@ def get_attribute_validator(name, attribute_class, create=False):
         enabled = not ns_dict.pop('disabled') if create else ns_dict.pop('enabled')
         attributes = attribute_class(
             enabled,
-            ns_dict.pop('not_before'),
-            ns_dict.pop('expires'))
+            ns_dict.pop('not_before', None),
+            ns_dict.pop('expires', None))
         setattr(ns, '{}_attributes'.format(name), attributes)
 
     return validator

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -61,7 +61,7 @@ def _default_certificate_profile():
                 KeyUsageType.key_cert_sign
             ],
             subject='C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=www.contoso.com',
-            ekus=[]
+            validity_in_months=12
         ),
         lifetime_actions=[LifetimeAction(
             trigger=Trigger(
@@ -79,12 +79,10 @@ def _default_certificate_profile():
         )
     )
     del template.id
-    del template.attributes.created
-    del template.attributes.updated
+    del template.attributes
     del template.issuer_parameters.certificate_type
     del template.lifetime_actions[0].trigger.lifetime_percentage
     del template.x509_certificate_properties.subject_alternative_names
-    del template.x509_certificate_properties.validity_in_months
     del template.x509_certificate_properties.ekus
     return template
 
@@ -135,8 +133,7 @@ def _scaffold_certificate_profile():
         )
     )
     del template.id
-    del template.attributes.created
-    del template.attributes.updated
+    del template.attributes
     return template
 
 
@@ -505,9 +502,13 @@ def download_secret(client, vault_base_url, secret_name, file_path, encoding=Non
 
 
 def create_certificate(client, vault_base_url, certificate_name, certificate_policy,
-                       disabled=False, expires=None, not_before=None, tags=None):
-    cert_attrs = CertificateAttributes(not disabled, not_before, expires)
+                       disabled=False, tags=None, validity=None):
+    cert_attrs = CertificateAttributes(not disabled)
     logger.info("Starting long running operation 'keyvault certificate create'")
+
+    if validity is not None:
+        certificate_policy['x509_certificate_properties']['validity_in_months'] = validity
+
     client.create_certificate(
         vault_base_url, certificate_name, certificate_policy, cert_attrs, tags)
 


### PR DESCRIPTION
Due to https://github.com/Azure/azure-rest-api-specs/issues/1153, the `--expires` and `--not-before` parameters for certificate creation do not work. 

This PR:
- **BC:** Removes these parameters from `keyvault certificate create`. A previous PR already removed them from the update command.
- Updates the `keyvault certificate get-default-policy` command to remove these two parameters (all of attributes actually) and to expose the previously deleted `validity_in_months` attribute, which is the only correct way to set the expiration for the certificate.
- Adds a `--validity` convenience argument to `keyvault certificate create` so that the default policy can be used but can be essentially "patched" with the value specified here.  This is necessary to enable the scenario described in #2836.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- N/A Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
