### PR TITLE
Fix #2980 for az account set, Shorten commands and parameters and all…

### DIFF
--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 2.0.4 (unreleased)
 ++++++++++++++++++
 * Support login when there are no subscriptions found (#2560)
+* Support short param name in az account set --subscription (#2980)
 
 2.0.3 (2017-04-17)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -25,6 +25,6 @@ register_cli_argument('login', 'allow_no_subscriptions', action='store_true', he
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 
-register_cli_argument('account', 'subscription', help='Name or ID of subscription.', completer=get_subscription_id_list)
+register_cli_argument('account', 'subscription', options_list=('--subscription', '-s'), help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
 register_cli_argument('account show', 'expanded_view', action='store_true', help="display more information like service principal's password and cloud environments")


### PR DESCRIPTION
…ow for single-character parameters

Now supports
```
az account set -s "subscription"
```