### PR TITLE
Add Python location to ‘az —version’

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -86,7 +86,7 @@ def show_version_info_exit(out_file):
     print(file=out_file)
     print('Python ({}) {}'.format(platform.system(), sys.version), file=out_file)
     print(file=out_file)
-    print('Python location {}'.format(sys.executable), file=out_file)
+    print("Python location '{}'".format(sys.executable), file=out_file)
     print(file=out_file)
     sys.exit(0)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -85,6 +85,9 @@ def show_version_info_exit(out_file):
           file=out_file)
     print(file=out_file)
     print('Python ({}) {}'.format(platform.system(), sys.version), file=out_file)
+    print(file=out_file)
+    print('Python location {}'.format(sys.executable), file=out_file)
+    print(file=out_file)
     sys.exit(0)
 
 


### PR DESCRIPTION
Example:

```
$ az --version
azure-cli (2.0.3+dev)

acr (2.0.1+dev)
acs (2.0.3+dev)
appservice (0.1.3+dev)
batch (2.0.1+dev)
cloud (2.0.1+dev)
component (2.0.1+dev)
configure (2.0.3+dev)
container (0.1.3+dev)
core (2.0.3+dev)
dla (0.0.2+dev)
dls (0.0.2+dev)
documentdb (0.1.3+dev)
feedback (2.0.1+dev)
find (0.0.2+dev)
iot (0.1.3+dev)
keyvault (2.0.1+dev)
lab (0.0.2+dev)
monitor (0.0.2+dev)
network (2.0.3+dev)
nspkg (2.0.0+dev)
profile (2.0.3+dev)
redis (0.2.0+dev)
resource (2.0.3+dev)
role (2.0.2+dev)
sql (2.0.1+dev)
storage (2.0.3+dev)
taskhelp (0.1.1b4+dev)
testsdk (0.1.0+dev)
utility-automation (0.1.1)
vm (2.0.3+dev)

Python (Darwin) 3.5.1 (v3.5.1:37a07cee5969, Dec  5 2015, 21:12:44) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]

Python location /Users/debekoe/Repos/derekbekoe-azure-cli/env/bin/python


```