### PR TITLE
add alias for az --version (#2926) 

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unreleased
+^^^^^^^^^^^^^^^^^^
+
+* Add 'az -v' as shortcut for 'az --version' (#2926)
+
 2.0.3 (2017-04-17)
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -20,7 +20,7 @@ def main(args, file=sys.stdout):  # pylint: disable=redefined-builtin
     azlogging.configure_logging(args)
     logger.debug('Command arguments %s', args)
 
-    if len(args) > 0 and args[0] == '--version':
+    if len(args) > 0 and (args[0] == '--version' or args[0] == '-v'):
         show_version_info_exit(file)
 
     azure_folder = get_config_dir()


### PR DESCRIPTION
Fixes #2926.
Added a alias for the "--version" parameter as requested in #2926 
now ````az -v```` can be used as equivalent to ````az --version````

History maintained.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
