### PR TITLE
Working example cluster name for `az acs create`

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,7 +7,6 @@ unreleased
 ^^^^^^^^^^^^^^^^^^
 
 * Add 'az -v' as shortcut for 'az --version' (#2926)
-* Fixed underscore in cluster name (#3024)
 
 2.0.3 (2017-04-17)
 ^^^^^^^^^^^^^^^^^^

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,6 +7,7 @@ unreleased
 ^^^^^^^^^^^^^^^^^^
 
 * Add 'az -v' as shortcut for 'az --version' (#2926)
+* Fixed underscore in cluster name (#3024)
 
 2.0.3 (2017-04-17)
 ^^^^^^^^^^^^^^^^^^

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -386,7 +386,7 @@ helps['acs create'] = """
     examples:
         - name: Create a Kubernetes container service and generate keys.
           text: >
-            az acs create -g MyResourceGroup -n MyContainer_service --orchestrator-type kubernetes --generate-ssh-keys
+            az acs create -g MyResourceGroup -n MyContainerService --orchestrator-type kubernetes --generate-ssh-keys
 """
 
 helps['acs delete'] = """


### PR DESCRIPTION
Fixes the example cluster name for `az acs create`. The following error message snippet tells the story:

```
Provisioning of resource(s) for container service 'MyContainer_service' in resource group 'MyResourceGroup' failed.\nMessage: 'The domain name label mycontainer_service-myresourcegroup-9d1a89 is invalid. It must conform to the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$.
```

The purpose of this PR is to improve the documentation at this resource:

https://docs.microsoft.com/en-us/cli/azure/acs#create

Fixes #3024