### PR TITLE
Change the random name generating algorithm

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -48,9 +48,6 @@ class IntegrationTestBase(unittest.TestCase):
 
         return result.assert_with_checks(checks)
 
-    def create_random_name(self, prefix, length):  # for override pylint: disable=no-self-use
-        return create_random_name(prefix, length)
-
     def create_temp_file(self, size_kb, full_random=False):
         """
         Create a temporary file for testing. The test harness will delete the file during tearing

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -3,19 +3,25 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import uuid
-import datetime
 import hashlib
+import math
+import os
+import base64
 
 
 def create_random_name(prefix='clitest', length=24):
     if len(prefix) > length:
         raise 'The length of the prefix must not be longer than random name length'
 
-    identity = '{}-{}'.format(str(uuid.getnode()),
-                              datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S%f')).encode('utf-8')
-    prefix += str(hashlib.sha256(identity).hexdigest())
-    return prefix[:length]
+    padding_size = length - len(prefix)
+    if padding_size < 8:
+        raise 'The randomized part of the name is shorter than 8, which may not be able to offer ' \
+              'enough randomness'
+
+    random_bytes = os.urandom(math.ceil(padding_size / 8) * 5)
+    random_padding = base64.b32encode(random_bytes)[:padding_size]
+
+    return prefix + random_padding.decode().lower()
 
 
 def get_sha1_hash(file_path):


### PR DESCRIPTION
@jaredmoo, please try this out in your SQL test recording.

This pull request replaced the original SHA256 based unique identifier generating algorithm with a system cryptographic-use random bytes base32 encode string. The change will offer higher randomness.
