### PR TITLE
Fix create random name method missing

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -51,6 +51,9 @@ class IntegrationTestBase(unittest.TestCase):
 
         return result.assert_with_checks(checks)
 
+    def create_random_name(self, prefix, length):  # pylint: disable=no-self-use
+        return create_random_name(prefix=prefix, length=length)
+
     def create_temp_file(self, size_kb, full_random=False):
         """
         Create a temporary file for testing. The test harness will delete the file during tearing


### PR DESCRIPTION
I remove this method from the base class in previous change. It breaks the live test cases.