### PR TITLE
Shorten the limitation on random name requirement

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -14,8 +14,8 @@ def create_random_name(prefix='clitest', length=24):
         raise 'The length of the prefix must not be longer than random name length'
 
     padding_size = length - len(prefix)
-    if padding_size < 8:
-        raise 'The randomized part of the name is shorter than 8, which may not be able to offer ' \
+    if padding_size < 4:
+        raise 'The randomized part of the name is shorter than 4, which may not be able to offer ' \
               'enough randomness'
 
     random_bytes = os.urandom(int(math.ceil(float(padding_size) / 8) * 5))


### PR DESCRIPTION
I reckon that I underestimate the chances when a short name is required.