### PR TITLE
Fix bytes returned from hex fingerprint -o tsv

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -206,7 +206,7 @@ def b64_to_hex(s):
     decoded = base64.b64decode(s)
     hex_data = binascii.hexlify(decoded).upper()
     if isinstance(hex_data, bytes):
-        return hex_data.decode("utf-8")
+        return str(hex_data.decode("utf-8"))
     return hex_data
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -204,7 +204,10 @@ def b64_to_hex(s):
     :rtype: str
     """
     decoded = base64.b64decode(s)
-    return binascii.hexlify(decoded).upper()
+    hex_data = binascii.hexlify(decoded).upper()
+    if isinstance(hex_data, bytes):
+        return hex_data.decode("utf-8")
+    return hex_data
 
 
 def random_string(length=16, force_lower=False, digits_only=False):

--- a/src/azure-cli-core/tests/test_util.py
+++ b/src/azure-cli-core/tests/test_util.py
@@ -145,7 +145,7 @@ class TestUtils(unittest.TestCase):
 class TestBase64ToHex(unittest.TestCase):
 
     def setUp(self):
-        self.base64 = 'PvOJgaPq5R004GyT1tB0IW3XUyM='
+        self.base64 = 'PvOJgaPq5R004GyT1tB0IW3XUyM='.encode('ascii')
 
     def test_b64_to_hex(self):
         self.assertEquals('3EF38981A3EAE51D34E06C93D6D074216DD75323', b64_to_hex(self.base64))

--- a/src/azure-cli-core/tests/test_util.py
+++ b/src/azure-cli-core/tests/test_util.py
@@ -9,7 +9,7 @@ import unittest
 import tempfile
 
 from azure.cli.core.util import \
-    (get_file_json, todict, to_snake_case, truncate_text, shell_safe_json_parse)
+    (get_file_json, todict, to_snake_case, truncate_text, shell_safe_json_parse, b64_to_hex)
 
 
 class TestUtils(unittest.TestCase):
@@ -140,6 +140,18 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(
             len(failed_strings), 0,
             'The following patterns failed: {}'.format(failed_strings))
+
+
+class TestBase64ToHex(unittest.TestCase):
+
+    def setUp(self):
+        self.base64 = 'PvOJgaPq5R004GyT1tB0IW3XUyM='
+
+    def test_b64_to_hex(self):
+        self.assertEquals('3EF38981A3EAE51D34E06C93D6D074216DD75323', b64_to_hex(self.base64))
+
+    def test_b64_to_hex_type(self):
+        self.assertIsInstance(b64_to_hex(self.base64), str)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The hex fingerprint of a Key Vault certificate returns as bytes in py3. This corrects that and returns a str as the method says it should.

```bash
$ az keyvault certificate show --vault-name testvaultdj -n testcert --query "x509ThumbprintHex" -o tsv
b'73863FFDAD3BA0E7C08BAEFBAD09F661298341C6'
```

After the fix
```bash
$ az keyvault certificate show --vault-name testvaultdj -n testcert --query "x509ThumbprintHex" -o tsv
73863FFDAD3BA0E7C08BAEFBAD09F661298341C6
```