### PR TITLE
BugFix: Use one of the loaded keys.

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unreleased
+----------
+
+* Fix to use one of the loaded keys.
+
 2.0.4 (2017-04-28)
 ++++++++++++++++++
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
@@ -36,6 +36,7 @@ def SecureCopy(user, host, src, dest,  # pylint: disable=too-many-arguments
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     keys = []
+    pkey = None
     if key_filename is not None:
         key = _load_key(key_filename)
         keys.append(key)
@@ -43,8 +44,9 @@ def SecureCopy(user, host, src, dest,  # pylint: disable=too-many-arguments
         agent = paramiko.agent.Agent()
         for key in agent.get_keys():
             keys.append(key)
-
-    ssh.connect(host, username=user, pkey=keys[0])
+    if keys:
+        pkey = keys[0]
+    ssh.connect(host, username=user, pkey=pkey)
 
     scp = SCPClient(ssh.get_transport())
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
@@ -36,7 +36,6 @@ def SecureCopy(user, host, src, dest,  # pylint: disable=too-many-arguments
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     keys = []
-    pkey = None
     if key_filename is not None:
         key = _load_key(key_filename)
         keys.append(key)
@@ -45,7 +44,7 @@ def SecureCopy(user, host, src, dest,  # pylint: disable=too-many-arguments
         for key in agent.get_keys():
             keys.append(key)
 
-    ssh.connect(host, username=user, pkey=pkey)
+    ssh.connect(host, username=user, pkey=keys[0])
 
     scp = SCPClient(ssh.get_transport())
 


### PR DESCRIPTION
It seems after a recent change none of the loaded keys are being used. I have been getting the error:
```
No authentication methods available
Traceback (most recent call last):
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\core\application.py", line 201, in execute
    result = expanded_arg.func(params)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\core\commands\__init__.py", line 417, in _execute_command
    reraise(*sys.exc_info())
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\six.py", line 686, in reraise
    raise value
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\core\commands\__init__.py", line 399, in _execute_command
    result = op(client, **kwargs) if client else op(**kwargs)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\command_modules\acs\custom.py", line 690, in k8s_get_credentials
    _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\command_modules\acs\custom.py", line 711, in _k8s_get_credentials_internal
    '.kube/config', path_candidate, key_filename=ssh_key_file)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\azure\cli\command_modules\acs\acs_client.py", line 47, in SecureCopy
    ssh.connect(host, username=user, pkey=pkey)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\paramiko\client.py", line 381, in connect
    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)
  File "C:\Users\paverma\AppData\Local\Continuum\Miniconda3\lib\site-packages\paramiko\client.py", line 623, in _auth
    raise SSHException('No authentication methods available')
paramiko.ssh_exception.SSHException: No authentication methods available
```