### PR TITLE
Improve code style and readability for DocumentDB

### DIFF
--- a/scripts/automation/style/run.py
+++ b/scripts/automation/style/run.py
@@ -71,8 +71,7 @@ if __name__ == '__main__':
         return_code_sum = run_pylint(selected_modules)
 
         # Run flake8 on modules
-        pep8_ready_modules = automation_path.filter_blacklisted_modules(
-            'documentdb', 'datalake', 'network')
+        pep8_ready_modules = automation_path.filter_blacklisted_modules('network')
 
         return_code_sum += run_pep8(pep8_ready_modules)
 

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/__init__.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/__init__.py
@@ -3,10 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import azure.cli.command_modules.documentdb._help # pylint: disable=unused-import
+import azure.cli.command_modules.documentdb._help  # pylint: disable=unused-import
+
 
 def load_params(_):
-    import azure.cli.command_modules.documentdb._params #pylint: disable=redefined-outer-name
+    import azure.cli.command_modules.documentdb._params  # pylint: disable=redefined-outer-name
+
 
 def load_commands():
-    import azure.cli.command_modules.documentdb.commands #pylint: disable=redefined-outer-name
+    import azure.cli.command_modules.documentdb.commands  # pylint: disable=redefined-outer-name

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_client_factory.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_client_factory.py
@@ -20,14 +20,15 @@ No credentials specified to access DocumentDB service. Please provide any of the
 UA_AGENT = "AZURECLI/{}".format(core_version)
 ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
 
-def _add_headers(client):
 
+def _add_headers(client):
     agents = [client.default_headers['User-Agent'], UA_AGENT]
     try:
         agents.append(os.environ[ENV_ADDITIONAL_USER_AGENT])
     except KeyError:
         pass
     client.default_headers['User-Agent'] = ' '.join(agents)
+
 
 def _get_url_connection(url_collection, account_name):
     if url_collection:
@@ -37,8 +38,8 @@ def _get_url_connection(url_collection, account_name):
     else:
         return None
 
-def get_document_client_factory(kwargs):
 
+def get_document_client_factory(kwargs):
     from pydocumentdb import document_client
     from azure.cli.core.commands.client_factory import get_data_service_client
     from azure.cli.core._profile import CLOUD
@@ -66,9 +67,12 @@ def get_document_client_factory(kwargs):
         if isinstance(ex, CLIError):
             raise ex
         # pylint:disable=line-too-long
-        raise CLIError('Failed to instantiate an Azure DocumentDB client using the provided credential ' + str(ex))
+        raise CLIError(
+            'Failed to instantiate an Azure DocumentDB client using the provided credential ' + str(
+                ex))
     _add_headers(client)
     return client
+
 
 def cf_documentdb(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_command_type.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_command_type.py
@@ -5,22 +5,25 @@
 
 from azure.cli.core.commands import create_command, command_table
 
-def cli_documentdb_data_plane_command(name, operation, client_factory,  # pylint: disable=too-many-arguments
-                                      transform=None, table_transformer=None,
-                                      exception_handler=None):
-    """ Registers an Azure CLI DocumentDB Data Plane command. These commands always include the
+
+def cli_documentdb_data_plane_command(name,  # pylint: disable=too-many-arguments
+                                      operation, client_factory, transform=None,
+                                      table_transformer=None, exception_handler=None):
+    """Registers an Azure CLI DocumentDB Data Plane command. These commands always include the
     parameters which can be used to obtain a documentdb client."""
 
     if not exception_handler:
         from ._exception_handler import generic_exception_handler
         exception_handler = generic_exception_handler
-    # pylint: disable=line-too-long
+
     command = create_command(__name__, name, operation, transform, table_transformer,
                              client_factory, exception_handler=exception_handler)
+
     # add parameters required to create a documentdb client
     group_name = 'DocumentDB Account'
 
-    command.add_argument('db_resource_group_name', '--resource-group-name', '-g', arg_group=group_name,
+    command.add_argument('db_resource_group_name', '--resource-group-name', '-g',
+                         arg_group=group_name,
                          help='name of the resource group')
     command.add_argument('db_account_name', '--name', '-n', arg_group=group_name,
                          help='DocumentDB account name.')
@@ -28,11 +31,11 @@ def cli_documentdb_data_plane_command(name, operation, client_factory,  # pylint
     command.add_argument('db_account_key', '--key', required=False, default=None,
                          arg_group=group_name,
                          help='DocumentDB account key. Must be used in conjunction with documentdb '
-                         'account name or url-connection.')
+                              'account name or url-connection.')
 
     command.add_argument('db_url_connection', '--url-connection', required=False, default=None,
                          arg_group=group_name,
-                         help='DocumentDB account url connection. Must be used in conjunction with documentdb '
-                         'account key.')
+                         help='DocumentDB account url connection. Must be used in conjunction with '
+                              'documentdb account key.')
 
     command_table[command.name] = command

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_exception_handler.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_exception_handler.py
@@ -9,21 +9,23 @@ import azure.cli.core.azlogging as azlogging
 
 logger = azlogging.get_az_logger(__name__)
 
+
 def duplicate_resource_exception_handler(ex):
-    # pylint:disable=line-too-long
     # wraps DocumentDB 409 error in CLIError
     from pydocumentdb.errors import HTTPFailure
     if isinstance(ex, HTTPFailure) and ex.status_code == 409:
-        raise CLIError('Operation Failed: Resource Already Exists (Server returned status code 409)')
+        raise CLIError(
+            'Operation Failed: Resource Already Exists (Server returned status code 409)')
     raise ex
 
+
 def resource_not_found_exception_handler(ex):
-    # pylint:disable=line-too-long
     # wraps DocumentDB 404 error in CLIError
     from pydocumentdb.errors import HTTPFailure
     if isinstance(ex, HTTPFailure) and ex.status_code == 404:
         raise CLIError('Operation Failed: Resource Not Found (Server returned status code 404)')
     raise ex
+
 
 def invalid_arg_found_exception_handler(ex):
     # wraps DocumentDB 400 error in CLIError
@@ -31,37 +33,36 @@ def invalid_arg_found_exception_handler(ex):
     if isinstance(ex, HTTPFailure) and ex.status_code == 400:
         cli_error = None
         try:
-            # pylint:disable=protected-access
-            if ex._http_error_message:
-                msg = json.loads(ex._http_error_message)
+            if ex._http_error_message:  # pylint:disable=protected-access
+                msg = json.loads(ex._http_error_message)  # pylint:disable=protected-access
                 if msg['message']:
                     msg = msg['message'].split('\n')[0]
                     msg = msg[len('Message: '):] if msg.find('Message: ') == 0 else msg
-                    # pylint:disable=line-too-long
-                    cli_error = CLIError('Operation Failed: Invalid Arg (Server returned status code 400 {})'.format(str(msg)))
-        # pylint:disable=broad-except
-        except Exception:
+                    cli_error = CLIError('Operation Failed: Invalid Arg '
+                                         '(Server returned status code 400 {})'.format(str(msg)))
+        except Exception:  # pylint:disable=broad-except
             pass
+
         if cli_error:
-            # pylint:disable=raising-bad-type
-            raise cli_error
-        # pylint:disable=line-too-long
-        raise CLIError('Operation Failed: Invalid Arg (Server returned status code 400\n {})'.format(str(ex)))
+            raise cli_error  # pylint:disable=raising-bad-type
+
+        raise CLIError('Operation Failed: Invalid Arg '
+                       '(Server returned status code 400\n {})'.format(str(ex)))
     raise ex
+
 
 def unknown_server_failure_exception_handler(ex):
     # wraps unknown documentdb error in CLIError
     from pydocumentdb.errors import HTTPFailure
     if isinstance(ex, HTTPFailure):
-        # pylint:disable=line-too-long
         raise CLIError('Operation Failed: {}'.format(str(ex)))
     raise ex
+
 
 def exception_handler_chain_builder(handlers):
     # creates a handler which chains the handler
     # as soon as one of the chained handlers raises CLIError, it raises CLIError
     # if no handler raises CLIError it raises the original exception
-    # pylint:disable=broad-except
     def chained_handler(ex):
         if isinstance(ex, CLIError):
             raise ex
@@ -70,21 +71,24 @@ def exception_handler_chain_builder(handlers):
                 h(ex)
             except CLIError as cli_error:
                 raise cli_error
-            except Exception:
+            except Exception:  # pylint:disable=broad-except
                 pass
         raise ex
+
     return chained_handler
+
 
 def network_exception_handler(ex):
     import requests as requests
     # wraps a connection exception in CLIError
     # pylint:disable=line-too-long
-    if isinstance(ex, requests.exceptions.ConnectionError) or isinstance(ex, requests.exceptions.HTTPError):
+    if isinstance(ex, requests.exceptions.ConnectionError) or \
+            isinstance(ex, requests.exceptions.HTTPError):
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(ex))
     raise ex
 
+
 def generic_exception_handler(ex):
-    # pylint:disable=line-too-long
     logger.debug(ex)
     chained_handler = exception_handler_chain_builder([duplicate_resource_exception_handler,
                                                        resource_not_found_exception_handler,

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_help.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_help.py
@@ -5,7 +5,6 @@
 
 from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
-# pylint: disable=line-too-long
 
 helps['documentdb'] = """
     type: group

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_params.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_params.py
@@ -11,8 +11,7 @@ from azure.cli.core.commands.parameters import (
     enum_choice_list,
     name_type,
     ignore_type,
-    file_type
-    )
+    file_type)
 
 from azure.cli.core.util import shell_safe_json_parse
 
@@ -25,16 +24,18 @@ from azure.mgmt.documentdb.models.failover_policy import FailoverPolicy
 from azure.mgmt.documentdb.models.location import Location
 from azure.cli.core.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 
+
 def validate_failover_policies(ns):
-    ''' Extracts multiple space-separated failoverPolicies in regionName=failoverPriority format '''
+    """ Extracts multiple space-separated failoverPolicies in regionName=failoverPriority format """
     fp_dict = []
     for item in ns.failover_policies:
         comps = item.split('=', 1)
         fp_dict.append(FailoverPolicy(comps[0], int(comps[1])))
     ns.failover_policies = fp_dict
 
+
 def validate_locations(ns):
-    ''' Extracts multiple space-separated locations in regionName=failoverPriority format '''
+    """ Extracts multiple space-separated locations in regionName=failoverPriority format """
     if ns.locations is None:
         ns.locations = []
         return
@@ -44,9 +45,11 @@ def validate_locations(ns):
         loc_dict.append(Location(location_name=comps[0], failover_priority=int(comps[1])))
     ns.locations = loc_dict
 
+
 def validate_ip_range_filter(ns):
     if ns.ip_range_filter:
         ns.ip_range_filter = ",".join(ns.ip_range_filter)
+
 
 register_cli_argument('documentdb', 'account_name', arg_type=name_type, help='Name of the DocumentDB database account', completer=get_resource_name_completion_list('Microsoft.DocumentDb/databaseAccounts'), id_part="name")
 

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/commands.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/commands.py
@@ -13,8 +13,10 @@ from ._command_type import cli_documentdb_data_plane_command
 mgmt_path = 'azure.mgmt.documentdb.operations.database_accounts_operations#'
 custome_path = 'azure.cli.command_modules.documentdb.custom#'
 
+
 def db_accounts_factory(_):
     return cf_documentdb().database_accounts
+
 
 cli_command(__name__, 'documentdb show', mgmt_path + 'DatabaseAccountsOperations.get', db_accounts_factory)
 cli_command(__name__, 'documentdb list-keys', mgmt_path + 'DatabaseAccountsOperations.list_keys', db_accounts_factory)
@@ -43,4 +45,3 @@ cli_documentdb_data_plane_command('documentdb collection exists', custome_path +
 cli_documentdb_data_plane_command('documentdb collection create', custome_path + 'cli_documentdb_collection_create', get_document_client_factory)
 cli_documentdb_data_plane_command('documentdb collection delete', custome_path + 'cli_documentdb_collection_delete', get_document_client_factory)
 cli_documentdb_data_plane_command('documentdb collection update', custome_path + 'cli_documentdb_collection_update', get_document_client_factory)
-

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
@@ -36,8 +36,8 @@ DEFAULT_INDEXING_POLICY = """{
   ]
 }"""
 
-# pylint:disable=too-many-arguments
-def cli_documentdb_create(client,
+
+def cli_documentdb_create(client,  # pylint:disable=too-many-arguments
                           resource_group_name,
                           account_name,
                           locations=None,
@@ -46,13 +46,12 @@ def cli_documentdb_create(client,
                           max_staleness_prefix=100,
                           max_interval=5,
                           ip_range_filter=None):
-    # pylint:disable=line-too-long
-    """Create a new Azure DocumentDB database account.
-    """
+    """Create a new Azure DocumentDB database account."""
 
     consistency_policy = None
     if default_consistency_level is not None:
-        consistency_policy = ConsistencyPolicy(default_consistency_level, max_staleness_prefix, max_interval)
+        consistency_policy = ConsistencyPolicy(default_consistency_level, max_staleness_prefix,
+                                               max_interval)
 
     from azure.mgmt.resource import ResourceManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -75,7 +74,8 @@ def cli_documentdb_create(client,
     docdb_account = client.get(resource_group_name, account_name)  # Workaround
     return docdb_account
 
-def cli_documentdb_update(client,
+
+def cli_documentdb_update(client,  # pylint: disable=too-many-arguments
                           resource_group_name,
                           account_name,
                           locations=None,
@@ -83,13 +83,13 @@ def cli_documentdb_update(client,
                           max_staleness_prefix=None,
                           max_interval=None,
                           ip_range_filter=None):
-    # pylint:disable=line-too-long
-    """Update an existing Azure DocumentDB database account.
-    """
+    """Update an existing Azure DocumentDB database account. """
     existing = client.get(resource_group_name, account_name)
 
     update_consistency_policy = False
-    if max_interval is not None or max_staleness_prefix is not None or default_consistency_level is not None:
+    if max_interval is not None or \
+       max_staleness_prefix is not None or \
+       default_consistency_level is not None:
         update_consistency_policy = True
 
     if max_staleness_prefix is None:
@@ -103,13 +103,15 @@ def cli_documentdb_update(client,
 
     consistency_policy = None
     if update_consistency_policy:
-        consistency_policy = ConsistencyPolicy(default_consistency_level, max_staleness_prefix, max_interval)
+        consistency_policy = ConsistencyPolicy(default_consistency_level, max_staleness_prefix,
+                                               max_interval)
     else:
         consistency_policy = existing.consistency_policy
 
     if not locations:
         for loc in existing.read_locations:
-            locations.append(Location(location_name=loc.location_name, failover_priority=loc.failover_priority))
+            locations.append(
+                Location(location_name=loc.location_name, failover_priority=loc.failover_priority))
 
     if ip_range_filter is None:
         ip_range_filter = existing.ip_range_filter
@@ -126,15 +128,16 @@ def cli_documentdb_update(client,
     docdb_account = client.get(resource_group_name, account_name)  # Workaround
     return docdb_account
 
-def cli_documentdb_list(client,
-                        resource_group_name=None):
-    """Lists all Azure DocumentDB database accounts within a given resource group or subscription.
-    """
 
+def cli_documentdb_list(client, resource_group_name=None):
+    """
+    Lists all Azure DocumentDB database accounts within a given resource group or subscription.
+    """
     if resource_group_name:
         return client.list_by_resource_group(resource_group_name)
     else:
         return client.list()
+
 
 ######################
 # data plane APIs
@@ -145,76 +148,78 @@ def cli_documentdb_list(client,
 def _get_database_link(database_id):
     return 'dbs/{}'.format(database_id)
 
+
 def _get_collection_link(database_id, collection_id):
     return 'dbs/{}/colls/{}'.format(database_id, collection_id)
+
 
 def _get_offer_link(database_id, offer_id):
     return 'dbs/{}/colls/{}'.format(database_id, offer_id)
 
+
 def cli_documentdb_database_exists(client, database_id):
-    """Returns a boolean indicating whether the database exists
-    """
-    # pylint:disable=line-too-long
-    return len(list(client.QueryDatabases({'query': 'SELECT * FROM root r WHERE r.id=@id',
-                                           'parameters': [{'name':'@id', 'value': database_id}]}))) > 0
+    """Returns a boolean indicating whether the database exists """
+    return len(list(client.QueryDatabases(
+        {'query': 'SELECT * FROM root r WHERE r.id=@id',
+         'parameters': [{'name': '@id', 'value': database_id}]}))) > 0
+
 
 def cli_documentdb_database_show(client, database_id):
-    """Shows an Azure DocumentDB database
-    """
+    """Shows an Azure DocumentDB database """
     return client.ReadDatabase(_get_database_link(database_id))
 
+
 def cli_documentdb_database_list(client):
-    """Lists all Azure DocumentDB databases
-    """
+    """Lists all Azure DocumentDB databases """
     return list(client.ReadDatabases())
 
+
 def cli_documentdb_database_create(client, database_id):
-    """Creates an Azure DocumentDB database
-    """
+    """Creates an Azure DocumentDB database """
     return client.CreateDatabase({'id': database_id})
 
+
 def cli_documentdb_database_delete(client, database_id):
-    """Deletes an Azure DocumentDB database
-    """
+    """Deletes an Azure DocumentDB database """
     client.DeleteDatabase(_get_database_link(database_id))
+
 
 # collection operations
 
 def cli_documentdb_collection_exists(client, database_id, collection_id):
-    """Returns a boolean indicating whether the collection exists
-    """
-    # pylint:disable=line-too-long
-    return len(list(client.QueryCollections(_get_database_link(database_id),
-                                            {'query': 'SELECT * FROM root r WHERE r.id=@id',
-                                             'parameters': [{'name':'@id', 'value': collection_id}]}))) > 0
+    """Returns a boolean indicating whether the collection exists """
+    return len(list(client.QueryCollections(
+        _get_database_link(database_id),
+        {'query': 'SELECT * FROM root r WHERE r.id=@id',
+         'parameters': [{'name': '@id', 'value': collection_id}]}))) > 0
+
 
 def cli_documentdb_collection_show(client, database_id, collection_id):
-    """Shows an Azure DocumentDB collection and its offer
-    """
+    """Shows an Azure DocumentDB collection and its offer """
     collection = client.ReadCollection(_get_collection_link(database_id, collection_id))
     offer = _find_offer(client, collection['_self'])
-    return {'collection' : collection, 'offer' : offer}
+    return {'collection': collection, 'offer': offer}
+
 
 def cli_documentdb_collection_list(client, database_id):
-    """Lists all Azure DocumentDB collections
-    """
+    """Lists all Azure DocumentDB collections """
     return list(client.ReadCollections(_get_database_link(database_id)))
 
+
 def cli_documentdb_collection_delete(client, database_id, collection_id):
-    """Deletes an Azure DocumentDB collection
-    """
+    """Deletes an Azure DocumentDB collection """
     client.DeleteCollection(_get_collection_link(database_id, collection_id))
+
 
 def _populate_collection_definition(collection,
                                     partition_key_path=None,
                                     indexing_policy=None):
-
     changed = False
 
     if partition_key_path:
         if 'partitionKey' not in collection:
             collection['partitionKey'] = {}
-        collection['partitionKey'] = {'paths' : [partition_key_path]}
+        collection['partitionKey'] = {'paths': [partition_key_path]}
         changed = True
 
     if indexing_policy:
@@ -222,14 +227,14 @@ def _populate_collection_definition(collection,
         collection['indexingPolicy'] = indexing_policy
     return changed
 
-def cli_documentdb_collection_create(client,
+
+def cli_documentdb_collection_create(client,  # pylint: disable=too-many-arguments
                                      database_id,
                                      collection_id,
                                      throughput=None,
                                      partition_key_path=None,
                                      indexing_policy=DEFAULT_INDEXING_POLICY):
-    """Creates an Azure DocumentDB collection
-    """
+    """Creates an Azure DocumentDB collection """
     collection = {'id': collection_id}
 
     options = {}
@@ -240,10 +245,11 @@ def cli_documentdb_collection_create(client,
                                     partition_key_path,
                                     indexing_policy)
 
-    # pylint:disable=line-too-long
-    created_collection = client.CreateCollection(_get_database_link(database_id), collection, options)
+    created_collection = client.CreateCollection(_get_database_link(database_id), collection,
+                                                 options)
     offer = _find_offer(client, created_collection['_self'])
     return {'collection': created_collection, 'offer': offer}
+
 
 def _find_offer(client, collection_self_link):
     logger.debug('finding offer')
@@ -253,23 +259,23 @@ def _find_offer(client, collection_self_link):
             return o
     return None
 
-def cli_documentdb_collection_update(client,
+
+def cli_documentdb_collection_update(client,  # pylint: disable=too-many-arguments
                                      database_id,
                                      collection_id,
                                      throughput=None,
                                      indexing_policy=None):
-    """Updates an Azure DocumentDB collection
-    """
+    """Updates an Azure DocumentDB collection """
     logger.debug('reading collection')
     collection = client.ReadCollection(_get_collection_link(database_id, collection_id))
     result = {}
 
-    if(_populate_collection_definition(collection,
-                                       None,
-                                       indexing_policy)):
+    if (_populate_collection_definition(collection,
+                                        None,
+                                        indexing_policy)):
         logger.debug('replacing collection')
-        # pylint:disable=line-too-long
-        result['collection'] = client.ReplaceCollection(_get_collection_link(database_id, collection_id), collection)
+        result['collection'] = client.ReplaceCollection(
+            _get_collection_link(database_id, collection_id), collection)
 
     if throughput:
         logger.debug('updating offer')


### PR DESCRIPTION
Enabling `flake8` check on DocumentDB code results in new PEP8 compliance issue. I fixed all of them in this pull request. Moving forward, style check will be run on DocumentDB for each commit.

Many changes are caused by the removal of `pylint: disable` statement. These switches are not recommended. Disabling a check for the entire scope of a file should be cautious about. I removed most of the `line-too-long` exempts and narrows the scope of other exempts.