### PR TITLE
prototype for deprecating logics

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=unused-import,line-too-long
-from azure.cli.core.commands import LongRunningOperation, cli_command
+from azure.cli.core.commands import LongRunningOperation, cli_command, cli_commands_removed
 from azure.cli.core.commands.arm import cli_generic_update_command
 from azure.cli.core.util import empty_on_404
 
@@ -113,8 +113,14 @@ cli_command(__name__, 'webapp list-runtimes', 'azure.cli.command_modules.appserv
 
 # end of the new ones #
 # beginning of the old ones ###
+
+# in June, remove all olds stuff below and replace with one following line
+# cli_commands_removed('appservice web', "'az appservice web' is forever gone. You should use 'az webapp'")
+
 cli_command(__name__, 'appservice web create', 'azure.cli.command_modules.appservice.custom#create_webapp', exception_handler=ex_handler_factory())
-cli_command(__name__, 'appservice web list', 'azure.cli.command_modules.appservice.custom#list_webapp', table_transformer=transform_web_list_output)
+cli_command(__name__, 'appservice web list', 'azure.cli.command_modules.appservice.custom#list_webapp',
+            deprecating_info='webapp list',  # this will emit a warning and point to the new command
+            table_transformer=transform_web_list_output)
 cli_command(__name__, 'appservice web show', 'azure.cli.command_modules.appservice.custom#show_webapp', exception_handler=empty_on_404, table_transformer=transform_web_output)
 cli_command(__name__, 'appservice web delete', 'azure.cli.command_modules.appservice.custom#delete_webapp')
 cli_command(__name__, 'appservice web stop', 'azure.cli.command_modules.appservice.custom#stop_webapp')


### PR DESCRIPTION
Throw out for initial evaluation. Please feel free to propose better mechanisms.
2 situations can be configured at command module level
1. Old command still works but a deprecation warning points users to newer version
     ```python
      cli_command(__name__, 'appservice web list', ... ,deprecating_info='az webapp list')
    ```
   will get you a warning of `Deprecating! Please switch to 'az webapp list'`
2. Error out on removed commands if command module likes to be super responsible
    ```python
     cli_commands_removed('appservice web', "'az appservice web' is forever gone. You should use 'az webapp'")
    ```
   will get you an error of `az appservice web' is forever gone. You should use 'az webapp`


