### PR TITLE
Fix nose test reporting

### DIFF
--- a/scripts/automation/tests/nose_helper.py
+++ b/scripts/automation/tests/nose_helper.py
@@ -54,7 +54,7 @@ def get_nose_runner(report_folder, parallel=True, process_timeout=600, process_r
 
         failed_tests = []
         for line in output.splitlines():
-            if line.startswith('test_') and line.endswith('ERROR') or line.endswith('FAIL'):
+            if line.endswith('... ERROR') or line.endswith('... FAIL'):
                 failed_tests.append(line)
 
         return result, test_report, failed_tests

--- a/scripts/automation/tests/run.py
+++ b/scripts/automation/tests/run.py
@@ -63,8 +63,8 @@ if __name__ == '__main__':
         parse.print_help()
         sys.exit(1)
 
-    retval, failed_tests = run_tests(selected_modules, not args.non_parallel, args.live)
-    if failed_tests:
+    success, failed_tests = run_tests(selected_modules, not args.non_parallel, args.live)
+    if failed_tests or not success:
         print('==== FAILED TESTS ====')
         for test in failed_tests:
             print(test)
@@ -72,4 +72,4 @@ if __name__ == '__main__':
         print('==== ALL TESTS PASSED! ====')
 
 
-    sys.exit(0 if retval else 1)
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
- Not all tests start with ‘test_’ . Tests can have docstrings explaining what they do and nose will show that string instead of the method name (eg. https://github.com/Azure/azure-cli/pull/3126/files#diff-7781589306c33626caa49df372858dfcR144).

- Also as a fail safe, check that the success value was false. This would have at least not showed TESTS  PASSED when it actually didn’t.

Screenshot below highlights the issue that this fixes.

cc: @troydai 

<img width="1127" alt="screen shot 2017-05-01 at 4 45 08 pm" src="https://cloud.githubusercontent.com/assets/16448634/25598996/98e8f494-2e8d-11e7-9694-2e6b2d106771.png">
