### PR TITLE
Preserve default name and required flag

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -78,6 +78,8 @@ class CliArgumentType(object):
             kwargs['options_list'] = [options_list]
         self.settings = {}
         self.update(overrides, **kwargs)
+        self.required = None
+        self.default_name = None
 
     def update(self, other=None, **kwargs):
         if other:
@@ -247,8 +249,11 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
         arg.type.update(other=argtype)
 
     def _resolve_default_value_from_cfg_file(self, arg, overrides):
+        if arg.type.required == None:
+            arg.type.required = arg.type.settings.get('required', False)
         if 'configured_default' in overrides.settings:
             def_config = overrides.settings.pop('configured_default', None)
+            arg.type.default_name = def_config
             # same blunt mechanism like we handled id-parts, for create command, no name default
             if (self.name.split()[-1] == 'create' and
                     overrides.settings.get('metavar', None) == 'NAME'):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -78,8 +78,6 @@ class CliArgumentType(object):
             kwargs['options_list'] = [options_list]
         self.settings = {}
         self.update(overrides, **kwargs)
-        self.required = None
-        self.default_name = None
 
     def update(self, other=None, **kwargs):
         if other:
@@ -249,11 +247,12 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
         arg.type.update(other=argtype)
 
     def _resolve_default_value_from_cfg_file(self, arg, overrides):
-        if arg.type.required is None:
-            arg.type.required = arg.type.settings.get('required', False)
+        if not hasattr(arg.type, 'required_tooling'):
+            required = arg.type.settings.get('required', False)
+            setattr(arg.type, 'required_tooling', required)
         if 'configured_default' in overrides.settings:
             def_config = overrides.settings.pop('configured_default', None)
-            arg.type.default_name = def_config
+            setattr(arg.type, 'default_name_tooling', def_config)
             # same blunt mechanism like we handled id-parts, for create command, no name default
             if (self.name.split()[-1] == 'create' and
                     overrides.settings.get('metavar', None) == 'NAME'):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -249,7 +249,7 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
         arg.type.update(other=argtype)
 
     def _resolve_default_value_from_cfg_file(self, arg, overrides):
-        if arg.type.required == None:
+        if arg.type.required is None:
             arg.type.required = arg.type.settings.get('required', False)
         if 'configured_default' in overrides.settings:
             def_config = overrides.settings.pop('configured_default', None)


### PR DESCRIPTION
This change is to preserve the argument's default name (or configured_default) and required flag for later access and better informed tooling support.

This also allows for reloading the configuration with potentially changed defaults without having to reload the entire command table.

Not sure if the change is in the spirit of the existing code, let me know if I can improve on it.