### PR TITLE
[Network] Network Watcher fixes

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+unreleased
+++++++++++++++++++
+
+* Add `network watcher test-connectivity` command.
+* Add support for `--filters` parameter for `network watcher packet-capture create`.
+
 2.0.4 (2017-04-28)
 ++++++++++++++++++
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -2015,6 +2015,25 @@ helps['network watcher test-ip-flow'] = """
           short-summary: Protocol to test.
 """
 
+helps['network watcher test-connectivity'] = """
+    type: command
+    short-summary: Test whether a direct TCP connection can be established between a Virtual
+        Machine and a given endpoint, such as another VM or an arbitrary remote server.
+    parameters:
+        - name: --source-resource
+          short-summary: Name or ID of the resource from which to originate traffic.
+          long-summary: Currently only Virtual Machines are supported.
+        - name: --source-port
+          short-summary: Port number from which to originate traffic.
+        - name: --dest-resource
+          short-summary: Name or ID of the resource to receive traffic.
+          long-summary: Currently only Virtual Machines are supported.
+        - name: --dest-port
+          short-summary: Port number on which to receive traffic.
+        - name: --dest-address
+          short-summary: The IP address or URI at which to receive traffic.
+"""
+
 helps['network watcher show-next-hop'] = """
     type: command
     short-summary: Show information on the 'next hop' for a VM.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -2087,6 +2087,8 @@ helps['network watcher packet-capture create'] = """
                 path must start with /var/captures.
         - name: --vm
           short-summary: Name or ID of the VM to target.
+        - name: --filters
+          short-summary: JSON encoded list of packet filters. Use `@<file path>` to load from file.
 """
 
 helps['network watcher flow-log'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -42,6 +42,7 @@ from azure.cli.command_modules.network._validators import \
 from azure.mgmt.network.models import ApplicationGatewaySslProtocol
 from azure.cli.command_modules.network.custom import list_traffic_manager_endpoints
 from azure.cli.core.profiles import ResourceType, get_sdk
+from azure.cli.core.util import get_json_object
 
 ApplicationGatewaySkuName, ApplicationGatewayCookieBasedAffinity, \
 ApplicationGatewayFirewallMode, ApplicationGatewayProtocol, \
@@ -689,6 +690,7 @@ register_cli_argument('network watcher packet-capture', 'capture_name', name_arg
 register_cli_argument('network watcher packet-capture', 'storage_account', arg_group='Storage')
 register_cli_argument('network watcher packet-capture', 'storage_path', arg_group='Storage')
 register_cli_argument('network watcher packet-capture', 'file_path', arg_group='Storage')
+register_cli_argument('network watcher packet-capture', 'filters', type=get_json_object)
 
 register_cli_argument('network watcher flow-log', 'enabled', validator=process_nw_flow_log_set_namespace, **three_state_flag())
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -32,6 +32,7 @@ from azure.cli.command_modules.network._validators import \
      process_nw_flow_log_set_namespace, process_nw_flow_log_show_namespace,
      process_ag_ssl_policy_set_namespace, process_route_table_create_namespace,
      process_nw_topology_namespace, process_nw_packet_capture_create_namespace,
+     process_nw_test_connectivity_namespace,
      validate_auth_cert, validate_cert, validate_inbound_nat_rule_id_list,
      validate_address_pool_id_list, validate_inbound_nat_rule_name_or_id,
      validate_address_pool_name_or_id, validate_servers, load_cert_file, validate_metadata,
@@ -677,6 +678,12 @@ for item in ['test-ip-flow', 'show-next-hop', 'show-security-group-view', 'packe
     register_cli_argument('network watcher {}'.format(item), 'vm', help='Name or ID of the VM to target.')
     register_cli_argument('network watcher {}'.format(item), 'resource_group_name', help='Name of the resource group the target VM is in. Do not use when supplying VM ID.')
     register_cli_argument('network watcher {}'.format(item), 'nic', help='Name or ID of the NIC resource to test. If the VM has multiple NICs and IP forwarding is enabled on any of them, this parameter is required.')
+
+register_cli_argument('network watcher test-connectivity', 'source_resource', validator=process_nw_test_connectivity_namespace)
+register_cli_argument('network watcher test-connectivity', 'source_port', type=int)
+register_cli_argument('network watcher test-connectivity', 'dest_resource', arg_group='Destination')
+register_cli_argument('network watcher test-connectivity', 'dest_address', arg_group='Destination')
+register_cli_argument('network watcher test-connectivity', 'dest_port', type=int, arg_group='Destination')
 
 register_cli_argument('network watcher packet-capture', 'capture_name', name_arg_type, help='Name of the packet capture session.')
 register_cli_argument('network watcher packet-capture', 'storage_account', arg_group='Storage')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -237,6 +237,7 @@ cli_command(__name__, 'network watcher configure', custom_path + 'configure_netw
 cli_command(__name__, 'network watcher list', nw_path + 'list_all', cf_network_watcher)
 
 cli_command(__name__, 'network watcher test-ip-flow', custom_path + 'check_nw_ip_flow', cf_network_watcher)
+cli_command(__name__, 'network watcher test-connectivity', custom_path + 'check_nw_connectivity', cf_network_watcher)
 cli_command(__name__, 'network watcher show-next-hop', custom_path + 'show_nw_next_hop', cf_network_watcher)
 cli_command(__name__, 'network watcher show-security-group-view', custom_path + 'show_nw_security_view', cf_network_watcher)
 cli_command(__name__, 'network watcher show-topology', nw_path + 'get_topology', cf_network_watcher)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -2461,6 +2461,18 @@ def configure_network_watcher(client, locations, resource_group_name=None, enabl
 
     return client.list_all()
 
+
+def check_nw_connectivity(client, watcher_rg, watcher_name, source_resource, source_port=None,
+                          dest_resource=None, dest_port=None, dest_address=None,
+                          resource_group_name=None):
+    ConnectivitySource, ConnectivityDestination = \
+        get_sdk(ResourceType.MGMT_NETWORK, 'ConnectivitySource', 'ConnectivityDestination',
+                mod='models')
+    source = ConnectivitySource(source_resource, source_port)
+    dest = ConnectivityDestination(dest_resource, dest_address, dest_port)
+    return client.check_connectivity(watcher_rg, watcher_name, source, dest)
+
+
 def check_nw_ip_flow(client, vm, watcher_rg, watcher_name, direction, protocol, local, remote,
                      resource_group_name=None, nic=None, location=None):
     VerificationIPFlowParameters = \

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -2528,13 +2528,14 @@ def show_nw_security_view(client, resource_group_name, vm, watcher_rg, watcher_n
 def create_nw_packet_capture(client, resource_group_name, capture_name, vm,
                              watcher_rg, watcher_name, location=None,
                              storage_account=None, storage_path=None, file_path=None,
-                             capture_size=None, capture_limit=None, time_limit=None):
+                             capture_size=None, capture_limit=None, time_limit=None, filters=None):
     PacketCapture, PacketCaptureStorageLocation = \
         get_sdk(ResourceType.MGMT_NETWORK, 'PacketCapture', 'PacketCaptureStorageLocation',
                 mod='models')
 
     storage_settings = PacketCaptureStorageLocation(storage_account, storage_path, file_path)
-    capture_params = PacketCapture(vm, storage_settings, capture_size, capture_limit, time_limit)
+    capture_params = PacketCapture(vm, storage_settings, capture_size, capture_limit, time_limit,
+                                   filters)
     return client.create(watcher_rg, watcher_name, capture_name, capture_params)
 
 

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-network==1.0.0rc2',
+    'azure-mgmt-network==1.0.0rc3',
     'azure-mgmt-trafficmanager==0.30.0',
     'azure-mgmt-dns==1.0.1',
     'azure-mgmt-resource==1.0.0rc1',

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -35,7 +35,7 @@ DEPENDENCIES = [
     'azure-mgmt-compute==1.0.0rc1',
     'azure-mgmt-keyvault==0.31.0',
     'azure-keyvault==0.2.0',
-    'azure-mgmt-network==1.0.0rc2',
+    'azure-mgmt-network==1.0.0rc3',
     'azure-mgmt-resource==1.0.0rc1',
     'azure-multiapi-storage==0.1.0',
     'azure-cli-core',


### PR DESCRIPTION
Adds `network watcher test-connectivity` command.
Adds support for `--filters` to `network watcher packet-capture create`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.  Cannot add test because service endpoint is not live. Have tested manually on service's staging subscription. (#3142)

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
