### PR TITLE
Infrastucture: Make sure that the command handler is called through CliCommand's __call__ method instead of directly calling the registered handler

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -259,7 +259,7 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
                 overrides.settings['default'] = config_value
                 overrides.settings['required'] = False
 
-    def execute(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         return self.handler(*args, **kwargs)
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -259,8 +259,8 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
                 overrides.settings['default'] = config_value
                 overrides.settings['required'] = False
 
-    def execute(self, **kwargs):
-        return self.handler(**kwargs)
+    def execute(self, *args, **kwargs):
+        return self.handler(*args, **kwargs)
 
 
 command_table = CommandTable()

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -259,6 +259,9 @@ class CliCommand(object):  # pylint:disable=too-many-instance-attributes
                 overrides.settings['default'] = config_value
                 overrides.settings['required'] = False
 
+    def execute(self, **kwargs):
+        return self(**kwargs)
+
     def __call__(self, *args, **kwargs):
         return self.handler(*args, **kwargs)
 

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -110,7 +110,7 @@ class AzCliCommandParser(argparse.ArgumentParser):
                             raise
                 param.completer = arg.completer
 
-            command_parser.set_defaults(func=metadata.handler,
+            command_parser.set_defaults(func=lambda *args, **kwargs: metadata.execute(*args, **kwargs),
                                         command=command_name,
                                         _validators=argument_validators,
                                         _parser=command_parser)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -110,10 +110,11 @@ class AzCliCommandParser(argparse.ArgumentParser):
                             raise
                 param.completer = arg.completer
 
-            command_parser.set_defaults(func=lambda *args, **kwargs: metadata.execute(*args, **kwargs),
-                                        command=command_name,
-                                        _validators=argument_validators,
-                                        _parser=command_parser)
+            command_parser.set_defaults(
+                func=metadata,
+                command=command_name,
+                _validators=argument_validators,
+                _parser=command_parser)
 
     def _get_subparser(self, path):
         """For each part of the path, walk down the tree of

--- a/src/azure-cli-core/tests/test_parser.py
+++ b/src/azure-cli-core/tests/test_parser.py
@@ -32,10 +32,10 @@ class TestParser(unittest.TestCase):
         parser = AzCliCommandParser()
         parser.load_command_table(cmd_table)
         args = parser.parse_args('command the-name'.split())
-        self.assertIs(args.func, test_handler1)
+        self.assertIs(args.func, command)
 
         args = parser.parse_args('sub-command the-second-name'.split())
-        self.assertIs(args.func, test_handler2)
+        self.assertIs(args.func, command2)
 
         AzCliCommandParser.error = VerifyError(self,)
         parser.parse_args('sub-command'.split())
@@ -53,7 +53,7 @@ class TestParser(unittest.TestCase):
         parser.load_command_table(cmd_table)
 
         args = parser.parse_args('test command --req yep'.split())
-        self.assertIs(args.func, test_handler)
+        self.assertIs(args.func, command)
 
         AzCliCommandParser.error = VerifyError(self)
         parser.parse_args('test command'.split())
@@ -71,7 +71,7 @@ class TestParser(unittest.TestCase):
         parser.load_command_table(cmd_table)
 
         args = parser.parse_args('test command --req yep nope'.split())
-        self.assertIs(args.func, test_handler)
+        self.assertIs(args.func, command)
 
         AzCliCommandParser.error = VerifyError(self)
         parser.parse_args('test command -req yep'.split())

--- a/src/command_modules/azure-cli-batch/tests/test_batch_commands.py
+++ b/src/command_modules/azure-cli-batch/tests/test_batch_commands.py
@@ -641,7 +641,7 @@ class TestBatchLoader(unittest.TestCase):
         args = list(self.command_pool._load_transformed_arguments(handler))
         with mock.patch.object(_command_type, 'get_op_handler', get_op_handler):
             with self.assertRaises(CLIError):
-                self.command_pool.cmd.execute(kwargs={'id': 'pool_test', 'vm_size': 'small'})
+                self.command_pool.cmd(kwargs={'id': 'pool_test', 'vm_size': 'small'})
 
         def function_result(client, **kwargs):
             # pylint: disable=function-redefined,unused-argument
@@ -649,7 +649,7 @@ class TestBatchLoader(unittest.TestCase):
 
         with mock.patch.object(_command_type, 'get_op_handler', get_op_handler):
             with self.assertRaises(CLIError):
-                self.command_pool.cmd.execute(kwargs={'id': 'pool_test', 'vm_size': 'small'})
+                self.command_pool.cmd(kwargs={'id': 'pool_test', 'vm_size': 'small'})
 
         def function_result(client, **kwargs):
             # pylint: disable=function-redefined,unused-argument
@@ -666,7 +666,7 @@ class TestBatchLoader(unittest.TestCase):
 
         with mock.patch.object(_command_type, 'get_op_handler', get_op_handler):
             with self.assertRaises(CLIError):
-                self.command_pool.cmd.execute(kwargs={'id': 'pool_test', 'vm_size': 'small'})
+                self.command_pool.cmd(kwargs={'id': 'pool_test', 'vm_size': 'small'})
 
         def function_result(client, **kwargs):
             # pylint: disable=function-redefined,unused-argument
@@ -681,5 +681,5 @@ class TestBatchLoader(unittest.TestCase):
         kwargs = {a: None for a, _ in args}
         kwargs['json_file'] = json_file
         with mock.patch.object(_command_type, 'get_op_handler', get_op_handler):
-            result = self.command_pool.cmd.execute(kwargs=kwargs)
+            result = self.command_pool.cmd(kwargs=kwargs)
             self.assertEqual(result, "Pool Created")


### PR DESCRIPTION
Before, the intent was that the command would be called through the CliCommand's execute method. However, this was accidentally bypassed, and the CliCommand's handler was directly called instead.

This change makes the CliCommand into a pure callable, and the application framework will now call the callable when executing a command.

This was done in preparation for being able to deprecate commands by setting a 'deprecated' flag on the command. Without calling through the CliCommand, there is no way for the command handler to actually make use of the deprecated attribute. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
