### PR TITLE
login: avoid the bad exception when the user account has no subscription and no tenants

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 2.0.5 (Unreleased)
 ^^^^^^^^^^^^^^^^^^
 * core: capture exceptions caused by unregistered provider and auto-register it   
+* login: avoid the bad exception when the user account has no subscription and no tenants
 
 2.0.4 (2017-04-28)
 ^^^^^^^^^^^^^^^^^^

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -145,6 +145,8 @@ class Profile(object):
             t_list = [s.tenant_id for s in subscriptions]
             bare_tenants = [t for t in subscription_finder.tenants if t not in t_list]
             subscriptions = Profile._build_tenant_level_accounts(bare_tenants)
+            if not subscriptions:
+                return []
 
         consolidated = Profile._normalize_properties(subscription_finder.user_id,
                                                      subscriptions,

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -283,6 +283,25 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertEqual(result[0]['tenantId'], self.tenant_id)
         self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
 
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_create_account_without_subscriptions_without_tenant(self, mock_auth_context):
+        finder = mock.MagicMock()
+        finder.find_through_interactive_flow.return_value = []
+        storage_mock = {'subscriptions': []}
+        profile = Profile(storage_mock)
+
+        # action
+        result = profile.find_subscriptions_on_login(True,
+                                                     '1234',
+                                                     'my-secret',
+                                                     False,
+                                                     None,
+                                                     allow_no_subscriptions=True,
+                                                     subscription_finder=finder)
+
+        # assert
+        self.assertTrue(0 == len(result))
+
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     def test_get_current_account_user(self, mock_read_cred_file):
         # setup


### PR DESCRIPTION
- [x ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
