### PR TITLE
Expose application event to notify clients before arguments are fed to parser

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -98,6 +98,7 @@ class Application(object):
     FILTER_RESULT = 'Application.FilterResults'
     GLOBAL_PARSER_CREATED = 'GlobalParser.Created'
     COMMAND_PARSER_LOADED = 'CommandParser.Loaded'
+    COMMAND_PARSER_PARSING = 'CommandParser.Parsing'
     COMMAND_PARSER_PARSED = 'CommandParser.Parsed'
     COMMAND_TABLE_LOADED = 'CommandTable.Loaded'
     COMMAND_TABLE_PARAMS_LOADED = 'CommandTableParams.Loaded'
@@ -170,6 +171,7 @@ class Application(object):
         if self.session['completer_active']:
             enable_autocomplete(self.parser)
 
+        self.raise_event(self.COMMAND_PARSER_PARSING, argv=argv)
         args = self.parser.parse_args(argv)
 
         self.raise_event(self.COMMAND_PARSER_PARSED, command=args.command, args=args)


### PR DESCRIPTION
Some command packages want to inspect the set of arguments before they are fed to the parser (i.e. to deprecate/hide commands and give the appropriate error message)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
