### PR TITLE
avail-set: make FD domain counts optional

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 2.0.5 (unreleased)
 ++++++++++++++++++
-* avail-set: make --platform-update-domain-count optional
+* avail-set: make UD&FD domain counts optional
 
 2.0.4 (2017-04-28)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -92,7 +92,7 @@ register_cli_argument('vm availability-set create', 'availability_set_name', nam
 register_cli_argument('vm availability-set create', 'unmanaged', action='store_true', help='contained VMs should use unmanaged disks')
 register_cli_argument('vm availability-set create', 'platform_update_domain_count', type=int,
                       help='Update Domain count. If unspecified, server picks the most optimal number like 5. For the latest defaults see https://docs.microsoft.com/en-us/rest/api/compute/availabilitysets/availabilitysets-create')
-register_cli_argument('vm availability-set create', 'platform_fault_domain_count', type=int, help='Fault Domain count. Example: 2')
+register_cli_argument('vm availability-set create', 'platform_fault_domain_count', type=int, help='Fault Domain count.')
 register_cli_argument('vm availability-set create', 'validate', help='Generate and validate the ARM template without creating any resources.', action='store_true')
 
 register_cli_argument('vm user', 'username', options_list=('--username', '-u'), help='The user name')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1897,7 +1897,7 @@ def create_vmss(vmss_name, resource_group_name, image,
 
 
 def create_av_set(availability_set_name, resource_group_name,
-                  platform_fault_domain_count, platform_update_domain_count=None,
+                  platform_fault_domain_count=2, platform_update_domain_count=None,
                   location=None, no_wait=False,
                   unmanaged=False, tags=None, validate=False):
     from azure.cli.core.util import random_string

--- a/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
@@ -520,7 +520,7 @@ class VMAvailSetScenarioTest(ResourceGroupVCRTestBase):
         self.execute()
 
     def body(self):
-        self.cmd('vm availability-set create -g {} -n {} --platform-fault-domain-count 2'.format(
+        self.cmd('vm availability-set create -g {} -n {}'.format(
             self.resource_group, self.name), checks=[
                 JMESPathCheck('name', self.name),
                 JMESPathCheck('platformFaultDomainCount', 2),


### PR DESCRIPTION
Chatted with CRP folks, for usability we will have client side default at 2, which is the minimum of all public regions

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
