### PR TITLE
Use urlopen instead of urlretrieve

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -5,11 +5,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-# 
+#
 # Bash script to install the Azure CLI
 #
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
-INSTALL_SCRIPT_SHA256=837c3766c591bc3d452764808eec171085950c4f1054d8754f1f335b09c0becf
+INSTALL_SCRIPT_SHA256=7419f49b066015d863f398198c4ac5ad026f5aa3705e898b552e4e03fc352552
 _TTY=/dev/tty
 
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -119,7 +119,7 @@ def create_virtualenv(tmp_dir, install_dir):
     download_location = os.path.join(tmp_dir, VIRTUALENV_ARCHIVE)
     print_status('Downloading virtualenv package from {}.'.format(VIRTUALENV_DOWNLOAD_URL))
     response = urlopen(VIRTUALENV_DOWNLOAD_URL)
-    with open(download_location, 'w') as f: f.write(response.read())
+    with open(download_location, 'wb') as f: f.write(response.read())
     print_status("Downloaded virtualenv package to {}.".format(download_location))
     if is_valid_sha256sum(download_location, VIRTUALENV_ARCHIVE_SHA256):
         print_status("Checksum of {} OK.".format(download_location))

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -26,10 +26,10 @@ import subprocess
 import hashlib
 try:
     # Attempt to load python 3 module
-    from urllib.request import urlretrieve
+    from urllib.request import urlopen
 except ImportError:
     # Import python 2 version
-    from urllib import urlretrieve
+    from urllib2 import urlopen
 
 try:
     # Rename raw_input to input to support Python 2
@@ -118,15 +118,15 @@ def is_valid_sha256sum(a_file, expected_sum):
 def create_virtualenv(tmp_dir, install_dir):
     download_location = os.path.join(tmp_dir, VIRTUALENV_ARCHIVE)
     print_status('Downloading virtualenv package from {}.'.format(VIRTUALENV_DOWNLOAD_URL))
-    downloaded_file, _ = urlretrieve(VIRTUALENV_DOWNLOAD_URL,
-                                     download_location)
-    print_status("Downloaded virtualenv package to {}.".format(downloaded_file))
-    if is_valid_sha256sum(downloaded_file, VIRTUALENV_ARCHIVE_SHA256):
-        print_status("Checksum of {} OK.".format(downloaded_file))
+    response = urlopen(VIRTUALENV_DOWNLOAD_URL)
+    with open(download_location, 'w') as f: f.write(response.read())
+    print_status("Downloaded virtualenv package to {}.".format(download_location))
+    if is_valid_sha256sum(download_location, VIRTUALENV_ARCHIVE_SHA256):
+        print_status("Checksum of {} OK.".format(download_location))
     else:
         raise CLIInstallError("The checksum of the downloaded virtualenv package does not match.")
-    print_status("Extracting '{}' to '{}'.".format(downloaded_file, tmp_dir))
-    package_tar = tarfile.open(downloaded_file)
+    print_status("Extracting '{}' to '{}'.".format(download_location, tmp_dir))
+    package_tar = tarfile.open(download_location)
     package_tar.extractall(path=tmp_dir)
     package_tar.close()
     virtualenv_dir_name = 'virtualenv-'+VIRTUALENV_VERSION


### PR DESCRIPTION
`urlretrieve` of `urllib` does not respect corporate proxy settings for some reason. `urllib2` in python 2.7 works as intended. This PR changes `urlretrieve` to `urlopen` and saves the file manually.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
