### PR TITLE
appservice: workaround a command error caused by a sdk library bug

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -95,7 +95,7 @@ cli_command(__name__, 'webapp config backup restore', custom_path + 'restore_bac
 
 cli_command(__name__, 'webapp deployment source config-local-git', custom_path + 'enable_local_git')
 cli_command(__name__, 'webapp deployment source config', custom_path + 'config_source_control', exception_handler=ex_handler_factory())
-cli_command(__name__, 'webapp deployment source sync', custom_path + 'sync_site_repo')
+cli_command(__name__, 'webapp deployment source sync', custom_path + 'sync_site_repo', exception_handler=ex_handler_factory())
 cli_command(__name__, 'webapp deployment source show', custom_path + 'show_source_control', exception_handler=empty_on_404)
 cli_command(__name__, 'webapp deployment source delete', custom_path + 'delete_source_control')
 cli_command(__name__, 'webapp deployment source update-token', custom_path + 'update_git_token', exception_handler=ex_handler_factory())

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -497,7 +497,7 @@ def enable_local_git(resource_group_name, name, slot=None):
 def sync_site_repo(resource_group_name, name, slot=None):
     try:
         return _generic_site_operation(resource_group_name, name, 'sync_repository', slot)
-    except CloudError as ex:
+    except CloudError as ex:  # Because of bad spec, sdk throws on 200. We capture it here
         if ex.status_code not in [200, 204]:
             raise ex
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -5,7 +5,6 @@
 
 # pylint: disable=no-self-use,too-many-arguments,too-many-lines
 from __future__ import print_function
-import json
 import threading
 try:
     from urllib.parse import urlparse
@@ -499,16 +498,8 @@ def sync_site_repo(resource_group_name, name, slot=None):
     try:
         return _generic_site_operation(resource_group_name, name, 'sync_repository', slot)
     except CloudError as ex:
-        raise _extract_real_error(ex)
-
-
-# webapp service's error payload doesn't follow ARM's error format, so we had to sniff out
-def _extract_real_error(ex):
-    try:
-        err = json.loads(ex.response.text)
-        return CLIError(err['Message'])
-    except Exception:  # pylint: disable=broad-except
-        return ex
+        if ex.status_code not in [200, 204]:
+            raise ex
 
 
 def list_app_service_plans(resource_group_name=None):

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -216,15 +216,14 @@ class Test_Webapp_Mocked(unittest.TestCase):
         log_mock.assert_called_with('myRG', 'myweb', None, None)
 
     @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation', autospec=True)
-    def test_sync_repository_with_error(self, site_op_mock):
-        resp = FakedResponse(400)
-        setattr(resp, 'text', '{"Message": "nice error"}')
-        site_op_mock.side_effect = CloudError(resp, error='error1')
+    def test_sync_repository_skip_bad_error(self, site_op_mock):
+        resp = FakedResponse(200)  # because of bad spec, sdk throws on 200.
+        setattr(resp, 'text', '{"Message": ""}')
+        site_op_mock.side_effect = CloudError(resp, error="bad error")
         # action
-        with self.assertRaises(CLIError) as ex:
-            sync_site_repo('myRG', 'myweb')
+        sync_site_repo('myRG', 'myweb')
         # assert
-        self.assertEqual("nice error", str(ex.exception))
+        pass  # if we are here, it means CLI has captured the bogus exception
 
     def test_match_host_names_from_cert(self):
         result = _match_host_names_from_cert(['*.mysite.com'], ['admin.mysite.com', 'log.mysite.com', 'mysite.com'])


### PR DESCRIPTION
The spec was wrong, but too late for webapp team to correct it for //build

~- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).~

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
