### PR TITLE
Fixing incorrect function reference in Service Fabric commands

### DIFF
--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
@@ -36,7 +36,7 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
         app_group.custom_command("report-health", "sf_report_app_health")
         app_group.custom_command("upgrade", "sf_upgrade_app")
         app_group.command("health", "get_application_health")
-        app_group.command("manifest", "get_application_health")
+        app_group.command("manifest", "get_application_manifest")
         app_group.command("provision", "provision_application_type")
         app_group.command("delete", "delete_application")
         app_group.command("unprovision", "unprovision_application_type")


### PR DESCRIPTION
Single line fix for incorrect command specification in Service Fabric commands. The bug was that both `az sf application health` and `az sf application manifest` called the `get_application_health` API.