### PR TITLE
Improvements to ServiceFabric commands

### DIFF
--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
@@ -13,12 +13,39 @@ custom_path = "azure.cli.command_modules.sf.custom#{}"
 cluster_operations = create_service_adapter("azure.servicefabric",
                                             "ServiceFabricClientAPIs")
 
-# No client for specific custom commands
+# Custom commands
+# TODO: Fix custom commands to accept client as additional argument instead of
+# generating
 cli_command(__name__, "sf cluster select",
             "azure.cli.command_modules.sf.custom#sf_select")
 cli_command(__name__, "sf application upload",
             "azure.cli.command_modules.sf.custom#sf_upload_app")
+cli_command(__name__, "sf compose create",
+            "azure.cli.command_modules.sf.custom#sf_create_compose_application")
+cli_command(__name__, "sf service create",
+            "azure.cli.command_modules.sf.custom#sf_create_service")
+cli_command(__name__, "sf service update",
+            "azure.cli.command_modules.sf.custom#sf_update_service")
+cli_command(__name__, "sf service report-health",
+            "azure.cli.command_modules.sf.custom#sf_report_svc_health")
+cli_command(__name__, "sf application create",
+            "azure.cli.command_modules.sf.custom#sf_create_app")
+cli_command(__name__, "sf application report-health",
+            "azure.cli.command_modules.sf.custom#sf_report_app_health")
+cli_command(__name__, "sf application upgrade",
+            "azure.cli.command_modules.sf.custom#sf_upgrade_app")
+cli_command(__name__, "sf node report-health",
+            "azure.cli.command_modules.sf.custom#sf_report_node_health")
+cli_command(__name__, "sf node service-package-upload",
+            "azure.cli.command_modules.sf.custom#sf_service_package_upload")
+cli_command(__name__, "sf replica report-health",
+            "azure.cli.command_modules.sf.custom#sf_report_replica_health")
+cli_command(__name__, "sf chaos start",
+            "azure.cli.command_modules.sf.custom#sf_start_chaos")
+cli_command(__name__, "sf partition report-health",
+            "azure.cli.command_modules.sf.custom#sf_report_partition_health")
 
+# Standard commands
 with ServiceGroup(__name__, cf_sf_client, cluster_operations,
                   custom_path) as sg:
     # Cluster level commands
@@ -32,9 +59,6 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
 
     # Application level commands
     with sg.group("sf application") as app_group:
-        app_group.custom_command("create", "sf_create_app")
-        app_group.custom_command("report-health", "sf_report_app_health")
-        app_group.custom_command("upgrade", "sf_upgrade_app")
         app_group.command("health", "get_application_health")
         app_group.command("manifest", "get_application_manifest")
         app_group.command("provision", "provision_application_type")
@@ -46,9 +70,6 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
 
     # Service level commands
     with sg.group("sf service") as svc_group:
-        svc_group.custom_command("create", "sf_create_service")
-        svc_group.custom_command("update", "sf_update_service")
-        svc_group.custom_command("report-health", "sf_report_svc_health")
         svc_group.command("list", "get_service_info_list")
         svc_group.command("manifest", "get_service_manifest")
         svc_group.command("application-name", "get_application_name_info")
@@ -58,23 +79,16 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
 
     # Partition level commands
     with sg.group("sf partition") as partition_group:
-        partition_group.custom_command("report-health",
-                                       "sf_report_partition_health")
         partition_group.command("info", "get_partition_info")
         partition_group.command("service-name", "get_service_name_info")
         partition_group.command("health", "get_partition_health")
 
     # Replica level commands
     with sg.group("sf replica") as replica_group:
-        replica_group.custom_command("report-health",
-                                     "sf_report_replica_health")
         replica_group.command("health", "get_replica_health")
 
     # Node level commands
     with sg.group("sf node") as node_group:
-        node_group.custom_command("report-health", "sf_report_node_health")
-        node_group.custom_command("service-package-upload",
-                                  "sf_service_package_upload")
         node_group.command("list", "get_node_info_list")
         node_group.command("remove-state", "remove_node_state")
         node_group.command("stop", "stop_node")
@@ -96,11 +110,6 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
 
     # Docker Compose commands
     with sg.group("sf compose") as compose_group:
-        compose_group.custom_command("create", "sf_create_compose_application")
         compose_group.command("status", "get_compose_application_status")
         compose_group.command("list", "get_compose_application_status_list")
         compose_group.command("remove", "remove_compose_application")
-
-    # Chaos test commands
-    with sg.group("sf chaos") as chaos_group:
-        chaos_group.custom_command("start", "sf_start_chaos")

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/commands.py
@@ -36,7 +36,7 @@ with ServiceGroup(__name__, cf_sf_client, cluster_operations,
         app_group.custom_command("report-health", "sf_report_app_health")
         app_group.custom_command("upgrade", "sf_upgrade_app")
         app_group.command("health", "get_application_health")
-        app_group.command("manifest", "get_application_health")
+        app_group.command("manifest", "get_application_manifest")
         app_group.command("provision", "provision_application_type")
         app_group.command("delete", "delete_application")
         app_group.command("unprovision", "unprovision_application_type")

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -644,6 +644,7 @@ def sup_service_update_flags(  # pylint: disable=too-many-arguments
         f += 512
     return f
 
+
 def sf_create_service(  # pylint: disable=too-many-arguments, too-many-locals
         app_id, name, service_type, stateful=False, stateless=False,
         singleton_scheme=False, named_scheme=False, int_scheme=False,
@@ -758,12 +759,14 @@ def sf_create_service(  # pylint: disable=too-many-arguments, too-many-locals
         part_schema = NamedPartitionSchemeDescription(len(named_scheme_list),
                                                       named_scheme_list)
     elif int_scheme:
+        # pylint: disable=redefined-variable-type
         part_schema = UniformInt64RangePartitionSchemeDescription(
             int_scheme_count,
             int_scheme_low,
             int_scheme_high
         )
     else:
+        # pylint: disable=redefined-variable-type
         part_schema = SingletonPartitionSchemeDescription()
     # correlation scheme
     correlation_desc = sup_correlation_scheme(correlated_service,
@@ -803,6 +806,7 @@ def sf_create_service(  # pylint: disable=too-many-arguments, too-many-locals
     if stateful:
         flags = sup_stateful_flags(replica_restart_wait, quorum_loss_wait,
                                    stand_by_replica_keep)
+        # pylint: disable=redefined-variable-type
         svc_desc = StatefulServiceDescription(name, service_type,
                                               part_schema,
                                               target_replica_set_size,

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -510,7 +510,7 @@ def sup_correlation_scheme(correlated_service, correlation):
             not all([correlated_service, correlation])):
         raise CLIError("Must specify both a correlation service and "
                        "correlation scheme")
-    elif any([correlated_service, correlated_service]):
+    elif any([correlated_service, correlation]):
         return ServiceCorrelationDescription(correlation, correlated_service)
     else:
         return None

--- a/src/command_modules/azure-cli-sf/setup.py
+++ b/src/command_modules/azure-cli-sf/setup.py
@@ -34,7 +34,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-servicefabric==5.6.130',
     'azure-cli-core',
-    'adal==0.4.3'
+    'adal>=0.4.3'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
This fixes a few critical problems in the Service Fabric commands:
- Correctly maps `application manifest` to `get_application_manifest`. Previously was erroneously mapped to a health command
- Fixes custom commands having to create multiple clients, and having duplicate parameters.
- Improves argument validation for `create service` and fixes argument passing for correlated services when no correlation services specified.
