### PR TITLE
The detection logic for determining if a parser represented a group or an individual comand was recently regressed

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -190,7 +190,8 @@ class AzCliCommandParser(argparse.ArgumentParser):
             or a command. Anything that has a func default is considered
             a group. This includes any dummy commands served up by the
             "filter out irrelevant commands based on argv" command filter """
-        return not self._defaults.get('func', None)
+        cmd = self._defaults.get('func', None)
+        return not (cmd and cmd.handler)
 
     def __getattribute__(self, name):
         """ Since getting the description can be expensive (require module loads), we defer


### PR DESCRIPTION
Fixes #3181

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
