### PR TITLE
dev-setup: install azure-mgmt-nspkg to avoid errors of no-name-in-module

### DIFF
--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -44,4 +44,5 @@ exec_command('pip install -e src/azure-cli-testsdk')
 # Ensure that the site package's azure/__init__.py has the old style namespace
 # package declaration by installing the old namespace package
 exec_command('pip install --force-reinstall azure-nspkg==1.0.0')
+exec_command('pip install --force-reinstall azure-mgmt-nspkg==1.0.0')
 print('Finished dev setup.')


### PR DESCRIPTION
To avoid errors like:
```bash
Run pylint
Modules: azure-cli-core
************* Module azure.cli.core.commands.parameters
E: 23, 4: No name 'mgmt' in module 'azure' (no-name-in-module)
E: 23, 4: Unable to import 'azure.mgmt.resource' (import-error)

```