### PR TITLE
webapp: fix broken log tail command

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.1.6 (unlreleased)
+++++++++++++++++++++
+* webapp: fix broken log tail commands
 
 0.1.5 (2017-05-05)
 ++++++++++++++++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -81,8 +81,9 @@ def create_webapp(resource_group_name, name, plan, runtime=None,
 
 
 def show_webapp(resource_group_name, name, slot=None, app_instance=None):
-    webapp = (_generic_site_operation(resource_group_name, name, 'get', slot)
-              if slot else app_instance)
+    webapp = app_instance
+    if not app_instance:
+        webapp = _generic_site_operation(resource_group_name, name, 'get', slot)
     _rename_server_farm_props(webapp)
     _fill_ftp_publishing_url(webapp, resource_group_name, name, slot)
     return webapp

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -82,7 +82,7 @@ def create_webapp(resource_group_name, name, plan, runtime=None,
 
 def show_webapp(resource_group_name, name, slot=None, app_instance=None):
     webapp = app_instance
-    if not app_instance:
+    if not app_instance:  # when the routine is invoked as a help method, not through commands
         webapp = _generic_site_operation(resource_group_name, name, 'get', slot)
     _rename_server_farm_props(webapp)
     _fill_ftp_publishing_url(webapp, resource_group_name, name, slot)

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands_thru_mock.py
@@ -21,7 +21,8 @@ from azure.cli.command_modules.appservice.custom import (set_deployment_user,
                                                          _match_host_names_from_cert,
                                                          bind_ssl_cert,
                                                          list_publish_profiles,
-                                                         config_source_control)
+                                                         config_source_control,
+                                                         show_webapp)
 
 # pylint: disable=line-too-long
 from vsts_cd_manager.continuous_delivery_manager import ContinuousDeliveryResult
@@ -214,6 +215,19 @@ class Test_Webapp_Mocked(unittest.TestCase):
         # assert
         webbrowser_mock.assert_called_with('https://haha.com')
         log_mock.assert_called_with('myRG', 'myweb', None, None)
+
+    @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._rename_server_farm_props', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.custom._fill_ftp_publishing_url', autospec=True)
+    def test_show_webapp(self, file_ftp_mock, rename_mock, site_op_mock):
+        faked_web = mock.MagicMock()
+        site_op_mock.return_value = faked_web
+        # action
+        result = show_webapp('myRG', 'myweb', slot=None, app_instance=None)
+        # assert (we invoke the site op)
+        self.assertEqual(faked_web, result)
+        self.assertTrue(rename_mock.called)
+        self.assertTrue(file_ftp_mock.called)
 
     @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation', autospec=True)
     def test_sync_repository_skip_bad_error(self, site_op_mock):


### PR DESCRIPTION
Fix #3227 
This was broken by the latest functionapp integration. Add unit test coverage as functional test for log streaming is not applicable to run as an automation test

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
