### PR TITLE
appservice: update short summary of appservice group to exclude webapp

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -9,7 +9,7 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps['appservice'] = """
     type: group
-    short-summary: Manage your Azure Web apps and App Service plans.
+    short-summary: Manage your App Service plans.
 """
 
 helps['appservice web'] = """
@@ -377,13 +377,13 @@ helps['webapp create'] = """
     type: command
     short-summary: Create a web app.
     examples:
-        - name: Create a basic App Service plan.  Name must be unique to yield a unique FQDN;
+        - name: Create an empty webapp.  Name must be unique to yield a unique FQDN;
                 for example, MyUniqueApp.azurewebsites.net.
           text: >
-            az webapp create
-            -g MyResourceGroup
-            -p MyPlan
-            -n MyUniqueApp
+            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueApp
+        - name: Create a webapp with node 6.2 stack runtime, and local git configured for web deployment
+          text: >
+            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueApp --runtime "node|6.2" --deployment-local-git
 """
 
 helps['webapp list-runtimes'] = """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -79,7 +79,7 @@ register_cli_argument('webapp create', 'name', options_list=('--name', '-n'), he
 register_cli_argument('webapp create', 'deployment_container_image_name', options_list=('--deployment-container-image-name', '-i'),
                       help='Linux only. Container image name from Docker Hub, e.g. publisher/image-name:version')
 register_cli_argument('webapp create', 'startup_file', help="Linux only. The web's startup file")
-register_cli_argument('webapp create', 'runtime', options_list=('--runtime', '-r'), help='canonicalized web runtime in the format of Framework|Version. For example, PHP|5.6')  # TODO ADD completer
+register_cli_argument('webapp create', 'runtime', options_list=('--runtime', '-r'), help="canonicalized web runtime in the format of Framework|Version, e.g. PHP|5.6. Use 'az webapp list-runtimes' for available list")  # TODO ADD completer
 register_cli_argument('webapp list-runtimes', 'linux', action='store_true', help='list runtime stacks for linux based webapps')  # TODO ADD completer
 
 register_cli_argument('webapp create', 'plan', options_list=('--plan', '-p'), completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),


### PR DESCRIPTION
The `appservice web` to be gone in June, removing it causes less confusions

### General Guidelines

~- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).~

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
