### PR TITLE
Change Pylint rules project-wise

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 max-complexity = 10
 ignore =
     E126,

--- a/pylintrc
+++ b/pylintrc
@@ -5,15 +5,22 @@
 # I0011 Warning locally suppressed using disable-msg
 # W0511 fixme
 # R0401 Cyclic import (because of https://github.com/PyCQA/pylint/issues/850)
-disable=C0111,C0103,I0011,W0511,R0401
+# R0913 Too many arguments - Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
+disable=C0111,C0103,I0011,W0511,R0401,R0913
+
+[FORMAT]
+max-line-length=120
+
 [VARIABLES]
 # Tells whether we should check for unused import in __init__ files.
 init-import=yes
+
 [DESIGN]
 # Maximum number of locals for function / method body
 max-locals=25
 # Maximum number of branch for function / method body
 max-branches=20
+
 [SIMILARITIES]
 min-similarity-lines=10
 

--- a/scripts/automation/tests/nose_helper.py
+++ b/scripts/automation/tests/nose_helper.py
@@ -5,7 +5,6 @@
 
 from __future__ import print_function
 
-# pylint: disable=too-many-arguments
 def get_nose_runner(report_folder, parallel=True, process_timeout=600, process_restart=True,
                     xunit_report=False, exclude_integration=True):
     """Create a nose execution method"""

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -396,7 +396,7 @@ class CommandHelpFile(HelpFile):  # pylint: disable=too-few-public-methods
 
 class HelpParameter(HelpObject):  # pylint: disable=too-few-public-methods, too-many-instance-attributes
 
-    def __init__(self, param_name, description, required, choices=None,  # pylint: disable=too-many-arguments
+    def __init__(self, param_name, description, required, choices=None,
                  default=None, group_name=None):
         super(HelpParameter, self).__init__()
         self.name = param_name

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -110,7 +110,7 @@ class Profile(object):
         self._management_resource_uri = CLOUD.endpoints.management
         self._ad_resource_uri = CLOUD.endpoints.active_directory_resource_id
 
-    def find_subscriptions_on_login(self,  # pylint: disable=too-many-arguments
+    def find_subscriptions_on_login(self,
                                     interactive,
                                     username,
                                     password,

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -50,7 +50,7 @@ class CloudSuffixNotSetException(CLIError):
 
 class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
 
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,
                  management=None,
                  resource_manager=None,
                  sql_management=None,
@@ -89,7 +89,7 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
 
 class CloudSuffixes(object):  # pylint: disable=too-few-public-methods
 
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,
                  storage_endpoint=None,
                  keyvault_dns=None,
                  sql_server_hostname=None,
@@ -113,7 +113,6 @@ class CloudSuffixes(object):  # pylint: disable=too-few-public-methods
 class Cloud(object):  # pylint: disable=too-few-public-methods
     """ Represents an Azure Cloud instance """
 
-    # pylint: disable=too-many-arguments
     def __init__(self,
                  name,
                  endpoints=None,

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -222,7 +222,6 @@ def _user_confirmed(confirmation, command_args):
         return False
 
 
-# pylint: disable=too-many-arguments
 def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=None,
                                setter_arg_name='parameters', table_transformer=None,
                                child_collection_prop_name=None, child_collection_key='name',

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -82,7 +82,7 @@ def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_
     return (client, subscription_id)
 
 
-def get_data_service_client(service_type, account_name, account_key, connection_string=None,  # pylint: disable=too-many-arguments
+def get_data_service_client(service_type, account_name, account_key, connection_string=None,
                             sas_token=None, endpoint_suffix=None):
     logger.debug('Getting data service client service_type=%s', service_type.__name__)
     try:

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -18,7 +18,7 @@ from azure.cli.core.commands.arm import (
     make_camel_case)
 
 
-def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None,  # pylint: disable=too-many-arguments
+def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None,
                                  parent_option_flag=None, parent_type=None, type_field=None,
                                  existing_id_flag_value='existingId', new_flag_value='new',
                                  none_flag_value='none', default_value_flag='new',
@@ -64,7 +64,7 @@ def register_folded_cli_argument(scope, base_name, resource_type, parent_name=No
     register_cli_argument(scope, type_field_name, help=argparse.SUPPRESS, default=None)
 
 
-def _name_id_fold(base_name, resource_type, type_field,  # pylint: disable=too-many-arguments
+def _name_id_fold(base_name, resource_type, type_field,
                   existing_id_flag_value, new_flag_value, none_flag_value,
                   parent_name=None, parent_option_flag=None, parent_type=None, base_required=True):
     def handle_folding(namespace):
@@ -188,7 +188,7 @@ def _validate_name_or_id(
     return (resource_id_parts, value_supplied_was_id)
 
 
-def get_folded_parameter_validator(  # pylint: disable=too-many-arguments
+def get_folded_parameter_validator(
         property_name, property_type, property_option,
         parent_name=None, parent_type=None, parent_option=None,
         allow_none=False, allow_new=False, default_none=False):

--- a/src/azure-cli-core/azure/cli/core/sdk/util.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/util.py
@@ -40,7 +40,6 @@ class ServiceGroup(object):
 
 
 class CommandGroup(object):
-    # pylint: disable=too-many-arguments
     def __init__(self, scope, group_name, client_factory, service_adapter=None, custom_path=None):
         self._scope = scope
         self._group_name = group_name
@@ -70,7 +69,6 @@ class CommandGroup(object):
                     client_factory=self._client_factory,
                     confirmation=confirmation)
 
-    # pylint: disable=too-many-arguments
     def generic_update_command(self, name, getter_op, setter_op, custom_func_name=None,
                                setter_arg_name='parameters'):
         if custom_func_name:

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -110,7 +110,7 @@ class SingleValueReplacer(RecordingProcessor):
 # Resource Group Preparer and its shorthand decorator
 
 class ResourceGroupPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clitest.rg',  # pylint: disable=too-many-arguments
+    def __init__(self, name_prefix='clitest.rg',
                  parameter_name='resource_group',
                  parameter_name_for_location='resource_group_location', location='westus',
                  dev_setting_name='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME',
@@ -141,7 +141,7 @@ class ResourceGroupPreparer(AbstractPreparer, SingleValueReplacer):
 # Storage Account Preparer and its shorthand decorator
 
 class StorageAccountPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,
                  name_prefix='clitest', sku='Standard_LRS', location='westus',
                  parameter_name='storage_account', resource_group_parameter_name='resource_group',
                  skip_delete=True, dev_setting_name='AZURE_CLI_TEST_DEV_STORAGE_ACCOUNT_NAME'):
@@ -185,7 +185,7 @@ class StorageAccountPreparer(AbstractPreparer, SingleValueReplacer):
 # Role based access control service principal preparer
 
 class RoleBasedServicePrincipalPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='http://clitest',  # pylint: disable=too-many-arguments
+    def __init__(self, name_prefix='http://clitest',
                  skip_assignment=True, parameter_name='sp_name', parameter_password='sp_password',
                  dev_setting_sp_name='AZURE_CLI_TEST_DEV_SP_NAME',
                  dev_setting_sp_password='AZURE_CLI_TEST_DEV_SP_PASSWORD'):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/vcr_test_base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/vcr_test_base.py
@@ -260,7 +260,6 @@ class VCRTestBase(unittest.TestCase):  # pylint: disable=too-many-instance-attri
         'x-ms-served-by',
     ]
 
-    # pylint: disable=too-many-arguments
     def __init__(self, test_file, test_name, run_live=False, debug=False, debug_vcr=False,
                  skip_setup=False, skip_teardown=False):
         super(VCRTestBase, self).__init__(test_name)
@@ -485,7 +484,6 @@ class VCRTestBase(unittest.TestCase):  # pylint: disable=too-many-instance-attri
 
 
 class ResourceGroupVCRTestBase(VCRTestBase):
-    # pylint: disable=too-many-arguments
 
     def __init__(self, test_file, test_name, resource_group='vcr_resource_group', run_live=False,
                  debug=False, debug_vcr=False, skip_setup=False, skip_teardown=False,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_utils.py
@@ -92,7 +92,7 @@ def get_access_key_by_storage_account_name(storage_account_name, resource_group_
         0].value  # pylint: disable=no-member
 
 
-def arm_deploy_template_new_storage(resource_group_name,  # pylint: disable=too-many-arguments
+def arm_deploy_template_new_storage(resource_group_name,
                                     registry_name,
                                     location,
                                     sku,
@@ -127,7 +127,7 @@ def arm_deploy_template_new_storage(resource_group_name,  # pylint: disable=too-
         get_arm_service_client().deployments, resource_group_name, deployment_name, properties)
 
 
-def arm_deploy_template_existing_storage(resource_group_name,  # pylint: disable=too-many-arguments
+def arm_deploy_template_existing_storage(resource_group_name,
                                          registry_name,
                                          location,
                                          sku,
@@ -183,7 +183,7 @@ def _arm_deploy_template(deployments_client,
     return deployments_client.create_or_update(resource_group_name, deployment_name, properties)
 
 
-def _parameters(registry_name,  # pylint: disable=too-many-arguments
+def _parameters(registry_name,
                 location,
                 sku,
                 admin_user_enabled,

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -46,7 +46,7 @@ def acr_list(resource_group_name=None):
         return client.list()
 
 
-def acr_create(registry_name,  # pylint: disable=too-many-arguments
+def acr_create(registry_name,
                resource_group_name,
                sku,
                location=None,

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
@@ -28,7 +28,7 @@ def _load_key(key_filename):
     return pkey
 
 
-def SecureCopy(user, host, src, dest,  # pylint: disable=too-many-arguments
+def SecureCopy(user, host, src, dest,
                key_filename=None,
                allow_agent=True):
     ssh = paramiko.SSHClient()
@@ -71,7 +71,7 @@ class ACSClient(object):
         if self.tunnel_server is not None:
             self.tunnel_server.close_tunnel()
 
-    def connect(self, host, username, port=2200,  # pylint: disable=too-many-arguments
+    def connect(self, host, username, port=2200,
                 key_filename=None):
         """
         Creates a connection to the remote server.

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -866,7 +866,7 @@ def _resolve_service_principal(client, identifier):
         raise CLIError("service principal '{}' doesn't exist".format(identifier))
 
 
-def create_application(client, display_name, homepage, identifier_uris,  # pylint: disable=too-many-arguments
+def create_application(client, display_name, homepage, identifier_uris,
                        available_to_other_tenants=False, password=None, reply_urls=None,
                        key_value=None, key_type=None, key_usage=None, start_date=None,
                        end_date=None):
@@ -883,7 +883,7 @@ def create_application(client, display_name, homepage, identifier_uris,  # pylin
     return client.create(app_create_param)
 
 
-def _build_application_creds(password=None, key_value=None, key_type=None,  # pylint: disable=too-many-arguments
+def _build_application_creds(password=None, key_value=None, key_type=None,
                              key_usage=None, start_date=None, end_date=None):
     if password and key_value:
         raise CLIError('specify either --password or --key-value, but not both.')
@@ -940,7 +940,7 @@ def create_role_assignment(role, assignee, resource_group_name=None, scope=None)
     return _create_role_assignment(role, assignee, resource_group_name, scope)
 
 
-def _create_role_assignment(role, assignee, resource_group_name=None, scope=None,  # pylint: disable=too-many-arguments
+def _create_role_assignment(role, assignee, resource_group_name=None, scope=None,
                             resolve_assignee=True):
     factory = _auth_client_factory(scope)
     assignments_client = factory.role_assignments

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -14,7 +14,7 @@ from ._client_factory import web_client_factory
 from ._validators import validate_existing_function_app, validate_existing_web_app
 
 
-def _generic_site_operation(resource_group_name, name, operation_name, slot=None,  # pylint: disable=too-many-arguments
+def _generic_site_operation(resource_group_name, name, operation_name, slot=None,
                             extra_parameter=None, client=None):
     client = client or web_client_factory()
     m = getattr(client.web_apps,

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/vsts_cd_provider.py
@@ -13,7 +13,7 @@ class VstsContinuousDeliveryProvider(object):
     def __init__(self):
         self._progress_last_message = ''
 
-    def setup_continuous_delivery(self,  # pylint:disable=too-many-arguments
+    def setup_continuous_delivery(self,
                                   resource_group_name, name, repo_url, branch, git_token,
                                   slot, cd_app_type, cd_account, cd_create_account, location):
         """

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
@@ -352,7 +352,7 @@ class BatchArgumentTree(object):
             if kwargs[self._request_param['name']] is None:
                 raise ValueError(message.format(self._request_param['model']))
 
-    def queue_argument(self, name=None, path=None, root=None,  # pylint:disable=too-many-arguments
+    def queue_argument(self, name=None, path=None, root=None,
                        options=None, type=None,  # pylint: disable=redefined-builtin
                        dependencies=None):
         """Add pending command line argument
@@ -697,7 +697,7 @@ class AzureBatchDataPlaneCommand(object):
                 options['options_list'] = [arg_name(param)]
                 yield (param, CliCommandArgument(param, **options))
 
-    def _resolve_conflict(self,  # pylint:disable=too-many-arguments
+    def _resolve_conflict(self,
                           arg, param, path, options, typestr, dependencies, conflicting):
         """Resolve conflicting command line arguments.
         :param str arg: Name of the command line argument.
@@ -900,7 +900,7 @@ def validate_client_parameters(namespace):
         namespace.account_key = None
 
 
-def cli_batch_data_plane_command(name,  # pylint:disable=too-many-arguments
+def cli_batch_data_plane_command(name,
                                  operation, client_factory, transform=None, flatten=FLATTEN,
                                  ignore=None, validator=None, silent=None):
     """ Registers an Azure CLI Batch Data Plane command. These commands must respond to a

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/custom.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/custom.py
@@ -46,7 +46,7 @@ def list_accounts(client, resource_group_name=None):
 
 
 @transfer_doc(AutoStorageBaseProperties)
-def create_account(client,  # pylint:disable=too-many-arguments
+def create_account(client,
                    resource_group_name, account_name, location, tags=None, storage_account=None,
                    keyvault=None, keyvault_url=None):
     properties = AutoStorageBaseProperties(storage_account_id=storage_account) \
@@ -64,7 +64,7 @@ def create_account(client,  # pylint:disable=too-many-arguments
 
 
 @transfer_doc(AutoStorageBaseProperties)
-def update_account(client, resource_group_name, account_name,  # pylint:disable=too-many-arguments
+def update_account(client, resource_group_name, account_name,
                    tags=None, storage_account=None):
     properties = AutoStorageBaseProperties(storage_account_id=storage_account) \
         if storage_account else None
@@ -99,7 +99,7 @@ def login_account(client, resource_group_name, account_name, shared_key_auth=Fal
 
 
 @transfer_doc(UpdateApplicationParameters)
-def update_application(client,  # pylint:disable=too-many-arguments
+def update_application(client,
                        resource_group_name, account_name, application_id, allow_updates=None,
                        display_name=None, default_version=None):
     parameters = UpdateApplicationParameters(allow_updates=allow_updates,
@@ -137,7 +137,7 @@ def _upload_package_blob(package_file, url):
 
 
 @transfer_doc(ApplicationPackageOperations.create)
-def create_application_package(client,  # pylint:disable=too-many-arguments
+def create_application_package(client,
                                resource_group_name, account_name, application_id, version,
                                package_file):
     # create application if not exist
@@ -207,7 +207,7 @@ def delete_certificate(client, thumbprint, abort=False):
 
 
 @transfer_doc(PoolResizeParameter)
-def resize_pool(client, pool_id, target_dedicated=None,  # pylint:disable=too-many-arguments
+def resize_pool(client, pool_id, target_dedicated=None,
                 resize_timeout=None, node_deallocation_option=None,
                 if_match=None, if_none_match=None, if_modified_since=None,
                 if_unmodified_since=None, abort=False):
@@ -232,7 +232,7 @@ def resize_pool(client, pool_id, target_dedicated=None,  # pylint:disable=too-ma
 
 
 @transfer_doc(PoolUpdatePropertiesParameter, StartTask)
-def update_pool(client,  # pylint:disable=too-many-arguments
+def update_pool(client,
                 pool_id, json_file=None, start_task_command_line=None, certificate_references=None,
                 application_package_references=None, metadata=None,
                 start_task_environment_settings=None, start_task_wait_for_success=None,
@@ -297,7 +297,7 @@ def list_job(client, job_schedule_id=None, filter=None,  # pylint: disable=redef
 
 
 @transfer_doc(TaskAddParameter, TaskConstraints)
-def create_task(client,  # pylint:disable=too-many-arguments
+def create_task(client,
                 job_id, json_file=None, task_id=None, command_line=None, resource_files=None,
                 environment_settings=None, affinity_info=None, max_wall_clock_time=None,
                 retention_time=None, max_task_retry_count=None,

--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/custom.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/custom.py
@@ -41,7 +41,6 @@ def update_endpoint(instance,
                     is_https_allowed=None,
                     query_string_caching_behavior=None,
                     tags=None):
-    # pylint: disable=too-many-arguments
     params = EndpointUpdateParameters(
         origin_host_header=origin_host_header,
         origin_path=origin_path,
@@ -77,7 +76,6 @@ def create_endpoint(client, resource_group_name, profile_name, name, origins, lo
                     is_compression_enabled=None, is_http_allowed=None, is_https_allowed=None,
                     query_string_caching_behavior=QueryStringCachingBehavior.ignore_query_string.
                     value, tags=None):
-    # pylint: disable=too-many-arguments
     is_compression_enabled = False if is_compression_enabled is None else is_compression_enabled
     is_http_allowed = True if is_http_allowed is None else is_http_allowed
     is_https_allowed = True if is_https_allowed is None else is_https_allowed
@@ -102,7 +100,6 @@ create_endpoint.__doc__ = Endpoint.__doc__
 
 def create_custom_domain(client, resource_group_name, profile_name, endpoint_name, name, hostname,
                          location=None, tags=None):
-    # pylint: disable=too-many-arguments
     from azure.mgmt.cdn.models import (CustomDomain)
     custom_domain = CustomDomain(location, hostname, tags=tags)
     return client.custom_domains.create(resource_group_name,
@@ -125,7 +122,6 @@ update_profile.__doc__ = ProfileUpdateParameters.__doc__
 def create_profile(client, resource_group_name, name,
                    sku=SkuName.standard_akamai.value,
                    location=None, tags=None):
-    # pylint: disable=too-many-arguments
     from azure.mgmt.cdn.models import (Profile, Sku)
     profile = Profile(location, Sku(name=sku), tags=tags)
     return client.profiles.create(resource_group_name, name, profile)

--- a/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/custom.py
+++ b/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/custom.py
@@ -17,7 +17,6 @@ def listresources(client, resource_group_name=None):
         return client.list()
 
 
-# pylint: disable=too-many-arguments
 def create(
         client, resource_group_name, account_name, sku_name, kind, location, tags=None, yes=None):
 

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/custom.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/custom.py
@@ -32,7 +32,6 @@ def list_adla_account(client, resource_group_name=None):
     return list(account_list)
 
 
-# pylint: disable=too-many-arguments
 def list_adla_jobs(client,
                    account_name,
                    top=500,
@@ -78,7 +77,6 @@ def list_adla_jobs(client,
     return to_return
 
 
-# pylint: disable=too-many-arguments
 def create_adla_account(client,
                         resource_group_name,
                         account_name,
@@ -104,7 +102,6 @@ def create_adla_account(client,
     return client.create(resource_group_name, account_name, create_params)
 
 
-# pylint: disable=too-many-arguments
 def update_adla_account(client,
                         account_name,
                         resource_group_name,
@@ -128,7 +125,6 @@ def update_adla_account(client,
 
 
 # firewall customizations
-# pylint: disable=too-many-arguments
 def add_adla_firewall_rule(client,
                            account_name,
                            firewall_rule_name,
@@ -143,7 +139,6 @@ def add_adla_firewall_rule(client,
 
 
 # catalog customizations
-# pylint: disable=too-many-arguments
 def create_adla_catalog_credential(client,
                                    account_name,
                                    database_name,
@@ -165,7 +160,6 @@ def create_adla_catalog_credential(client,
     client.create_credential(account_name, database_name, credential_name, create_params)
 
 
-# pylint: disable=too-many-arguments
 def update_adla_catalog_credential(client,
                                    account_name,
                                    database_name,
@@ -244,7 +238,6 @@ def list_catalog_table_statistics(client,
 
 
 # job customizations
-# pylint: disable=too-many-arguments
 def submit_adla_job(client,
                     account_name,
                     job_name,

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/custom.py
@@ -29,7 +29,6 @@ def list_adls_account(client, resource_group_name=None):
     return list(account_list)
 
 
-# pylint: disable=too-many-arguments
 def create_adls_account(client,
                         resource_group_name,
                         account_name,
@@ -72,7 +71,6 @@ def create_adls_account(client,
     return client.create(resource_group_name, account_name, create_params)
 
 
-# pylint: disable=too-many-arguments
 def update_adls_account(client,
                         account_name,
                         resource_group_name,
@@ -94,7 +92,6 @@ def update_adls_account(client,
 
 
 # firewall customizations
-# pylint: disable=too-many-arguments
 def add_adls_firewall_rule(client,
                            account_name,
                            firewall_rule_name,

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_command_type.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/_command_type.py
@@ -6,7 +6,7 @@
 from azure.cli.core.commands import create_command, command_table
 
 
-def cli_documentdb_data_plane_command(name,  # pylint: disable=too-many-arguments
+def cli_documentdb_data_plane_command(name,
                                       operation, client_factory, transform=None,
                                       table_transformer=None, exception_handler=None):
     """Registers an Azure CLI DocumentDB Data Plane command. These commands always include the

--- a/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
+++ b/src/command_modules/azure-cli-documentdb/azure/cli/command_modules/documentdb/custom.py
@@ -37,7 +37,7 @@ DEFAULT_INDEXING_POLICY = """{
 }"""
 
 
-def cli_documentdb_create(client,  # pylint:disable=too-many-arguments
+def cli_documentdb_create(client,
                           resource_group_name,
                           account_name,
                           locations=None,
@@ -77,7 +77,7 @@ def cli_documentdb_create(client,  # pylint:disable=too-many-arguments
     return docdb_account
 
 
-def cli_documentdb_update(client,  # pylint: disable=too-many-arguments
+def cli_documentdb_update(client,
                           resource_group_name,
                           account_name,
                           locations=None,
@@ -234,7 +234,7 @@ def _populate_collection_definition(collection,
     return changed
 
 
-def cli_documentdb_collection_create(client,  # pylint: disable=too-many-arguments
+def cli_documentdb_collection_create(client,
                                      database_id,
                                      collection_id,
                                      throughput=None,
@@ -266,7 +266,7 @@ def _find_offer(client, collection_self_link):
     return None
 
 
-def cli_documentdb_collection_update(client,  # pylint: disable=too-many-arguments
+def cli_documentdb_collection_update(client,
                                      database_id,
                                      collection_id,
                                      throughput=None,

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -132,7 +132,6 @@ def space_toolbar(settings_items, cols, empty_space):
 class Shell(object):
     """ represents the shell """
 
-    # pylint: disable=too-many-arguments
     def __init__(self, completer=None, styles=None,
                  lexer=None, history=InMemoryHistory(),
                  app=None, input_custom=sys.stdout, output_custom=None):

--- a/src/command_modules/azure-cli-interactive/azclishell/color_styles.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/color_styles.py
@@ -8,7 +8,6 @@ from prompt_toolkit.styles import style_from_dict
 from pygments.token import Token
 
 
-# pylint: disable=too-many-arguments
 def color_mapping(curr_completion, completion, prompt, command, subcommand,
                   param, text, line, example, toolbar):
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -212,7 +212,7 @@ def get_default_policy(client, scaffold=False):  # pylint: disable=unused-argume
         return _default_certificate_profile()
 
 
-def create_keyvault(client,  # pylint:disable=too-many-arguments
+def create_keyvault(client,
                     resource_group_name, vault_name, location=None, sku=SkuName.standard.value,
                     enabled_for_deployment=None,
                     enabled_for_disk_encryption=None,
@@ -310,7 +310,7 @@ def _object_id_args_helper(object_id, spn, upn):
     return object_id
 
 
-def set_policy(client, resource_group_name, vault_name,  # pylint:disable=too-many-arguments
+def set_policy(client, resource_group_name, vault_name,
                object_id=None, spn=None, upn=None, key_permissions=None, secret_permissions=None,
                certificate_permissions=None):
     """ Update security policy settings for a Key Vault. """
@@ -346,7 +346,7 @@ def set_policy(client, resource_group_name, vault_name,  # pylint:disable=too-ma
                                        properties=vault.properties))
 
 
-def delete_policy(client,  # pylint:disable=too-many-arguments
+def delete_policy(client,
                   resource_group_name, vault_name, object_id=None, spn=None, upn=None):
     """ Delete security policy settings for a Key Vault. """
     from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
@@ -367,7 +367,6 @@ def delete_policy(client,  # pylint:disable=too-many-arguments
                                        properties=vault.properties))
 
 
-# pylint: disable=too-many-arguments
 def create_key(client, vault_base_url, key_name, destination, key_size=None, key_ops=None,
                disabled=False, expires=None, not_before=None, tags=None):
     from azure.keyvault.generated.models import KeyAttributes
@@ -397,7 +396,7 @@ def restore_key(client, vault_base_url, file_path):
 restore_key.__doc__ = KeyVaultClient.restore_key.__doc__
 
 
-# pylint: disable=too-many-arguments,assignment-from-no-return,unused-variable
+# pylint: disable=assignment-from-no-return,unused-variable
 def import_key(client, vault_base_url, key_name, destination=None, key_ops=None, disabled=False,
                expires=None, not_before=None, tags=None, pem_file=None, pem_password=None,
                byok_file=None):

--- a/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/tests/test_keyvault_commands.py
@@ -22,7 +22,7 @@ from azure.cli.command_modules.keyvault._params import secret_encoding_values
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 
-def _create_keyvault(test,  # pylint: disable=too-many-arguments
+def _create_keyvault(test,
                      vault_name, resource_group, location, retry_wait=30, max_retries=10):
     # need premium KeyVault to store keys in HSM
     test.cmd('keyvault create -g {} -n {} -l {} --sku premium'.format(resource_group, vault_name,

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -34,7 +34,6 @@ def _metric_names_filter_builder(metric_names=None):
     return ' or '.join(filters)
 
 
-# pylint: disable=too-many-arguments
 def list_metrics(client, resource_id, time_grain,
                  start_time=None, end_time=None, metric_names=None):
     '''Lists the metric values for a resource.
@@ -103,7 +102,6 @@ def _validate_start_time(start_time, end_time):
     return result_time
 
 
-# pylint: disable=too-many-arguments
 def list_activity_log(client, filters=None, correlation_id=None, resource_group=None,
                       resource_id=None, resource_provider=None, start_time=None, end_time=None,
                       caller=None, status=None, max_events=50, select=None):
@@ -150,7 +148,6 @@ def _single(collection):
     return len([x for x in collection if x]) == 1
 
 
-# pylint: disable=too-many-arguments
 def _build_activity_log_odata_filter(correlation_id=None, resource_group=None, resource_id=None,
                                      resource_provider=None, start_time=None, end_time=None,
                                      caller=None, status=None):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_template_builder.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_template_builder.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=too-many-arguments
 
 from collections import OrderedDict
 import json

--- a/src/command_modules/azure-cli-network/tests/test_dns_zone_import.py
+++ b/src/command_modules/azure-cli-network/tests/test_dns_zone_import.py
@@ -12,7 +12,6 @@ TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 class TestDnsZoneImport(unittest.TestCase):
 
-    # pylint: disable=too-many-arguments
     def _check_soa(self, zone, zone_name, ttl, serial_number, refresh, retry, expire, min_ttl):
         record = zone[zone_name]['soa']
         self.assertEqual(record['ttl'], ttl)

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/custom.py
@@ -11,7 +11,6 @@ logger = azlogging.get_az_logger(__name__)
 
 
 def cli_redis_export(client, resource_group_name, name, prefix, container, file_format=None):
-    # pylint:disable=too-many-arguments
     from azure.mgmt.redis.models import ExportRDBParameters
     parameters = ExportRDBParameters(prefix, container, file_format)
     return client.export(resource_group_name, name, parameters)
@@ -86,7 +85,7 @@ def wrong_vmsize_argument_exception_handler(ex):
     raise ex
 
 
-def cli_redis_create(client,  # pylint:disable=too-many-arguments
+def cli_redis_create(client,
                      resource_group_name, name, location, sku, vm_size, tags=None,
                      redis_configuration=None, enable_non_ssl_port=None, tenant_settings=None,
                      shard_count=None, subnet_id=None, static_ip=None):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -73,7 +73,7 @@ def create_resource_group(rg_name, location, tags=None):
     return rcf.resource_groups.create_or_update(rg_name, parameters)
 
 
-def create_appliance(resource_group_name,  # pylint: disable=too-many-arguments
+def create_appliance(resource_group_name,
                      appliance_name, managedby_resource_group_id,
                      location, kind, managedapp_definition_id=None,
                      plan_name=None, plan_publisher=None, plan_product=None,
@@ -150,7 +150,7 @@ def show_appliancedefinition(resource_group_name=None, appliance_definition_name
     return appliancedef
 
 
-def create_appliancedefinition(resource_group_name,  # pylint: disable=too-many-arguments
+def create_appliancedefinition(resource_group_name,
                                appliance_definition_name, location,
                                lock_level, package_file_uri, authorizations,
                                description, display_name, tags=None):
@@ -222,7 +222,7 @@ def export_group_as_template(
     print(json.dumps(result.template, indent=2))
 
 
-def deploy_arm_template(resource_group_name,  # pylint: disable=too-many-arguments
+def deploy_arm_template(resource_group_name,
                         template_file=None, template_uri=None, deployment_name=None,
                         parameters=None, mode='incremental', no_wait=False):
     return _deploy_arm_template_core(resource_group_name, template_file, template_uri,
@@ -300,7 +300,7 @@ def _merge_parameters(parameter_list):
     return parameters
 
 
-def _deploy_arm_template_core(resource_group_name,  # pylint: disable=too-many-arguments
+def _deploy_arm_template_core(resource_group_name,
                               template_file=None, template_uri=None, deployment_name=None,
                               parameter_list=None, mode='incremental', validate_only=False,
                               no_wait=False):
@@ -345,7 +345,7 @@ def export_deployment_as_template(resource_group_name, deployment_name):
     print(json.dumps(result.template, indent=2))  # pylint: disable=no-member
 
 
-def create_resource(properties,  # pylint: disable=too-many-arguments
+def create_resource(properties,
                     resource_group_name=None, resource_provider_namespace=None,
                     parent_resource_path=None, resource_type=None, resource_name=None,
                     resource_id=None, api_version=None, location=None, is_full_object=False):
@@ -355,7 +355,7 @@ def create_resource(properties,  # pylint: disable=too-many-arguments
     return res.create_resource(properties, location, is_full_object)
 
 
-def show_resource(resource_group_name=None,  # pylint: disable=too-many-arguments
+def show_resource(resource_group_name=None,
                   resource_provider_namespace=None, parent_resource_path=None, resource_type=None,
                   resource_name=None, resource_id=None, api_version=None):
     res = _ResourceUtils(resource_group_name, resource_provider_namespace,
@@ -364,7 +364,7 @@ def show_resource(resource_group_name=None,  # pylint: disable=too-many-argument
     return res.get_resource()
 
 
-def delete_resource(resource_group_name=None,  # pylint: disable=too-many-arguments
+def delete_resource(resource_group_name=None,
                     resource_provider_namespace=None, parent_resource_path=None, resource_type=None,
                     resource_name=None, resource_id=None, api_version=None):
     res = _ResourceUtils(resource_group_name, resource_provider_namespace,
@@ -373,7 +373,7 @@ def delete_resource(resource_group_name=None,  # pylint: disable=too-many-argume
     return res.delete()
 
 
-def update_resource(parameters,  # pylint: disable=too-many-arguments
+def update_resource(parameters,
                     resource_group_name=None, resource_provider_namespace=None,
                     parent_resource_path=None, resource_type=None, resource_name=None,
                     resource_id=None, api_version=None):
@@ -383,7 +383,7 @@ def update_resource(parameters,  # pylint: disable=too-many-arguments
     return res.update(parameters)
 
 
-def tag_resource(tags,  # pylint: disable=too-many-arguments
+def tag_resource(tags,
                  resource_group_name=None, resource_provider_namespace=None,
                  parent_resource_path=None, resource_type=None, resource_name=None,
                  resource_id=None, api_version=None):
@@ -405,7 +405,7 @@ def get_deployment_operations(client, resource_group_name, deployment_name, oper
     return result
 
 
-def list_resources(resource_group_name=None,  # pylint: disable=too-many-arguments
+def list_resources(resource_group_name=None,
                    resource_provider_namespace=None, resource_type=None, name=None, tag=None,
                    location=None):
     rcf = _resource_client_factory()
@@ -420,7 +420,7 @@ def list_resources(resource_group_name=None,  # pylint: disable=too-many-argumen
     return list(resources)
 
 
-def _list_resources_odata_filter_builder(resource_group_name=None,  # pylint: disable=too-many-arguments
+def _list_resources_odata_filter_builder(resource_group_name=None,
                                          resource_provider_namespace=None,
                                          resource_type=None, name=None, tag=None, location=None):
     """Build up OData filter string from parameters
@@ -695,7 +695,7 @@ def get_policy_assignment_completion_list(prefix, **kwargs):  # pylint: disable=
     return [i.name for i in result]
 
 
-def list_locks(resource_group_name=None,  # pylint: disable=too-many-arguments
+def list_locks(resource_group_name=None,
                resource_provider_namespace=None, parent_resource_path=None, resource_type=None,
                resource_name=None, filter_string=None):
     """
@@ -728,7 +728,7 @@ def list_locks(resource_group_name=None,  # pylint: disable=too-many-arguments
         resource_name, filter=filter_string)
 
 
-def _validate_lock_params_match_lock(  # pylint: disable=too-many-arguments
+def _validate_lock_params_match_lock(
         lock_client, name, resource_group_name, resource_provider_namespace, parent_resource_path,
         resource_type, resource_name):
     """
@@ -796,7 +796,7 @@ def get_lock(name, resource_group_name=None):
     return lock_client.management_locks.get_at_resource_group_level(resource_group_name, name)
 
 
-def delete_lock(name,  # pylint: disable=too-many-arguments
+def delete_lock(name,
                 resource_group_name=None, resource_provider_namespace=None,
                 parent_resource_path=None, resource_type=None, resource_name=None):
     """
@@ -848,7 +848,7 @@ def _extract_lock_params(resource_group_name, resource_provider_namespace,
     return (resource_group_name, resource_name, resource_provider_namespace, resource_type)
 
 
-def create_lock(name,  # pylint: disable=too-many-arguments
+def create_lock(name,
                 resource_group_name=None, resource_provider_namespace=None, notes=None,
                 parent_resource_path=None, resource_type=None, resource_name=None, level=None):
     """
@@ -966,7 +966,7 @@ def _validate_resource_inputs(resource_group_name, resource_provider_namespace,
 
 
 class _ResourceUtils(object):  # pylint: disable=too-many-instance-attributes
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,
                  resource_group_name=None, resource_provider_namespace=None,
                  parent_resource_path=None, resource_type=None, resource_name=None,
                  resource_id=None, api_version=None, rcf=None):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -131,7 +131,6 @@ def create_role_assignment(role, assignee, resource_group_name=None, scope=None)
 
 
 def _create_role_assignment(role, assignee, resource_group_name=None, scope=None,
-                            # pylint: disable=too-many-arguments
                             resolve_assignee=True):
     factory = _auth_client_factory(scope)
     assignments_client = factory.role_assignments
@@ -149,7 +148,7 @@ def _create_role_assignment(role, assignee, resource_group_name=None, scope=None
                                      custom_headers=custom_headers)
 
 
-def list_role_assignments(assignee=None, role=None, resource_group_name=None,  # pylint: disable=too-many-arguments
+def list_role_assignments(assignee=None, role=None, resource_group_name=None,
                           scope=None, include_inherited=False,
                           show_all=False, include_groups=False):
     '''
@@ -212,7 +211,7 @@ def _get_displayable_name(graph_object):
         return ''
 
 
-def delete_role_assignments(ids=None, assignee=None, role=None,  # pylint: disable=too-many-arguments
+def delete_role_assignments(ids=None, assignee=None, role=None,
                             resource_group_name=None, scope=None, include_inherited=False):
     factory = _auth_client_factory(scope)
     assignments_client = factory.role_assignments
@@ -238,7 +237,7 @@ def delete_role_assignments(ids=None, assignee=None, role=None,  # pylint: disab
         raise CLIError('No matched assignments were found to delete')
 
 
-def _search_role_assignments(assignments_client, definitions_client,  # pylint: disable=too-many-arguments
+def _search_role_assignments(assignments_client, definitions_client,
                              scope, assignee, role, include_inherited, include_groups):
     assignee_object_id = None
     if assignee:
@@ -346,7 +345,7 @@ def list_users(client, upn=None, display_name=None, query_filter=None):
     return client.list(filter=(' and ').join(sub_filters))
 
 
-def create_user(client, user_principal_name, display_name, password,  # pylint: disable=too-many-arguments
+def create_user(client, user_principal_name, display_name, password,
                 mail_nickname=None, immutable_id=None, force_change_password_next_login=False):
     '''
     :param mail_nickname: mail alias. default to user principal name
@@ -375,7 +374,7 @@ def list_groups(client, display_name=None, query_filter=None):
     return client.list(filter=(' and ').join(sub_filters))
 
 
-def create_application(client, display_name, homepage, identifier_uris,  # pylint: disable=too-many-arguments
+def create_application(client, display_name, homepage, identifier_uris,
                        available_to_other_tenants=False, password=None, reply_urls=None,
                        key_value=None, key_type=None, key_usage=None, start_date=None,
                        end_date=None):
@@ -392,7 +391,7 @@ def create_application(client, display_name, homepage, identifier_uris,  # pylin
     return client.create(app_create_param)
 
 
-def update_application(client, identifier, display_name=None, homepage=None,  # pylint: disable=too-many-arguments
+def update_application(client, identifier, display_name=None, homepage=None,
                        identifier_uris=None, password=None, reply_urls=None, key_value=None,
                        key_type=None, key_usage=None, start_date=None, end_date=None):
     object_id = _resolve_application(client, identifier)
@@ -431,7 +430,7 @@ def _resolve_application(client, identifier):
     return result[0].object_id if result else identifier
 
 
-def _build_application_creds(password=None, key_value=None, key_type=None,  # pylint: disable=too-many-arguments
+def _build_application_creds(password=None, key_value=None, key_type=None,
                              key_usage=None, start_date=None, end_date=None):
     if password and key_value:
         raise CLIError('specify either --password or --key-value, but not both.')

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -32,7 +32,7 @@ az_config = AzConfig()
 logger = azlogging.get_az_logger(__name__)
 
 
-def sf_create_compose_application(  # pylint: disable=too-many-arguments
+def sf_create_compose_application(
         compose_file, application_id, repo_user=None, encrypted=False,
         repo_pass=None, timeout=60):
     # We need to read from a file which makes this a custom command
@@ -90,7 +90,7 @@ def sf_create_compose_application(  # pylint: disable=too-many-arguments
     sf_client.create_compose_application(model, timeout)
 
 
-def sf_select(endpoint, cert=None,  # pylint: disable=too-many-arguments
+def sf_select(endpoint, cert=None,
               key=None, pem=None, ca=None, no_verify=False):
     """
     Connects to a Service Fabric cluster endpoint.
@@ -616,7 +616,7 @@ def sup_stateful_flags(rep_restart_wait=None, quorum_loss_wait=None,
     return f
 
 
-def sup_service_update_flags(  # pylint: disable=too-many-arguments
+def sup_service_update_flags(
         target_rep_size=None, instance_count=None, rep_restart_wait=None,
         quorum_loss_wait=None, standby_rep_keep=None, min_rep_size=None,
         placement_constraints=None, placement_policy=None, correlation=None,
@@ -825,7 +825,7 @@ def sf_create_service(  # pylint: disable=too-many-arguments, too-many-locals
     sf_client.create_service(app_id, svc_desc, timeout)
 
 
-def sf_update_service(service_id,  # pylint: disable=too-many-arguments
+def sf_update_service(service_id,
                       stateless=False, stateful=False,
                       constraints=None,
                       correlation=None, correlated_service=None,
@@ -950,7 +950,7 @@ def sf_update_service(service_id,  # pylint: disable=too-many-arguments
     sf_client.update_service(service_id, sud, timeout)
 
 
-def sf_start_chaos(  # pylint: disable=too-many-arguments
+def sf_start_chaos(
         time_to_run="4294967295", max_cluster_stabilization=60,
         max_concurrent_faults=1, disable_move_replica_faults=False,
         wait_time_between_faults=20,
@@ -1034,7 +1034,7 @@ def sf_start_chaos(  # pylint: disable=too-many-arguments
     sf_client.start_chaos(chaos_params, timeout)
 
 
-def sf_report_app_health(application_id,  # pylint: disable=too-many-arguments
+def sf_report_app_health(application_id,
                          source_id, health_property,
                          health_state, ttl=None, description=None,
                          sequence_number=None, remove_when_expired=None,
@@ -1111,7 +1111,7 @@ def sf_report_app_health(application_id,  # pylint: disable=too-many-arguments
     sf_client.report_application_health(application_id, info, timeout)
 
 
-def sf_report_svc_health(service_id,  # pylint: disable=too-many-arguments
+def sf_report_svc_health(service_id,
                          source_id, health_property, health_state,
                          ttl=None, description=None, sequence_number=None,
                          remove_when_expired=None, timeout=60):
@@ -1191,7 +1191,7 @@ def sf_report_svc_health(service_id,  # pylint: disable=too-many-arguments
     sf_client.report_service_health(service_id, info, timeout)
 
 
-def sf_report_partition_health(  # pylint: disable=too-many-arguments
+def sf_report_partition_health(
         partition_id, source_id, health_property, health_state, ttl=None,
         description=None, sequence_number=None, remove_when_expired=None,
         timeout=60):
@@ -1270,7 +1270,7 @@ def sf_report_partition_health(  # pylint: disable=too-many-arguments
     sf_client.report_partition_health(partition_id, info, timeout)
 
 
-def sf_report_replica_health(  # pylint: disable=too-many-arguments
+def sf_report_replica_health(
         partition_id, replica_id, source_id, health_state, health_property,
         service_kind="Stateful", ttl=None, description=None,
         sequence_number=None, remove_when_expired=None, timeout=60):
@@ -1358,7 +1358,7 @@ def sf_report_replica_health(  # pylint: disable=too-many-arguments
                                     service_kind, timeout)
 
 
-def sf_report_node_health(node_name,  # pylint: disable=too-many-arguments
+def sf_report_node_health(node_name,
                           source_id, health_property, health_state,
                           ttl=None, description=None, sequence_number=None,
                           remove_when_expired=None, timeout=60):
@@ -1437,7 +1437,7 @@ def sf_report_node_health(node_name,  # pylint: disable=too-many-arguments
     sf_client.report_node_health(node_name, info, timeout)
 
 
-def sf_service_package_upload(node_name,  # pylint: disable=too-many-arguments
+def sf_service_package_upload(node_name,
                               service_manifest_name,
                               application_type_name, application_type_version,
                               share_policy=None, timeout=60):

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -125,7 +125,7 @@ def _db_create_special(
 
 
 # Copies a database. Wrapper function to make create mode more convenient.
-def db_copy(  # pylint: disable=too-many-arguments
+def db_copy(
         client,
         database_name,
         server_name,
@@ -150,7 +150,7 @@ def db_copy(  # pylint: disable=too-many-arguments
 
 
 # Copies a replica. Wrapper function to make create mode more convenient.
-def db_create_replica(  # pylint: disable=too-many-arguments
+def db_create_replica(
         client,
         database_name,
         server_name,
@@ -176,7 +176,7 @@ def db_create_replica(  # pylint: disable=too-many-arguments
 
 # Creates a database from a database point in time backup.
 # Wrapper function to make create mode more convenient.
-def db_restore(  # pylint: disable=too-many-arguments
+def db_restore(
         client,
         database_name,
         server_name,
@@ -236,7 +236,7 @@ def db_failover(
         link_id=primary_link.name)
 
 
-def db_delete_replica_link(  # pylint: disable=too-many-arguments
+def db_delete_replica_link(
         client,
         database_name,
         server_name,
@@ -273,7 +273,7 @@ def db_delete_replica_link(  # pylint: disable=too-many-arguments
         link_id=link.name)
 
 
-def db_export(  # pylint: disable=too-many-arguments
+def db_export(
         client,
         database_name,
         server_name,
@@ -295,7 +295,7 @@ def db_export(  # pylint: disable=too-many-arguments
         parameters=kwargs)
 
 
-def db_import(  # pylint: disable=too-many-arguments
+def db_import(
         client,
         database_name,
         server_name,
@@ -480,7 +480,7 @@ def _get_storage_key(
 
 
 # Common code for updating audit and threat detection policy
-def _db_security_policy_update(  # pylint: disable=too-many-arguments
+def _db_security_policy_update(
         instance,
         enabled,
         storage_account,
@@ -523,7 +523,7 @@ def _db_security_policy_update(  # pylint: disable=too-many-arguments
 
 
 # Update audit policy. Custom update function to apply parameters to instance.
-def db_audit_policy_update(  # pylint: disable=too-many-arguments
+def db_audit_policy_update(
         instance,
         state=None,
         storage_account=None,
@@ -558,7 +558,7 @@ def db_audit_policy_update(  # pylint: disable=too-many-arguments
 
 
 # Update threat detection policy. Custom update function to apply parameters to instance.
-def db_threat_detection_policy_update(  # pylint: disable=too-many-arguments
+def db_threat_detection_policy_update(
         instance,
         state=None,
         storage_account=None,
@@ -744,7 +744,7 @@ def firewall_rule_allow_all_azure_ips(
 
 # Update firewall rule. Custom update function is required,
 # see https://github.com/Azure/azure-cli/issues/2264
-def firewall_rule_update(  # pylint: disable=too-many-arguments
+def firewall_rule_update(
         client,
         firewall_rule_name,
         server_name,

--- a/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/tests/test_sql_commands.py
@@ -22,7 +22,6 @@ server_name_max_length = 63
 
 
 class SqlServerPreparer(AbstractPreparer, SingleValueReplacer):
-    # pylint: disable=too-many-arguments
     def __init__(self, name_prefix=server_name_prefix, parameter_name='server', location='westus',
                  admin_user='admin123', admin_password='SecretPassword123',
                  resource_group_parameter_name='resource_group', skip_delete=True):
@@ -649,7 +648,6 @@ class SqlServerDwMgmtScenarioTest(ScenarioTest):
 class SqlServerDbReplicaMgmtScenarioTest(ScenarioTest):
 
     # create 2 servers in the same resource group, and 1 server in a different resource group
-    # pylint: disable=too-many-arguments
     @ResourceGroupPreparer(parameter_name="resource_group_1",
                            parameter_name_for_location="resource_group_location_1")
     @ResourceGroupPreparer(parameter_name="resource_group_2",

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
@@ -7,7 +7,7 @@ from azure.cli.core.commands import create_command, command_table
 from ._validators import validate_client_parameters
 
 
-def cli_storage_data_plane_command(name, operation, client_factory,  # pylint: disable=too-many-arguments
+def cli_storage_data_plane_command(name, operation, client_factory,
                                    transform=None, table_transformer=None, exception_handler=None):
     """ Registers an Azure CLI Storage Data Plane command. These commands always include the
     four parameters which can be used to obtain a storage client: account-name, account-key,

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -21,7 +21,6 @@ from azure.cli.command_modules.storage.util import (create_blob_service_from_sto
 BlobCopyResult = namedtuple('BlobCopyResult', ['name', 'copy_id'])
 
 
-# pylint: disable=too-many-arguments
 def storage_blob_copy_batch(client, source_client,
                             destination_container=None, source_container=None, source_share=None,
                             source_sas=None, pattern=None, dryrun=False):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/file.py
@@ -7,7 +7,6 @@
 Commands for storage file share operations
 """
 
-# pylint: disable=too-many-arguments
 
 import os.path
 from azure.cli.core.azlogging import get_az_logger

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=too-many-arguments
 
 from collections import OrderedDict
 import json

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -48,7 +48,6 @@ def log_pprint_template(template):
     logger.info('==== END TEMPLATE ====')
 
 
-# pylint: disable=too-many-arguments
 def check_existence(value, resource_group, provider_namespace, resource_type,
                     parent_name=None, parent_type=None):
     # check for name or ID and set the type flags


### PR DESCRIPTION
1. Disable too-many-arguments pylint error. Due to the nature of the
project many methods' arguments set directly reflects the command
options. As a result, there is no way to reduce the arguments set size.
The too-many-arguments disable statement is widely used to the extend
that essentially the rule doesn't matter anymore. I'll disable the rule
globally.

2. Extend the max length to 120 from 100, which is the default pylint
value. The 120 characters lenght is the default github review page's
line limitation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
