### PR TITLE
[VM] Add unit test to verify stability of multi-NIC ordering

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -57,8 +57,6 @@
     <Compile Include="azure-cli-core\azure\cli\core\sdk\__init__.py" />
     <Compile Include="azure-cli-core\azure\cli\core\sdk\__init__.py" />
     <Compile Include="azure-cli-core\azure\cli\core\telemetry_upload.py" />
-    <Compile Include="azure-cli-core\azure\cli\core\test_utils\vcr_test_base.py" />
-    <Compile Include="azure-cli-core\azure\cli\core\test_utils\__init__.py" />
     <Compile Include="azure-cli-core\azure\cli\core\_config.py" />
     <Compile Include="azure-cli-core\azure\cli\core\_debug.py" />
     <Compile Include="azure-cli-core\azure\cli\core\_environment.py" />
@@ -99,11 +97,13 @@
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\base.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\checkers.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\const.py" />
+    <Compile Include="azure-cli-testsdk\azure\cli\testsdk\decorators.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\exceptions.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\patches.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\preparers.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\recording_processors.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\utilities.py" />
+    <Compile Include="azure-cli-testsdk\azure\cli\testsdk\vcr_test_base.py" />
     <Compile Include="azure-cli-testsdk\azure\cli\testsdk\__init__.py" />
     <Compile Include="azure-cli-testsdk\setup.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\__init__.py" />
@@ -664,7 +664,6 @@
     <Folder Include="azure-cli-core\azure\cli\core\extensions\" />
     <Folder Include="azure-cli-core\azure\cli\core\profiles\" />
     <Folder Include="azure-cli-core\azure\cli\core\sdk\" />
-    <Folder Include="azure-cli-core\azure\cli\core\test_utils\" />
     <Folder Include="azure-cli-core\tests\" />
     <Folder Include="azure-cli-core\tests\__pycache__\" />
     <Folder Include="azure-cli-nspkg\" />


### PR DESCRIPTION
Added a unit test in support of TS issue #3005. This ensures that, for a consistent input order, the generated template code has a consistent order.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [X] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
