### PR TITLE
RP Auto-Reg: capture missing subscription registration error on LRO

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -468,6 +468,7 @@ def create_command(module_name, name, operation,
                         continue  # retry
                     if exception_handler:
                         exception_handler(ex)
+                        return
                     else:
                         reraise(*sys.exc_info())
         except _load_client_exception_class() as client_exception:

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -445,36 +445,31 @@ def create_command(module_name, name, operation,
         client = client_factory(kwargs) if client_factory else None
         try:
             op = get_op_handler(operation)
-            try:
+            for _ in range(2):  # for possible retry, we do maximum 2 times.
                 try:
                     result = op(client, **kwargs) if client else op(**kwargs)
-                except CloudError as ex:
+                    if no_wait_param and kwargs.get(no_wait_param, None):
+                        return None  # return None for 'no-wait'
+
+                    # apply results transform if specified
+                    if transform_result:
+                        return transform_result(result)
+
+                    # otherwise handle based on return type of results
+                    if _is_poller(result):
+                        return LongRunningOperation('Starting {}'.format(name))(result)
+                    elif _is_paged(result):
+                        return list(result)
+                    return result
+                except Exception as ex:  # pylint: disable=broad-except
                     rp = _check_rp_not_registered_err(ex)
                     if rp:
                         _register_rp(rp)
-                        result = op(client, **kwargs) if client else op(**kwargs)
+                        continue  # retry
+                    if exception_handler:
+                        exception_handler(ex)
                     else:
                         reraise(*sys.exc_info())
-
-                if no_wait_param and kwargs.get(no_wait_param, None):
-                    return None  # return None for 'no-wait'
-
-                # apply results transform if specified
-                if transform_result:
-                    return transform_result(result)
-
-                # otherwise handle based on return type of results
-                if _is_poller(result):
-                    return LongRunningOperation('Starting {}'.format(name))(result)
-                elif _is_paged(result):
-                    return list(result)
-                return result
-            except Exception as ex:  # pylint: disable=broad-except
-                if exception_handler:
-                    exception_handler(ex)
-                else:
-                    reraise(*sys.exc_info())
-
         except _load_client_exception_class() as client_exception:
             fault_type = name.replace(' ', '-') + '-client-error'
             telemetry.set_exception(client_exception, fault_type=fault_type,


### PR DESCRIPTION
`MissingSubscriptionRegistration` could surface during LRO polling, which was not caught by out current code. I had to expand the scope to capture it. 
The code change is trivial, as i just put the whole handler invocation into a loop body with count at 2 Feel free to propose neater coding practice. I have tried to extract to a individual method, but it doesn't look better
//cc: @derekbekoe @johanste

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
