### PR TITLE
Reverse Jenkins build cadence to daily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   agent none
-  triggers { pollSCM('H/1 * * * *')}
+  triggers { cron('0 3 * * *') }
   stages {
     stage ('Build') {
       agent { label 'linux-build' } 


### PR DESCRIPTION
Running live test for every commit deems to be too much a burden of our infrastructure as the scale of the tests keeps increasing. This change reverses the live test cadence to be daily.