### PR TITLE
ad:mention time format in descriptions for --start-date/--end-date

### DIFF
--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+2.0.5 (unrelease)
+++++++++++++++++++
+* ad: for 'app create' command, mention time format in the arg descriptions for --start-date/--end-date
 
 2.0.4 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -16,8 +16,8 @@ register_cli_argument('ad app', 'homepage', help='the url where users can sign i
 register_cli_argument('ad app', 'identifier', options_list=('--id',), help='identifier uri, application id, or object id')
 register_cli_argument('ad app', 'identifier_uris', nargs='+', help='space separated unique URIs that Azure AD can use for this app.')
 register_cli_argument('ad app', 'reply_urls', nargs='+', help='space separated URIs to which Azure AD will redirect in response to an OAuth 2.0 request. The value does not need to be a physical endpoint, but must be a valid URI.')
-register_cli_argument('ad app', 'start_date', help="the date in iso8601 format when credentials becoming valid, e.g. '2017-01-01T01:00:00+00:00' or '2017-01-01'. Default value is current time")
-register_cli_argument('ad app', 'end_date', help="the date in iso8601 format when credentials get expired, e.g. '2017-12-31T11:59:59+00:00' or '2017-12-31'. Default value is one year after current time")
+register_cli_argument('ad app', 'start_date', help="Date or datetime at which credentials become valid(e.g. '2017-01-01T01:00:00+00:00' or '2017-01-01'). Default value is current time")
+register_cli_argument('ad app', 'end_date', help="Date or datetime after which credentials expire(e.g. '2017-12-31T11:59:59+00:00' or '2017-12-31'). Default value is one year after current time")
 register_cli_argument('ad app', 'available_to_other_tenants', action='store_true', help='the application can be used from any Azure AD tenants')
 register_cli_argument('ad app', 'key_value', help='the value for the key credentials associated with the application')
 # TODO: Update these with **enum_choice_list(...) when SDK supports proper enums

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -16,8 +16,8 @@ register_cli_argument('ad app', 'homepage', help='the url where users can sign i
 register_cli_argument('ad app', 'identifier', options_list=('--id',), help='identifier uri, application id, or object id')
 register_cli_argument('ad app', 'identifier_uris', nargs='+', help='space separated unique URIs that Azure AD can use for this app.')
 register_cli_argument('ad app', 'reply_urls', nargs='+', help='space separated URIs to which Azure AD will redirect in response to an OAuth 2.0 request. The value does not need to be a physical endpoint, but must be a valid URI.')
-register_cli_argument('ad app', 'start_date', help='the start date after which password or key would be valid. Default value is current time')
-register_cli_argument('ad app', 'end_date', help='the end date till which password or key is valid. Default value is one year after current time')
+register_cli_argument('ad app', 'start_date', help="the date in iso8601 format when credentials becoming valid, e.g. '2017-01-01T01:00:00+00:00' or '2017-01-01'. Default value is current time")
+register_cli_argument('ad app', 'end_date', help="the date in iso8601 format when credentials get expired, e.g. '2017-12-31T11:59:59+00:00' or '2017-12-31'. Default value is one year after current time")
 register_cli_argument('ad app', 'available_to_other_tenants', action='store_true', help='the application can be used from any Azure AD tenants')
 register_cli_argument('ad app', 'key_value', help='the value for the key credentials associated with the application')
 # TODO: Update these with **enum_choice_list(...) when SDK supports proper enums


### PR DESCRIPTION
Ran into it when tried to create a AAD app
Fix #1068

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
~~- [ ] Each new command has a test.~~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
