### PR TITLE
vm: update the warning text on generating ssh keys

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -683,8 +683,7 @@ def validate_ssh_key(namespace):
             content = _generate_ssh_keys(private_key_filepath, public_key_filepath)
             logger.warning("SSH key files '%s' and '%s' have been generated under ~/.ssh to "
                            "allow SSH access to the VM. If using machines without "
-                           "permanent storage like Azure Cloud Shell without an attached "
-                           "file share, back up your keys to a safe location",
+                           "permanent storage, back up your keys to a safe location.",
                            private_key_filepath, public_key_filepath)
         else:
             raise CLIError('An RSA key file or key value must be supplied to SSH Key Value. '


### PR DESCRIPTION
Fix #3342 
Drop the `cloud console` mentioning which has a perm storage now. Moving forward let us try not to mention other products any more, as their evolvings will render the cLI text not accurate any more
### General Guidelines

~- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).~

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
