### PR TITLE
output deprecating message on using --expanded-view

### DIFF
--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+++++++++++++++++++
+2.0.5 (unreleased)
+* Output deprecating information on using '--expeanded-view'
 
 2.0.4 (2017-04-28)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 ++++++++++++++++++
 2.0.5 (unreleased)
-* Output deprecating information on using '--expeanded-view'
+* Output deprecating information on using '--expanded-view'
 
 2.0.4 (2017-04-28)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
+import argparse
 from azure.cli.core.commands import register_cli_argument
 from .custom import load_subscriptions
 
@@ -27,4 +28,4 @@ register_cli_argument('logout', 'username', help='account user, if missing, logo
 
 register_cli_argument('account', 'subscription', options_list=('--subscription', '-s'), help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
-register_cli_argument('account show', 'expanded_view', action='store_true', help="display more information like service principal's password and cloud environments")
+register_cli_argument('account show', 'expanded_view', action='store_true', help=argparse.SUPPRESS)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -37,6 +37,8 @@ def show_subscription(subscription=None, expanded_view=None):
     if not expanded_view:
         return profile.get_subscription(subscription)
     else:
+        logger.warning("'--expanded-view' is deprecating and will be removed in a future release. "
+                       "You can get the same information using 'az cloud show'")
         return profile.get_expanded_subscription_info(subscription)
 
 

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 2.0.5 (unreleased)
 ++++++++++++++++++
 * ad: for 'app create' command, mention time format in the arg descriptions for --start-date/--end-date
-* output deprecating information on using '--expeanded-view'
+* output deprecating information on using '--expanded-view'
 
 unreleased
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,9 +2,10 @@
 
 Release History
 ===============
-2.0.5 (unrelease)
+2.0.5 (unreleased)
 ++++++++++++++++++
 * ad: for 'app create' command, mention time format in the arg descriptions for --start-date/--end-date
+* output deprecating information on using '--expeanded-view'
 
 unreleased
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
+import argparse
 from azure.cli.core.commands import CliArgumentType
 from azure.cli.core.commands import register_cli_argument
 from azure.cli.core.commands.parameters import enum_choice_list
@@ -31,7 +32,7 @@ register_cli_argument('ad sp create', 'identifier', options_list=('--id',), help
 register_cli_argument('ad sp create-for-rbac', 'scopes', nargs='+')
 register_cli_argument('ad sp create-for-rbac', 'role', completer=get_role_definition_name_completion_list)
 register_cli_argument('ad sp create-for-rbac', 'skip_assignment', action='store_true', help='do not create default assignment')
-register_cli_argument('ad sp create-for-rbac', 'expanded_view', action='store_true', help='Once created, display more information like subscription and cloud environments')
+register_cli_argument('ad sp create-for-rbac', 'expanded_view', action='store_true', help=argparse.SUPPRESS)
 
 for item in ['create-for-rbac', 'reset-credentials']:
     register_cli_argument('ad sp {}'.format(item), 'name', name_arg_type)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -655,6 +655,8 @@ def create_service_principal_for_rbac(
                     raise
 
     if expanded_view:
+        logger.warning("'--expanded-view' is deprecating and will be removed in a future release. "
+                       "You can get the same information using 'az cloud show'")
         from azure.cli.core._profile import Profile
         profile = Profile()
         result = profile.get_expanded_subscription_info(scopes[0].split('/')[2] if scopes else None,


### PR DESCRIPTION
Was exposed for java sdk team. They confirmed they have updated their end and no longer require this function anymore.
### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
