### PR TITLE
[VM] `vm open-port` fix

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -946,7 +946,6 @@
     <Folder Include="command_modules\azure-cli-vm\azure\cli\" />
     <Folder Include="command_modules\azure-cli-vm\azure\cli\command_modules\" />
     <Folder Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\" />
-    <Folder Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\" />
     <Folder Include="command_modules\azure-cli-vm\tests\" />
     <Folder Include="command_modules\azure-cli-vm\tests\keyvault\" />
     <Folder Include="command_modules\azure-cli-dls\" />

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -6,6 +6,7 @@ unreleased
 * diagnostics: Fix incorrect Linux diagnostics default config with update for LAD v.3.0 extension
 * disk: support cross subscription blob import
 * vm: support license type on create
+* BC: vm open-port: command always returns the NSG. Previously it returned the NIC or Subnet.
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1215,20 +1215,18 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
     # update the NIC or subnet if a new NSG was created
     if created_nsg and not apply_to_subnet:
         nic.network_security_group = nsg
-        return LongRunningOperation('Updating NIC')(
-            network.network_interfaces.create_or_update(
-                resource_group_name, nic.name, nic)
-        )
+        LongRunningOperation('Updating NIC')(network.network_interfaces.create_or_update(
+            resource_group_name, nic.name, nic))
     elif created_nsg and apply_to_subnet:
         subnet.network_security_group = nsg
-        return LongRunningOperation('Updating subnet')(
-            network.subnets.create_or_update(
-                resource_group_name=resource_group_name,
-                virtual_network_name=subnet_id['name'],
-                subnet_name=subnet_id['child_name'],
-                subnet_parameters=subnet
-            )
-        )
+        LongRunningOperation('Updating subnet')(network.subnets.create_or_update(
+            resource_group_name=resource_group_name,
+            virtual_network_name=subnet_id['name'],
+            subnet_name=subnet_id['child_name'],
+            subnet_parameters=subnet
+        ))
+
+    return network.network_security_groups.get(resource_group_name, nsg_name)
 
 
 def _build_nic_list(nic_ids):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1177,6 +1177,7 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
         raise CLIError("No NIC associated with VM '{}'".format(vm_name))
 
     # get existing NSG or create a new one
+    created_nsg = False
     nic = network.network_interfaces.get(resource_group_name, os.path.split(nic_ids[0].id)[1])
     if not apply_to_subnet:
         nsg = nic.network_security_group
@@ -1197,6 +1198,7 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
                 parameters=NetworkSecurityGroup(location=location)
             )
         )
+        created_nsg = True
 
     # update the NSG with the new rule to allow inbound traffic
     SecurityRule = get_sdk(ResourceType.MGMT_NETWORK, 'SecurityRule', mod='models')
@@ -1210,14 +1212,14 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
             resource_group_name, nsg_name, rule_name, rule)
     )
 
-    # update the NIC or subnet
-    if not apply_to_subnet:
+    # update the NIC or subnet if a new NSG was created
+    if created_nsg and not apply_to_subnet:
         nic.network_security_group = nsg
         return LongRunningOperation('Updating NIC')(
             network.network_interfaces.create_or_update(
                 resource_group_name, nic.name, nic)
         )
-    else:
+    elif created_nsg and apply_to_subnet:
         subnet.network_security_group = nsg
         return LongRunningOperation('Updating subnet')(
             network.subnets.create_or_update(

--- a/src/command_modules/azure-cli-vm/tests/recordings/test_vm_open_port.yaml
+++ b/src/command_modules/azure-cli-vm/tests/recordings/test_vm_open_port.yaml
@@ -6,23 +6,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b0d4f74-1697-11e7-9a38-f4b7e2e85440]
+      x-ms-client-request-id: [0fb8f1a8-3a91-11e7-b05a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5075a256-2327-4846-b023-231e045604b5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"b8d1de5a-64b6-4f37-bdd3-0fd302008576\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_3bihPHQTJ0\",\r\n        \"createOption\": \"FromImage\"\
+        \      \"name\": \"osdisk_YXbKt2a4DE\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
         \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/disks/osdisk_3bihPHQTJ0\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/disks/osdisk_YXbKt2a4DE\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -36,7 +37,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:18 GMT']
+      Date: ['Tue, 16 May 2017 23:40:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -52,20 +53,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b345bb4-1697-11e7-9c1d-f4b7e2e85440]
+      x-ms-client-request-id: [0fdcf78a-3a91-11e7-b103-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"3698e0ce-cf23-48dd-97c5-bb6f7aa1659b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"467e1f68-631a-4a50-9a85-7f0893f75459\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a841d97c-9eed-4000-bef6-05ba81198e68\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"acf9de26-2136-403a-8429-12c3eaa63554\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"3698e0ce-cf23-48dd-97c5-bb6f7aa1659b\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"467e1f68-631a-4a50-9a85-7f0893f75459\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -74,8 +76,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"yqoxwrdrqerepkqkjgsgl2amrc.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-F9-C9\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"dpfibvfzyeaejlgmx3vt4p22cc.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-30-5C-3C\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -85,8 +87,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:18 GMT']
-      ETag: [W/"3698e0ce-cf23-48dd-97c5-bb6f7aa1659b"]
+      Date: ['Tue, 16 May 2017 23:40:36 GMT']
+      ETag: [W/"467e1f68-631a-4a50-9a85-7f0893f75459"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -96,41 +98,42 @@ interactions:
       content-length: ['2189']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"destinationPortRange": "*", "sourcePortRange": "*", "protocol":
-      "*", "access": "allow", "destinationAddressPrefix": "*", "priority": 900, "sourceAddressPrefix":
-      "*", "direction": "inbound"}, "name": "open-port-all"}'
+    body: '{"name": "open-port-all", "properties": {"sourceAddressPrefix": "*", "direction":
+      "inbound", "priority": 900, "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix":
+      "*", "access": "allow", "sourcePortRange": "*"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['232']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b5bde98-1697-11e7-9144-f4b7e2e85440]
+      x-ms-client-request-id: [101557dc-3a91-11e7-af60-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"open-port-all\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all\"\
-        ,\r\n  \"etag\": \"W/\\\"78ec4e59-badc-48a2-a4e8-9645691d75bb\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4432927e-5f08-4b52-ab69-d46c6dfebee0\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
         : \"*\",\r\n    \"sourceAddressPrefix\": \"*\",\r\n    \"destinationAddressPrefix\"\
         : \"*\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 900,\r\n    \"\
         direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a223ce3a-20ce-4309-9092-7cd0c0a84eaf?api-version=2017-03-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/49f2734e-6fc7-4471-84c1-3f0de0678807?api-version=2017-03-01']
       Cache-Control: [no-cache]
       Content-Length: ['570']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:18 GMT']
+      Date: ['Tue, 16 May 2017 23:40:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -139,18 +142,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b5bde98-1697-11e7-9144-f4b7e2e85440]
+      x-ms-client-request-id: [101557dc-3a91-11e7-af60-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a223ce3a-20ce-4309-9092-7cd0c0a84eaf?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/49f2734e-6fc7-4471-84c1-3f0de0678807?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:29 GMT']
+      Date: ['Tue, 16 May 2017 23:40:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -166,15 +170,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8b5bde98-1697-11e7-9144-f4b7e2e85440]
+      x-ms-client-request-id: [101557dc-3a91-11e7-af60-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"open-port-all\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all\"\
-        ,\r\n  \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
         : \"*\",\r\n    \"sourceAddressPrefix\": \"*\",\r\n    \"destinationAddressPrefix\"\
@@ -183,8 +188,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:29 GMT']
-      ETag: [W/"35b90cac-1fef-48fd-901c-d0f80a58ba43"]
+      Date: ['Tue, 16 May 2017 23:40:48 GMT']
+      ETag: [W/"b5a3dd59-d43b-4102-9161-9cf9edf79734"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -194,169 +199,28 @@ interactions:
       content-length: ['571']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "W/\"3698e0ce-cf23-48dd-97c5-bb6f7aa1659b\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic",
-      "properties": {"macAddress": "00-0D-3A-36-F9-C9", "enableIPForwarding": false,
-      "virtualMachine": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/virtualMachines/vm1"},
-      "ipConfigurations": [{"etag": "W/\"3698e0ce-cf23-48dd-97c5-bb6f7aa1659b\"",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1",
-      "properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
-      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
-      "privateIPAddress": "10.0.0.4", "privateIPAllocationMethod": "Dynamic", "primary":
-      true, "provisioningState": "Succeeded", "privateIPAddressVersion": "IPv4"},
-      "name": "ipconfigvm1"}], "provisioningState": "Succeeded", "resourceGuid": "a841d97c-9eed-4000-bef6-05ba81198e68",
-      "primary": true, "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
-      "enableAcceleratedNetworking": false, "dnsSettings": {"internalDomainNameSuffix":
-      "yqoxwrdrqerepkqkjgsgl2amrc.dx.internal.cloudapp.net", "dnsServers": [], "appliedDnsServers":
-      []}}, "tags": {}, "location": "westus"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1788']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9283a5fa-1697-11e7-8767-f4b7e2e85440]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-03-01
-  response:
-    body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\",\r\n \
-        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a841d97c-9eed-4000-bef6-05ba81198e68\"\
-        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
-        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
-        : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
-        \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"yqoxwrdrqerepkqkjgsgl2amrc.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-F9-C9\",\r\n    \"enableAcceleratedNetworking\"\
-        : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
-        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
-        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/virtualMachines/vm1\"\
-        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\
-        \n}"}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/bfe5fff4-9760-4e4d-876f-4281ec837b72?api-version=2017-03-01']
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:56:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['2189']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9283a5fa-1697-11e7-8767-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/bfe5fff4-9760-4e4d-876f-4281ec837b72?api-version=2017-03-01
-  response:
-    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['29']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9283a5fa-1697-11e7-8767-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-03-01
-  response:
-    body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\",\r\n \
-        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a841d97c-9eed-4000-bef6-05ba81198e68\"\
-        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\"\
-        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
-        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
-        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
-        : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
-        \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"yqoxwrdrqerepkqkjgsgl2amrc.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-F9-C9\",\r\n    \"enableAcceleratedNetworking\"\
-        : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
-        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
-        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/virtualMachines/vm1\"\
-        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\
-        \n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:01 GMT']
-      ETag: [W/"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['2189']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a61e706e-1697-11e7-b60e-f4b7e2e85440]
+      x-ms-client-request-id: [173d4736-3a91-11e7-8990-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1NSG\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
-        ,\r\n  \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"e1a9a417-53a8-4b13-af8d-d5f60e85669a\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"06d0b2ae-cf07-4f71-9961-a6d1f2d0560d\"\
         ,\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"default-allow-ssh\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/default-allow-ssh\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"\
         *\",\r\n          \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\"\
@@ -364,7 +228,7 @@ interactions:
         access\": \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         open-port-all\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
         ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
@@ -373,7 +237,7 @@ interactions:
         : \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
         : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowVnetInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -383,7 +247,7 @@ interactions:
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -392,7 +256,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/DenyAllInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
         \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
@@ -401,7 +265,7 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowVnetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
         \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
@@ -410,7 +274,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
         \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowInternetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -419,7 +283,7 @@ interactions:
         \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
         \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
         \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/DenyAllOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"35b90cac-1fef-48fd-901c-d0f80a58ba43\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
         \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
@@ -432,8 +296,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:03 GMT']
-      ETag: [W/"35b90cac-1fef-48fd-901c-d0f80a58ba43"]
+      Date: ['Tue, 16 May 2017 23:40:48 GMT']
+      ETag: [W/"b5a3dd59-d43b-4102-9161-9cf9edf79734"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -449,23 +313,132 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a6dc6c08-1697-11e7-8dd1-f4b7e2e85440]
+      x-ms-client-request-id: [177a9bbe-3a91-11e7-a894-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG?api-version=2017-03-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm1NSG\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
+        ,\r\n  \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"06d0b2ae-cf07-4f71-9961-a6d1f2d0560d\"\
+        ,\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"default-allow-ssh\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/default-allow-ssh\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"\
+        *\",\r\n          \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        open-port-all\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/securityRules/open-port-all\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Allow\",\r\n          \"priority\": 900,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
+        : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowVnetInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/DenyAllInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
+        \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
+        \     \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowVnetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
+        \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
+        : \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/AllowInternetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n    \
+        \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
+        \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
+        \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG/defaultSecurityRules/DenyAllOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"b5a3dd59-d43b-4102-9161-9cf9edf79734\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
+        \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
+        \      \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Outbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"networkInterfaces\"\
+        : [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
+        \r\n      }\r\n    ]\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 16 May 2017 23:40:49 GMT']
+      ETag: [W/"b5a3dd59-d43b-4102-9161-9cf9edf79734"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['6735']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [17a1289a-3a91-11e7-9813-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5075a256-2327-4846-b023-231e045604b5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"b8d1de5a-64b6-4f37-bdd3-0fd302008576\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
         ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
         \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_3bihPHQTJ0\",\r\n        \"createOption\": \"FromImage\"\
+        \      \"name\": \"osdisk_YXbKt2a4DE\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
         \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/disks/osdisk_3bihPHQTJ0\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Compute/disks/osdisk_YXbKt2a4DE\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"ubuntu\",\r\n      \"linuxConfiguration\"\
@@ -479,7 +452,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:05 GMT']
+      Date: ['Tue, 16 May 2017 23:40:49 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -495,20 +468,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a709bdd2-1697-11e7-b314-f4b7e2e85440]
+      x-ms-client-request-id: [17c33206-3a91-11e7-a030-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"467e1f68-631a-4a50-9a85-7f0893f75459\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a841d97c-9eed-4000-bef6-05ba81198e68\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"acf9de26-2136-403a-8429-12c3eaa63554\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"467e1f68-631a-4a50-9a85-7f0893f75459\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -517,8 +491,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"yqoxwrdrqerepkqkjgsgl2amrc.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-F9-C9\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"dpfibvfzyeaejlgmx3vt4p22cc.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-30-5C-3C\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -528,8 +502,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:05 GMT']
-      ETag: [W/"9b75fd4e-85cc-4c69-94c4-46b63b7e7c6d"]
+      Date: ['Tue, 16 May 2017 23:40:49 GMT']
+      ETag: [W/"467e1f68-631a-4a50-9a85-7f0893f75459"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -545,15 +519,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a72f21a8-1697-11e7-97c5-f4b7e2e85440]
+      x-ms-client-request-id: [17efc81a-3a91-11e7-87e9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1Subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"3d59c338-7994-44e4-8d70-2fa4e0ecfdeb\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"f459dd81-724d-4c66-b439-6cfe004dd253\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/24\",\r\n    \"ipConfigurations\": [\r\n     \
         \ {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
@@ -561,8 +536,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:05 GMT']
-      ETag: [W/"3d59c338-7994-44e4-8d70-2fa4e0ecfdeb"]
+      Date: ['Tue, 16 May 2017 23:40:49 GMT']
+      ETag: [W/"f459dd81-724d-4c66-b439-6cfe004dd253"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -579,21 +554,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a7573208-1697-11e7-bb17-f4b7e2e85440]
+      x-ms-client-request-id: [18173da4-3a91-11e7-bfea-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"newNsg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
-        ,\r\n  \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\"\
-        ,\r\n    \"resourceGuid\": \"2b91219b-09b1-428a-b93c-49083df6ba8f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"83ba7695-815c-4917-815e-234b1c1ea744\",\r\n \
         \   \"securityRules\": [],\r\n    \"defaultSecurityRules\": [\r\n      {\r\
         \n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -603,7 +579,7 @@ interactions:
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -612,7 +588,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
         \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
@@ -621,7 +597,7 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
         \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
@@ -630,7 +606,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
         \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowInternetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -639,7 +615,7 @@ interactions:
         \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
         \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
         \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"fda9a35f-5618-4aa5-9eb8-ddbd6616c68a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f0b25726-7cfc-4939-a5da-c5aefd86a8c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
         \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
@@ -648,17 +624,17 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Outbound\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/360caa80-6fa6-42e9-9c90-8cba9d9e18e5?api-version=2017-03-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/fe380d2b-71a6-4500-9f37-fb8df9299b7b?api-version=2017-03-01']
       Cache-Control: [no-cache]
       Content-Length: ['5138']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:06 GMT']
+      Date: ['Tue, 16 May 2017 23:40:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -667,18 +643,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a7573208-1697-11e7-bb17-f4b7e2e85440]
+      x-ms-client-request-id: [18173da4-3a91-11e7-bfea-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/360caa80-6fa6-42e9-9c90-8cba9d9e18e5?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/fe380d2b-71a6-4500-9f37-fb8df9299b7b?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:17 GMT']
+      Date: ['Tue, 16 May 2017 23:41:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -694,21 +671,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a7573208-1697-11e7-bb17-f4b7e2e85440]
+      x-ms-client-request-id: [18173da4-3a91-11e7-bfea-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"newNsg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
-        ,\r\n  \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"2b91219b-09b1-428a-b93c-49083df6ba8f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"83ba7695-815c-4917-815e-234b1c1ea744\",\r\n \
         \   \"securityRules\": [],\r\n    \"defaultSecurityRules\": [\r\n      {\r\
         \n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -718,7 +696,7 @@ interactions:
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -727,7 +705,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
         \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
@@ -736,7 +714,7 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
         \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
@@ -745,7 +723,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
         \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowInternetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -754,7 +732,7 @@ interactions:
         \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
         \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
         \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"a89b28c2-a57e-49e9-845d-3cdf498d5777\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d8504aba-c21f-422d-ab19-c595af79b03e\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
         \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
@@ -765,8 +743,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:17 GMT']
-      ETag: [W/"a89b28c2-a57e-49e9-845d-3cdf498d5777"]
+      Date: ['Tue, 16 May 2017 23:41:01 GMT']
+      ETag: [W/"d8504aba-c21f-422d-ab19-c595af79b03e"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -776,41 +754,42 @@ interactions:
       content-length: ['5145']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"destinationPortRange": "*", "sourcePortRange": "*", "protocol":
-      "*", "access": "allow", "destinationAddressPrefix": "*", "priority": 900, "sourceAddressPrefix":
-      "*", "direction": "inbound"}, "name": "open-port-all"}'
+    body: '{"name": "open-port-all", "properties": {"sourceAddressPrefix": "*", "direction":
+      "inbound", "priority": 900, "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix":
+      "*", "access": "allow", "sourcePortRange": "*"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['232']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af17e3ba-1697-11e7-abf2-f4b7e2e85440]
+      x-ms-client-request-id: [1f3f0f50-3a91-11e7-8863-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"open-port-all\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all\"\
-        ,\r\n  \"etag\": \"W/\\\"9b8c6e07-b5d1-4234-8c5e-d5c4f03a734b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"0be30305-b192-4910-9c71-632a08861433\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
         : \"*\",\r\n    \"sourceAddressPrefix\": \"*\",\r\n    \"destinationAddressPrefix\"\
         : \"*\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 900,\r\n    \"\
         direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/364634b9-909f-4cd2-816a-dd5bec8bb6ae?api-version=2017-03-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/f00ef70d-073b-448c-86c2-4422acef345e?api-version=2017-03-01']
       Cache-Control: [no-cache]
       Content-Length: ['570']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:18 GMT']
+      Date: ['Tue, 16 May 2017 23:41:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['10']
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -819,18 +798,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af17e3ba-1697-11e7-abf2-f4b7e2e85440]
+      x-ms-client-request-id: [1f3f0f50-3a91-11e7-8863-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/364634b9-909f-4cd2-816a-dd5bec8bb6ae?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f00ef70d-073b-448c-86c2-4422acef345e?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:29 GMT']
+      Date: ['Tue, 16 May 2017 23:41:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -846,15 +826,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af17e3ba-1697-11e7-abf2-f4b7e2e85440]
+      x-ms-client-request-id: [1f3f0f50-3a91-11e7-8863-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"open-port-all\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all\"\
-        ,\r\n  \"etag\": \"W/\\\"3180cf40-8b1d-454c-becc-3ae196aecae0\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"f26b729e-2bbc-4236-9d9c-dc34973b52e7\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
         : \"*\",\r\n    \"sourceAddressPrefix\": \"*\",\r\n    \"destinationAddressPrefix\"\
@@ -863,8 +844,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:29 GMT']
-      ETag: [W/"3180cf40-8b1d-454c-becc-3ae196aecae0"]
+      Date: ['Tue, 16 May 2017 23:41:13 GMT']
+      ETag: [W/"f26b729e-2bbc-4236-9d9c-dc34973b52e7"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -874,60 +855,63 @@ interactions:
       content-length: ['571']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "W/\"3d59c338-7994-44e4-8d70-2fa4e0ecfdeb\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet",
-      "properties": {"addressPrefix": "10.0.0.0/24", "networkSecurityGroup": {"etag":
-      "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg",
-      "properties": {"resourceGuid": "2b91219b-09b1-428a-b93c-49083df6ba8f", "securityRules":
-      [], "defaultSecurityRules": [{"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"",
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet",
+      "etag": "W/\"f459dd81-724d-4c66-b439-6cfe004dd253\"", "properties": {"provisioningState":
+      "Succeeded", "addressPrefix": "10.0.0.0/24", "networkSecurityGroup": {"id":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg",
+      "etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"", "properties": {"securityRules":
+      [], "provisioningState": "Succeeded", "defaultSecurityRules": [{"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetInBound",
-      "properties": {"destinationPortRange": "*", "description": "Allow inbound traffic
-      from all VMs in VNET", "direction": "Inbound", "protocol": "*", "access": "Allow",
-      "destinationAddressPrefix": "VirtualNetwork", "priority": 65000, "sourceAddressPrefix":
-      "VirtualNetwork", "provisioningState": "Succeeded", "sourcePortRange": "*"},
-      "name": "AllowVnetInBound"}, {"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"",
+      "name": "AllowVnetInBound", "properties": {"sourceAddressPrefix": "VirtualNetwork",
+      "direction": "Inbound", "priority": 65000, "provisioningState": "Succeeded",
+      "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix": "VirtualNetwork",
+      "access": "Allow", "sourcePortRange": "*", "description": "Allow inbound traffic
+      from all VMs in VNET"}}, {"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
-      "properties": {"destinationPortRange": "*", "description": "Allow inbound traffic
-      from azure load balancer", "direction": "Inbound", "protocol": "*", "access":
-      "Allow", "destinationAddressPrefix": "*", "priority": 65001, "sourceAddressPrefix":
-      "AzureLoadBalancer", "provisioningState": "Succeeded", "sourcePortRange": "*"},
-      "name": "AllowAzureLoadBalancerInBound"}, {"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"",
+      "name": "AllowAzureLoadBalancerInBound", "properties": {"sourceAddressPrefix":
+      "AzureLoadBalancer", "direction": "Inbound", "priority": 65001, "provisioningState":
+      "Succeeded", "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix":
+      "*", "access": "Allow", "sourcePortRange": "*", "description": "Allow inbound
+      traffic from azure load balancer"}}, {"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllInBound",
-      "properties": {"destinationPortRange": "*", "description": "Deny all inbound
-      traffic", "direction": "Inbound", "protocol": "*", "access": "Deny", "destinationAddressPrefix":
-      "*", "priority": 65500, "sourceAddressPrefix": "*", "provisioningState": "Succeeded",
-      "sourcePortRange": "*"}, "name": "DenyAllInBound"}, {"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"",
+      "name": "DenyAllInBound", "properties": {"sourceAddressPrefix": "*", "direction":
+      "Inbound", "priority": 65500, "provisioningState": "Succeeded", "destinationPortRange":
+      "*", "protocol": "*", "destinationAddressPrefix": "*", "access": "Deny", "sourcePortRange":
+      "*", "description": "Deny all inbound traffic"}}, {"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetOutBound",
-      "properties": {"destinationPortRange": "*", "description": "Allow outbound traffic
-      from all VMs to all VMs in VNET", "direction": "Outbound", "protocol": "*",
-      "access": "Allow", "destinationAddressPrefix": "VirtualNetwork", "priority":
-      65000, "sourceAddressPrefix": "VirtualNetwork", "provisioningState": "Succeeded",
-      "sourcePortRange": "*"}, "name": "AllowVnetOutBound"}, {"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"",
+      "name": "AllowVnetOutBound", "properties": {"sourceAddressPrefix": "VirtualNetwork",
+      "direction": "Outbound", "priority": 65000, "provisioningState": "Succeeded",
+      "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix": "VirtualNetwork",
+      "access": "Allow", "sourcePortRange": "*", "description": "Allow outbound traffic
+      from all VMs to all VMs in VNET"}}, {"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
       "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowInternetOutBound",
-      "properties": {"destinationPortRange": "*", "description": "Allow outbound traffic
-      from all VMs to Internet", "direction": "Outbound", "protocol": "*", "access":
-      "Allow", "destinationAddressPrefix": "Internet", "priority": 65001, "sourceAddressPrefix":
-      "*", "provisioningState": "Succeeded", "sourcePortRange": "*"}, "name": "AllowInternetOutBound"},
-      {"etag": "W/\"a89b28c2-a57e-49e9-845d-3cdf498d5777\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound",
-      "properties": {"destinationPortRange": "*", "description": "Deny all outbound
-      traffic", "direction": "Outbound", "protocol": "*", "access": "Deny", "destinationAddressPrefix":
-      "*", "priority": 65500, "sourceAddressPrefix": "*", "provisioningState": "Succeeded",
-      "sourcePortRange": "*"}, "name": "DenyAllOutBound"}], "provisioningState": "Succeeded"},
-      "location": "westus"}, "provisioningState": "Succeeded"}, "name": "vm1Subnet"}'
+      "name": "AllowInternetOutBound", "properties": {"sourceAddressPrefix": "*",
+      "direction": "Outbound", "priority": 65001, "provisioningState": "Succeeded",
+      "destinationPortRange": "*", "protocol": "*", "destinationAddressPrefix": "Internet",
+      "access": "Allow", "sourcePortRange": "*", "description": "Allow outbound traffic
+      from all VMs to Internet"}}, {"etag": "W/\"d8504aba-c21f-422d-ab19-c595af79b03e\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound",
+      "name": "DenyAllOutBound", "properties": {"sourceAddressPrefix": "*", "direction":
+      "Outbound", "priority": 65500, "provisioningState": "Succeeded", "destinationPortRange":
+      "*", "protocol": "*", "destinationAddressPrefix": "*", "access": "Deny", "sourcePortRange":
+      "*", "description": "Deny all outbound traffic"}}], "resourceGuid": "83ba7695-815c-4917-815e-234b1c1ea744"},
+      "location": "westus"}}, "name": "vm1Subnet"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['4339']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b63ffeec-1697-11e7-8f60-f4b7e2e85440]
+      x-ms-client-request-id: [26673678-3a91-11e7-afe4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1Subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"32c1cb2b-991e-4536-8e5b-53c411b9c1e3\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4b1faf1a-281a-4eb0-8225-5c85f49f8ed9\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/24\",\r\n    \"networkSecurityGroup\": {\r\n \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
@@ -935,10 +919,10 @@ interactions:
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
         \r\n      }\r\n    ]\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/c401ae58-d935-4c57-88fb-9d74e801f0d4?api-version=2017-03-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7780cb3c-66c8-45b8-9076-1b7ec01060c7?api-version=2017-03-01']
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:31 GMT']
+      Date: ['Tue, 16 May 2017 23:41:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Retry-After: ['3']
@@ -947,7 +931,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['806']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -956,18 +940,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b63ffeec-1697-11e7-8f60-f4b7e2e85440]
+      x-ms-client-request-id: [26673678-3a91-11e7-afe4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c401ae58-d935-4c57-88fb-9d74e801f0d4?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/7780cb3c-66c8-45b8-9076-1b7ec01060c7?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:34 GMT']
+      Date: ['Tue, 16 May 2017 23:41:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -983,15 +968,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b63ffeec-1697-11e7-8f60-f4b7e2e85440]
+      x-ms-client-request-id: [26673678-3a91-11e7-afe4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1Subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"63ff1aae-705e-4b66-a59d-6360a593c7ef\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fd8c47c9-4595-4936-876b-68369f62ed80\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/24\",\r\n    \"networkSecurityGroup\": {\r\n \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
@@ -1001,8 +987,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:35 GMT']
-      ETag: [W/"63ff1aae-705e-4b66-a59d-6360a593c7ef"]
+      Date: ['Tue, 16 May 2017 23:41:18 GMT']
+      ETag: [W/"fd8c47c9-4595-4936-876b-68369f62ed80"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1018,21 +1004,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9ddd81e-1697-11e7-a9bc-f4b7e2e85440]
+      x-ms-client-request-id: [29636d2e-3a91-11e7-b928-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"name\": \"newNsg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
-        ,\r\n  \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
         : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
-        ,\r\n    \"resourceGuid\": \"2b91219b-09b1-428a-b93c-49083df6ba8f\",\r\n \
+        ,\r\n    \"resourceGuid\": \"83ba7695-815c-4917-815e-234b1c1ea744\",\r\n \
         \   \"securityRules\": [\r\n      {\r\n        \"name\": \"open-port-all\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
         ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
@@ -1041,7 +1028,7 @@ interactions:
         : \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
         : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
         : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1051,7 +1038,7 @@ interactions:
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1060,7 +1047,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
         \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllInBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
         \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
@@ -1069,7 +1056,7 @@ interactions:
         access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
         : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
         AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
         \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
@@ -1078,7 +1065,7 @@ interactions:
         ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
         \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
         \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowInternetOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
         ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
@@ -1087,7 +1074,7 @@ interactions:
         \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
         \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
         \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound\"\
-        ,\r\n        \"etag\": \"W/\\\"caf86478-953e-48b0-a2db-a0548c82b687\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
         \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
@@ -1100,8 +1087,108 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Sat, 01 Apr 2017 04:57:37 GMT']
-      ETag: [W/"caf86478-953e-48b0-a2db-a0548c82b687"]
+      Date: ['Tue, 16 May 2017 23:41:18 GMT']
+      ETag: [W/"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['6043']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [298021f4-3a91-11e7-9cf2-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg?api-version=2017-03-01
+  response:
+    body: {string: "{\r\n  \"name\": \"newNsg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg\"\
+        ,\r\n  \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\
+        ,\r\n    \"resourceGuid\": \"83ba7695-815c-4917-815e-234b1c1ea744\",\r\n \
+        \   \"securityRules\": [\r\n      {\r\n        \"name\": \"open-port-all\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/securityRules/open-port-all\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Allow\",\r\n          \"priority\": 900,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
+        : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
+        \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
+        \     \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowVnetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
+        \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
+        : \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/AllowInternetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n    \
+        \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
+        \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
+        \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/networkSecurityGroups/newNsg/defaultSecurityRules/DenyAllOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
+        \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
+        \      \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Outbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"subnets\": [\r\n\
+        \      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_open_port/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
+        \r\n      }\r\n    ]\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 16 May 2017 23:41:19 GMT']
+      ETag: [W/"1849fbb6-9d1b-4064-a0ce-ac84b5cebf68"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
@@ -95,7 +95,7 @@ class VMOpenPortTest(ResourceGroupVCRTestBase):
         vm = self.vm_name
 
         # min params - apply to existing NIC (updates existing NSG)
-        nsg_id = self.cmd('vm open-port -g {} -n {} --port * --priority 900'.format(rg, vm))['networkSecurityGroup']['id']
+        nsg_id = self.cmd('vm open-port -g {} -n {} --port * --priority 900'.format(rg, vm))['id']
         nsg_name = os.path.split(nsg_id)[1]
         self.cmd('network nsg show -g {} -n {}'.format(rg, nsg_name),
                  checks=JMESPathCheck("length(securityRules[?name == 'open-port-all'])", 1))


### PR DESCRIPTION
Closes #3322.

With the change, the `vm open-port` command will no longer attempt to update the NIC or subnet unless a NSG was not already found and had to be created.  Avoids an unnecessary REST call and opportunity for failure. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
