### PR TITLE
Case insensitive command path

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -267,7 +267,6 @@
     <Compile Include="command_modules\azure-cli-dls\setup.py" />
     <Compile Include="command_modules\azure-cli-dls\tests\test_dls_commands.py" />
     <Compile Include="command_modules\azure-cli-dls\tests\__init__.py" />
-    <Compile Include="command_modules\azure-cli-documentdb\setup.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\command_modules\feedback\commands.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\command_modules\feedback\custom.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\command_modules\feedback\_help.py">

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+unreleased
+^^^^^^^^^^^^^^^^^^
+* Command paths are no longer case sensitive.
+
 2.0.6 (2017-05-09)
 ^^^^^^^^^^^^^^^^^^
 * RP Auto-Reg: capture missing subscription registration error on LRO (#3268)

--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -35,7 +35,7 @@ class Configuration(object):  # pylint: disable=too-few-public-methods
         import azure.cli.core.commands as commands
         # Find the first noun on the command line and only load commands from that
         # module to improve startup time.
-        result = commands.get_command_table(argv[0] if argv else None)
+        result = commands.get_command_table(argv[0].lower() if argv else None)
 
         if argv is None:
             return result
@@ -73,7 +73,7 @@ class Configuration(object):  # pylint: disable=too-few-public-methods
         command_so_far = ""
         try:
             for part in parts:
-                best_match = best_match[part]
+                best_match = best_match[part.lower()]
                 command_so_far = ' '.join((command_so_far, part))
                 if isinstance(best_match, CliCommand):
                     break
@@ -154,13 +154,14 @@ class Application(object):
 
         # Rudimentary parsing to get the command
         nouns = []
-        for noun in argv:
+        for i in range(len(argv)):  # pylint: disable=consider-using-enumerate
             try:
-                if noun[0] == '-':
+                if argv[i][0] == '-':
                     break
             except IndexError:
                 pass
-            nouns.append(noun)
+            argv[i] = argv[i].lower()
+            nouns.append(argv[i])
         command = ' '.join(nouns)
 
         if argv[-1] in ('--help', '-h') or command in command_table:

--- a/src/command_modules/azure-cli-rdbms/tests/recordings/test_mysql_proxy_resources_mgmt.yaml
+++ b/src/command_modules/azure-cli-rdbms/tests/recordings/test_mysql_proxy_resources_mgmt.yaml
@@ -8,7 +8,7 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -20,15 +20,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:27:39 GMT']
+      date: ['Mon, 15 May 2017 22:03:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
-    body: '{"location": "westeurope", "properties": {"administratorLoginPassword":
-      "SecretPassword123", "createMode": "Default", "administratorLogin": "cloudsa"}}'
+    body: '{"location": "westeurope", "properties": {"administratorLogin": "cloudsa",
+      "createMode": "Default", "administratorLoginPassword": "SecretPassword123"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -36,26 +36,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServer","startTime":"2017-05-11T03:27:45.467Z"}'}
+    body: {string: '{"operation":"UpsertElasticServer","startTime":"2017-05-15T22:03:20.13Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/f05443d8-5782-4a55-b24c-bb9ea0d49445?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/982198dc-a2ed-4c1b-a089-f2b5ff1e4515?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['74']
+      content-length: ['73']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:27:43 GMT']
+      date: ['Mon, 15 May 2017 22:03:20 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/f05443d8-5782-4a55-b24c-bb9ea0d49445?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/982198dc-a2ed-4c1b-a089-f2b5ff1e4515?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['60']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -65,72 +65,18 @@ interactions:
       CommandName: [mysql server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/f05443d8-5782-4a55-b24c-bb9ea0d49445?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/982198dc-a2ed-4c1b-a089-f2b5ff1e4515?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"f05443d8-5782-4a55-b24c-bb9ea0d49445","status":"InProgress","startTime":"2017-05-11T03:27:45.467Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['108']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:28:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [mysql server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/f05443d8-5782-4a55-b24c-bb9ea0d49445?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"f05443d8-5782-4a55-b24c-bb9ea0d49445","status":"InProgress","startTime":"2017-05-11T03:27:45.467Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['108']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:29:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [mysql server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/f05443d8-5782-4a55-b24c-bb9ea0d49445?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"f05443d8-5782-4a55-b24c-bb9ea0d49445","status":"Succeeded","startTime":"2017-05-11T03:27:45.467Z"}'}
+    body: {string: '{"name":"982198dc-a2ed-4c1b-a089-f2b5ff1e4515","status":"InProgress","startTime":"2017-05-15T22:03:20.13Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:29:51 GMT']
+      date: ['Mon, 15 May 2017 22:04:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -146,7 +92,61 @@ interactions:
       CommandName: [mysql server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/982198dc-a2ed-4c1b-a089-f2b5ff1e4515?api-version=2017-04-30-preview
+  response:
+    body: {string: '{"name":"982198dc-a2ed-4c1b-a089-f2b5ff1e4515","status":"InProgress","startTime":"2017-05-15T22:03:20.13Z"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['107']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 15 May 2017 22:04:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [mysql server create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/982198dc-a2ed-4c1b-a089-f2b5ff1e4515?api-version=2017-04-30-preview
+  response:
+    body: {string: '{"name":"982198dc-a2ed-4c1b-a089-f2b5ff1e4515","status":"Succeeded","startTime":"2017-05-15T22:03:20.13Z"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['106']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 15 May 2017 22:05:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [mysql server create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -157,7 +157,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['698']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:29:52 GMT']
+      date: ['Mon, 15 May 2017 22:05:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -174,26 +174,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:29:55.96Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:05:26.263Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/181b0745-c71d-4b16-8d9b-fe2ac78b0307?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/b0279a32-3d1a-4e0d-ab11-aa9079808439?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['86']
+      content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:29:56 GMT']
+      date: ['Mon, 15 May 2017 22:05:26 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/181b0745-c71d-4b16-8d9b-fe2ac78b0307?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/b0279a32-3d1a-4e0d-ab11-aa9079808439?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -203,18 +203,18 @@ interactions:
       CommandName: [mysql server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/181b0745-c71d-4b16-8d9b-fe2ac78b0307?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/b0279a32-3d1a-4e0d-ab11-aa9079808439?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"181b0745-c71d-4b16-8d9b-fe2ac78b0307","status":"Succeeded","startTime":"2017-05-11T03:29:55.96Z"}'}
+    body: {string: '{"name":"b0279a32-3d1a-4e0d-ab11-aa9079808439","status":"Succeeded","startTime":"2017-05-15T22:05:26.263Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['106']
+      content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:13 GMT']
+      date: ['Mon, 15 May 2017 22:05:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -230,7 +230,7 @@ interactions:
       CommandName: [mysql server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -241,7 +241,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:15 GMT']
+      date: ['Mon, 15 May 2017 22:05:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -257,7 +257,7 @@ interactions:
       CommandName: [mysql server firewall-rule show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -268,7 +268,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:19 GMT']
+      date: ['Mon, 15 May 2017 22:05:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -284,7 +284,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -295,7 +295,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:21 GMT']
+      date: ['Mon, 15 May 2017 22:05:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -312,21 +312,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:30:22.5Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:05:48.117Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/dddf6930-713f-42ce-94eb-ae4ad4c339c3?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/bcdab038-4912-47fb-9f66-9384be2ce740?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['85']
+      content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:23 GMT']
+      date: ['Mon, 15 May 2017 22:05:47 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/dddf6930-713f-42ce-94eb-ae4ad4c339c3?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/bcdab038-4912-47fb-9f66-9384be2ce740?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -341,18 +341,18 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/dddf6930-713f-42ce-94eb-ae4ad4c339c3?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/bcdab038-4912-47fb-9f66-9384be2ce740?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"dddf6930-713f-42ce-94eb-ae4ad4c339c3","status":"Succeeded","startTime":"2017-05-11T03:30:22.5Z"}'}
+    body: {string: '{"name":"bcdab038-4912-47fb-9f66-9384be2ce740","status":"Succeeded","startTime":"2017-05-15T22:05:48.117Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['105']
+      content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:40 GMT']
+      date: ['Mon, 15 May 2017 22:06:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -368,7 +368,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -379,7 +379,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['424']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:42 GMT']
+      date: ['Mon, 15 May 2017 22:06:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -395,7 +395,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -406,7 +406,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['424']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:44 GMT']
+      date: ['Mon, 15 May 2017 22:06:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -423,21 +423,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:30:44.92Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:06:07.113Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/9c212295-cb54-403c-9c5c-95604377d361?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/e1062dd4-f142-45f4-92c3-5c81a702332b?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['86']
+      content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:30:45 GMT']
+      date: ['Mon, 15 May 2017 22:06:04 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/9c212295-cb54-403c-9c5c-95604377d361?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/e1062dd4-f142-45f4-92c3-5c81a702332b?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -452,18 +452,18 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/9c212295-cb54-403c-9c5c-95604377d361?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/e1062dd4-f142-45f4-92c3-5c81a702332b?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"9c212295-cb54-403c-9c5c-95604377d361","status":"Succeeded","startTime":"2017-05-11T03:30:44.92Z"}'}
+    body: {string: '{"name":"e1062dd4-f142-45f4-92c3-5c81a702332b","status":"Succeeded","startTime":"2017-05-15T22:06:07.113Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['106']
+      content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:02 GMT']
+      date: ['Mon, 15 May 2017 22:06:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -479,7 +479,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -490,7 +490,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:06 GMT']
+      date: ['Mon, 15 May 2017 22:06:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -506,7 +506,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -517,7 +517,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:07 GMT']
+      date: ['Mon, 15 May 2017 22:06:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -534,26 +534,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:31:08.747Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:06:24.27Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/0f82844a-c753-4142-94c0-9b2f279be610?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/16b41f7b-1ea6-4f7d-b423-81d599bbb2d7?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['87']
+      content-length: ['86']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:09 GMT']
+      date: ['Mon, 15 May 2017 22:06:25 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/0f82844a-c753-4142-94c0-9b2f279be610?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/16b41f7b-1ea6-4f7d-b423-81d599bbb2d7?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -563,18 +563,18 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/0f82844a-c753-4142-94c0-9b2f279be610?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/16b41f7b-1ea6-4f7d-b423-81d599bbb2d7?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"0f82844a-c753-4142-94c0-9b2f279be610","status":"Succeeded","startTime":"2017-05-11T03:31:08.747Z"}'}
+    body: {string: '{"name":"16b41f7b-1ea6-4f7d-b423-81d599bbb2d7","status":"Succeeded","startTime":"2017-05-15T22:06:24.27Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['107']
+      content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:26 GMT']
+      date: ['Mon, 15 May 2017 22:06:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -590,7 +590,7 @@ interactions:
       CommandName: [mysql server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -601,7 +601,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['416']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:27 GMT']
+      date: ['Mon, 15 May 2017 22:06:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -618,26 +618,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule2?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:31:28.703Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:06:41.23Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/be47fb95-2257-44ba-bf8b-21472142ac12?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/772af2f7-fbb8-4c4e-85ed-312f29307fc9?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['87']
+      content-length: ['86']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:28 GMT']
+      date: ['Mon, 15 May 2017 22:06:42 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/be47fb95-2257-44ba-bf8b-21472142ac12?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/772af2f7-fbb8-4c4e-85ed-312f29307fc9?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -647,18 +647,18 @@ interactions:
       CommandName: [mysql server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/be47fb95-2257-44ba-bf8b-21472142ac12?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/772af2f7-fbb8-4c4e-85ed-312f29307fc9?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"be47fb95-2257-44ba-bf8b-21472142ac12","status":"Succeeded","startTime":"2017-05-11T03:31:28.703Z"}'}
+    body: {string: '{"name":"772af2f7-fbb8-4c4e-85ed-312f29307fc9","status":"Succeeded","startTime":"2017-05-15T22:06:41.23Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['107']
+      content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:45 GMT']
+      date: ['Mon, 15 May 2017 22:06:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -674,7 +674,7 @@ interactions:
       CommandName: [mysql server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -685,7 +685,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['424']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:48 GMT']
+      date: ['Mon, 15 May 2017 22:06:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -701,7 +701,7 @@ interactions:
       CommandName: [mysql server firewall-rule list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -712,7 +712,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['853']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:50 GMT']
+      date: ['Mon, 15 May 2017 22:07:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -729,21 +729,105 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-11T03:31:52.12Z"}'}
+    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-15T22:07:03.517Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/4f995961-d36b-48a7-8c18-ead9903cb124?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/e7e505ec-f239-4279-b778-38f9dd041629?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['83']
+      content-length: ['84']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:31:52 GMT']
+      date: ['Mon, 15 May 2017 22:07:02 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/4f995961-d36b-48a7-8c18-ead9903cb124?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/e7e505ec-f239-4279-b778-38f9dd041629?api-version=2017-04-30-preview']
+      pragma: [no-cache]
+      retry-after: ['15']
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [mysql server firewall-rule delete]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/e7e505ec-f239-4279-b778-38f9dd041629?api-version=2017-04-30-preview
+  response:
+    body: {string: '{"name":"e7e505ec-f239-4279-b778-38f9dd041629","status":"Succeeded","startTime":"2017-05-15T22:07:03.517Z"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['107']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 15 May 2017 22:07:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [mysql server firewall-rule list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules?api-version=2017-04-30-preview
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule2","name":"rule2","type":"Microsoft.DBforMySQL/servers/firewallRules","properties":{"startIpAddress":"123.123.123.123","endIpAddress":"123.123.123.124"}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['436']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 15 May 2017 22:07:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [mysql server firewall-rule delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule2?api-version=2017-04-30-preview
+  response:
+    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-15T22:07:21.793Z"}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/818f6f4c-4252-4e84-b612-39eefd87ea39?api-version=2017-04-30-preview']
+      cache-control: [no-cache]
+      content-length: ['84']
+      content-type: [application/json; charset=utf-8]
+      date: ['Mon, 15 May 2017 22:07:21 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/818f6f4c-4252-4e84-b612-39eefd87ea39?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -758,102 +842,18 @@ interactions:
       CommandName: [mysql server firewall-rule delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/4f995961-d36b-48a7-8c18-ead9903cb124?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/818f6f4c-4252-4e84-b612-39eefd87ea39?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"4f995961-d36b-48a7-8c18-ead9903cb124","status":"Succeeded","startTime":"2017-05-11T03:31:52.12Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['106']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [mysql server firewall-rule list]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule2","name":"rule2","type":"Microsoft.DBforMySQL/servers/firewallRules","properties":{"startIpAddress":"123.123.123.123","endIpAddress":"123.123.123.124"}}]}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['436']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [mysql server firewall-rule delete]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/firewallRules/rule2?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-11T03:32:10.047Z"}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/c54dc6f6-6510-411b-96a3-bb4d869f9ece?api-version=2017-04-30-preview']
-      cache-control: [no-cache]
-      content-length: ['84']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:10 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/c54dc6f6-6510-411b-96a3-bb4d869f9ece?api-version=2017-04-30-preview']
-      pragma: [no-cache]
-      retry-after: ['15']
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [mysql server firewall-rule delete]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/c54dc6f6-6510-411b-96a3-bb4d869f9ece?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"c54dc6f6-6510-411b-96a3-bb4d869f9ece","status":"Succeeded","startTime":"2017-05-11T03:32:10.047Z"}'}
+    body: {string: '{"name":"818f6f4c-4252-4e84-b612-39eefd87ea39","status":"Succeeded","startTime":"2017-05-15T22:07:21.793Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:27 GMT']
+      date: ['Mon, 15 May 2017 22:07:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -869,7 +869,7 @@ interactions:
       CommandName: [mysql server firewall-rule list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -880,7 +880,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:29 GMT']
+      date: ['Mon, 15 May 2017 22:07:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -896,7 +896,7 @@ interactions:
       CommandName: [mysql db list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -907,7 +907,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:30 GMT']
+      date: ['Mon, 15 May 2017 22:07:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -923,7 +923,7 @@ interactions:
       CommandName: [mysql server configuration show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -936,7 +936,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['613']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:34 GMT']
+      date: ['Mon, 15 May 2017 22:07:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -953,26 +953,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['31']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/log_slow_admin_statements?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-11T03:32:37.28Z"}'}
+    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-15T22:07:43.59Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/dbce8daf-3b4f-46c7-9162-e60bc454b07e?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/4ef49f21-d029-497c-80af-74f6ad985f8c?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['79']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:35 GMT']
+      date: ['Mon, 15 May 2017 22:07:42 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/dbce8daf-3b4f-46c7-9162-e60bc454b07e?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/4ef49f21-d029-497c-80af-74f6ad985f8c?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -982,18 +982,18 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/dbce8daf-3b4f-46c7-9162-e60bc454b07e?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/4ef49f21-d029-497c-80af-74f6ad985f8c?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"dbce8daf-3b4f-46c7-9162-e60bc454b07e","status":"Succeeded","startTime":"2017-05-11T03:32:37.28Z"}'}
+    body: {string: '{"name":"4ef49f21-d029-497c-80af-74f6ad985f8c","status":"Succeeded","startTime":"2017-05-15T22:07:43.59Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:52 GMT']
+      date: ['Mon, 15 May 2017 22:07:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1009,7 +1009,7 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -1022,7 +1022,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['611']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:52 GMT']
+      date: ['Mon, 15 May 2017 22:07:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1039,26 +1039,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['44']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/log_slow_admin_statements?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-11T03:32:54.707Z"}'}
+    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-15T22:08:02.743Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/ef2bc503-e2da-40c1-a71a-9936b6c448ca?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/0fa89413-f136-48e4-8fd0-a48ed8ca3e32?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['80']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:32:55 GMT']
+      date: ['Mon, 15 May 2017 22:08:01 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/ef2bc503-e2da-40c1-a71a-9936b6c448ca?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/0fa89413-f136-48e4-8fd0-a48ed8ca3e32?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1068,18 +1068,18 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/ef2bc503-e2da-40c1-a71a-9936b6c448ca?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/0fa89413-f136-48e4-8fd0-a48ed8ca3e32?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"ef2bc503-e2da-40c1-a71a-9936b6c448ca","status":"Succeeded","startTime":"2017-05-11T03:32:54.707Z"}'}
+    body: {string: '{"name":"0fa89413-f136-48e4-8fd0-a48ed8ca3e32","status":"Succeeded","startTime":"2017-05-15T22:08:02.743Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:10 GMT']
+      date: ['Mon, 15 May 2017 22:08:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1095,7 +1095,7 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -1108,7 +1108,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['613']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:11 GMT']
+      date: ['Mon, 15 May 2017 22:08:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1124,7 +1124,7 @@ interactions:
       CommandName: [mysql server configuration list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -1153,7 +1153,7 @@ interactions:
         or disable the slow query log","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"system-default"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/sql_mode","name":"sql_mode","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"","description":"The
         current server SQL mode.","defaultValue":"","dataType":"Set","allowedValues":",ALLOW_INVALID_DATES,ANSI_QUOTES,ERROR_FOR_DIVISION_BY_ZERO,HIGH_NOT_PRECEDENCE,IGNORE_SPACE,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_BACKSLASH_ESCAPES,NO_DIR_IN_CREATE,NO_ENGINE_SUBSTITUTION,NO_FIELD_OPTIONS,NO_KEY_OPTIONS,NO_TABLE_OPTIONS,NO_UNSIGNED_SUBTRACTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,PAD_CHAR_TO_FULL_LENGTH,PIPES_AS_CONCAT,REAL_AS_FLOAT,STRICT_ALL_TABLES,STRICT_TRANS_TABLES","source":"system-default"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/wait_timeout","name":"wait_timeout","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"120","description":"The
         number of seconds the server waits for activity on a noninteractive connection
-        before closing it.","defaultValue":"120","dataType":"Integer","allowedValues":"60-240","source":"system-default"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/server_id","name":"server_id","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"1350920817","description":"The
+        before closing it.","defaultValue":"120","dataType":"Integer","allowedValues":"60-240","source":"system-default"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/server_id","name":"server_id","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"1079156240","description":"The
         server ID, used in replication to give each master and slave a unique identity.","defaultValue":"1000","dataType":"Integer","allowedValues":"1000-4294967295","source":"user-override"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/max_allowed_packet","name":"max_allowed_packet","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"536870912","description":"The
         maximum size of one packet or any generated/intermediate string, or any parameter
         sent by the mysql_stmt_send_long_data() C API function.","defaultValue":"536870912","dataType":"Integer","allowedValues":"1024-1073741824","source":"system-default"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/slave_net_timeout","name":"slave_net_timeout","type":"Microsoft.DBforMySQL/servers/configurations","properties":{"value":"60","description":"The
@@ -1165,7 +1165,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12185']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:14 GMT']
+      date: ['Mon, 15 May 2017 22:08:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1182,26 +1182,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['31']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/configurations/slow_query_log?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-11T03:33:18.827Z"}'}
+    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-15T22:08:20.283Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/bf4c10b4-640f-4aa4-ba34-8b8d777d9aa5?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/de35c9aa-05c6-4f9c-98a4-71163a14bf18?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['80']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:17 GMT']
+      date: ['Mon, 15 May 2017 22:08:18 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/bf4c10b4-640f-4aa4-ba34-8b8d777d9aa5?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/operationResults/de35c9aa-05c6-4f9c-98a4-71163a14bf18?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1211,18 +1211,18 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/bf4c10b4-640f-4aa4-ba34-8b8d777d9aa5?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westeurope/azureAsyncOperation/de35c9aa-05c6-4f9c-98a4-71163a14bf18?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"bf4c10b4-640f-4aa4-ba34-8b8d777d9aa5","status":"Succeeded","startTime":"2017-05-11T03:33:18.827Z"}'}
+    body: {string: '{"name":"de35c9aa-05c6-4f9c-98a4-71163a14bf18","status":"Succeeded","startTime":"2017-05-15T22:08:20.283Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:33 GMT']
+      date: ['Mon, 15 May 2017 22:08:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1238,7 +1238,7 @@ interactions:
       CommandName: [mysql server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
@@ -1250,7 +1250,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['538']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:35 GMT']
+      date: ['Mon, 15 May 2017 22:08:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1266,18 +1266,18 @@ interactions:
       CommandName: [mysql server-logs list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 mysqlmanagementclient/0.1.0 Azure-SDK-For-Python AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/logFiles?api-version=2017-04-30-preview
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/logFiles/mysql-slow-azuredbclitest000002-2017051103.log","name":"mysql-slow-azuredbclitest000002-2017051103.log","type":"Microsoft.DBforMySQL/servers/logFiles","properties":{"name":"mysql-slow-azuredbclitest000002-2017051103.log","sizeInKB":1,"createdTime":"0001-01-01T00:00:00+00:00","lastModifiedTime":"2017-05-11T03:33:17+00:00","type":"slowlog","url":"https://wasd2prodweu1afse0.file.core.windows.net/e17b3abb4e4a4d4bb00a10ba6a28a700/serverlogs/mysql-slow-azuredbclitest000002-2017051103.log?sv=2015-04-05&sr=f&sig=Lp0u45t87XcZw1iq0SluOUBxUdVufPfVc6ZKHBPZOBQ%3D&se=2017-05-11T04%3A33%3A38Z&sp=r"}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/servers/azuredbclitest000002/logFiles/mysql-slow-azuredbclitest000002-2017051522.log","name":"mysql-slow-azuredbclitest000002-2017051522.log","type":"Microsoft.DBforMySQL/servers/logFiles","properties":{"name":"mysql-slow-azuredbclitest000002-2017051522.log","sizeInKB":1,"createdTime":"0001-01-01T00:00:00+00:00","lastModifiedTime":"2017-05-15T22:08:19+00:00","type":"slowlog","url":"https://wasd2prodweu1afse2.file.core.windows.net/ca8acc9193d34085bf074733e21a0bbc/serverlogs/mysql-slow-azuredbclitest000002-2017051522.log?sv=2015-04-05&sr=f&sig=t1A2HUKDROydMRBcS8IMcB2UW0UpDbKuK6cGfwJ%2Bfhw%3D&se=2017-05-15T23%3A08%3A37Z&sp=r"}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1038']
+      content-length: ['1040']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:37 GMT']
+      date: ['Mon, 15 May 2017 22:08:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1294,7 +1294,7 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1305,12 +1305,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 11 May 2017 03:33:40 GMT']
+      date: ['Mon, 15 May 2017 22:08:37 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdBVDNaRUNPMzZHNEFGVjNRT1ZBTFdMUlJPNk5aSk1ONEVUTHxBQThGNEE0REUyMjc4QTRBLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdFRVRDREJBVEZYUUZMQklIREhPUkg1SEFMRk4yVU9CRFlLM3wwODE1RDgwRTg4MTM1NUM3LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-rdbms/tests/recordings/test_postgres_proxy_resources_mgmt.yaml
+++ b/src/command_modules/azure-cli-rdbms/tests/recordings/test_postgres_proxy_resources_mgmt.yaml
@@ -8,7 +8,7 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -20,15 +20,15 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:42 GMT']
+      date: ['Mon, 15 May 2017 22:08:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 201, message: Created}
 - request:
-    body: '{"location": "westeurope", "properties": {"administratorLoginPassword":
-      "SecretPassword123", "createMode": "Default", "administratorLogin": "cloudsa"}}'
+    body: '{"location": "westeurope", "properties": {"administratorLogin": "cloudsa",
+      "createMode": "Default", "administratorLoginPassword": "SecretPassword123"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -36,27 +36,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServer","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"operation":"UpsertElasticServer","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['73']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:33:45 GMT']
+      date: ['Mon, 15 May 2017 22:08:40 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['60']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -66,19 +66,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:34:48 GMT']
+      date: ['Mon, 15 May 2017 22:09:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -94,19 +94,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:35:19 GMT']
+      date: ['Mon, 15 May 2017 22:10:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -122,19 +122,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:35:51 GMT']
+      date: ['Mon, 15 May 2017 22:10:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -150,19 +150,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:36:24 GMT']
+      date: ['Mon, 15 May 2017 22:11:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -178,19 +178,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:36:56 GMT']
+      date: ['Mon, 15 May 2017 22:11:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -206,19 +206,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"InProgress","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:37:28 GMT']
+      date: ['Mon, 15 May 2017 22:12:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -234,131 +234,19 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/6882378b-436e-43fb-ac09-84f0a585ed05?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['107']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:38:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [postgres server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['107']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:38:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [postgres server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['107']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:39:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [postgres server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"InProgress","startTime":"2017-05-11T03:33:45.29Z"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['107']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:39:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [postgres server create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.6+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b6bc2e79-b434-4b74-857b-f2f89cb864b0?api-version=2017-04-30-preview
-  response:
-    body: {string: '{"name":"b6bc2e79-b434-4b74-857b-f2f89cb864b0","status":"Succeeded","startTime":"2017-05-11T03:33:45.29Z"}'}
+    body: {string: '{"name":"6882378b-436e-43fb-ac09-84f0a585ed05","status":"Succeeded","startTime":"2017-05-15T22:08:42.25Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:07 GMT']
+      date: ['Mon, 15 May 2017 22:12:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -374,7 +262,7 @@ interactions:
       CommandName: [postgres server create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -386,7 +274,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['711']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:09 GMT']
+      date: ['Mon, 15 May 2017 22:12:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -403,22 +291,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:40:14.093Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:12:52.997Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/4141d4c0-0ecf-4ccb-bd8a-002d3af705cb?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/c0ca4b82-be21-4382-8620-833c24508302?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:12 GMT']
+      date: ['Mon, 15 May 2017 22:12:51 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/4141d4c0-0ecf-4ccb-bd8a-002d3af705cb?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/c0ca4b82-be21-4382-8620-833c24508302?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -433,19 +321,19 @@ interactions:
       CommandName: [postgres server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/4141d4c0-0ecf-4ccb-bd8a-002d3af705cb?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/c0ca4b82-be21-4382-8620-833c24508302?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"4141d4c0-0ecf-4ccb-bd8a-002d3af705cb","status":"Succeeded","startTime":"2017-05-11T03:40:14.093Z"}'}
+    body: {string: '{"name":"c0ca4b82-be21-4382-8620-833c24508302","status":"Succeeded","startTime":"2017-05-15T22:12:52.997Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:27 GMT']
+      date: ['Mon, 15 May 2017 22:13:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -461,7 +349,7 @@ interactions:
       CommandName: [postgres server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -473,7 +361,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:30 GMT']
+      date: ['Mon, 15 May 2017 22:13:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -489,7 +377,7 @@ interactions:
       CommandName: [postgres server firewall-rule show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -501,7 +389,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:32 GMT']
+      date: ['Mon, 15 May 2017 22:13:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -517,7 +405,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -529,7 +417,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:34 GMT']
+      date: ['Mon, 15 May 2017 22:13:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -546,27 +434,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:40:38.13Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:13:13.363Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/c2f44fe8-8d8c-4447-8d93-f2c1f60eedfe?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/f507467c-51a5-4a88-8a16-717ae81109ba?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['86']
+      content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:35 GMT']
+      date: ['Mon, 15 May 2017 22:13:12 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/c2f44fe8-8d8c-4447-8d93-f2c1f60eedfe?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/f507467c-51a5-4a88-8a16-717ae81109ba?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -576,19 +464,19 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/c2f44fe8-8d8c-4447-8d93-f2c1f60eedfe?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/f507467c-51a5-4a88-8a16-717ae81109ba?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"c2f44fe8-8d8c-4447-8d93-f2c1f60eedfe","status":"Succeeded","startTime":"2017-05-11T03:40:38.13Z"}'}
+    body: {string: '{"name":"f507467c-51a5-4a88-8a16-717ae81109ba","status":"Succeeded","startTime":"2017-05-15T22:13:13.363Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['106']
+      content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:52 GMT']
+      date: ['Mon, 15 May 2017 22:13:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -604,7 +492,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -616,7 +504,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['434']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:53 GMT']
+      date: ['Mon, 15 May 2017 22:13:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -632,7 +520,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -644,7 +532,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['434']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:55 GMT']
+      date: ['Mon, 15 May 2017 22:13:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -661,27 +549,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:40:59.34Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:13:31.24Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/d1378697-5579-4d3b-81c4-9eff13259696?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/67abc1d3-7293-4cd7-9b6a-b9f357b24322?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['86']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:40:57 GMT']
+      date: ['Mon, 15 May 2017 22:13:32 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/d1378697-5579-4d3b-81c4-9eff13259696?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/67abc1d3-7293-4cd7-9b6a-b9f357b24322?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -691,19 +579,19 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/d1378697-5579-4d3b-81c4-9eff13259696?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/67abc1d3-7293-4cd7-9b6a-b9f357b24322?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"d1378697-5579-4d3b-81c4-9eff13259696","status":"Succeeded","startTime":"2017-05-11T03:40:59.34Z"}'}
+    body: {string: '{"name":"67abc1d3-7293-4cd7-9b6a-b9f357b24322","status":"Succeeded","startTime":"2017-05-15T22:13:31.24Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:12 GMT']
+      date: ['Mon, 15 May 2017 22:13:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -719,7 +607,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -731,7 +619,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:15 GMT']
+      date: ['Mon, 15 May 2017 22:13:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -747,7 +635,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -759,7 +647,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:16 GMT']
+      date: ['Mon, 15 May 2017 22:13:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -776,27 +664,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:41:17.563Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:13:51.16Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/33b9f70f-6d30-4519-8c08-1b51c98a39e5?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/2646daa5-0291-4087-8f7f-93dea16a5473?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['87']
+      content-length: ['86']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:17 GMT']
+      date: ['Mon, 15 May 2017 22:13:51 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/33b9f70f-6d30-4519-8c08-1b51c98a39e5?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/2646daa5-0291-4087-8f7f-93dea16a5473?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -806,19 +694,19 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/33b9f70f-6d30-4519-8c08-1b51c98a39e5?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/2646daa5-0291-4087-8f7f-93dea16a5473?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"33b9f70f-6d30-4519-8c08-1b51c98a39e5","status":"Succeeded","startTime":"2017-05-11T03:41:17.563Z"}'}
+    body: {string: '{"name":"2646daa5-0291-4087-8f7f-93dea16a5473","status":"Succeeded","startTime":"2017-05-15T22:13:51.16Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['107']
+      content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:34 GMT']
+      date: ['Mon, 15 May 2017 22:14:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -834,7 +722,7 @@ interactions:
       CommandName: [postgres server firewall-rule update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -846,7 +734,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['426']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:36 GMT']
+      date: ['Mon, 15 May 2017 22:14:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -863,22 +751,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule2?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-11T03:41:37.627Z"}'}
+    body: {string: '{"operation":"UpsertElasticServerFirewallRules","startTime":"2017-05-15T22:14:11.837Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/e0ea54d6-4364-4649-973e-9cf2b310e744?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/bb69cc16-9ced-44ec-925b-c759385a5fb6?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['87']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:37 GMT']
+      date: ['Mon, 15 May 2017 22:14:11 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/e0ea54d6-4364-4649-973e-9cf2b310e744?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/bb69cc16-9ced-44ec-925b-c759385a5fb6?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -893,19 +781,19 @@ interactions:
       CommandName: [postgres server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/e0ea54d6-4364-4649-973e-9cf2b310e744?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/bb69cc16-9ced-44ec-925b-c759385a5fb6?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"e0ea54d6-4364-4649-973e-9cf2b310e744","status":"Succeeded","startTime":"2017-05-11T03:41:37.627Z"}'}
+    body: {string: '{"name":"bb69cc16-9ced-44ec-925b-c759385a5fb6","status":"Succeeded","startTime":"2017-05-15T22:14:11.837Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:54 GMT']
+      date: ['Mon, 15 May 2017 22:14:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -921,7 +809,7 @@ interactions:
       CommandName: [postgres server firewall-rule create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -933,7 +821,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['434']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:57 GMT']
+      date: ['Mon, 15 May 2017 22:14:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -949,7 +837,7 @@ interactions:
       CommandName: [postgres server firewall-rule list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -961,7 +849,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['873']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:41:59 GMT']
+      date: ['Mon, 15 May 2017 22:14:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -978,27 +866,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule1?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-11T03:42:00.213Z"}'}
+    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-15T22:14:30.467Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/0332e85a-3455-43ef-82fa-afe738a3be63?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/952d2f43-f99e-42b7-b1a3-5cb63bb3884d?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['84']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:00 GMT']
+      date: ['Mon, 15 May 2017 22:14:31 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/0332e85a-3455-43ef-82fa-afe738a3be63?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/952d2f43-f99e-42b7-b1a3-5cb63bb3884d?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1008,19 +896,19 @@ interactions:
       CommandName: [postgres server firewall-rule delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/0332e85a-3455-43ef-82fa-afe738a3be63?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/952d2f43-f99e-42b7-b1a3-5cb63bb3884d?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"0332e85a-3455-43ef-82fa-afe738a3be63","status":"Succeeded","startTime":"2017-05-11T03:42:00.213Z"}'}
+    body: {string: '{"name":"952d2f43-f99e-42b7-b1a3-5cb63bb3884d","status":"Succeeded","startTime":"2017-05-15T22:14:30.467Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:16 GMT']
+      date: ['Mon, 15 May 2017 22:14:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1036,7 +924,7 @@ interactions:
       CommandName: [postgres server firewall-rule list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1048,7 +936,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['446']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:18 GMT']
+      date: ['Mon, 15 May 2017 22:14:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1065,22 +953,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/firewallRules/rule2?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-11T03:42:21.627Z"}'}
+    body: {string: '{"operation":"DropElasticServerFirewallRule","startTime":"2017-05-15T22:14:49.307Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/ffae27aa-2796-427c-836c-beb01162e3b0?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/766ccadc-8b60-409f-861d-d15754a1a2e2?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['84']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:19 GMT']
+      date: ['Mon, 15 May 2017 22:14:48 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/ffae27aa-2796-427c-836c-beb01162e3b0?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/766ccadc-8b60-409f-861d-d15754a1a2e2?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -1095,19 +983,19 @@ interactions:
       CommandName: [postgres server firewall-rule delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/ffae27aa-2796-427c-836c-beb01162e3b0?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/766ccadc-8b60-409f-861d-d15754a1a2e2?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"ffae27aa-2796-427c-836c-beb01162e3b0","status":"Succeeded","startTime":"2017-05-11T03:42:21.627Z"}'}
+    body: {string: '{"name":"766ccadc-8b60-409f-861d-d15754a1a2e2","status":"Succeeded","startTime":"2017-05-15T22:14:49.307Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:36 GMT']
+      date: ['Mon, 15 May 2017 22:15:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1123,7 +1011,7 @@ interactions:
       CommandName: [postgres server firewall-rule list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1135,7 +1023,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:40 GMT']
+      date: ['Mon, 15 May 2017 22:15:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1151,7 +1039,7 @@ interactions:
       CommandName: [postgres db list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1164,7 +1052,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['434']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:48 GMT']
+      date: ['Mon, 15 May 2017 22:15:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1180,7 +1068,7 @@ interactions:
       CommandName: [postgres server configuration show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1193,7 +1081,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['542']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:50 GMT']
+      date: ['Mon, 15 May 2017 22:15:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1210,27 +1098,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['32']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/configurations/array_nulls?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-11T03:42:54.317Z"}'}
+    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-15T22:15:10.347Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/4e0eb028-ed0e-402a-8225-2320b21f3441?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b2899b8b-b028-4ff2-9cf4-77cedcaf9e39?api-version=2017-04-30-preview']
       cache-control: [no-cache]
       content-length: ['80']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:42:53 GMT']
+      date: ['Mon, 15 May 2017 22:15:11 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/4e0eb028-ed0e-402a-8225-2320b21f3441?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/b2899b8b-b028-4ff2-9cf4-77cedcaf9e39?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1240,19 +1128,19 @@ interactions:
       CommandName: [postgres server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/4e0eb028-ed0e-402a-8225-2320b21f3441?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/b2899b8b-b028-4ff2-9cf4-77cedcaf9e39?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"4e0eb028-ed0e-402a-8225-2320b21f3441","status":"Succeeded","startTime":"2017-05-11T03:42:54.317Z"}'}
+    body: {string: '{"name":"b2899b8b-b028-4ff2-9cf4-77cedcaf9e39","status":"Succeeded","startTime":"2017-05-15T22:15:10.347Z"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:09 GMT']
+      date: ['Mon, 15 May 2017 22:15:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1268,7 +1156,7 @@ interactions:
       CommandName: [postgres server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1281,7 +1169,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['542']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:11 GMT']
+      date: ['Mon, 15 May 2017 22:15:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1298,22 +1186,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['44']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/configurations/array_nulls?api-version=2017-04-30-preview
   response:
-    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-11T03:43:15.137Z"}'}
+    body: {string: '{"operation":"UpdateElasticServerConfig","startTime":"2017-05-15T22:15:28.37Z"}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/056da99c-3d38-48f6-910f-777808a336dd?api-version=2017-04-30-preview']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/2b1836a3-f75c-4590-9608-03550c56ebe6?api-version=2017-04-30-preview']
       cache-control: [no-cache]
-      content-length: ['80']
+      content-length: ['79']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:13 GMT']
+      date: ['Mon, 15 May 2017 22:15:29 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/056da99c-3d38-48f6-910f-777808a336dd?api-version=2017-04-30-preview']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/operationResults/2b1836a3-f75c-4590-9608-03550c56ebe6?api-version=2017-04-30-preview']
       pragma: [no-cache]
       retry-after: ['15']
       server: [Microsoft-HTTPAPI/2.0]
@@ -1328,19 +1216,19 @@ interactions:
       CommandName: [postgres server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/056da99c-3d38-48f6-910f-777808a336dd?api-version=2017-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforPostgreSQL/locations/westeurope/azureAsyncOperation/2b1836a3-f75c-4590-9608-03550c56ebe6?api-version=2017-04-30-preview
   response:
-    body: {string: '{"name":"056da99c-3d38-48f6-910f-777808a336dd","status":"Succeeded","startTime":"2017-05-11T03:43:15.137Z"}'}
+    body: {string: '{"name":"2b1836a3-f75c-4590-9608-03550c56ebe6","status":"Succeeded","startTime":"2017-05-15T22:15:28.37Z"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['107']
+      content-length: ['106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:30 GMT']
+      date: ['Mon, 15 May 2017 22:15:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1356,7 +1244,7 @@ interactions:
       CommandName: [postgres server configuration set]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1369,7 +1257,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['542']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:31 GMT']
+      date: ['Mon, 15 May 2017 22:15:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1385,7 +1273,7 @@ interactions:
       CommandName: [postgres server configuration list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1477,7 +1365,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['42658']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:33 GMT']
+      date: ['Mon, 15 May 2017 22:15:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1493,19 +1381,19 @@ interactions:
       CommandName: [postgres server-logs list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 postgresqlmanagementclient/0.1.0 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/logFiles?api-version=2017-04-30-preview
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/logFiles/postgresql-2017-05-11_033955.log","name":"postgresql-2017-05-11_033955.log","type":"Microsoft.DBforPostgreSQL/servers/logFiles","properties":{"name":"postgresql-2017-05-11_033955.log","sizeInKB":1,"createdTime":"0001-01-01T00:00:00+00:00","lastModifiedTime":"2017-05-11T03:43:15+00:00","type":"text","url":"https://wasd2prodweu1afse0.file.core.windows.net/dbef51d8131e4dcfb1664f2d0e0ad0e9/pg_log/postgresql-2017-05-11_033955.log?sv=2015-04-05&sr=f&sig=ssCEjy%2BrCEYFamR4g1Ljnrmw%2BEUkaTnrjiwKZNQTscc%3D&se=2017-05-11T04%3A43%3A36Z&sp=r"}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforPostgreSQL/servers/azuredbclitest000002/logFiles/postgresql-2017-05-15_221242.log","name":"postgresql-2017-05-15_221242.log","type":"Microsoft.DBforPostgreSQL/servers/logFiles","properties":{"name":"postgresql-2017-05-15_221242.log","sizeInKB":1,"createdTime":"0001-01-01T00:00:00+00:00","lastModifiedTime":"2017-05-15T22:15:30+00:00","type":"text","url":"https://wasd2prodweu1afse2.file.core.windows.net/a9c5086332b643fe978d0490ace42404/pg_log/postgresql-2017-05-15_221242.log?sv=2015-04-05&sr=f&sig=TRwbMf0Lo1%2BDA6C6RmQEt%2FwRChHuzi3WZTmyxNE%2Faas%3D&se=2017-05-15T23%3A15%3A49Z&sp=r"}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['817']
+      content-length: ['819']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 11 May 2017 03:43:36 GMT']
+      date: ['Mon, 15 May 2017 22:15:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0]
@@ -1522,7 +1410,7 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.7
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
           AZURECLI/2.0.6+dev]
       accept-language: [en-US]
@@ -1533,12 +1421,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 11 May 2017 03:43:38 GMT']
+      date: ['Mon, 15 May 2017 22:15:50 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdXT1FYNUQyNlFPVVlSNzVTWVpRSEZUVTNDTUhMVlVXRUhTQnwzNzA5MUI2QkY2NDhDNDA5LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdHRTJUTlBaTU1JSkJNWUg0WjU2R1pST0VTUTRPQU9XRjZZWXw0RjRBMEVBMjUyQTNENzczLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-rdbms/tests/test_rdbms_commands.py
+++ b/src/command_modules/azure-cli-rdbms/tests/test_rdbms_commands.py
@@ -371,3 +371,8 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
                               JMESPathCheck('type(@)', 'array')]).get_output_in_json()
 
         self.assertIsNotNone(result[0]['name'])
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Closes #3325.

1. Command path and command name are no longer case sensitive
2. Long and short options REMAIN case-sensitive

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
