### PR TITLE
Tests for VSCode extension

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tooling.py
+++ b/src/azure-cli-core/azure/cli/core/tooling.py
@@ -23,6 +23,7 @@ from azure.cli.core._config import az_config, GLOBAL_CONFIG_PATH, DEFAULTS_SECTI
 from azure.cli.core.help_files import helps
 from azure.cli.core.util import CLIError
 
+
 GLOBAL_ARGUMENTS = {
     'verbose': {
         'options': ['--verbose'],
@@ -47,8 +48,10 @@ GLOBAL_ARGUMENTS = {
     }
 }
 
+
 def initialize():
     _load_profile()
+
 
 def _load_profile():
     azure_folder = cli_config_dir()
@@ -57,11 +60,13 @@ def _load_profile():
 
     ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
 
+
 def load_command_table():
     APPLICATION.initialize(Configuration())
     command_table = APPLICATION.configuration.get_command_table()
     _install_modules(command_table)
     return command_table
+
 
 def _install_modules(command_table):
     for cmd in command_table:
@@ -85,19 +90,26 @@ def _install_modules(command_table):
             traceback.print_exc(file=stderr)
     _update_command_definitions(command_table)
 
+
 HELP_CACHE = {}
+
+
 def get_help(group_or_command):
     if group_or_command not in HELP_CACHE and group_or_command in helps:
         HELP_CACHE[group_or_command] = yaml.load(helps[group_or_command])
     return HELP_CACHE.get(group_or_command)
 
+
 PROFILE = Profile()
+
+
 def get_current_subscription():
     _load_profile()
     try:
         return PROFILE.get_subscription()[_SUBSCRIPTION_NAME]
     except CLIError:
-        return None # Not logged in
+        return None  # Not logged in
+
 
 def get_configured_defaults():
     _reload_config()
@@ -112,17 +124,21 @@ def get_configured_defaults():
     except configparser.NoSectionError:
         return {}
 
+
 def is_required(argument):
     required_tooling = hasattr(argument.type, 'required_tooling') and argument.type.required_tooling is True
     return required_tooling and argument.name != 'is_linux'
+
 
 def get_defaults(arguments):
     _reload_config()
     return {name: _get_default(argument) for name, argument in arguments.items()}
 
+
 def _get_default(argument):
     configured = _find_configured_default(argument)
     return configured or argument.type.settings.get('default')
+
 
 def run_argument_value_completer(command, argument, cli_arguments):
     try:
@@ -138,18 +154,21 @@ def run_argument_value_completer(command, argument, cli_arguments):
             except TypeError:
                 return None
 
+
 def _to_argument_object(command, cli_arguments):
-    result = lambda: None
+    result = lambda: None  # noqa: E731
     for argument_name, value in cli_arguments.items():
         name, _ = _find_argument(command, argument_name)
         setattr(result, name, value)
     return result
+
 
 def _find_argument(command, argument_name):
     for name, argument in command.arguments.items():
         if argument_name in argument.options_list:
             return name, argument
     return None, None
+
 
 def _add_defaults(command, arguments):
     _reload_config()
@@ -161,8 +180,10 @@ def _add_defaults(command, arguments):
 
     return arguments
 
+
 def _reload_config():
     az_config.config_parser.read(GLOBAL_CONFIG_PATH)
+
 
 def _find_configured_default(argument):
     if not (hasattr(argument.type, 'default_name_tooling') and argument.type.default_name_tooling):

--- a/src/azure-cli-core/azure/cli/core/tooling.py
+++ b/src/azure-cli-core/azure/cli/core/tooling.py
@@ -1,7 +1,8 @@
 """
 Tooling Integration
 
-This module is used by the Azure CLI Tools extension for VSCode. It should not be used anywhere else and will be removed in a future release.
+This module is used by the Azure CLI Tools extension for VSCode. It should not be used
+anywhere else and will be removed in a future release.
 """
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.

--- a/src/azure-cli-core/azure/cli/core/tooling.py
+++ b/src/azure-cli-core/azure/cli/core/tooling.py
@@ -1,0 +1,173 @@
+"""tooling integration"""
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from __future__ import print_function
+
+import os
+import traceback
+from importlib import import_module
+from sys import stderr
+import pkgutil
+import yaml
+
+from six.moves import configparser
+
+from azure.cli.core.application import APPLICATION, Configuration
+from azure.cli.core.commands import _update_command_definitions, BLACKLISTED_MODS
+from azure.cli.core._profile import _SUBSCRIPTION_NAME, Profile
+from azure.cli.core._session import ACCOUNT
+from azure.cli.core._environment import get_config_dir as cli_config_dir
+from azure.cli.core._config import az_config, GLOBAL_CONFIG_PATH, DEFAULTS_SECTION
+from azure.cli.core.help_files import helps
+from azure.cli.core.util import CLIError
+
+GLOBAL_ARGUMENTS = {
+    'verbose': {
+        'options': ['--verbose'],
+        'help': 'Increase logging verbosity. Use --debug for full debug logs.'
+    },
+    'debug': {
+        'options': ['--debug'],
+        'help': 'Increase logging verbosity to show all debug logs.'
+    },
+    'output': {
+        'options': ['--output', '-o'],
+        'help': 'Output format',
+        'choices': ['json', 'tsv', 'table', 'jsonc']
+    },
+    'help': {
+        'options': ['--help', '-h'],
+        'help': 'Get more information about a command'
+    },
+    'query': {
+        'options': ['--query'],
+        'help': 'JMESPath query string. See http://jmespath.org/ for more information and examples.'
+    }
+}
+
+def initialize():
+    _load_profile()
+
+def _load_profile():
+    azure_folder = cli_config_dir()
+    if not os.path.exists(azure_folder):
+        os.makedirs(azure_folder)
+
+    ACCOUNT.load(os.path.join(azure_folder, 'azureProfile.json'))
+
+def load_command_table():
+    APPLICATION.initialize(Configuration())
+    command_table = APPLICATION.configuration.get_command_table()
+    _install_modules(command_table)
+    return command_table
+
+def _install_modules(command_table):
+    for cmd in command_table:
+        command_table[cmd].load_arguments()
+
+    try:
+        mods_ns_pkg = import_module('azure.cli.command_modules')
+        installed_command_modules = [modname for _, modname, _ in
+                                     pkgutil.iter_modules(mods_ns_pkg.__path__)
+                                     if modname not in BLACKLISTED_MODS]
+    except ImportError:
+        pass
+    for mod in installed_command_modules:
+        try:
+            mod = import_module('azure.cli.command_modules.' + mod)
+            mod.load_params(mod)
+            mod.load_commands()
+
+        except Exception:  # pylint: disable=broad-except
+            print("Error loading: {}".format(mod), file=stderr)
+            traceback.print_exc(file=stderr)
+    _update_command_definitions(command_table)
+
+HELP_CACHE = {}
+def get_help(group_or_command):
+    if group_or_command not in HELP_CACHE and group_or_command in helps:
+        HELP_CACHE[group_or_command] = yaml.load(helps[group_or_command])
+    return HELP_CACHE.get(group_or_command)
+
+PROFILE = Profile()
+def get_current_subscription():
+    _load_profile()
+    try:
+        return PROFILE.get_subscription()[_SUBSCRIPTION_NAME]
+    except CLIError:
+        return None # Not logged in
+
+def get_configured_defaults():
+    _reload_config()
+    try:
+        options = az_config.config_parser.options(DEFAULTS_SECTION)
+        defaults = {}
+        for opt in options:
+            value = az_config.get(DEFAULTS_SECTION, opt)
+            if value:
+                defaults[opt] = value
+        return defaults
+    except configparser.NoSectionError:
+        return {}
+
+def is_required(argument):
+    required_tooling = hasattr(argument.type, 'required_tooling') and argument.type.required_tooling is True
+    return required_tooling and argument.name != 'is_linux'
+
+def get_defaults(arguments):
+    _reload_config()
+    return {name: _get_default(argument) for name, argument in arguments.items()}
+
+def _get_default(argument):
+    configured = _find_configured_default(argument)
+    return configured or argument.type.settings.get('default')
+
+def run_argument_value_completer(command, argument, cli_arguments):
+    try:
+        args = _to_argument_object(command, cli_arguments)
+        _add_defaults(command, args)
+        return argument.completer('', '', args)
+    except TypeError:
+        try:
+            return argument.completer('')
+        except TypeError:
+            try:
+                return argument.completer()
+            except TypeError:
+                return None
+
+def _to_argument_object(command, cli_arguments):
+    result = lambda: None
+    for argument_name, value in cli_arguments.items():
+        name, _ = _find_argument(command, argument_name)
+        setattr(result, name, value)
+    return result
+
+def _find_argument(command, argument_name):
+    for name, argument in command.arguments.items():
+        if argument_name in argument.options_list:
+            return name, argument
+    return None, None
+
+def _add_defaults(command, arguments):
+    _reload_config()
+    for name, argument in command.arguments.items():
+        if not hasattr(arguments, name):
+            default = _find_configured_default(argument)
+            if default:
+                setattr(arguments, name, default)
+
+    return arguments
+
+def _reload_config():
+    az_config.config_parser.read(GLOBAL_CONFIG_PATH)
+
+def _find_configured_default(argument):
+    if not (hasattr(argument.type, 'default_name_tooling') and argument.type.default_name_tooling):
+        return None
+    try:
+        return az_config.get(DEFAULTS_SECTION, argument.type.default_name_tooling, None)
+    except configparser.NoSectionError:
+        return None

--- a/src/azure-cli-core/azure/cli/core/tooling.py
+++ b/src/azure-cli-core/azure/cli/core/tooling.py
@@ -1,4 +1,8 @@
-"""tooling integration"""
+"""
+Tooling Integration
+
+This module is used by the Azure CLI Tools extension for VSCode. It should not be used anywhere else and will be removed in a future release.
+"""
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/azure-cli-core/tests/test_tooling.py
+++ b/src/azure-cli-core/tests/test_tooling.py
@@ -23,6 +23,7 @@ TEST_ARGUMENT_WITH_CHOICES = 'sku'
 TEST_COMMAND_WITH_COMPLETER = 'account set'
 TEST_ARGUMENT_WITH_COMPLETER = 'subscription'
 
+
 class ToolingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -118,6 +119,7 @@ class ToolingTest(unittest.TestCase):
     def test_configured_defaults(self):
         defaults = get_configured_defaults()
         self.assertTrue(isinstance(defaults, dict))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/tests/test_tooling.py
+++ b/src/azure-cli-core/tests/test_tooling.py
@@ -1,0 +1,123 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: skip-file
+import unittest
+import collections
+
+from azure.cli.core.tooling import initialize, load_command_table, get_help, is_required, GLOBAL_ARGUMENTS, get_defaults, run_argument_value_completer, get_current_subscription, get_configured_defaults
+
+TEST_GROUP = 'webapp'
+TEST_COMMAND = 'webapp create'
+TEST_ARGUMENT = 'plan'
+TEST_ARGUMENT_OPTIONS = ['--plan', '-p']
+TEST_OPTIONAL_ARGUMENT = 'runtime'
+TEST_GLOBAL_ARGUMENT = 'output'
+TEST_GLOBAL_ARGUMENT_OPTIONS = ['--output', '-o']
+TEST_ARGUMENT_WITH_DEFAULT = 'deployment_source_branch'
+TEST_ARGUMENT_WITHOUT_DEFAULT = 'deployment_source_url'
+TEST_COMMAND_WITH_CHOICES = 'appservice plan create'
+TEST_ARGUMENT_WITH_CHOICES = 'sku'
+TEST_COMMAND_WITH_COMPLETER = 'account set'
+TEST_ARGUMENT_WITH_COMPLETER = 'subscription'
+
+class ToolingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        initialize()
+        cls.command_table = load_command_table()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.command_table = None
+
+    def test_group_help(self):
+        help = get_help(TEST_GROUP)
+        self.assertIsNotNone(help)
+        self.assertTrue(help.get('short-summary'))
+
+    def test_command(self):
+        command = self.command_table.get(TEST_COMMAND)
+        self.assertIsNotNone(command)
+        self.assertEqual(TEST_COMMAND, command.name)
+
+    def test_command_help(self):
+        help = get_help(TEST_COMMAND)
+        self.assertIsNotNone(help)
+        self.assertTrue(help.get('short-summary'))
+        examples = help.get('examples')
+        self.assertNotEqual(0, len(examples))
+        self.assertTrue(examples[0]['name'])
+        self.assertTrue(examples[0]['text'])
+
+    def test_argument(self):
+        command = self.command_table.get(TEST_COMMAND)
+        self.assertIsNotNone(command)
+        argument = command.arguments.get(TEST_ARGUMENT)
+        self.assertIsNotNone(argument)
+        self.assertSequenceEqual(TEST_ARGUMENT_OPTIONS, argument.options_list)
+
+    def test_argument_help(self):
+        command = self.command_table.get(TEST_COMMAND)
+        self.assertIsNotNone(command)
+        argument = command.arguments.get(TEST_ARGUMENT)
+        self.assertIsNotNone(argument)
+        self.assertTrue(argument.type.settings.get('help'))
+
+    def test_global_argument(self):
+        argument = GLOBAL_ARGUMENTS.get(TEST_GLOBAL_ARGUMENT)
+        self.assertIsNotNone(argument)
+        self.assertSequenceEqual(TEST_GLOBAL_ARGUMENT_OPTIONS, argument['options'])
+        self.assertTrue(argument['help'])
+        self.assertNotEqual(0, len(argument['choices']))
+
+    def test_required_argument(self):
+        command = self.command_table.get(TEST_COMMAND)
+        self.assertIsNotNone(command)
+        self.assertTrue(is_required(command.arguments.get(TEST_ARGUMENT)))
+        self.assertFalse(is_required(command.arguments.get(TEST_OPTIONAL_ARGUMENT)))
+
+    def test_is_linux_optional(self):
+        command = self.command_table.get('appservice plan create')
+        self.assertIsNotNone(command)
+        self.assertFalse(is_required(command.arguments.get('is_linux')))
+
+    def test_argument_defaults(self):
+        command = self.command_table.get(TEST_COMMAND)
+        self.assertIsNotNone(command)
+        defaults = get_defaults(command.arguments)
+        self.assertIsNotNone(defaults)
+        self.assertTrue(defaults.get(TEST_ARGUMENT_WITH_DEFAULT))
+        self.assertFalse(defaults.get(TEST_ARGUMENT_WITHOUT_DEFAULT))
+
+    def test_argument_choices(self):
+        command = self.command_table.get(TEST_COMMAND_WITH_CHOICES)
+        self.assertIsNotNone(command)
+        argument = command.arguments[TEST_ARGUMENT_WITH_CHOICES]
+        self.assertIsNotNone(argument)
+        self.assertIsNotNone(argument.choices)
+        self.assertIsNone(argument.completer)
+        self.assertNotEqual(0, len(argument.choices))
+
+    def test_argument_completer(self):
+        command = self.command_table.get(TEST_COMMAND_WITH_COMPLETER)
+        self.assertIsNotNone(command)
+        argument = command.arguments[TEST_ARGUMENT_WITH_COMPLETER]
+        self.assertIsNotNone(argument)
+        self.assertIsNone(argument.choices)
+        self.assertIsNotNone(argument.completer)
+        values = run_argument_value_completer(command, argument, {})
+        self.assertTrue(isinstance(values, collections.Sequence))
+
+    def test_current_subscription(self):
+        subscription = get_current_subscription()
+        self.assertTrue(subscription is None or isinstance(subscription, str))
+
+    def test_configured_defaults(self):
+        defaults = get_configured_defaults()
+        self.assertTrue(isinstance(defaults, dict))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a set of tests to serve as a canary for when changes in the CLI will affect the VSCode extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode.azurecli). It includes a module for the extension to consume and the tests to test against. This module encapsulates a few lines of code that seem to rely heavily on the CLI's implementation and are more likely to require updates with changes to the underlying parts of the CLI.

Not sure where this code should go, I've put it in azure.cli.core.tooling to get started.