### PR TITLE
profile support: validate_content parameter is not supported in 2015-04-05 data storage sdk

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -10,13 +10,13 @@ from azure.common import AzureException
 
 from azure.cli.core.util import CLIError
 from azure.cli.core.azlogging import get_az_logger
+from azure.cli.core.profiles import supported_api_version, ResourceType
 from azure.cli.command_modules.storage.util import (create_blob_service_from_storage_client,
                                                     create_file_share_from_storage_client,
                                                     create_short_lived_share_sas,
                                                     create_short_lived_container_sas,
                                                     filter_none, collect_blobs, collect_files,
                                                     mkdir_p)
-
 
 BlobCopyResult = namedtuple('BlobCopyResult', ['name', 'copy_id'])
 
@@ -173,32 +173,43 @@ def storage_blob_upload_batch(client, source, destination, pattern=None, source_
                 if_none_match=if_none_match,
                 timeout=timeout)
 
-        return client.append_blob_from_path(
-            container_name=destination_container_name,
-            blob_name=blob_name,
-            file_path=file_path,
-            progress_callback=lambda c, t: None,
-            validate_content=validate_content,
-            maxsize_condition=maxsize_condition,
-            lease_id=lease_id,
-            timeout=timeout)
+        append_blob_args = {
+            'container_name': destination_container_name,
+            'blob_name': blob_name,
+            'file_path': file_path,
+            'progress_callback': lambda c, t: None,
+            'maxsize_condition': maxsize_condition,
+            'lease_id': lease_id,
+            'timeout': timeout
+        }
+
+        if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
+            append_blob_args['validate_content'] = validate_content
+
+        return client.append_blob_from_path(**append_blob_args)
 
     def _upload_blob(file_path, blob_name):
-        return client.create_blob_from_path(
-            container_name=destination_container_name,
-            blob_name=blob_name,
-            file_path=file_path,
-            progress_callback=lambda c, t: None,
-            content_settings=content_settings,
-            metadata=metadata,
-            validate_content=validate_content,
-            max_connections=max_connections,
-            lease_id=lease_id,
-            if_modified_since=if_modified_since,
-            if_unmodified_since=if_unmodified_since,
-            if_match=if_match,
-            if_none_match=if_none_match,
-            timeout=timeout)
+
+        create_blob_args = {
+            'container_name': destination_container_name,
+            'blob_name': blob_name,
+            'file_path': file_path,
+            'progress_callback': lambda c, t: None,
+            'content_settings': content_settings,
+            'metadata': metadata,
+            'max_connections': max_connections,
+            'lease_id': lease_id,
+            'if_modified_since': if_modified_since,
+            'if_unmodified_since': if_unmodified_since,
+            'if_match': if_match,
+            'if_none_match': if_none_match,
+            'timeout': timeout
+        }
+
+        if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
+            create_blob_args['validate_content'] = validate_content
+
+        return client.create_blob_from_path(**create_blob_args)
 
     upload_action = _upload_blob if blob_type == 'block' or blob_type == 'page' else _append_blob
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -10,7 +10,7 @@ from sys import stderr
 
 from azure.cli.core.decorators import transfer_doc
 from azure.cli.core.util import CLIError
-from azure.cli.core.profiles import get_sdk, ResourceType
+from azure.cli.core.profiles import get_sdk, supported_api_version, ResourceType
 
 from azure.cli.command_modules.storage._factory import \
     (storage_client_factory, generic_data_service_factory)
@@ -190,15 +190,21 @@ def upload_blob(  # pylint: disable=too-many-locals
                 if_match=if_match,
                 if_none_match=if_none_match,
                 timeout=timeout)
-        return client.append_blob_from_path(
-            container_name=container_name,
-            blob_name=blob_name,
-            file_path=file_path,
-            progress_callback=_update_progress,
-            validate_content=validate_content,
-            maxsize_condition=maxsize_condition,
-            lease_id=lease_id,
-            timeout=timeout)
+
+        append_blob_args = {
+            'container_name': container_name,
+            'blob_name': blob_name,
+            'file_path': file_path,
+            'progress_callback': _update_progress,
+            'maxsize_condition': maxsize_condition,
+            'lease_id': lease_id,
+            'timeout': timeout
+        }
+
+        if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
+            append_blob_args['validate_content'] = validate_content
+
+        return client.append_blob_from_path(**append_blob_args)
 
     def upload_block_blob():
         import os
@@ -208,22 +214,26 @@ def upload_blob(  # pylint: disable=too-many-locals
             client.MAX_BLOCK_SIZE = 100 * 1024 * 1024
             client.MAX_SINGLE_PUT_SIZE = 256 * 1024 * 1024
 
-        return client.create_blob_from_path(
-            container_name=container_name,
-            blob_name=blob_name,
-            file_path=file_path,
-            progress_callback=_update_progress,
-            content_settings=content_settings,
-            metadata=metadata,
-            validate_content=validate_content,
-            max_connections=max_connections,
-            lease_id=lease_id,
-            if_modified_since=if_modified_since,
-            if_unmodified_since=if_unmodified_since,
-            if_match=if_match,
-            if_none_match=if_none_match,
-            timeout=timeout
-        )
+        create_blob_args = {
+            'container_name': container_name,
+            'blob_name': blob_name,
+            'file_path': file_path,
+            'progress_callback': _update_progress,
+            'content_settings': content_settings,
+            'metadata': metadata,
+            'max_connections': max_connections,
+            'lease_id': lease_id,
+            'if_modified_since': if_modified_since,
+            'if_unmodified_since': if_unmodified_since,
+            'if_match': if_match,
+            'if_none_match': if_none_match,
+            'timeout': timeout
+        }
+
+        if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
+            create_blob_args['validate_content'] = validate_content
+
+        return client.create_blob_from_path(**create_blob_args)
 
     type_func = {
         'append': upload_append_blob,


### PR DESCRIPTION
Conditionally removing the use of validate_content for the older api

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
