### PR TITLE
vmss: let 'list_vmss_instance_connectio_info' include instance id in the output

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -10,7 +10,8 @@ unreleased
 * vm: fix "vm extension list" crash if the VM has no extensions
 * vmss: update arg description for 'vmss delete-instances --instance-ids'
 * vmss: hide arg 'vmss show --ids', which is not supposed to work because of 'instance-id' arg
-* vmss: including instance ids in list_vmss_instance_connectio_info
+* BC: vmss list-instance-connection-info: include instance IDs in the output
+
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -10,6 +10,7 @@ unreleased
 * vm: fix "vm extension list" crash if the VM has no extensions
 * vmss: update arg description for 'vmss delete-instances --instance-ids'
 * vmss: hide arg 'vmss show --ids', which is not supposed to work because of 'instance-id' arg
+* vmss: including instance ids in list_vmss_instance_connectio_info
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1475,9 +1475,11 @@ def list_vmss_instance_connection_info(resource_group_name, vm_scale_set_name):
     public_ip_address = public_ip.ip_address
 
     # loop around inboundnatrule
-    instance_addresses = []
+    instance_addresses = {}
     for rule in lb.inbound_nat_rules:
-        instance_addresses.append('{}:{}'.format(public_ip_address, rule.frontend_port))
+        instance_id = parse_resource_id(rule.backend_ip_configuration.id)['child_name']
+        instance_addresses['instance ' + instance_id] = '{}:{}'.format(public_ip_address,
+                                                                       rule.frontend_port)
 
     return instance_addresses
 

--- a/src/command_modules/azure-cli-vm/tests/recordings/test_vmss_vms.yaml
+++ b/src/command_modules/azure-cli-vm/tests/recordings/test_vmss_vms.yaml
@@ -6,69 +6,70 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [062e2430-0da3-11e7-9849-f4b7e2e85440]
+      x-ms-client-request-id: [56de12a8-3c11-11e7-be53-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"0\",\r\
         \n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n        \"\
         tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"\
-        latestModelApplied\": true,\r\n        \"vmId\": \"5c94da1a-9d2f-4be5-9659-be1bce27b233\"\
+        latestModelApplied\": true,\r\n        \"vmId\": \"ca8d7293-39e7-4e7b-a1ae-499abe408de5\"\
         ,\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n\
         \            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\"\
-        ,\r\n            \"sku\": \"16.04-LTS\",\r\n            \"version\": \"16.04.201703070\"\
+        ,\r\n            \"sku\": \"16.04-LTS\",\r\n            \"version\": \"16.04.201705160\"\
         \r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"\
-        Linux\",\r\n            \"name\": \"vmss1_vmss1_0_OsDisk_1_a6cb1cb57e21456aa681cf71da5ce278\"\
+        Linux\",\r\n            \"name\": \"vmss1_vmss1_0_OsDisk_1_075e5daf39d34402b9b2d485d2fc25d0\"\
         ,\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\"\
         : \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\"\
-        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_0_OsDisk_1_a6cb1cb57e21456aa681cf71da5ce278\"\
-        \r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n     \
-        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss10jpv000000\"\
-        ,\r\n          \"adminUsername\": \"admin123\",\r\n          \"linuxConfiguration\"\
-        : {\r\n            \"disablePasswordAuthentication\": false\r\n          },\r\
-        \n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"\
-        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss10jpvNic\"\
+        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_0_OsDisk_1_075e5daf39d34402b9b2d485d2fc25d0\"\
+        \r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n \
+        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n\
+        \          \"computerName\": \"vmss1unkt000000\",\r\n          \"adminUsername\"\
+        : \"admin123\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\"\
+        : false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n   \
+        \     \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1unktNic\"\
         }]},\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"\
         type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n\
         \      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_KNM1_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_ZVL8_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
         ,\r\n      \"name\": \"vmss1_0\"\r\n    },\r\n    {\r\n      \"instanceId\"\
-        : \"1\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n\
+        : \"3\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D1_v2\",\r\n\
         \        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n\
-        \        \"latestModelApplied\": true,\r\n        \"vmId\": \"76c988cf-d70f-4db9-8eb7-94ea8454f231\"\
+        \        \"latestModelApplied\": true,\r\n        \"vmId\": \"0575a6a4-2c5c-46e5-93e4-192dbf6d714e\"\
         ,\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n\
         \            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\"\
-        ,\r\n            \"sku\": \"16.04-LTS\",\r\n            \"version\": \"16.04.201703070\"\
+        ,\r\n            \"sku\": \"16.04-LTS\",\r\n            \"version\": \"16.04.201705160\"\
         \r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"\
-        Linux\",\r\n            \"name\": \"vmss1_vmss1_1_OsDisk_1_39eee64c75814913883343f89901afcb\"\
+        Linux\",\r\n            \"name\": \"vmss1_vmss1_3_OsDisk_1_3f8ab64a2dfe42d8b879992dac509c16\"\
         ,\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\"\
         : \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\"\
-        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_1_OsDisk_1_39eee64c75814913883343f89901afcb\"\
-        \r\n            }\r\n          },\r\n          \"dataDisks\": []\r\n     \
-        \   },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss10jpv000001\"\
-        ,\r\n          \"adminUsername\": \"admin123\",\r\n          \"linuxConfiguration\"\
-        : {\r\n            \"disablePasswordAuthentication\": false\r\n          },\r\
-        \n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"\
-        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss10jpvNic\"\
-        }]},\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"\
-        type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n\
-        \      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_KNM1_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1\"\
-        ,\r\n      \"name\": \"vmss1_1\"\r\n    }\r\n  ]\r\n}"}
+        : \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_3_OsDisk_1_3f8ab64a2dfe42d8b879992dac509c16\"\
+        \r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n \
+        \         \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n\
+        \          \"computerName\": \"vmss1unkt000003\",\r\n          \"adminUsername\"\
+        : \"admin123\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\"\
+        : false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n   \
+        \     \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1unktNic\"\
+        }]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n     \
+        \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"tags\": {},\r\n      \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_VMS_ZVL8_/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3\"\
+        ,\r\n      \"name\": \"vmss1_3\"\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:25:49 GMT']
+      Date: ['Thu, 18 May 2017 21:31:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3886']
+      content-length: ['3949']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -77,29 +78,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [06f07174-0da3-11e7-a39e-f4b7e2e85440]
+      x-ms-client-request-id: [570ae286-3c11-11e7-b8a6-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/0?api-version=2016-04-30-preview
   response:
     body: {string: "{\r\n  \"instanceId\": \"0\",\r\n  \"sku\": {\r\n    \"name\"\
         : \"Standard_D1_v2\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"properties\"\
-        : {\r\n    \"latestModelApplied\": true,\r\n    \"vmId\": \"5c94da1a-9d2f-4be5-9659-be1bce27b233\"\
+        : {\r\n    \"latestModelApplied\": true,\r\n    \"vmId\": \"ca8d7293-39e7-4e7b-a1ae-499abe408de5\"\
         ,\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"\
         publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n  \
-        \      \"sku\": \"16.04-LTS\",\r\n        \"version\": \"16.04.201703070\"\
+        \      \"sku\": \"16.04-LTS\",\r\n        \"version\": \"16.04.201705160\"\
         \r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n\
-        \        \"name\": \"vmss1_vmss1_0_OsDisk_1_a6cb1cb57e21456aa681cf71da5ce278\"\
+        \        \"name\": \"vmss1_vmss1_0_OsDisk_1_075e5daf39d34402b9b2d485d2fc25d0\"\
         ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_0_OsDisk_1_a6cb1cb57e21456aa681cf71da5ce278\"\
-        \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"vmss10jpv000000\",\r\n      \"adminUsername\"\
-        : \"admin123\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss10jpvNic\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/disks/vmss1_vmss1_0_OsDisk_1_075e5daf39d34402b9b2d485d2fc25d0\"\
+        \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmss1unkt000000\"\
+        ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1unktNic\"\
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0\"\
@@ -107,14 +110,205 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:25:50 GMT']
+      Date: ['Thu, 18 May 2017 21:31:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1749']
+      content-length: ['1776']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [57336046-3c11-11e7-8eaf-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D1_v2\",\r\n   \
+        \ \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
+        \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1unkt\"\
+        ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
+        : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
+        \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
+        \      \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n   \
+        \       \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n  \
+        \          \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n   \
+        \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\"\
+        ,\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04-LTS\"\
+        ,\r\n          \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"\
+        networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1unktNic\"\
+        ,\"properties\":{\"primary\":true,\"ipConfigurations\":[{\"name\":\"vmss1unktIPConfig\"\
+        ,\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
+        },\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
+        }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
+        }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        overprovision\": true,\r\n    \"uniqueId\": \"0bc85e7c-0462-4fc7-b273-ad051c96f18b\"\
+        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
+        ,\r\n  \"name\": \"vmss1\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 18 May 2017 21:31:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2092']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [5749ff14-3c11-11e7-8dcd-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB?api-version=2017-03-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vmss1LB\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB\"\
+        ,\r\n  \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"4c02d161-e0e1-41f1-a376-4d567f0302f1\"\
+        ,\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"\
+        loadBalancerFrontEnd\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"\
+        publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP\"\
+        \r\n          },\r\n          \"inboundNatRules\": [\r\n            {\r\n\
+        \              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.0\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.2\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.3\"\
+        \r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n\
+        \            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"vmss1LBBEPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"backendIPConfigurations\": [\r\n            {\r\n       \
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
+        \ \"loadBalancingRules\": [],\r\n    \"probes\": [],\r\n    \"inboundNatRules\"\
+        : [\r\n      {\r\n        \"name\": \"vmss1LBNatPool.0\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.0\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          },\r\n          \"frontendPort\": 50000,\r\n          \"backendPort\"\
+        : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
+        : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        vmss1LBNatPool.1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\"\
+        : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
+        : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        vmss1LBNatPool.2\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.2\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\"\
+        : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
+        : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        vmss1LBNatPool.3\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.3\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          },\r\n          \"frontendPort\": 50003,\r\n          \"backendPort\"\
+        : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
+        : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/vmss1unktNic/ipConfigurations/vmss1unktIPConfig\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\"\
+        : [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"vmss1LBNatPool\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
+        ,\r\n        \"etag\": \"W/\\\"d1729eb4-d8e5-4b3c-9382-efc78376c1d7\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendPortRangeStart\": 50000,\r\n          \"frontendPortRangeEnd\"\
+        : 50119,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 18 May 2017 21:31:22 GMT']
+      ETag: [W/"d1729eb4-d8e5-4b3c-9382-efc78376c1d7"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['9481']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [57763a7a-3c11-11e7-9761-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP?api-version=2017-03-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vmss1LBPublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/publicIPAddresses/vmss1LBPublicIP\"\
+        ,\r\n  \"etag\": \"W/\\\"2e0f3d24-8123-434b-8b52-8aa2a78e2161\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"9f37d257-206f-4b65-b4b1-7f7546caa55f\"\
+        ,\r\n    \"ipAddress\": \"13.91.90.158\",\r\n    \"publicIPAddressVersion\"\
+        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
+        : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\
+        \n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 18 May 2017 21:31:22 GMT']
+      ETag: [W/"2e0f3d24-8123-434b-8b52-8aa2a78e2161"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['854']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -124,21 +318,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [07ad33ec-0da3-11e7-85f4-f4b7e2e85440]
+      x-ms-client-request-id: [57a122b6-3c11-11e7-8637-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/restart?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/d9231659-89cc-480b-9a43-b70a5036ebbb?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 20 Mar 2017 19:25:52 GMT']
+      Date: ['Thu, 18 May 2017 21:31:23 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/d9231659-89cc-480b-9a43-b70a5036ebbb?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -151,20 +346,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [07ad33ec-0da3-11e7-85f4-f4b7e2e85440]
+      x-ms-client-request-id: [57a122b6-3c11-11e7-8637-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d9231659-89cc-480b-9a43-b70a5036ebbb?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:25:52.4633722+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:31:23.4797967+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"d9231659-89cc-480b-9a43-b70a5036ebbb\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:26:22 GMT']
+      Date: ['Thu, 18 May 2017 21:31:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -180,20 +376,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [07ad33ec-0da3-11e7-85f4-f4b7e2e85440]
+      x-ms-client-request-id: [57a122b6-3c11-11e7-8637-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d9231659-89cc-480b-9a43-b70a5036ebbb?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:25:52.4633722+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:31:23.4797967+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"d9231659-89cc-480b-9a43-b70a5036ebbb\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:26:53 GMT']
+      Date: ['Thu, 18 May 2017 21:32:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -209,49 +406,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [07ad33ec-0da3-11e7-85f4-f4b7e2e85440]
+      x-ms-client-request-id: [57a122b6-3c11-11e7-8637-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d9231659-89cc-480b-9a43-b70a5036ebbb?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:25:52.4633722+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:31:23.4797967+00:00\",\r\
+        \n  \"endTime\": \"2017-05-18T21:32:47.6319747+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"d9231659-89cc-480b-9a43-b70a5036ebbb\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:27:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [07ad33ec-0da3-11e7-85f4-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:25:52.4633722+00:00\",\r\
-        \n  \"endTime\": \"2017-03-20T19:27:28.7749681+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"9361ac49-5b7c-4bb9-a5f1-bf1b57331fc2\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:27:53 GMT']
+      Date: ['Thu, 18 May 2017 21:32:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -267,37 +436,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [50caaa98-0da3-11e7-a457-f4b7e2e85440]
+      x-ms-client-request-id: [8e8418ee-3c11-11e7-a515-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/0/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
         ,\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.2\",\r\n    \"statuses\"\
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
         : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
         \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
-        2017-03-20T19:27:23+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        2017-05-18T21:32:42+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
         : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:27:22.3191597+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:32:41.3815748+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/starting\",\r\n      \"level\"\
         : \"Info\",\r\n      \"displayStatus\": \"VM starting\"\r\n    }\r\n  ]\r\n\
         }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:27:54 GMT']
+      Date: ['Thu, 18 May 2017 21:32:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['776']
+      content-length: ['777']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -306,37 +476,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [516213dc-0da3-11e7-9e3a-f4b7e2e85440]
+      x-ms-client-request-id: [8ebf46ae-3c11-11e7-aeaa-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.2\",\r\n    \"statuses\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
+        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
         : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
         \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
-        2017-03-20T19:27:07+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        2017-05-18T21:32:41+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
         : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:27:22.3191597+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:31:32.8553832+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\"\
         : \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n\
         }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:27:54 GMT']
+      Date: ['Thu, 18 May 2017 21:32:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['774']
+      content-length: ['775']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -346,25 +517,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
+      x-ms-client-request-id: [8ee41e6c-3c11-11e7-8da9-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/poweroff?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/0cb686eb-e468-4427-aec9-1d53ce81a565?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 20 Mar 2017 19:27:56 GMT']
+      Date: ['Thu, 18 May 2017 21:32:56 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/0cb686eb-e468-4427-aec9-1d53ce81a565?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -373,600 +545,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
+      x-ms-client-request-id: [8ee41e6c-3c11-11e7-8da9-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/0cb686eb-e468-4427-aec9-1d53ce81a565?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:32:56.1637354+00:00\",\r\
+        \n  \"endTime\": \"2017-05-18T21:33:16.3836742+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"0cb686eb-e468-4427-aec9-1d53ce81a565\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:28:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:28:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:29:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:29:57 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:30:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:30:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:31:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:31:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:32:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:32:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:33:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:34:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:34:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:35:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:35:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:36:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:36:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:37:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:37:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\
-        \r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:38:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51fdf636-0da3-11e7-ba53-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/703d88ee-34ec-4623-bf49-ca0d8906656b?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:27:57.0836306+00:00\",\r\
-        \n  \"endTime\": \"2017-03-20T19:38:13.8998318+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"703d88ee-34ec-4623-bf49-ca0d8906656b\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:38:36 GMT']
+      Date: ['Thu, 18 May 2017 21:33:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -982,37 +575,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d00b43ee-0da4-11e7-a62e-f4b7e2e85440]
+      x-ms-client-request-id: [a1666b94-3c11-11e7-8ced-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/0/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
         ,\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.2\",\r\n    \"statuses\"\
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
         : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
         \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
-        2017-03-20T19:37:49+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        2017-05-18T21:32:42+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
         : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:38:13.8685568+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:32:58.3513779+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/stopped\",\r\n      \"level\"\
         : \"Info\",\r\n      \"displayStatus\": \"VM stopped\"\r\n    }\r\n  ]\r\n\
         }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:38:37 GMT']
+      Date: ['Thu, 18 May 2017 21:33:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['774']
+      content-length: ['775']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1021,36 +615,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d0a59d42-0da4-11e7-b8e6-f4b7e2e85440]
+      x-ms-client-request-id: [a1922aac-3c11-11e7-83a6-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\"\
-        : [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n\
-        \        \"level\": \"Warning\",\r\n        \"displayStatus\": \"Not Ready\"\
-        ,\r\n        \"message\": \"VM Agent is unresponsive.\",\r\n        \"time\"\
-        : \"2017-03-20T19:38:39+00:00\"\r\n      }\r\n    ]\r\n  },\r\n  \"statuses\"\
-        : [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n     \
-        \ \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n      \"time\": \"2017-03-20T19:28:08.2942515+00:00\"\r\n    },\r\n \
-        \   {\r\n      \"code\": \"PowerState/stopped\",\r\n      \"level\": \"Info\"\
-        ,\r\n      \"displayStatus\": \"VM stopped\"\r\n    }\r\n  ]\r\n}"}
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
+        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
+        : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
+        \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
+        2017-05-18T21:32:41+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:33:16.3680391+00:00\"\r\n\
+        \    },\r\n    {\r\n      \"code\": \"PowerState/stopped\",\r\n      \"level\"\
+        : \"Info\",\r\n      \"displayStatus\": \"VM stopped\"\r\n    }\r\n  ]\r\n\
+        }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:38:37 GMT']
+      Date: ['Thu, 18 May 2017 21:33:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['758']
+      content-length: ['775']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1060,21 +656,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d1269b68-0da4-11e7-b089-f4b7e2e85440]
+      x-ms-client-request-id: [a1b0a9f0-3c11-11e7-bf64-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/start?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/cd2769c2-83c1-474e-b000-5f1a4f43263c?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5e217ee3-08ef-4fc7-bdb3-8da6d0b6f3b1?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 20 Mar 2017 19:38:38 GMT']
+      Date: ['Thu, 18 May 2017 21:33:27 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/cd2769c2-83c1-474e-b000-5f1a4f43263c?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5e217ee3-08ef-4fc7-bdb3-8da6d0b6f3b1?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -1087,20 +684,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d1269b68-0da4-11e7-b089-f4b7e2e85440]
+      x-ms-client-request-id: [a1b0a9f0-3c11-11e7-bf64-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/cd2769c2-83c1-474e-b000-5f1a4f43263c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5e217ee3-08ef-4fc7-bdb3-8da6d0b6f3b1?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:38:39.9876122+00:00\",\r\
-        \n  \"endTime\": \"2017-03-20T19:38:52.2109156+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"cd2769c2-83c1-474e-b000-5f1a4f43263c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:27.6968387+00:00\",\r\
+        \n  \"endTime\": \"2017-05-18T21:33:39.9006464+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5e217ee3-08ef-4fc7-bdb3-8da6d0b6f3b1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:39:10 GMT']
+      Date: ['Thu, 18 May 2017 21:33:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1116,37 +714,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e4a1a876-0da4-11e7-9a5e-f4b7e2e85440]
+      x-ms-client-request-id: [b432fc26-3c11-11e7-a3a9-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/0/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
         ,\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.2\",\r\n    \"statuses\"\
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
         : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
         \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
-        2017-03-20T19:37:49+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        2017-05-18T21:33:58+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
         : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:38:52.195273+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:33:39.8693943+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\"\
         : \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n\
         }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:39:11 GMT']
+      Date: ['Thu, 18 May 2017 21:33:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['773']
+      content-length: ['775']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1155,37 +754,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e539ba12-0da4-11e7-939a-f4b7e2e85440]
+      x-ms-client-request-id: [b45f16ae-3c11-11e7-bf5a-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.2\",\r\n    \"statuses\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
+        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.10\",\r\n    \"statuses\"\
         : [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n \
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n\
         \        \"message\": \"Guest Agent is running\",\r\n        \"time\": \"\
-        2017-03-20T19:39:08+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
+        2017-05-18T21:32:41+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\"\
         : []\r\n  },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:38:52.195273+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:33:39.8693943+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\"\
         : \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n\
         }"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:39:12 GMT']
+      Date: ['Thu, 18 May 2017 21:33:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['773']
+      content-length: ['775']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1195,21 +795,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5c9886c-0da4-11e7-a1bc-f4b7e2e85440]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A/deallocate?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 20 Mar 2017 19:39:13 GMT']
+      Date: ['Thu, 18 May 2017 21:33:58 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -1222,27 +823,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5c9886c-0da4-11e7-a1bc-f4b7e2e85440]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:39:14.6411283+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9c12a435-3f26-409e-8240-89bd08647a0c\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:59.261791+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"dee2b8f1-61b7-4cf2-94b0-82899880738f\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:39:43 GMT']
+      Date: ['Thu, 18 May 2017 21:34:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1251,27 +853,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5c9886c-0da4-11e7-a1bc-f4b7e2e85440]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:39:14.6411283+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9c12a435-3f26-409e-8240-89bd08647a0c\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:59.261791+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"dee2b8f1-61b7-4cf2-94b0-82899880738f\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:40:14 GMT']
+      Date: ['Thu, 18 May 2017 21:34:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1280,27 +883,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5c9886c-0da4-11e7-a1bc-f4b7e2e85440]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:39:14.6411283+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"9c12a435-3f26-409e-8240-89bd08647a0c\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:59.261791+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"dee2b8f1-61b7-4cf2-94b0-82899880738f\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:40:45 GMT']
+      Date: ['Thu, 18 May 2017 21:35:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['134']
+      content-length: ['133']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1309,20 +913,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e5c9886c-0da4-11e7-a1bc-f4b7e2e85440]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/9c12a435-3f26-409e-8240-89bd08647a0c?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:39:14.6411283+00:00\",\r\
-        \n  \"endTime\": \"2017-03-20T19:40:55.665846+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"9c12a435-3f26-409e-8240-89bd08647a0c\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:59.261791+00:00\",\r\n\
+        \  \"status\": \"InProgress\",\r\n  \"name\": \"dee2b8f1-61b7-4cf2-94b0-82899880738f\"\
+        \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:41:15 GMT']
+      Date: ['Thu, 18 May 2017 21:35:59 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['133']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b492c19c-3c11-11e7-abe1-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/dee2b8f1-61b7-4cf2-94b0-82899880738f?api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:33:59.261791+00:00\",\r\n\
+        \  \"endTime\": \"2017-05-18T21:36:30.2838863+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"dee2b8f1-61b7-4cf2-94b0-82899880738f\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 18 May 2017 21:36:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1338,32 +973,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2ee29528-0da5-11e7-8425-f4b7e2e85440]
+      x-ms-client-request-id: [0f3ddef6-3c12-11e7-b524-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/0/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
         ,\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n \
         \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:40:55.6345745+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:36:30.268273+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
         level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
         \n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:41:16 GMT']
+      Date: ['Thu, 18 May 2017 21:36:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['454']
+      content-length: ['453']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1372,25 +1008,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f691c68-0da5-11e7-b56d-f4b7e2e85440]
+      x-ms-client-request-id: [0f61f6ac-3c12-11e7-826c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/1/instanceView?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/3/instanceView?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"placementGroupId\": \"f6cee656-1cfb-4905-af98-5fee8e7db1e0\"\
-        ,\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n \
+    body: {string: "{\r\n  \"placementGroupId\": \"0f2eed66-9bb2-439a-b4a0-c6ed0f63fb2f\"\
+        ,\r\n  \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n \
         \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n      \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n      \"time\": \"2017-03-20T19:40:50.5546538+00:00\"\r\n\
+        \ succeeded\",\r\n      \"time\": \"2017-05-18T21:36:25.1429881+00:00\"\r\n\
         \    },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"\
         level\": \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\
         \n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:41:16 GMT']
+      Date: ['Thu, 18 May 2017 21:36:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1407,25 +1044,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2fe78c26-0da5-11e7-9ad9-f4b7e2e85440]
+      x-ms-client-request-id: [0f8a86fa-3c12-11e7-8145-64510658e3b3]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualmachines/%2A?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/11fbea2c-1e31-4e65-8059-c44f6666089a?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5c9b5614-94b3-42cd-acd2-256b218f38b1?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 20 Mar 2017 19:41:18 GMT']
+      Date: ['Thu, 18 May 2017 21:36:31 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/11fbea2c-1e31-4e65-8059-c44f6666089a?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/5c9b5614-94b3-42cd-acd2-256b218f38b1?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1434,20 +1072,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2fe78c26-0da5-11e7-9ad9-f4b7e2e85440]
+      x-ms-client-request-id: [0f8a86fa-3c12-11e7-8145-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/11fbea2c-1e31-4e65-8059-c44f6666089a?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5c9b5614-94b3-42cd-acd2-256b218f38b1?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-20T19:41:19.3305432+00:00\",\r\
-        \n  \"endTime\": \"2017-03-20T19:41:34.7110856+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"11fbea2c-1e31-4e65-8059-c44f6666089a\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-18T21:36:32.2840038+00:00\",\r\
+        \n  \"endTime\": \"2017-05-18T21:36:47.6130815+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"5c9b5614-94b3-42cd-acd2-256b218f38b1\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:41:48 GMT']
+      Date: ['Thu, 18 May 2017 21:37:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1463,10 +1102,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.6 msrest_azure/0.4.7
-          computemanagementclient/0.33.1rc1 Azure-SDK-For-Python AZURECLI/TEST/2.0.1+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42c83402-0da5-11e7-8805-f4b7e2e85440]
+      x-ms-client-request-id: [220ce94c-3c12-11e7-9f07-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_vms/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines?api-version=2016-04-30-preview
   response:
@@ -1474,7 +1114,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 20 Mar 2017 19:41:49 GMT']
+      Date: ['Thu, 18 May 2017 21:37:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
@@ -1662,6 +1662,8 @@ class VMSSVMsScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('type(@)', 'object'),
             JMESPathCheck('instanceId', str(self.instance_ids[0]))
         ])
+        result = self.cmd('vmss list-instance-connection-info --resource-group {} --name {}'.format(self.resource_group, self.ss_name))
+        self.assertTrue(result['instance 0'].split('.')[1], '5000')
         self.cmd('vmss restart --resource-group {} --name {} --instance-ids *'.format(self.resource_group, self.ss_name))
         self._check_vms_power_state('PowerState/running', 'PowerState/starting')
         self.cmd('vmss stop --resource-group {} --name {} --instance-ids *'.format(self.resource_group, self.ss_name))


### PR DESCRIPTION
~For #2962, the change is fairly trivial, but we just can't do it now as it is a breaking change. So emit out a warn and do it for the next release~
EDIT: Fix #2962 very few users are using this command, so I go ahead and just submit the change 

```json
{
  "instance 0": "13.64.254.52:50000",
  "instance 1": "13.64.254.52:50001"
}
```

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
