### PR TITLE
vmss/vm: misc bug fixes

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -7,6 +7,9 @@ unreleased
 * disk: support cross subscription blob import
 * vm: support license type on create
 * BC: vm open-port: command always returns the NSG. Previously it returned the NIC or Subnet.
+* vm: fix "vm extension list" crash if the VM has no extensions
+* vmss: update arg description for 'vmss delete-instances --instance-ids'
+* vmss: hide arg 'vmss show --ids', which is not supposed to work because of 'instance-id' arg
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -119,6 +119,7 @@ for dest in ['vm_scale_set_name', 'virtual_machine_scale_set_name', 'name']:
     register_cli_argument('vmss restart', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
     register_cli_argument('vmss start', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
     register_cli_argument('vmss stop', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
+    register_cli_argument('vmss show', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
     register_cli_argument('vmss update-instances', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
 
 register_cli_argument('vmss', 'instance_id', id_part='child_name')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -143,7 +143,8 @@ register_cli_argument('vmss extension image', 'orderby', help='The sort to apply
 register_cli_argument('vmss extension image', 'top', help='Return top number of records')
 register_cli_argument('vmss extension image', 'version', help='Extension version')
 
-register_cli_argument('vmss update-instances', 'instance_ids', multi_ids_type, help='Space separated list of IDs (ex: 1 2 3 ...) or * for all instances.')
+for scope in ['update-instances', 'delete-instances']:
+    register_cli_argument('vmss ' + scope, 'instance_ids', multi_ids_type, help='Space separated list of IDs (ex: 1 2 3 ...) or * for all instances.')
 
 for scope in ['vm diagnostics', 'vmss diagnostics']:
     register_cli_argument(scope, 'version', help='version of the diagnostics extension. Will use the latest if not specfied')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -861,7 +861,7 @@ def get_boot_log(resource_group_name, vm_name):
 def list_extensions(resource_group_name, vm_name):
     vm = get_vm(resource_group_name, vm_name)
     extension_type = 'Microsoft.Compute/virtualMachines/extensions'
-    result = [r for r in vm.resources if r.type == extension_type]
+    result = [r for r in (vm.resources or []) if r.type == extension_type]
     return result
 
 

--- a/src/command_modules/azure-cli-vm/tests/recordings/test_vm_extension.yaml
+++ b/src/command_modules/azure-cli-vm/tests/recordings/test_vm_extension.yaml
@@ -6,39 +6,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [57fcff76-0231-11e7-89d8-f4b7e2e85440]
+      x-ms-client-request-id: [1f1ca5f6-3b4f-11e7-867b-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?$expand=instanceView&api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8e6af570-9500-48e8-abc6-ebbfbe474519\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"234d7e4b-20a4-462f-8dee-376f4a9b39cc\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_t1mMxjK58H\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
+        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
+        \     \"name\": \"osdisk_7DUD4hDsJX\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
         \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_t1mMxjK58H\"\
-        \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"user11\"\
-        ,\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_7DUD4hDsJX\"\
+        \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"myvm\"\
+        ,\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
+        Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
+        tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm\"\
+        ,\r\n  \"name\": \"myvm\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 17 May 2017 22:21:05 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1517']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1f3f8d82-3b4f-11e7-a110-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?$expand=instanceView&api-version=2016-04-30-preview
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"234d7e4b-20a4-462f-8dee-376f4a9b39cc\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
+        \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
+        \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
+        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
+        \     \"name\": \"osdisk_7DUD4hDsJX\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
+        \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_7DUD4hDsJX\"\
+        \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"myvm\"\
+        ,\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.10\",\r\n\
+        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:54:16+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
-        \   },\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
-        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-03-06T05:53:55.2041861+00:00\"\
+        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
+        \       \"time\": \"2017-05-17T22:20:57+00:00\"\r\n          }\r\n       \
+        \ ],\r\n        \"extensionHandlers\": []\r\n      },\r\n      \"statuses\"\
+        : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
+        \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n          \"time\": \"2017-05-17T22:21:00.3913774+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -47,31 +95,31 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:54:21 GMT']
+      Date: ['Wed, 17 May 2017 22:21:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['2322']
+      content-length: ['2301']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"autoUpgradeMinorVersion": true,
-      "protectedSettings": {"username": "foouser1", "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT"},
-      "type": "VMAccessForLinux", "publisher": "Microsoft.OSTCExtensions", "typeHandlerVersion":
-      "1.2"}}'
+    body: '{"location": "westus", "properties": {"typeHandlerVersion": "1.2", "publisher":
+      "Microsoft.OSTCExtensions", "autoUpgradeMinorVersion": true, "type": "VMAccessForLinux",
+      "protectedSettings": {"ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8InHIPLAu6lMc0d+5voyXqigZfT5r6fAM1+FQAi+mkPDdk2hNq1BG0Bwfc88Gm7BImw8TS+x2bnZmhCbVnHd6BPCDY7a+cHCSqrQMW89Cv6Vl4ueGOeAWHpJTV9CTLVz4IY1x4HBdkLI2lKIHri9+z7NIdvFk7iOkMVGyez5H1xDbF2szURxgc4I2/o5wycSwX+G8DrtsBvWLmFv9YAPx+VkEHQDjR0WWezOjuo1rDn6MQfiKfqAjPuInwNOg5AIxXAOResrin2PUlArNtdDH1zlvI4RZi36+tJO7mtm3dJiKs4Sj7G6b1CjIU6aaj27MmKy3arIFChYav9yYM3IT",
+      "username": "foouser1"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['611']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
+      x-ms-client-request-id: [1f5d95d2-3b4f-11e7-9378-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -82,16 +130,16 @@ interactions:
         ,\r\n  \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux\"\
         ,\r\n  \"name\": \"VMAccessForLinux\"\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/a6c14058-7403-427b-87e9-28bc77a0dafd?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['512']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:54:21 GMT']
+      Date: ['Wed, 17 May 2017 22:21:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -100,21 +148,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
+      x-ms-client-request-id: [1f5d95d2-3b4f-11e7-9378-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/a6c14058-7403-427b-87e9-28bc77a0dafd?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-17T22:21:07.7828184+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"a6c14058-7403-427b-87e9-28bc77a0dafd\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:54:51 GMT']
+      Date: ['Wed, 17 May 2017 22:21:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -130,51 +178,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
+      x-ms-client-request-id: [1f5d95d2-3b4f-11e7-9378-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/a6c14058-7403-427b-87e9-28bc77a0dafd?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-17T22:21:07.7828184+00:00\",\r\
+        \n  \"endTime\": \"2017-05-17T22:22:01.4395522+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"a6c14058-7403-427b-87e9-28bc77a0dafd\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:55:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/828b720c-71ac-4188-a449-c4c0f170b6c8?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:54:22.0747096+00:00\",\r\
-        \n  \"endTime\": \"2017-03-06T05:55:24.8715653+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"828b720c-71ac-4188-a449-c4c0f170b6c8\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:55:52 GMT']
+      Date: ['Wed, 17 May 2017 22:22:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -190,11 +208,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58224680-0231-11e7-9b5a-f4b7e2e85440]
+      x-ms-client-request-id: [1f5d95d2-3b4f-11e7-9378-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -207,7 +225,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:55:52 GMT']
+      Date: ['Wed, 17 May 2017 22:22:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -223,51 +241,52 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f633e42-0231-11e7-88ac-f4b7e2e85440]
+      x-ms-client-request-id: [445b4202-3b4f-11e7-8b9e-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm?$expand=instanceView&api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"8e6af570-9500-48e8-abc6-ebbfbe474519\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"234d7e4b-20a4-462f-8dee-376f4a9b39cc\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
-        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
-        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
-        \      \"name\": \"osdisk_t1mMxjK58H\",\r\n        \"createOption\": \"FromImage\"\
+        ,\r\n        \"sku\": \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n\
+        \      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n   \
+        \     \"name\": \"osdisk_7DUD4hDsJX\",\r\n        \"createOption\": \"FromImage\"\
         ,\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n\
         \          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_t1mMxjK58H\"\
-        \r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
-        : {\r\n      \"computerName\": \"myvm\",\r\n      \"adminUsername\": \"user11\"\
-        ,\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\"\
-        : false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
-        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/disks/osdisk_7DUD4hDsJX\"\
+        \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
+        : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"myvm\"\
+        ,\r\n      \"adminUsername\": \"user11\",\r\n      \"linuxConfiguration\"\
+        : {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n  \
+        \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
+        :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Network/networkInterfaces/myvmVMNic\"\
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
-        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.10\",\r\n\
+        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
-        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-03-06T05:55:42+00:00\"\
-        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
-        \      {\r\n            \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.4.6.0\",\r\n            \"status\"\
-        : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
-        \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
-        \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensions\"\
-        : [\r\n        {\r\n          \"name\": \"VMAccessForLinux\",\r\n        \
-        \  \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n          \"\
-        typeHandlerVersion\": \"1.4.6.0\",\r\n          \"statuses\": [\r\n      \
-        \      {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n \
-        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"\
-        Provisioning succeeded\",\r\n              \"message\": \"Enable succeeded.\"\
+        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
+        \       \"time\": \"2017-05-17T22:21:53+00:00\"\r\n          }\r\n       \
+        \ ],\r\n        \"extensionHandlers\": [\r\n          {\r\n            \"\
+        type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n            \"typeHandlerVersion\"\
+        : \"1.4.6.0\",\r\n            \"status\": {\r\n              \"code\": \"\
+        ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
+        \             \"displayStatus\": \"Ready\",\r\n              \"message\":\
+        \ \"Plugin enabled\"\r\n            }\r\n          }\r\n        ]\r\n    \
+        \  },\r\n      \"extensions\": [\r\n        {\r\n          \"name\": \"VMAccessForLinux\"\
+        ,\r\n          \"type\": \"Microsoft.OSTCExtensions.VMAccessForLinux\",\r\n\
+        \          \"typeHandlerVersion\": \"1.4.6.0\",\r\n          \"statuses\"\
+        : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
+        : \"Provisioning succeeded\",\r\n              \"message\": \"Enable succeeded.\"\
         \r\n            }\r\n          ]\r\n        }\r\n      ],\r\n      \"statuses\"\
         : [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\
         \n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-03-06T05:55:24.8559493+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2017-05-17T22:22:01.4395522+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -283,14 +302,14 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:55:53 GMT']
+      Date: ['Wed, 17 May 2017 22:22:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['3687']
+      content-length: ['3710']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -299,11 +318,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffc677a-0231-11e7-ad99-f4b7e2e85440]
+      x-ms-client-request-id: [4485306e-3b4f-11e7-9990-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
@@ -316,7 +335,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:55:55 GMT']
+      Date: ['Wed, 17 May 2017 22:22:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -333,22 +352,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
+      x-ms-client-request-id: [44a7d3a8-3b4f-11e7-b35e-64510658e3b3]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Compute/virtualMachines/myvm/extensions/VMAccessForLinux?api-version=2016-04-30-preview
   response:
     body: {string: ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/bac4dedd-728e-42f7-8b3d-9d639a6c9dba?api-version=2016-04-30-preview']
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Mon, 06 Mar 2017 05:55:55 GMT']
+      Date: ['Wed, 17 May 2017 22:22:09 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?monitor=true&api-version=2016-04-30-preview']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Compute/locations/westus/operations/bac4dedd-728e-42f7-8b3d-9d639a6c9dba?monitor=true&api-version=2016-04-30-preview']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -361,21 +380,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
+      x-ms-client-request-id: [44a7d3a8-3b4f-11e7-b35e-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/bac4dedd-728e-42f7-8b3d-9d639a6c9dba?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\
+    body: {string: "{\r\n  \"startTime\": \"2017-05-17T22:22:10.2833515+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"bac4dedd-728e-42f7-8b3d-9d639a6c9dba\"\
         \r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:56:26 GMT']
+      Date: ['Wed, 17 May 2017 22:22:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -391,51 +410,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 computemanagementclient/1.0.0rc1 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.6+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
+      x-ms-client-request-id: [44a7d3a8-3b4f-11e7-b35e-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/bac4dedd-728e-42f7-8b3d-9d639a6c9dba?api-version=2016-04-30-preview
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
-        \n  \"status\": \"InProgress\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\
-        \r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-05-17T22:22:10.2833515+00:00\",\r\
+        \n  \"endTime\": \"2017-05-17T22:22:53.8618694+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"bac4dedd-728e-42f7-8b3d-9d639a6c9dba\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:56:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.5
-          msrest_azure/0.4.7 computemanagementclient/0.33.1rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.0+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9093f2c6-0231-11e7-b7fd-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f9c537d5-b7b0-4e8a-b594-82cbc30e9f27?api-version=2016-04-30-preview
-  response:
-    body: {string: "{\r\n  \"startTime\": \"2017-03-06T05:55:56.7044573+00:00\",\r\
-        \n  \"endTime\": \"2017-03-06T05:57:13.6275803+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"f9c537d5-b7b0-4e8a-b594-82cbc30e9f27\"\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 06 Mar 2017 05:57:26 GMT']
+      Date: ['Wed, 17 May 2017 22:23:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/tests/test_vm_commands.py
@@ -586,6 +586,9 @@ class VMExtensionScenarioTest(ResourceGroupVCRTestBase):
         config_file = _write_config_file(user_name)
 
         try:
+            self.cmd('vm extension list --vm-name {} --resource-group {}'.format(self.vm_name, self.resource_group), checks=[
+                JMESPathCheck('length([])', 0)
+            ])
             self.cmd('vm extension set -n {} --publisher {} --version 1.2  --vm-name {} --resource-group {} --protected-settings "{}"'
                      .format(extension_name, publisher, self.vm_name, self.resource_group, config_file))
             self.cmd('vm get-instance-view -n {} -g {}'.format(self.vm_name, self.resource_group), checks=[


### PR DESCRIPTION
Fix bugs I ran into when I investigated diagnostics support. Since related change is trivial, I combine them
* vm: fix "vm extension list" crash if the VM has no extensions
* vmss: update arg description for 'vmss delete-instances --instance-ids'
* vmss: hide arg 'vmss show --ids', which is not supposed to work because of 'instance-id' arg

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
