### PR TITLE
login: expose ADFS flow for azure stack env

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -7,6 +7,7 @@ unreleased
 ^^^^^^^^^^^^^^^^^^
 * Command paths are no longer case sensitive.
 * Certain boolean-type parameters are no longer case sensitive.
+* Support login to ADFS on prem server like Azure Stack
 
 2.0.6 (2017-05-09)
 ^^^^^^^^^^^^^^^^^^

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -58,7 +58,8 @@ _COMMON_TENANT = 'common'
 
 def _authentication_context_factory(authority, cache):
     import adal
-    return adal.AuthenticationContext(authority, cache=cache, api_version=None)
+    return adal.AuthenticationContext(authority, cache=cache, api_version=None,
+                                      validate_authority=(not is_adfs(authority)))
 
 
 _AUTH_CTX_FACTORY = _authentication_context_factory
@@ -70,7 +71,13 @@ logger.debug('Current cloud config:\n%s', str(CLOUD))
 
 
 def get_authority_url(tenant=None):
-    return CLOUD.endpoints.active_directory + '/' + (tenant or _COMMON_TENANT)
+    authority_url = CLOUD.endpoints.active_directory
+    return (authority_url + '/' + (tenant or _COMMON_TENANT)
+            if not is_adfs(authority_url) else authority_url)
+
+
+def is_adfs(authority_url):
+    return authority_url.lower().endswith('/adfs')
 
 
 def _load_tokens_from_file(file_path):

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -454,19 +454,19 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
     @mock.patch('adal.AuthenticationContext.acquire_token_with_username_password', autospec=True)
     @mock.patch('adal.AuthenticationContext.acquire_token', autospec=True)
     @mock.patch('azure.cli.core._profile.CLOUD', autospec=True)
-    def test_find_subscriptions_thru_username_password_azure_stack(self, mock_get_cloud, mock_acquire_token,
-                                                                   mock_acquire_token_username_password):
+    def test_find_subscriptions_thru_username_password_adfs(self, mock_get_cloud, mock_acquire_token,
+                                                            mock_acquire_token_username_password):
         TEST_ADFS_AUTH_URL = 'https://adfs.local.azurestack.external/adfs'
 
-        def test_acuqire_token(self, resource, username, password, client_id):
-            global acuqire_token_invoked
-            acuqire_token_invoked = True
+        def test_acquire_token(self, resource, username, password, client_id):
+            global acquire_token_invoked
+            acquire_token_invoked = True
             if (self.authority.url == TEST_ADFS_AUTH_URL and self.authority.is_adfs_authority):
                 return Test_Profile.token_entry1
             else:
                 raise ValueError('AuthContext was not initialized correctly for ADFS')
 
-        mock_acquire_token_username_password.side_effect = test_acuqire_token
+        mock_acquire_token_username_password.side_effect = test_acquire_token
         mock_acquire_token.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
@@ -481,7 +481,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
 
         # assert
         self.assertEqual([self.subscription1], subs)
-        self.assertTrue(acuqire_token_invoked)
+        self.assertTrue(acquire_token_invoked)
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
     @mock.patch('azure.cli.core._profile.logger', autospec=True)


### PR DESCRIPTION
Fix #3319 
Note, from ADAL's aspect, the tenant should be 'adfs', which means in the  `login` command users should supply `--tenant adfs`, but I decided not to enforce this from CLI as it is a bit odd for on-prem user. So users  can just configure in the cloud context using original authority url `.../adfs`, and then run `az login -u <user> -p <pwd>`

//cc: @bganapa

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
