### PR TITLE
Fix #2513: Update logging effect in automation

### DIFF
--- a/nose.cfg
+++ b/nose.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+logging-filter=azure.cli.testsdk,vcr_test_base

--- a/scripts/automation/tests/nose_helper.py
+++ b/scripts/automation/tests/nose_helper.py
@@ -5,6 +5,10 @@
 
 from __future__ import print_function
 
+import os.path
+from ..utilities.path import get_repo_root
+
+
 def get_nose_runner(report_folder, parallel=True, process_timeout=600, process_restart=True,
                     xunit_report=False, exclude_integration=True):
     """Create a nose execution method"""
@@ -24,7 +28,7 @@ def get_nose_runner(report_folder, parallel=True, process_timeout=600, process_r
                 or not os.path.isdir(report_folder):
             raise ValueError('Report folder {} does not exist'.format(report_folder))
 
-        arguments = [__file__, '-v', '--nologcapture']
+        arguments = [__file__, '-v', '-c', os.path.join(get_repo_root(), 'nose.cfg')]
         if parallel:
             arguments += ['--processes=-1', '--process-timeout={}'.format(process_timeout)]
             if process_restart:
@@ -36,12 +40,8 @@ def get_nose_runner(report_folder, parallel=True, process_timeout=600, process_r
         else:
             test_report = ''
 
-        if exclude_integration:
-            arguments += ['--ignore-files=integration*']
-
         debug_file = os.path.join(report_folder, 'test-debug.log')
         arguments += ['--debug-log={}'.format(debug_file)]
-        arguments += ['--nologcapture']
         arguments.extend(test_folders)
         result = nose.run(argv=arguments)
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-import datetime
 import unittest
 import os
 import inspect
@@ -29,7 +27,7 @@ from .recording_processors import (SubscriptionRecordingProcessor, OAuthRequestR
 from .utilities import create_random_name
 from .decorators import live_only
 
-logger = logging.getLogger('azuer.cli.testsdk')
+logger = logging.getLogger('azure.cli.testsdk')
 
 
 class IntegrationTestBase(unittest.TestCase):
@@ -37,19 +35,9 @@ class IntegrationTestBase(unittest.TestCase):
         super(IntegrationTestBase, self).__init__(method_name)
         self.diagnose = os.environ.get(ENV_TEST_DIAGNOSE, None) == 'True'
 
-    def cmd(self, command, checks=None, expect_failure=False):
-        if self.diagnose:
-            begin = datetime.datetime.now()
-            print('\nExecuting command: {}'.format(command))
-
-        result = execute(command, expect_failure=expect_failure)
-
-        if self.diagnose:
-            duration = datetime.datetime.now() - begin
-            print('\nCommand accomplished in {} s. Exit code {}.\n{}'.format(
-                duration.total_seconds(), result.exit_code, result.output))
-
-        return result.assert_with_checks(checks)
+    @classmethod
+    def cmd(cls, command, checks=None, expect_failure=False):
+        return execute(command, expect_failure=expect_failure).assert_with_checks(checks)
 
     def create_random_name(self, prefix, length):  # pylint: disable=no-self-use
         return create_random_name(prefix=prefix, length=length)
@@ -238,16 +226,20 @@ class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-at
 
 class ExecutionResult(object):  # pylint: disable=too-few-public-methods
     def __init__(self, command, expect_failure=False, in_process=True):
-        logger.info('Execute command %s', command)
         if in_process:
             self._in_process_execute(command)
         else:
             self._out_of_process_execute(command)
 
         if expect_failure and self.exit_code == 0:
-            raise AssertionError('The command is expected to fail but it doesn\'.')
+            logger.error('Command "%s" => %d. (It did not fail as expected) Output: %s', command,
+                         self.exit_code, self.output)
+            raise AssertionError('The command did not fail as it was expected.')
         elif not expect_failure and self.exit_code != 0:
+            logger.error('Command "%s" => %d. Output: %s', command, self.exit_code, self.output)
             raise AssertionError('The command failed. Exit code: {}'.format(self.exit_code))
+
+        logger.info('Command "%s" => %d.', command, self.exit_code)
 
         self.json_value = None
         self.skip_assert = os.environ.get(ENV_SKIP_ASSERT, None) == 'True'
@@ -259,8 +251,6 @@ class ExecutionResult(object):  # pylint: disable=too-few-public-methods
                 checks.extend(each)
             elif callable(each):
                 checks.append(each)
-
-        logger.info('Checkers to be executed %s', len(checks))
 
         if not self.skip_assert:
             for c in checks:


### PR DESCRIPTION
1. Print the executed commands and exit code when a test is failed.
2. Print the failed commands' output.
3. Hide msrest, vcr, or any other logger.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
