### PR TITLE
login:  support login with a user account with no associated subscriptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -471,7 +471,6 @@ class SubscriptionFinder(object):
                 temp_credentials[_ACCESS_TOKEN])
             all_subscriptions.extend(subscriptions)
 
-        self.tenants = tenants
         return all_subscriptions
 
     def _find_using_specific_tenant(self, tenant, access_token):
@@ -484,7 +483,7 @@ class SubscriptionFinder(object):
         for s in subscriptions:
             setattr(s, 'tenant_id', tenant)
             all_subscriptions.append(s)
-        self.tenants = [tenant]
+        self.tenants.append(tenant)
         return all_subscriptions
 
 

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -284,6 +284,40 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_create_account_without_subscriptions_thru_common(self, mock_auth_context):
+        mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
+        tenant_object = mock.MagicMock()
+        tenant_object.id = "foo-bar"
+        tenant_object.tenant_id = self.token_entry1['id']
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.subscriptions.list.return_value = []
+        mock_arm_client.tenants.list.return_value = []
+
+        finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
+                                    None,
+                                    lambda _: mock_arm_client)
+
+        storage_mock = {'subscriptions': []}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        profile._management_resource_uri = 'https://management.core.windows.net/'
+
+        # action
+        result = profile.find_subscriptions_on_login(False,
+                                                     '1234',
+                                                     'my-secret',
+                                                     True,
+                                                     None,
+                                                     allow_no_subscriptions=True,
+                                                     subscription_finder=finder)
+
+        # assert
+        self.assertTrue(1, len(result))
+        self.assertEqual(result[0]['id'], self.tenant_id)
+        self.assertEqual(result[0]['state'], 'Enabled')
+        self.assertEqual(result[0]['tenantId'], self.tenant_id)
+        self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
+
+    @mock.patch('adal.AuthenticationContext', autospec=True)
     def test_create_account_without_subscriptions_without_tenant(self, mock_auth_context):
         finder = mock.MagicMock()
         finder.find_through_interactive_flow.return_value = []

--- a/src/azure-cli-core/tests/test_profile.py
+++ b/src/azure-cli-core/tests/test_profile.py
@@ -255,7 +255,7 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                          extended_info['endpoints'].active_directory)
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
-    def test_create_account_without_subscriptions(self, mock_auth_context):
+    def test_create_account_without_subscriptions_thru_service_principal(self, mock_auth_context):
         mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
         mock_arm_client.subscriptions.list.return_value = []
@@ -277,21 +277,22 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
                                                      subscription_finder=finder)
 
         # assert
-        self.assertTrue(1, len(result))
+        self.assertEqual(1, len(result))
         self.assertEqual(result[0]['id'], self.tenant_id)
         self.assertEqual(result[0]['state'], 'Enabled')
         self.assertEqual(result[0]['tenantId'], self.tenant_id)
         self.assertEqual(result[0]['name'], 'N/A(tenant level account)')
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
-    def test_create_account_without_subscriptions_thru_common(self, mock_auth_context):
-        mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
+    def test_create_account_without_subscriptions_thru_common_tenant(self, mock_auth_context):
+        mock_auth_context.acquire_token.return_value = self.token_entry1
+        mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
         tenant_object = mock.MagicMock()
         tenant_object.id = "foo-bar"
-        tenant_object.tenant_id = self.token_entry1['id']
+        tenant_object.tenant_id = self.tenant_id
         mock_arm_client = mock.MagicMock()
         mock_arm_client.subscriptions.list.return_value = []
-        mock_arm_client.tenants.list.return_value = []
+        mock_arm_client.tenants.list.return_value = (x for x in [tenant_object])
 
         finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
                                     None,
@@ -305,13 +306,13 @@ class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-method
         result = profile.find_subscriptions_on_login(False,
                                                      '1234',
                                                      'my-secret',
-                                                     True,
+                                                     False,
                                                      None,
                                                      allow_no_subscriptions=True,
                                                      subscription_finder=finder)
 
         # assert
-        self.assertTrue(1, len(result))
+        self.assertEqual(1, len(result))
         self.assertEqual(result[0]['id'], self.tenant_id)
         self.assertEqual(result[0]['state'], 'Enabled')
         self.assertEqual(result[0]['tenantId'], self.tenant_id)

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 2.0.5 (unreleased)
 * Output deprecating information on using '--expanded-view'
 * Add get-access-token command to provide raw AAD token
+* Support login with a user account with no associated subscriptions
 
 2.0.4 (2017-04-28)
 ++++++++++++++++++


### PR DESCRIPTION
This was broken by the latest resource SDK with new paging support based on generators. I am adding new tests for it. 

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
