### PR TITLE
Fix concurrent invocations of ‘az’ due to cloud config writes

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -8,6 +8,7 @@ unreleased
 * Command paths are no longer case sensitive.
 * Certain boolean-type parameters are no longer case sensitive.
 * Support login to ADFS on prem server like Azure Stack
+* Fix concurrent writes to clouds.config (#3255)
 
 2.0.6 (2017-05-09)
 ^^^^^^^^^^^^^^^^^^

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -235,7 +235,11 @@ def init_known_clouds(force=False):
     stored_cloud_names = config.sections()
     for c in KNOWN_CLOUDS:
         if force or c.name not in stored_cloud_names:
-            _save_cloud(c, overwrite=force)
+            _config_add_cloud(config, c, overwrite=force)
+    if not os.path.isdir(GLOBAL_CONFIG_DIR):
+        os.makedirs(GLOBAL_CONFIG_DIR)
+    with open(CLOUD_CONFIG_FILE, 'w') as configfile:
+        config.write(configfile)
 
 
 def get_clouds():
@@ -340,9 +344,8 @@ def switch_active_cloud(cloud_name):
     _set_active_subscription(cloud_name)
 
 
-def _save_cloud(cloud, overwrite=False):
-    config = get_config_parser()
-    config.read(CLOUD_CONFIG_FILE)
+def _config_add_cloud(config, cloud, overwrite=False):
+    """ Add a cloud to a config object """
     try:
         config.add_section(cloud.name)
     except configparser.DuplicateSectionError:
@@ -356,6 +359,12 @@ def _save_cloud(cloud, overwrite=False):
     for k, v in cloud.suffixes.__dict__.items():
         if v is not None:
             config.set(cloud.name, 'suffix_{}'.format(k), v)
+
+
+def _save_cloud(cloud, overwrite=False):
+    config = get_config_parser()
+    config.read(CLOUD_CONFIG_FILE)
+    _config_add_cloud(config, cloud, overwrite=overwrite)
     if not os.path.isdir(GLOBAL_CONFIG_DIR):
         os.makedirs(GLOBAL_CONFIG_DIR)
     with open(CLOUD_CONFIG_FILE, 'w') as configfile:

--- a/src/azure-cli-core/tests/test_cloud.py
+++ b/src/azure-cli-core/tests/test_cloud.py
@@ -178,8 +178,8 @@ class TestCloud(unittest.TestCase):
             from multiprocessing import Pool
 
             pool_size = 20
-            with Pool(pool_size) as p:
-                p.map(init_known_clouds, [True] * pool_size)
+            p = Pool(pool_size)
+            p.map(init_known_clouds, [True] * pool_size)
 
             # Check we can read the file with no exceptions
             config = get_config_parser()


### PR DESCRIPTION
When initializing cloud config, write all clouds once instead of writing for each cloud

Closes https://github.com/Azure/azure-cli/issues/3255

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).