### PR TITLE
shasum fallback to sha256sum

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -22,8 +22,7 @@ elif command -v sha256sum >/dev/null 2>&1
 then
   echo "$INSTALL_SCRIPT_SHA256 $install_script" | sha256sum -c - || exit
 fi
-command -v python > /dev/null 2>&1
-if [ "$?" -ne 0 ]
+if ! command -v python >/dev/null 2>&1
 then
   echo "ERROR: Python not found. 'command -v python' returned failure."
   echo "If python is available on the system, add it to PATH. For example 'sudo ln -s /usr/bin/python3 /usr/bin/python'"

--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -15,10 +15,12 @@ _TTY=/dev/tty
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit
 echo "Downloading Azure CLI install script from $INSTALL_SCRIPT_URL to $install_script."
 curl -# $INSTALL_SCRIPT_URL > $install_script || exit
-shasum -v
-if [ "$?" -eq 0 ]
+if command -v shasum >/dev/null 2>&1
 then
   echo "$INSTALL_SCRIPT_SHA256  $install_script" | shasum -a 256 -c - || exit
+elif command -v sha256sum >/dev/null 2>&1
+then
+  echo "$INSTALL_SCRIPT_SHA256 $install_script" | sha256sum -c - || exit
 fi
 command -v python > /dev/null 2>&1
 if [ "$?" -ne 0 ]


### PR DESCRIPTION
Add sha256sum(1) as a backup for shasum(1) when verifying checksum; shasum is not included by default in some linux distros (e.g. redhat).

Modify shasum check to use the command(1) builtin.

Refactor command checks not to rely on value of `$?`.