### PR TITLE
[Network] Fix output format for list-usages.

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -9,6 +9,7 @@ unreleased
 * `express-route peering create`: fix bug when creating a peering without route filtering.
 * `express-route update`: fix bug where --provider and --bandwidth arguments did not work.
 * `network watcher show-topology`: Fix bug with location defaulting logic.
+* `network list-usages`: improve output for TSV and table format.
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -185,4 +185,23 @@ def transform_waf_rule_sets_table_output(result):
                 item_obj['ruleGroup'] = rule_group_name
                 transformed.append(item_obj)
     return transformed
-    
+
+
+def transform_network_usage_list(result):
+    result = list(result)
+    for item in result:
+        item.current_value = str(item.current_value)
+        item.limit = str(item.limit)
+        item.local_name = item.name.localized_value
+    return result
+
+
+def transform_network_usage_table(result):
+    transformed = []
+    for item in result:
+        transformed.append(OrderedDict([
+            ('Name', item['localName']),
+            ('CurrentValue', item['currentValue']),
+            ('Limit', item['limit'])
+        ]))
+    return transformed

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -32,7 +32,8 @@ from ._format import \
      transform_nsg_create_output, transform_vnet_gateway_create_output,
      transform_vpn_connection, transform_vpn_connection_list,
      transform_vpn_connection_create_output, transform_geographic_hierachy_table_output,
-     transform_service_community_table_output, transform_waf_rule_sets_table_output)
+     transform_service_community_table_output, transform_waf_rule_sets_table_output,
+     transform_network_usage_list, transform_network_usage_table)
 
 
 custom_path = 'azure.cli.command_modules.network.custom#'
@@ -357,7 +358,7 @@ cli_generic_update_command(__name__, 'network vnet subnet update',
 
 # Usages operations
 usage_path = 'azure.mgmt.network.operations.usages_operations#UsagesOperations.'
-cli_command(__name__, 'network list-usages', usage_path + 'list', cf_usages)
+cli_command(__name__, 'network list-usages', usage_path + 'list', cf_usages, transform=transform_network_usage_list, table_transformer=transform_network_usage_table)
 
 # VirtualNetworkGatewayConnectionsOperations
 vpn_conn_path = 'azure.mgmt.network.operations.virtual_network_gateway_connections_operations#VirtualNetworkGatewayConnectionsOperations.'


### PR DESCRIPTION
Fix #2684. 

This is the same fix I applied for VM list-usage.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
