### PR TITLE
[Network] Improvements to App-Gateway and LB defaults

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -10,6 +10,11 @@ unreleased
 * `express-route update`: fix bug where --provider and --bandwidth arguments did not work.
 * `network watcher show-topology`: Fix bug with location defaulting logic.
 * `network list-usages`: improve output for TSV and table format.
+* `application-gateway http-listener create`: Default frontend IP if only one exists.
+* `application-gateway rule create`: Default address pool, HTTP settings, and HTTP listener if
+   only one exists.
+* `lb rule create`: Default frontend IP and backend pool if only one exists.
+* `lb inbound-nat-rule create`: Default frontend IP if only one exists.
 
 2.0.6 (2017-05-09)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -938,14 +938,8 @@ helps['network lb inbound-nat-rule create'] = """
     examples:
         - name: Create a basic inbound NAT rule for port 80.
           text: >
-            az network lb inbound-nat-rule create
-            -g MyResourceGroup
-            --lb-name MyLb
-            -n MyNatRule
-            --protocol Tcp
-            --frontend-ip-name MyIpConfig
-            --frontend-port 80
-            --backend-port 80
+            az network lb inbound-nat-rule create -g MyResourceGroup --lb-name MyLb -n MyNatRule
+            --protocol Tcp --frontend-port 80 --backend-port 80
 """
 
 helps['network lb inbound-nat-rule delete'] = """
@@ -1026,15 +1020,8 @@ helps['network lb rule create'] = """
         - name: Create a basic load balancing rule that assigns a front-facing IP configuration
                 and port to a backend address pool and port.
           text: >
-            az network lb rule create
-            -g MyResourceGroup
-            --lb-name MyLb
-            -n MyLbRule
-            --protocol Tcp
-            --frontend-ip-name MyIpConfig
-            --frontend-port 80
-            --backend-pool-name m_pool
-            --backend-port 80
+            az network lb rule create -g MyResourceGroup --lb-name MyLb -n MyLbRule
+            --protocol Tcp --frontend-port 80 --backend-port 80
 """
 
 helps['network lb rule delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -219,6 +219,16 @@ register_cli_argument('network application-gateway http-listener', 'ssl_cert', h
 register_cli_argument('network application-gateway http-listener', 'protocol', ignore_type)
 register_cli_argument('network application-gateway http-listener', 'host_name', help='Host name to use for multisite gateways.')
 
+# Add help text to clarify the "default if one" policy.
+default_existing = 'If only one exists, omit to use as default.'
+register_cli_argument('network application-gateway http-listener create', 'frontend_ip', help='The name or ID of the frontend IP configuration. {}'.format(default_existing))
+register_cli_argument('network application-gateway rule create', 'address_pool', help='The name or ID of the backend address pool. {}'.format(default_existing))
+register_cli_argument('network application-gateway rule create', 'http_settings', help='The name or ID of the HTTP settings. {}'.format(default_existing))
+register_cli_argument('network application-gateway rule create', 'http_listener', help='The name or ID of the HTTP listener. {}'.format(default_existing))
+register_cli_argument('network lb rule create', 'backend_address_pool_name', help='The name of the backend address pool. {}'.format(default_existing))
+register_cli_argument('network lb rule create', 'frontend_ip_name', help='The name of the frontend IP configuration. {}'.format(default_existing))
+register_cli_argument('network lb inbound-nat-rule create', 'frontend_ip_name', help='The name of the frontend IP configuration. {}'.format(default_existing))
+
 register_cli_argument('network application-gateway http-settings', 'cookie_based_affinity', cookie_based_affinity_type, help='Enable or disable cookie-based affinity.')
 register_cli_argument('network application-gateway http-settings', 'timeout', help='Request timeout in seconds.')
 register_cli_argument('network application-gateway http-settings', 'probe', help='Name or ID of the probe to associate with the HTTP settings.', validator=process_ag_http_settings_create_namespace, completer=get_ag_subresource_completion_list('probes'))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -91,7 +91,6 @@ def _upsert(parent, collection_name, obj_to_add, key_name):
 def _get_default_value(balancer, property_name, option_name):
     values = [x.name for x in getattr(balancer, property_name)]
     if len(values) > 1:
-        from azure.cli.core.util import CLIError
         raise CLIError("Multiple possible values found for '{0}': {1}\nSpecify '{0}' "
                        "explicitly.".format(option_name, ', '.join(values)))
     return values[0]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -87,6 +87,16 @@ def _upsert(parent, collection_name, obj_to_add, key_name):
 
     collection.append(obj_to_add)
 
+
+def _get_default_value(balancer, property_name, option_name):
+    values = [x.name for x in getattr(balancer, property_name)]
+    if len(values) > 1:
+        from azure.cli.core.util import CLIError
+        raise CLIError("Multiple possible values found for '{0}': {1}\nSpecify '{0}' "
+                       "explicitly.".format(option_name, ', '.join(values)))
+    return values[0]
+
+
 #region Generic list commands
 def _generic_list(operation_name, resource_group_name):
     ncf = _network_client_factory()
@@ -312,7 +322,7 @@ def update_ag_frontend_port(instance, parent, item_name, port=None): # pylint: d
     return parent
 
 def create_ag_http_listener(resource_group_name, application_gateway_name, item_name,
-                            frontend_ip, frontend_port, host_name=None, ssl_cert=None,
+                            frontend_port, frontend_ip=None, host_name=None, ssl_cert=None,
                             no_wait=False):
     ApplicationGatewayHttpListener = get_sdk(
         ResourceType.MGMT_NETWORK,
@@ -320,6 +330,8 @@ def create_ag_http_listener(resource_group_name, application_gateway_name, item_
         mod='models')
     ncf = _network_client_factory()
     ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    if not frontend_ip:
+        frontend_ip = _get_default_value(ag, 'frontend_ip_configurations', '--frontend-ip')
     new_listener = ApplicationGatewayHttpListener(
         name=item_name,
         frontend_ip_configuration=SubResource(frontend_ip),
@@ -433,14 +445,21 @@ def update_ag_probe(instance, parent, item_name, protocol=None, host=None, path=
     return parent
 
 def create_ag_request_routing_rule(resource_group_name, application_gateway_name, item_name,
-                                   address_pool, http_settings, http_listener, url_path_map=None,
-                                   rule_type='Basic', no_wait=False):
+                                   address_pool=None, http_settings=None, http_listener=None,
+                                   url_path_map=None, rule_type='Basic', no_wait=False):
     ApplicationGatewayRequestRoutingRule = get_sdk(
         ResourceType.MGMT_NETWORK,
         'ApplicationGatewayRequestRoutingRule',
         mod='models')
     ncf = _network_client_factory()
     ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    if not address_pool:
+        address_pool = _get_default_value(ag, 'backend_address_pools', '--address-pool')
+    if not http_settings:
+        http_settings = _get_default_value(ag, 'backend_http_settings_collection',
+                                           '--http-settings')
+    if not http_listener:
+        http_listener = _get_default_value(ag, 'http_listeners', '--http-listener')
     new_rule = ApplicationGatewayRequestRoutingRule(
         name=item_name,
         rule_type=rule_type,
@@ -732,9 +751,12 @@ def create_load_balancer(load_balancer_name, resource_group_name, location=None,
 
 def create_lb_inbound_nat_rule(
         resource_group_name, load_balancer_name, item_name, protocol, frontend_port,
-        frontend_ip_name, backend_port, floating_ip="false", idle_timeout=None):
+        backend_port, frontend_ip_name=None, floating_ip="false", idle_timeout=None):
     ncf = _network_client_factory()
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
+    if not frontend_ip_name:
+        frontend_ip_name = _get_default_value(lb, 'frontend_ip_configurations',
+                                              '--frontend-ip-name')
     frontend_ip = _get_property(lb.frontend_ip_configurations, frontend_ip_name) # pylint: disable=no-member
     new_rule = InboundNatRule(
         name=item_name, protocol=protocol,
@@ -869,11 +891,17 @@ def set_lb_probe(instance, parent, item_name, protocol=None, port=None, # pylint
 
 def create_lb_rule(
         resource_group_name, load_balancer_name, item_name,
-        protocol, frontend_port, backend_port, frontend_ip_name,
-        backend_address_pool_name, probe_name=None, load_distribution='default',
+        protocol, frontend_port, backend_port, frontend_ip_name=None,
+        backend_address_pool_name=None, probe_name=None, load_distribution='default',
         floating_ip='false', idle_timeout=None):
     ncf = _network_client_factory()
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
+    if not frontend_ip_name:
+        frontend_ip_name = _get_default_value(lb, 'frontend_ip_configurations',
+                                              '--frontend-ip-name')
+    if not backend_address_pool_name:
+        backend_address_pool_name = _get_default_value(lb, 'backend_address_pools',
+                                                       '--backend-pool-name')
     new_rule = LoadBalancingRule(
         name=item_name,
         protocol=protocol,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -93,6 +93,9 @@ def _get_default_value(balancer, property_name, option_name):
     if len(values) > 1:
         raise CLIError("Multiple possible values found for '{0}': {1}\nSpecify '{0}' "
                        "explicitly.".format(option_name, ', '.join(values)))
+    elif not values:
+        raise CLIError("No existing values found for '{0}'. Create one first and try "
+                       "again.".format(option_name))
     return values[0]
 
 


### PR DESCRIPTION
Fixes #3377.

Attempts to default things like frontend IP, backend address pool, HTTP settings and HTTP listener when the collection contains only a single item. This is normally the case since we create these automatically when creating AppGateways/LoadBalancers.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
