### PR TITLE
fix a set up break triggered by new versions of requests and msrest

### DIFF
--- a/scripts/automation/tests/verify_dependencies.py
+++ b/scripts/automation/tests/verify_dependencies.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 
 ALLOWED_ERRORS = [
+    "has requirement requests~=2.14.1, but you have requests 2.16.5.",
     "has requirement azure-common[autorest]==1.1.4, but you have azure-common 1.1.6.",
     "has requirement azure-common~=1.1.5, but you have azure-common 1.1.4."
 ]

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -34,7 +34,7 @@ DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-web==0.32.0',
     # v1.17 breaks on wildcard cert https://github.com/shazow/urllib3/issues/981
-    'urllib3[secure]==1.16',
+    'urllib3[secure]>=1.18',
     'xmltodict',
     'pyOpenSSL',
     'vsts-cd-manager',


### PR DESCRIPTION
I hope this will get #3498  fixed, maybe #3497 as well
This was triggered by the [msrest 0.4.8](https://github.com/Azure/msrest-for-python/releases/tag/v0.4.8) released last week. The new requests package pulled in now throws on any lower version of urllib3. 
Note, the change of fixing the version in the command module was done when urllib3 had not released a fix yet.  

### General Guidelines

~- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).~

### Command Guidelines

~- [ ] Each command and parameter has a meaningful description.~
~- [ ] Each new command has a test.~

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
