### PR TITLE
RuntimeError: Requests dependency 'urllib3' must be version >= 1.21.1, < 1.22!

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 (unreleased)
 ++++++++++++++++++++
+* update urllib3 dependency version to 1.21.1
 * webapp: add reliability fixes in configuring source control (#3245)
 * BC: az webapp config update: Remove unsupported --node-version argument for Windows webapps. Instead use "az webapp config appsettings set" with the WEBSITE_NODE_DEFAULT_VERSION key.
 

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -33,8 +33,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-web==0.32.0',
-    # v1.17 breaks on wildcard cert https://github.com/shazow/urllib3/issues/981
-    'urllib3[secure]==1.16',
+    'urllib3[secure]>=1.21.1',
     'xmltodict',
     'pyOpenSSL',
     'vsts-cd-manager',


### PR DESCRIPTION
The urllib3 module was locked to a year-old version based on a bug fixed over 6 months ago. Module dependencies are currently in conflict because of this lock.

```
jorhett@glamdring ~$ az account show
Traceback (most recent call last):
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/requests/__init__.py", line 58, in <module>
    assert minor >= 21
AssertionError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/azure/cli/main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/azure/cli/core/application.py", line 203, in execute
    result = expanded_arg.func(params)
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 278, in __call__
    return self.handler(*args, **kwargs)
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 438, in _execute_command
    from msrestazure.azure_exceptions import CloudError
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/msrestazure/__init__.py", line 28, in <module>
    from .azure_configuration import AzureConfiguration
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/msrestazure/azure_configuration.py", line 33, in <module>
    from msrest import Configuration
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/msrest/__init__.py", line 27, in <module>
    from .configuration import Configuration
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/msrest/configuration.py", line 36, in <module>
    import requests
  File "/Users/jorhett/lib/azure-cli/lib/python3.6/site-packages/requests/__init__.py", line 61, in <module>
    raise RuntimeError('Requests dependency \'urllib3\' must be version >= 1.21.1, < 1.22!')
RuntimeError: Requests dependency 'urllib3' must be version >= 1.21.1, < 1.22!
```