### PR TITLE
Add release notes link to GitHub releases

### DIFF
--- a/scripts/github_bot/api/app.py
+++ b/scripts/github_bot/api/app.py
@@ -60,6 +60,9 @@ The module has been published to PyPI.
 View HISTORY.rst of the module for a changelog.
 
 {}
+
+Full changelog at https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli
+
 """
 
 def _verify_parse_request(req):

--- a/scripts/github_bot/api/app.py
+++ b/scripts/github_bot/api/app.py
@@ -61,7 +61,7 @@ View HISTORY.rst of the module for a changelog.
 
 {}
 
-Full changelog at https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli
+Full release notes at https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli
 
 """
 


### PR DESCRIPTION
Adds link to https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli in GitHub release notes.

e.g. https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.0.7