### PR TITLE
Add tool to summarize pylint disable statement in source

### DIFF
--- a/scripts/automation/style/pylint_disable_check.py
+++ b/scripts/automation/style/pylint_disable_check.py
@@ -1,0 +1,78 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# gather all the pylint disable statements
+
+import os
+import re
+import itertools
+import tabulate
+from ..utilities.path import get_repo_root
+
+
+def get_files(root):
+    for root, dirs, files in os.walk('src'):
+        for py_file in files:
+            if py_file.endswith('.py'):
+                yield os.path.join(root, py_file)
+
+
+def get_rules(file_path):
+    rgx = re.compile('# pylint: disable=(\w|-|,|\s)+')
+    with open(file_path) as f:
+        for index, l in enumerate(f.readlines()):
+            if not l:
+                break
+
+            m = rgx.search(l)
+            if m:
+                rules = (r.strip() for r in m.group(0).strip().split('=')[1].split(','))
+                for r in rules:
+                    yield r, index, file_path
+
+
+def get_all_rules(root):
+    return itertools.chain.from_iterable(get_rules(f) for f in get_files('src'))
+
+
+def group_by_rules(rules_iter):
+    sortiter = sorted(rules_iter, key=lambda each: each[0])
+    for k, g in itertools.groupby(sortiter, lambda each: each[0]):
+        group = list(g)
+        yield k, len(group)
+
+
+def group_by_files(rules_iter):
+    sortiter = sorted(rules_iter, key=lambda each: each[2])
+    for k, g in itertools.groupby(sortiter, lambda each: each[2]):
+        group = list(g)
+        count = len(group)
+        with open(k, 'r') as f:
+            line_number = len(f.readlines())
+
+        yield k, count, line_number, int(line_number / count)
+
+
+def main():
+    src_folder = os.path.join(get_repo_root(), 'src')
+    all_rules = [e for e in get_all_rules(src_folder)]
+
+
+    with open('pylint_report.txt', 'w') as f:
+        f.write('GROUP BY RULES\n')
+        f.writelines(tabulate.tabulate(sorted(group_by_rules(all_rules), key=lambda each: each[1], reverse=True),
+                                       headers=('rule', 'count')))
+
+        f.write('\n\nGROUP BY FILES\n')
+        f.writelines(tabulate.tabulate(sorted(group_by_files(all_rules), key=lambda each: each[1], reverse=True),
+                                       headers=('file', 'pylint count', 'total lines', 'every n line')))
+
+    with open('pylint_all_disables.csv', 'w') as f:
+        for r in all_rules:
+            f.write('{},{},{}\n'.format(*r))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -29,7 +29,8 @@ DEPENDENCIES = [
     'flake8>=3.2.1',
     'pycodestyle>=2.2.0',
     'nose>=1.3.7',
-    'six>=1.10.0'
+    'six>=1.10.0',
+    'tabulate>=0.7.7'
 ]
 
 setup(


### PR DESCRIPTION
The tool will scan all the source files and generate a report of the status of all the pylint disables in our code base. There are many unnecessary escapes we can remove from the source code and this tool helps us to organize the effort.

Here's the rules we escaped today:
```
rule                               count
-------------------------------  -------
line-too-long                        196
no-member                            134
unused-argument                      120
too-few-public-methods                78
unused-variable                       66
redefined-outer-name                  62
unused-import                         55
protected-access                      33
no-self-use                           32
too-many-instance-attributes          30
broad-except                          27
import-error                          21
too-many-locals                       20
too-many-arguments                    18
too-many-statements                   14
too-many-lines                        13
redefined-builtin                     12
bare-except                           11
method-hidden                          8
bad-continuation                       6
deprecated-method                      5
no-name-in-module                      5
attribute-defined-outside-init         4
function-redefined                     4
too-many-branches                      4
superfluous-parens                     3
too-many-public-methods                3
too-many-return-statements             3
unsubscriptable-object                 3
E1101                                  2
access-member-before-definition        2
consider-using-enumerate               2
dangerous-default-value                2
old-style-class                        2
too-many-function-args                 2
wrong-import-order                     2
                                       1
assignment-from-no-return              1
cell-var-from-loop                     1
global-statement                       1
no-self-argument                       1
not-callable                           1
redefined-variable-type                1
too-many-format-args                   1
trailing-whitespace                    1
ungrouped-imports                      1

```