### PR TITLE
Eliminating too-many-arguments pylint disable rule

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -32,8 +32,6 @@ from ._introspection import (extract_args_from_signature,
 logger = azlogging.get_az_logger(__name__)
 
 
-# pylint: disable=too-many-arguments,too-few-public-methods
-
 CONFIRM_PARAM_NAME = 'yes'
 
 BLACKLISTED_MODS = ['context', 'container', 'shell', 'documentdb']
@@ -68,7 +66,7 @@ class VersionConstraint(object):
             cli_command(*args, **kwargs)
 
 
-class CliArgumentType(object):
+class CliArgumentType(object):  # pylint: disable=too-few-public-methods
     REMOVE = '---REMOVE---'
 
     def __init__(self, overrides=None, **kwargs):
@@ -86,7 +84,7 @@ class CliArgumentType(object):
         self.settings.update(**kwargs)
 
 
-class CliCommandArgument(object):
+class CliCommandArgument(object):  # pylint: disable=too-few-public-methods
     _NAMED_ARGUMENTS = ('options_list', 'validator', 'completer', 'id_part', 'arg_group')
 
     def __init__(self, dest=None, argtype=None, **kwargs):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -184,10 +184,9 @@ class StorageAccountPreparer(AbstractPreparer, SingleValueReplacer):
 # KeyVault Preparer and its shorthand decorator
 
 class KeyVaultPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self,  # pylint: disable=too-many-arguments
-                 name_prefix='clitest', sku='standard', location='westus',
-                 parameter_name='key_vault', resource_group_parameter_name='resource_group',
-                 skip_delete=True, dev_setting_name='AZURE_CLI_TEST_DEV_KEY_VAULT_NAME'):
+    def __init__(self, name_prefix='clitest', sku='standard', location='westus', parameter_name='key_vault',
+                 resource_group_parameter_name='resource_group', skip_delete=True,
+                 dev_setting_name='AZURE_CLI_TEST_DEV_KEY_VAULT_NAME'):
         super(KeyVaultPreparer, self).__init__(name_prefix, 24)
         self.location = location
         self.sku = sku

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -32,7 +32,6 @@ from msrestazure.azure_exceptions import CloudError
 import azure.cli.core.azlogging as azlogging
 from azure.cli.command_modules.acs import acs_client, proxy
 from azure.cli.command_modules.acs._actions import _is_valid_ssh_rsa_public_key
-# pylint: disable=too-few-public-methods,too-many-arguments,no-self-use,line-too-long
 from azure.cli.core.util import CLIError, shell_safe_json_parse
 from azure.cli.core._profile import Profile
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -282,13 +281,12 @@ def dcos_install_cli(install_location=None, client_version='1.8'):
 
 
 def k8s_install_cli(client_version='latest', install_location=None):
-    """
-    Downloads the kubectl command line from Kubernetes
-    """
+    """ Downloads the kubectl command line from Kubernetes """
 
     if client_version == 'latest':
         context = _ssl_context()
-        version = urlopen('https://storage.googleapis.com/kubernetes-release/release/stable.txt', context=context).read()
+        version = urlopen('https://storage.googleapis.com/kubernetes-release/release/stable.txt',
+                          context=context).read()
         client_version = version.decode('UTF-8').strip()
 
     file_url = ''
@@ -471,8 +469,8 @@ def acs_create(resource_group_name, deployment_name, name, ssh_key_value, dns_na
                 store_acs_service_principal(subscription_id, client_secret, service_principal)
             # Either way, update the role assignment, this fixes things if we fail part-way through
             if not _add_role_assignment('Contributor', service_principal):
-                raise CLIError(
-                    'Could not create a service principal with the right permissions. Are you an Owner on this project?')
+                raise CLIError('Could not create a service principal with the right permissions. '
+                               'Are you an Owner on this project?')
         else:
             # --service-principal specfied, validate --client-secret was too
             if not client_secret:
@@ -661,15 +659,15 @@ def _create_non_kubernetes(resource_group_name, deployment_name, dns_name_prefix
         "outputs": {
             "masterFQDN": {
                 "type": "string",
-                "value": "[reference(concat('Microsoft.ContainerService/containerServices/', '{}')).masterProfile.fqdn]".format(name)
+                "value": "[reference(concat('Microsoft.ContainerService/containerServices/', '{}')).masterProfile.fqdn]".format(name)  # pylint: disable=line-too-long
             },
             "sshMaster0": {
                 "type": "string",
-                "value": "[concat('ssh ', '{0}', '@', reference(concat('Microsoft.ContainerService/containerServices/', '{1}')).masterProfile.fqdn, ' -A -p 2200')]".format(admin_username, name)
+                "value": "[concat('ssh ', '{0}', '@', reference(concat('Microsoft.ContainerService/containerServices/', '{1}')).masterProfile.fqdn, ' -A -p 2200')]".format(admin_username, name)  # pylint: disable=line-too-long
             },
             "agentFQDN": {
                 "type": "string",
-                "value": "[reference(concat('Microsoft.ContainerService/containerServices/', '{}')).agentPoolProfiles[0].fqdn]".format(name)
+                "value": "[reference(concat('Microsoft.ContainerService/containerServices/', '{}')).agentPoolProfiles[0].fqdn]".format(name)  # pylint: disable=line-too-long
             }
         }
     }

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=no-self-use,too-many-arguments,too-many-lines
 from __future__ import print_function
 import threading
 try:
@@ -34,7 +33,7 @@ from ._client_factory import web_client_factory, ex_handler_factory
 
 logger = azlogging.get_az_logger(__name__)
 
-# pylint:disable=no-member,superfluous-parens
+# pylint:disable=no-member,superfluous-parens,too-many-lines
 
 
 def create_webapp(resource_group_name, name, plan, runtime=None,

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_command_type.py
@@ -484,7 +484,7 @@ class BatchArgumentTree(object):
 
 class AzureBatchDataPlaneCommand(object):
     # pylint: disable=too-many-instance-attributes, too-few-public-methods
-    def __init__(self, module_name, name,  # pylint:disable=too-many-arguments, too-many-statements
+    def __init__(self, module_name, name,  # pylint:disable=too-many-statements
                  operation, factory, transform_result,
                  flatten, ignore, validator, silent):
 

--- a/src/command_modules/azure-cli-batch/tests/batch_preparers.py
+++ b/src/command_modules/azure-cli-batch/tests/batch_preparers.py
@@ -10,8 +10,7 @@ from azure.cli.testsdk.base import execute
 
 
 class BatchAccountPreparer(AbstractPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clibatch',  # pylint: disable=too-many-arguments
-                 parameter_name='batch_account_name', location='westus',
+    def __init__(self, name_prefix='clibatch', parameter_name='batch_account_name', location='westus',
                  resource_group_parameter_name='resource_group', skip_delete=True,
                  dev_setting_name='AZURE_CLI_TEST_DEV_BATCH_ACCT_NAME'):
         super(BatchAccountPreparer, self).__init__(name_prefix, 24)

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/custom.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=unused-argument,too-many-arguments
+# pylint: disable=unused-argument
 from azure.cli.core.util import CLIError, to_snake_case
 
 from azure.cli.core.cloud import (Cloud,

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-# pylint: disable=no-self-use,too-many-arguments,no-member,line-too-long,too-few-public-methods
+# pylint: disable=no-self-use,no-member,line-too-long,too-few-public-methods
 
 from __future__ import print_function
 from os.path import exists

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/custom.py
@@ -5,7 +5,8 @@
 import getpass
 
 
-# pylint: disable=too-many-locals, unused-argument, too-many-statements, too-many-arguments
+# pylint: disable=too-many-locals, unused-argument, too-many-statements,
+
 def create_lab_vm(client, resource_group, lab_name, name, notes=None, image=None, image_type=None,
                   size=None, admin_username=getpass.getuser(), admin_password=None,
                   ssh_key=None, authentication_type='password',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from collections import Counter, OrderedDict
 from msrestazure.azure_exceptions import CloudError
 
-# pylint: disable=no-self-use,too-many-arguments,no-member,too-many-lines
+# pylint: disable=no-self-use,no-member,too-many-lines
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core.commands.arm import parse_resource_id, is_valid_resource_id, resource_id
 from azure.cli.core.commands.client_factory import get_subscription_id

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/custom.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/custom.py
@@ -121,13 +121,8 @@ def _download_log_files(
             urlretrieve(f.url, f.name)
 
 
-def _list_log_files_with_filter(  # pylint: disable=too-many-arguments
-        client,
-        resource_group_name,
-        server_name,
-        filename_contains=None,
-        file_last_written=None,
-        max_file_size=None):
+def _list_log_files_with_filter(client, resource_group_name, server_name, filename_contains=None,
+                                file_last_written=None, max_file_size=None):
     """List all the log files of a given server.
 
     :param resource_group_name: The name of the resource group that

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -313,10 +313,8 @@ def _get_missing_parameters(parameters, template, prompt_fn):
     return parameters
 
 
-def _deploy_arm_template_core(resource_group_name,  # pylint: disable=too-many-arguments
-                              template_file=None, template_uri=None, deployment_name=None,
-                              parameter_list=None, mode='incremental', validate_only=False,
-                              no_wait=False):
+def _deploy_arm_template_core(resource_group_name, template_file=None, template_uri=None, deployment_name=None,
+                              parameter_list=None, mode='incremental', validate_only=False, no_wait=False):
     DeploymentProperties, TemplateLink = get_sdk(ResourceType.MGMT_RESOURCE_RESOURCES,
                                                  'DeploymentProperties',
                                                  'TemplateLink',

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -278,7 +278,7 @@ def sf_upload_app(path, show_progress=False):
             total_files_size), file=sys.stderr)
 
 
-def sf_create_app(client,  # pylint: disable=too-many-locals,too-many-arguments
+def sf_create_app(client,  # pylint: disable=too-many-locals
                   app_name, app_type, app_version, parameters=None,
                   min_node_count=0, max_node_count=0, metrics=None,
                   timeout=60):
@@ -371,7 +371,7 @@ def sf_create_app(client,  # pylint: disable=too-many-locals,too-many-arguments
     client.create_application(app_desc, timeout)
 
 
-def sf_upgrade_app(  # pylint: disable=too-many-arguments,too-many-locals
+def sf_upgrade_app(  # pylint: disable=too-many-locals
         client, app_id, app_version, parameters, mode="UnmonitoredAuto",
         replica_set_check_timeout=None, force_restart=None,
         failure_action=None, health_check_wait_duration="0",
@@ -661,7 +661,7 @@ def sup_service_update_flags(
     return str(f)
 
 
-def sf_create_service(  # pylint: disable=too-many-arguments, too-many-locals
+def sf_create_service(  # pylint: disable=too-many-locals
         client, app_id, name, service_type, stateful=False, stateless=False,
         singleton_scheme=False, named_scheme=False, int_scheme=False,
         named_scheme_list=None, int_scheme_low=None, int_scheme_high=None,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=no-self-use,too-many-arguments,too-many-lines
+# pylint: disable=no-self-use,too-many-lines
 from __future__ import print_function
 import getpass
 import json

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/disk_encryption.py
@@ -26,7 +26,7 @@ extension_info = {
 }
 
 
-def enable(resource_group_name, vm_name,  # pylint: disable=too-many-arguments,too-many-locals, too-many-statements
+def enable(resource_group_name, vm_name,  # pylint: disable=too-many-locals, too-many-statements
            aad_client_id,
            disk_encryption_keyvault,
            aad_client_secret=None, aad_client_cert_thumbprint=None,


### PR DESCRIPTION
The rule too-many-arguments is disabled project-wise.