### PR TITLE
fix acs kube get-credentials ssh-key loading

### DIFF
--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unlreleased
+++++++++++++++++++
+
+* Fix acs kube get-credentials ssh-key loading (
+
 2.0.7 (2017-05-30)
 ++++++++++++++++++
 

--- a/src/command_modules/azure-cli-acs/HISTORY.rst
+++ b/src/command_modules/azure-cli-acs/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-unlreleased
+unreleased
 ++++++++++++++++++
 
 * Fix acs kube get-credentials ssh-key loading (

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -722,8 +722,8 @@ def _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file):
 
     # TODO: this only works for public cloud, need other casing for national clouds
 
-    acs_client.SecureCopy(user, '{}.{}.cloudapp.azure.com'.format(dns_prefix, location),
-                          '.kube/config', path_candidate, key_filename=ssh_key_file)
+    acs_client.secure_copy(user, '{}.{}.cloudapp.azure.com'.format(dns_prefix, location),
+                           '.kube/config', path_candidate, key_filename=ssh_key_file)
 
     # merge things
     if path_candidate != path:


### PR DESCRIPTION
When using `acs create`, the CLI assumes the use of `~/.ssh/id_rsa` if not otherwise specified. In `acs kubernetes get-credentials`, it only tries to load the specified --ssh-key-file or what ever is in the ssh agent at the time. This will fail if `~/.ssh/id_rsa` is not added to the agent or not specified on the command line.

This pull request will load `~/.ssh/id_rsa` if no keys are found in the ssh agent and no key is specified via --ssh-key-file. It will also provide a better message to the user in the case no keys are found.

Fixes #2403 #3605

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))