### PR TITLE
webapp: ensure default browser is used on osx and w/o error on launching

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 0.1.8 (unreleased)
 ++++++++++++++++++++
 webapp: expose "traffic-routing" commands to configure static routing
+webapp: launch default web browser w/o errors in osx 
 
 0.1.7 (2017-05-30)
 ++++++++++++++++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -810,8 +810,17 @@ def view_in_browser(resource_group_name, name, slot=None, logs=False):
 
 
 def _open_page_in_browser(url):
-    import webbrowser
-    webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
+    import sys
+    if sys.platform == 'darwin':
+        # handle 2 things:
+        # a. On OSX sierra, 'python -m webbrowser -t <url>' emits out "execution error: <url> doesn't
+        #    understand the "open location" message"
+        # b. Python 2.x can't sniff out the default browser
+        import subprocess
+        subprocess.Popen(['open', url])
+    else:
+        import webbrowser
+        webbrowser.open(url, new=2)  # 2 means: open in a new tab, if possible
 
 
 # TODO: expose new blob suport

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -811,7 +811,7 @@ def view_in_browser(resource_group_name, name, slot=None, logs=False):
 
 def _open_page_in_browser(url):
     import sys
-    if sys.platform == 'darwin':
+    if sys.platform.lower() == 'darwin':
         # handle 2 things:
         # a. On OSX sierra, 'python -m webbrowser -t <url>' emits out "execution error: <url> doesn't
         #    understand the "open location" message"


### PR DESCRIPTION
Fix #3608, Fix #3604


- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
