### PR TITLE
Improve concurrent handling of clouds.config file

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.8 (unreleased)
+^^^^^^^^^^^^^^^^^^
+* Improve concurrent handling of clouds.config file.
+
 2.0.7 (2017-05-30)
 ^^^^^^^^^^^^^^^^^^
 * Command paths are no longer case sensitive.

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -243,8 +243,6 @@ def init_known_clouds(force=False):
 
 
 def get_clouds():
-    # ensure the known clouds are always in cloud config
-    init_known_clouds()
     clouds = []
     # load the config again as it may have changed
     config = get_config_parser()

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -40,13 +40,8 @@ def get_sha1_hash(file_path):
 
 def find_recording_dir(test_file):
     """ Find the directory containing the recording of given test file based on current profile. """
-    from azure.cli.core._profile import get_active_cloud, init_known_clouds
-    from azure.cli.core.cloud import CloudNotRegisteredException
-    try:
-        api_profile = get_active_cloud().profile
-    except CloudNotRegisteredException:
-        init_known_clouds()
-        api_profile = get_active_cloud().profile
+    from azure.cli.core._profile import get_active_cloud
+    api_profile = get_active_cloud().profile
 
     base_dir = os.path.join(os.path.dirname(test_file), 'recordings')
     return os.path.join(base_dir, api_profile)


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/3617

Only init known clouds once (when _profile is loaded) rather than on each call to get_clouds.
This means at most, we write to clouds.config once.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [n/a] Each command and parameter has a meaningful description.
- [n/a] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
