### PR TITLE
webapp: mask docker registry passwords from 'webapp appsettings/container' commands' output

### DIFF
--- a/src/command_modules/azure-cli-appservice/HISTORY.rst
+++ b/src/command_modules/azure-cli-appservice/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 webapp: expose "traffic-routing" commands to configure static routing
 webapp: launch default web browser w/o errors in osx 
 webapp: improve the help of "az webapp log tail/download"
+BC: webapp: mask docker registry passwords from 'appsettings/container' commands' output
 
 0.1.7 (2017-05-30)
 ++++++++++++++++++++

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -344,6 +344,7 @@ def _filter_for_container_settings(settings):
     return [x for x in settings if x['name'] in CONTAINER_APPSETTING_NAMES]
 
 
+# TODO: remove this when #3660(service tracking issue) is resolved
 def _mask_creds_related_appsettings(settings):
     for x in [x1 for x1 in settings if x1 in APPSETTINGS_TO_MASK]:
         settings[x] = None

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -157,7 +157,7 @@ def get_app_settings(resource_group_name, name, slot=None):
                               .connection_string_names or []
     result = [{'name': p,
                'value': result.properties[p],
-               'slotSetting': p in slot_constr_names} for p in result.properties]
+               'slotSetting': p in slot_constr_names} for p in _mask_creds_related_appsettings(result.properties)]
     return result
 
 
@@ -234,7 +234,7 @@ def update_app_settings(resource_group_name, name, settings=None, slot=None, slo
         slot_cfg_names.app_setting_names += new_slot_setting_names
         client.web_apps.update_slot_configuration_names(resource_group_name, name, slot_cfg_names)
 
-    return result.properties
+    return _mask_creds_related_appsettings(result.properties)
 
 
 def delete_app_settings(resource_group_name, name, setting_names, slot=None):
@@ -251,8 +251,9 @@ def delete_app_settings(resource_group_name, name, setting_names, slot=None):
 
     if is_slot_settings:
         client.web_apps.update_slot_configuration_names(resource_group_name, name, slot_cfg_names)
-    return _generic_site_operation(resource_group_name, name, 'update_application_settings',
-                                   slot, app_settings)
+    return _mask_creds_related_appsettings(_generic_site_operation(resource_group_name, name,
+                                                                   'update_application_settings',
+                                                                   slot, app_settings).properties)
 
 
 def update_connection_strings(resource_group_name, name, connection_string_type,
@@ -309,6 +310,7 @@ def delete_connection_strings(resource_group_name, name, setting_names, slot=Non
 
 CONTAINER_APPSETTING_NAMES = ['DOCKER_REGISTRY_SERVER_URL', 'DOCKER_REGISTRY_SERVER_USERNAME',
                               'DOCKER_REGISTRY_SERVER_PASSWORD', 'DOCKER_CUSTOM_IMAGE_NAME']
+APPSETTINGS_TO_MASK = ['DOCKER_REGISTRY_SERVER_PASSWORD']
 
 
 def update_container_settings(resource_group_name, name, docker_registry_server_url=None,
@@ -326,7 +328,7 @@ def update_container_settings(resource_group_name, name, docker_registry_server_
         _add_linux_fx_version(resource_group_name, name, docker_custom_image_name)
     update_app_settings(resource_group_name, name, settings, slot)
     settings = get_app_settings(resource_group_name, name, slot)
-    return _filter_for_container_settings(settings)
+    return _mask_creds_related_appsettings(_filter_for_container_settings(settings))
 
 
 def delete_container_settings(resource_group_name, name, slot=None):
@@ -335,11 +337,17 @@ def delete_container_settings(resource_group_name, name, slot=None):
 
 def show_container_settings(resource_group_name, name, slot=None):
     settings = get_app_settings(resource_group_name, name, slot)
-    return _filter_for_container_settings(settings)
+    return _mask_creds_related_appsettings(_filter_for_container_settings(settings))
 
 
 def _filter_for_container_settings(settings):
     return [x for x in settings if x['name'] in CONTAINER_APPSETTING_NAMES]
+
+
+def _mask_creds_related_appsettings(settings):
+    for x in [x1 for x1 in settings if x1 in APPSETTINGS_TO_MASK]:
+        settings[x] = None
+    return settings
 
 
 def add_hostname(resource_group_name, webapp_name, hostname, slot=None):

--- a/src/command_modules/azure-cli-appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/tests/test_webapp_commands.py
@@ -326,10 +326,13 @@ class LinuxWebappSceanrioTest(ResourceGroupVCRTestBase):
         self.cmd('webapp config set -g {} -n {} --startup-file {}'.format(self.resource_group, webapp, 'process.json'), checks=[
             JMESPathCheck('appCommandLine', 'process.json')
         ])
-        self.cmd('webapp config container set -g {} -n {} --docker-custom-image-name {} --docker-registry-server-password {} --docker-registry-server-user {} --docker-registry-server-url {}'.format(
+        result = self.cmd('webapp config container set -g {} -n {} --docker-custom-image-name {} --docker-registry-server-password {} --docker-registry-server-user {} --docker-registry-server-url {}'.format(
             self.resource_group, webapp, 'foo-image', 'foo-password', 'foo-user', 'foo-url'))
+        self.assertEqual(set(x['value'] for x in result if x['name'] == 'DOCKER_REGISTRY_SERVER_PASSWORD'), set([None]))  # we mask the password
+
         result = self.cmd('webapp config container show -g {} -n {} '.format(self.resource_group, webapp))
         self.assertEqual(set(x['name'] for x in result), set(['DOCKER_REGISTRY_SERVER_URL', 'DOCKER_REGISTRY_SERVER_USERNAME', 'DOCKER_CUSTOM_IMAGE_NAME', 'DOCKER_REGISTRY_SERVER_PASSWORD']))
+        self.assertEqual(set(x['value'] for x in result if x['name'] == 'DOCKER_REGISTRY_SERVER_PASSWORD'), set([None]))   # we mask the password
         sample = next((x for x in result if x['name'] == 'DOCKER_REGISTRY_SERVER_URL'))
         self.assertEqual(sample, {'name': 'DOCKER_REGISTRY_SERVER_URL', 'slotSetting': False, 'value': 'foo-url'})
         self.cmd('webapp config container delete -g {} -n {}'.format(self.resource_group, webapp))


### PR DESCRIPTION
Fix #3599 

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
