### PR TITLE
vm: fix the error of 'Too many open files' when do 'vm image list --all'

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -9,10 +9,6 @@ Release History
 ^^^^^^^^^^^^^^^^^^
 * Remove useless line-too-long suppression
 * vm: support attaching data disks on vm create (#3644)
-
-2.0.8 (unreleased)
-++++++++++++++++++
->>>>>>> vm: fix the error of 'Too many open files' when do 'vm image list --all'
 * Improve table output for vm/vmss commands: get-instance-view, list, show, list-usage, etc
 * Fix all bad-continuation pylint disables
 * support configuring disk caching on attaching a managed disk (#3513)

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -1,10 +1,18 @@
 .. :changelog:
 Release History
 ===============
+(unreleased)
+^^^^^^^^^^^^^^^^^^
+* vm/vmss: lower thread number used for 'vm image list --all' to avoid exceeding the OS opened file limits  
+
 2.0.8 (2017-06-13)
 ^^^^^^^^^^^^^^^^^^
 * Remove useless line-too-long suppression
 * vm: support attaching data disks on vm create (#3644)
+
+2.0.8 (unreleased)
+++++++++++++++++++
+>>>>>>> vm: fix the error of 'Too many open files' when do 'vm image list --all'
 * Improve table output for vm/vmss commands: get-instance-view, list, show, list-usage, etc
 * Fix all bad-continuation pylint disables
 * support configuring disk caching on attaching a managed disk (#3513)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
@@ -28,7 +28,7 @@ def _resource_not_exists(resource_type):
 
 
 def _get_thread_count():
-    return 40
+    return 5  # don't increase too much till https://github.com/Azure/msrestazure-for-python/issues/6 is fixed
 
 
 def load_images_thru_services(publisher, offer, sku, location):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -641,7 +641,7 @@ helps['vm image'] = """
 
 helps['vm image list'] = """
     type: command
-    short-summary: List the VM images available in the Azure Marketplace.
+    short-summary: List the VM/VMSS images available in the Azure Marketplace.
     examples:
         - name: List all available images.
           text: az vm image list --all

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -208,8 +208,8 @@ def list_vm_images(image_location=None, publisher_name=None, offer=None, sku=Non
 
     if load_thru_services:
         if not publisher_name and not offer and not sku:
-            logger.warning("You are retrieving all the images from server which could take more than a mintue. "
-                           " To shorten the wait, provide '--publisher', '--offer' or '--sku'. Partial name search "
+            logger.warning("You are retrieving all the images from server which could take more than a minute. "
+                           "To shorten the wait, provide '--publisher', '--offer' or '--sku'. Partial name search "
                            "is supported.")
         all_images = load_images_thru_services(publisher_name, offer, sku, image_location)
     else:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -199,14 +199,18 @@ def list_vm_images(image_location=None, publisher_name=None, offer=None, sku=Non
                    all=False):  # pylint: disable=redefined-builtin
     '''vm image list
     :param str image_location:Image location
-    :param str publisher_name:Image publisher name
-    :param str offer:Image offer name
-    :param str sku:Image sku name
+    :param str publisher_name:Image publisher name, partial name is accepted
+    :param str offer:Image offer name, partial name is accepted
+    :param str sku:Image sku name, partial name is accepted
     :param bool all:Retrieve image list from live Azure service rather using an offline image list
     '''
     load_thru_services = all
 
     if load_thru_services:
+        if not publisher_name and not offer and not sku:
+            logger.warning("You are retrieving all the images from server which could take more than a mintue. "
+                           " To shorten the wait, provide '--publisher', '--offer' or '--sku'. Partial name search "
+                           "is supported.")
         all_images = load_images_thru_services(publisher_name, offer, sku, image_location)
     else:
         logger.warning(


### PR DESCRIPTION
Fix #3649 
`lsof -p <p-id>` showed the active socket number peeked at less than 100 vs 1000 before the change.
 A whole live query returns 4000+ images after around 50 seconds. Supplying either `--publisher` or `--offer` take way less time at < 10 seconds.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
