### PR TITLE
Fix failing Docker builds by adding 'make' as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --upgrade pip wheel jmespath-terminal
 # openssh - included for ssh-keygen
 # ca-certificates 
 # wget - required for installing jp
-RUN apk update && apk add bash gcc openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git && update-ca-certificates
+RUN apk update && apk add bash gcc make openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git && update-ca-certificates
 # We also, install jp
 RUN wget https://github.com/jmespath/jp/releases/download/0.1.2/jp-linux-amd64 -qO /usr/local/bin/jp && chmod +x /usr/local/bin/jp
 

--- a/packaged_releases/docker/Dockerfile
+++ b/packaged_releases/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install --upgrade pip wheel jmespath-terminal
 # ca-certificates 
 # wget - required for installing jp
 RUN apk update \
-        && apk add bash gcc openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git \
+        && apk add bash gcc make openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git \
         && update-ca-certificates
 # We also, install jp
 RUN wget https://github.com/jmespath/jp/releases/download/0.1.2/jp-linux-amd64 -qO /usr/local/bin/jp \


### PR DESCRIPTION
Something somewhere changed so not we require `make` to build the Docker image.

Closes https://github.com/Azure/azure-cli/issues/3657