### PR TITLE
[ARM] Fix issue with deployment parameter parsing

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -616,8 +616,6 @@
     <Compile Include="command_modules\azure-cli-sf\azure\cli\command_modules\sf\_params.py" />
     <Compile Include="command_modules\azure-cli-sf\azure\cli\command_modules\sf\__init__.py" />
     <Compile Include="command_modules\azure-cli-sf\setup.py" />
-    <Compile Include="command_modules\azure-cli-sf\tests\manual_scenario_sf_commands.py" />
-    <Compile Include="command_modules\azure-cli-sf\tests\manual_sf_commands.py" />
     <Compile Include="command_modules\azure-cli-sql\azure\cli\command_modules\sql\commands.py" />
     <Compile Include="command_modules\azure-cli-sql\azure\cli\command_modules\sql\custom.py" />
     <Compile Include="command_modules\azure-cli-sql\azure\cli\command_modules\sql\help.py" />
@@ -937,12 +935,10 @@
     <Folder Include="command_modules\azure-cli-redis\azure\cli\command_modules\" />
     <Folder Include="command_modules\azure-cli-redis\azure\cli\command_modules\redis\" />
     <Folder Include="command_modules\azure-cli-redis\tests\" />
-    <Folder Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\" />
     <Folder Include="command_modules\azure-cli-resource\tests\" />
     <Folder Include="command_modules\azure-cli-role\tests\" />
     <Folder Include="command_modules\azure-cli-redis\azure\cli\command_modules\redis\tests\" />
     <Folder Include="command_modules\azure-cli-role\tests\" />
-    <Folder Include="command_modules\azure-cli-role\tests\recordings\" />
     <Folder Include="command_modules\azure-cli-sf\" />
     <Folder Include="command_modules\azure-cli-sf\azure\" />
     <Folder Include="command_modules\azure-cli-sf\azure\cli\" />
@@ -1122,6 +1118,9 @@
     <Content Include="command_modules\azure-cli-resource\tests\crossrg_deploy.json" />
     <Content Include="command_modules\azure-cli-resource\tests\simple_deploy.json" />
     <Content Include="command_modules\azure-cli-resource\tests\simple_deploy_parameters.json" />
+    <Content Include="command_modules\azure-cli-resource\tests\test-object.json" />
+    <Content Include="command_modules\azure-cli-resource\tests\test-params.json" />
+    <Content Include="command_modules\azure-cli-resource\tests\test-template.json" />
     <Content Include="command_modules\azure-cli-role\HISTORY.rst" />
     <Content Include="command_modules\azure-cli-sf\HISTORY.rst" />
     <Content Include="command_modules\azure-cli-sql\HISTORY.rst" />
@@ -1138,11 +1137,6 @@
     <Content Include="command_modules\azure-cli-vm\tests\sample-public.json" />
     <Content Include="command_modules\azure-cli-vm\tests\vmss_create_test_plan.md" />
     <Content Include="command_modules\azure-cli-vm\tests\vm_create_test_plan.md" />
-    <Content Include="command_modules\azure-cli-role\tests\recordings\test_application_set_scenario.yaml" />
-    <Content Include="command_modules\azure-cli-role\tests\recordings\test_create_for_rbac_with_secret.yaml" />
-    <Content Include="command_modules\azure-cli-role\tests\recordings\test_role_assignment_scenario.yaml" />
-    <Content Include="command_modules\azure-cli-role\tests\recordings\test_role_create_scenario.yaml" />
-    <Content Include="command_modules\azure-cli-role\tests\recordings\test_sp_create_scenario.yaml" />
   </ItemGroup>
   <ItemGroup>
     <Interpreter Include="..\env\">

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -1,9 +1,16 @@
 .. :changelog:
 
 Release History
+
 ===============
+
+unreleased
+++++++++++++++++++
+* `group deployment create`: Fixes issue where some parameter files were no longer recognized using @<file> syntax.
+
+
 2.0.8 (2017-06-13)
-^^^^^^^^^^^^^^^^^^
+++++++++++++++++++
 * Fix up some parsing and error messages. (#3584)
 * Fix various pylint disable rules
 * Fix --resource-type parsing for the lock command to accept <resource-namespace>/<resource-type>

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_validators.py
@@ -62,11 +62,11 @@ def validate_deployment_parameters(namespace):
     parameters = {}
     for params in namespace.parameters or []:
         for item in params:
-            if not _try_parse_key_value_object(parameters, item):
-                param_obj = _try_load_file_object(item) or _try_parse_json_object(item)
-                if not param_obj:
-                    raise CLIError('Unable to parse parameter: {}'.format(item))
+            param_obj = _try_load_file_object(item) or _try_parse_json_object(item)
+            if param_obj:
                 parameters.update(param_obj)
+            elif not _try_parse_key_value_object(parameters, item):
+                raise CLIError('Unable to parse parameter: {}'.format(item))
 
     namespace.parameters = parameters
 

--- a/src/command_modules/azure-cli-resource/tests/recordings/latest/test_group_deployment.yaml
+++ b/src/command_modules/azure-cli-resource/tests/recordings/latest/test_group_deployment.yaml
@@ -1,350 +1,1070 @@
 interactions:
 - request:
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001","name":"cli_test_deployment000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [984358f0-4c90-11e7-8df4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test","name":"azure-cli-deployment-test","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001","name":"cli_test_deployment000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['240']
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"dhcpOptions": {}, "subnets": [{"properties":
-      {"addressPrefix": "10.0.0.0/24"}, "name": "subnet1"}], "addressSpace": {"addressPrefixes":
-      ["10.0.0.0/16"]}}, "tags": {}}'
+    body: '{"tags": {}, "location": "westus", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}, "subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "subnet1"}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Length: ['205']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9864d83e-4c90-11e7-a276-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2017-03-01
   response:
-    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"afaa273d-fae6-4176-8e47-5f3f865704fe\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"2e8849fc-07a0-48ba-8b8a-b03fb20355de\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"240e9c40-73c7-4893-83a0-d30f69019829\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"d09ae1e7-9c02-4ca6-a4aa-e763eb6f73c1\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n        \"etag\": \"W/\\\"afaa273d-fae6-4176-8e47-5f3f865704fe\\\"\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
+        ,\r\n        \"etag\": \"W/\\\"2e8849fc-07a0-48ba-8b8a-b03fb20355de\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8c6d54b6-72de-49cb-87be-4a6bb7702d08?api-version=2017-03-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['1072']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['3']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ad102992-75fc-4bfa-adfa-ced6b93b3a71?api-version=2017-03-01']
+      cache-control: [no-cache]
+      content-length: ['1160']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['3']
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9864d83e-4c90-11e7-a276-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8c6d54b6-72de-49cb-87be-4a6bb7702d08?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ad102992-75fc-4bfa-adfa-ced6b93b3a71?api-version=2017-03-01
   response:
     body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network vnet create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9864d83e-4c90-11e7-a276-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2017-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1?api-version=2017-03-01
   response:
-    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1\"\
-        ,\r\n  \"etag\": \"W/\\\"8a5432ce-5584-4583-be8a-b322c796f079\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"vnet1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1\"\
+        ,\r\n  \"etag\": \"W/\\\"f3010535-1488-4c62-9947-dc69cccdd1c7\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"240e9c40-73c7-4893-83a0-d30f69019829\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"d09ae1e7-9c02-4ca6-a4aa-e763eb6f73c1\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\"\
-        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
-        ,\r\n        \"etag\": \"W/\\\"8a5432ce-5584-4583-be8a-b322c796f079\\\"\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
+        ,\r\n        \"etag\": \"W/\\\"f3010535-1488-4c62-9947-dc69cccdd1c7\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:41 GMT']
-      ETag: [W/"8a5432ce-5584-4583-be8a-b322c796f079"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1074']
+      cache-control: [no-cache]
+      content-length: ['1162']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:17 GMT']
+      etag: [W/"f3010535-1488-4c62-9947-dc69cccdd1c7"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "properties": {"backendAddressPools": "[parameters(''backendAddressPools'')]",
-      "frontendIPConfigurations": [{"properties": {"privateIPAllocationMethod": "[parameters(''privateIPAllocationMethod'')]",
-      "subnet": {"id": "[parameters(''subnetId'')]"}}, "name": "LoadBalancerFrontEnd"}]},
-      "name": "[parameters(''name'')]", "location": "[parameters(''location'')]",
-      "apiVersion": "2016-03-30", "type": "Microsoft.Network/loadBalancers"}], "contentVersion":
-      "1.0.0.0", "parameters": {"location": {"type": "string"}, "privateIPAllocationMethod":
-      {"type": "string"}, "backendAddressPools": {"type": "array"}, "name": {"type":
-      "string"}, "subnetId": {"type": "string"}}, "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "parameters": {"location": {"value": "westus"}, "privateIPAllocationMethod":
-      {"value": "Dynamic"}, "backendAddressPools": {"value": [{"name": "bepool1"},
-      {"name": "bepool2"}]}, "name": {"value": "test-lb"}, "subnetId": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}}}}'
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "parameters":
+      {"location": {"type": "string"}, "tags": {"type": "object"}, "privateIPAllocationMethod":
+      {"type": "string"}, "name": {"type": "string"}, "backendAddressPools": {"type":
+      "array"}, "subnetId": {"type": "string"}}, "resources": [{"dependsOn": [], "location":
+      "[parameters(\''location\'')]", "tags": "[parameters(\''tags\'')]", "name":
+      "[parameters(\''name\'')]", "properties": {"backendAddressPools": "[parameters(\''backendAddressPools\'')]",
+      "frontendIPConfigurations": [{"name": "LoadBalancerFrontEnd", "properties":
+      {"privateIPAllocationMethod": "[parameters(\''privateIPAllocationMethod\'')]",
+      "subnet": {"id": "[parameters(\''subnetId\'')]"}}}]}, "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "2016-03-30"}], "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
+      "parameters": {"location": {"value": "westus"}, "tags": {"value": {"key": "super=value"}},
+      "privateIPAllocationMethod": {"value": "Dynamic"}, "name": {"value": "test-lb"},
+      "subnetId": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},
+      "backendAddressPools": {"value": [{"name": "bepool1"}, {"name": "bepool2"}]}},
+      "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment validate]
       Connection: [keep-alive]
-      Content-Length: ['1228']
+      Content-Length: ['1375']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9ad7925e-4c90-11e7-9479-a0b3ccf7272a]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/deployment_dry_run","name":"deployment_dry_run","properties":{"templateHash":"18048340065001902796","parameters":{"location":{"type":"String","value":"westus"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"name":{"type":"String","value":"test-lb"},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:42.0844954Z","duration":"PT0S","correlationId":"522bdd66-c165-41e3-8913-93f10b835055","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"apiVersion":"2016-03-30","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/loadBalancers/test-lb","name":"test-lb","type":"Microsoft.Network/loadBalancers","location":"westus","properties":{"backendAddressPools":[{"name":"bepool1"},{"name":"bepool2"}],"frontendIPConfigurations":[{"properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"name":"LoadBalancerFrontEnd"}]}}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/deployment_dry_run","name":"deployment_dry_run","properties":{"templateHash":"6408713692666354622","parameters":{"location":{"type":"String","value":"westus"},"tags":{"type":"Object","value":{"key":"super=value"}},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"name":{"type":"String","value":"test-lb"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:19.3122369Z","duration":"PT0S","correlationId":"d30de1dd-6b13-4d1c-843e-158c7ed0317c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"apiVersion":"2016-03-30","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","name":"test-lb","type":"Microsoft.Network/loadBalancers","location":"westus","tags":{"key":"super=value"},"properties":{"backendAddressPools":[{"name":"bepool1"},{"name":"bepool2"}],"frontendIPConfigurations":[{"name":"LoadBalancerFrontEnd","properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}}}]}}]}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1676']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      cache-control: [no-cache]
+      content-length: ['1935']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"mode": "Incremental", "template": {"resources": [{"dependsOn":
-      [], "properties": {"backendAddressPools": "[parameters(''backendAddressPools'')]",
-      "frontendIPConfigurations": [{"properties": {"privateIPAllocationMethod": "[parameters(''privateIPAllocationMethod'')]",
-      "subnet": {"id": "[parameters(''subnetId'')]"}}, "name": "LoadBalancerFrontEnd"}]},
-      "name": "[parameters(''name'')]", "location": "[parameters(''location'')]",
-      "apiVersion": "2016-03-30", "type": "Microsoft.Network/loadBalancers"}], "contentVersion":
-      "1.0.0.0", "parameters": {"location": {"type": "string"}, "privateIPAllocationMethod":
-      {"type": "string"}, "backendAddressPools": {"type": "array"}, "name": {"type":
-      "string"}, "subnetId": {"type": "string"}}, "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
-      "parameters": {"location": {"value": "westus"}, "privateIPAllocationMethod":
-      {"value": "Dynamic"}, "backendAddressPools": {"value": [{"name": "bepool1"},
-      {"name": "bepool2"}]}, "name": {"value": "test-lb"}, "subnetId": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}}}}'
+    body: 'b''{"properties": {"template": {"contentVersion": "1.0.0.0", "parameters":
+      {"location": {"type": "string"}, "tags": {"type": "object"}, "privateIPAllocationMethod":
+      {"type": "string"}, "name": {"type": "string"}, "backendAddressPools": {"type":
+      "array"}, "subnetId": {"type": "string"}}, "resources": [{"dependsOn": [], "location":
+      "[parameters(\''location\'')]", "tags": "[parameters(\''tags\'')]", "name":
+      "[parameters(\''name\'')]", "properties": {"backendAddressPools": "[parameters(\''backendAddressPools\'')]",
+      "frontendIPConfigurations": [{"name": "LoadBalancerFrontEnd", "properties":
+      {"privateIPAllocationMethod": "[parameters(\''privateIPAllocationMethod\'')]",
+      "subnet": {"id": "[parameters(\''subnetId\'')]"}}}]}, "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "2016-03-30"}], "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"},
+      "parameters": {"location": {"value": "westus"}, "tags": {"value": {"key": "super=value"}},
+      "privateIPAllocationMethod": {"value": "Dynamic"}, "name": {"value": "test-lb"},
+      "subnetId": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"},
+      "backendAddressPools": {"value": [{"name": "bepool1"}, {"name": "bepool2"}]}},
+      "mode": "Incremental"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
       Connection: [keep-alive]
-      Content-Length: ['1228']
+      Content-Length: ['1375']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b58cf52-4c90-11e7-9b16-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"18048340065001902796","parameters":{"location":{"type":"String","value":"westus"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"name":{"type":"String","value":"test-lb"},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-06-08T21:22:43.2188091Z","duration":"PT0.2770006S","correlationId":"c18f33be-ece9-4c12-96b9-eabd6fd111ff","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"6408713692666354622","parameters":{"location":{"type":"String","value":"westus"},"tags":{"type":"Object","value":{"key":"super=value"}},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"name":{"type":"String","value":"test-lb"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-06-15T20:10:20.2470721Z","duration":"PT0.2383683S","correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment/operationStatuses/08587046499225358060?api-version=2017-05-10']
-      Cache-Control: [no-cache]
-      Content-Length: ['1028']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:22:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/operationStatuses/08587040494654689172?api-version=2017-05-10']
+      cache-control: [no-cache]
+      content-length: ['1170']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A20Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A22Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A23Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A25Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A27Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A28Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A30Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A31Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A33Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A35Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A36Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A38Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3477']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A39Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3477']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A41Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['16465']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A42Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['16465']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A44Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"b73560a9-5d20-4dce-8bdf-538b84e5aea1","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/b73560a9-5d20-4dce-8bdf-538b84e5aea1/ticks/636331542203426587","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"properties":{"statusCode":"Created","serviceRequestId":null},"status":{"value":"Accepted","localizedValue":"Accepted"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:20.3426587Z","submissionTimestamp":"2017-06-15T20:10:41.3300109Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20029']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A45Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"b73560a9-5d20-4dce-8bdf-538b84e5aea1","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/b73560a9-5d20-4dce-8bdf-538b84e5aea1/ticks/636331542203426587","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"properties":{"statusCode":"Created","serviceRequestId":null},"status":{"value":"Accepted","localizedValue":"Accepted"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:20.3426587Z","submissionTimestamp":"2017-06-15T20:10:41.3300109Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20029']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A46Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"b73560a9-5d20-4dce-8bdf-538b84e5aea1","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/b73560a9-5d20-4dce-8bdf-538b84e5aea1/ticks/636331542203426587","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"properties":{"statusCode":"Created","serviceRequestId":null},"status":{"value":"Accepted","localizedValue":"Accepted"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:20.3426587Z","submissionTimestamp":"2017-06-15T20:10:41.3300109Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20029']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A48Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"b73560a9-5d20-4dce-8bdf-538b84e5aea1","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/b73560a9-5d20-4dce-8bdf-538b84e5aea1/ticks/636331542203426587","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"properties":{"statusCode":"Created","serviceRequestId":null},"status":{"value":"Accepted","localizedValue":"Accepted"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:20.3426587Z","submissionTimestamp":"2017-06-15T20:10:41.3300109Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20029']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 monitorclient/0.3.0 Azure-SDK-For-Python AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.insights/eventtypes/management/values?$filter=eventTimestamp%20ge%202017-05-05T04%3A10%3A49Z%20and%20correlationId%20eq%20%27b8232cfd-5846-4949-a2b5-60475b16d780%27&api-version=2015-04-01
+  response:
+    body: {string: '{"value":[{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"74a75f6d-5f5d-4a25-99f5-34381d6dedae","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/74a75f6d-5f5d-4a25-99f5-34381d6dedae/ticks/636331542214496826","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:21.4496826Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/8c76c4e6-ab23-4f0f-9e72-45dcf55fbb95/ticks/636331542212153096","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"statusCode":"Created","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","responseBody":"{\"name\":\"test-lb\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"type\":\"Microsoft.Network/loadBalancers\",\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\",\"privateIPAddress\":\"10.0.0.4\",\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}],\"backendAddressPools\":[{\"name\":\"bepool1\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}},{\"name\":\"bepool2\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\",\"etag\":\"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\"properties\":{\"provisioningState\":\"Succeeded\"}}],\"loadBalancingRules\":[],\"probes\":[],\"inboundNatRules\":[],\"outboundNatRules\":[],\"inboundNatPools\":[]}}"},"status":{"value":"Succeeded","localizedValue":"Succeeded"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:21.2153096Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Network/loadBalancers/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"59544866-db93-4a1c-a670-4188f831748f","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"f6b7e036-afe7-451f-8002-f7050a3f24c3","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/events/59544866-db93-4a1c-a670-4188f831748f/ticks/636331542209653184","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Network","localizedValue":"Microsoft.Network"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":{"value":"Microsoft.Network/loadBalancers","localizedValue":"Microsoft.Network/loadBalancers"},"operationId":"739eb912-937c-4fed-a9be-2bb7934d4d41","operationName":{"value":"Microsoft.Network/loadBalancers/write","localizedValue":"Microsoft.Network/loadBalancers/write"},"properties":{"requestbody":"{\"location\":\"westus\",\"tags\":{\"key\":\"super=value\"},\"properties\":{\"backendAddressPools\":[{\"name\":\"bepool1\"},{\"name\":\"bepool2\"}],\"frontendIPConfigurations\":[{\"name\":\"LoadBalancerFrontEnd\",\"properties\":{\"privateIPAllocationMethod\":\"Dynamic\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"}}}]}}"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:20.9653184Z","submissionTimestamp":"2017-06-15T20:10:40.24568Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"b73560a9-5d20-4dce-8bdf-538b84e5aea1","eventName":{"value":"EndRequest","localizedValue":"End
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/b73560a9-5d20-4dce-8bdf-538b84e5aea1/ticks/636331542203426587","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"properties":{"statusCode":"Created","serviceRequestId":null},"status":{"value":"Accepted","localizedValue":"Accepted"},"subStatus":{"value":"Created","localizedValue":"Created
+        (HTTP Status Code: 201)"},"eventTimestamp":"2017-06-15T20:10:20.3426587Z","submissionTimestamp":"2017-06-15T20:10:41.3300109Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},{"authorization":{"action":"Microsoft.Resources/deployments/write","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment"},"caller":"admin2@AzureSDKTeam.onmicrosoft.com","channels":"Operation","claims":{"aud":"https://management.core.windows.net/","iss":"https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/","iat":"1497556604","nbf":"1497556604","exp":"1497560504","http://schemas.microsoft.com/claims/authnclassreference":"1","aio":"Y2ZgYHCpMd2zJSHh9sHaqmOLfZk6DMyjWdwmHe1d2/0hNSkhmAkA","http://schemas.microsoft.com/claims/authnmethodsreferences":"pwd","appid":"04b07795-8ddb-461a-bbee-02f9e1bf7b46","appidacr":"0","e_exp":"262800","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname":"Admin2","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname":"Admin2","groups":"e4bb0b56-1014-40f8-88ab-3d8a8cb0e086,d758a069-52cc-47f6-bc00-961cea17be39","ipaddr":"167.220.0.229","name":"Admin2","http://schemas.microsoft.com/identity/claims/objectidentifier":"5963f50c-7c43-405c-af7e-53294de76abd","platf":"14","puid":"1003BFFD959F8423","http://schemas.microsoft.com/identity/claims/scope":"user_impersonation","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":"sDgexRwCNIfY-hzQjjCDvZT7Izdfo4Syrr4x0dDNzR4","http://schemas.microsoft.com/identity/claims/tenantid":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name":"admin2@AzureSDKTeam.onmicrosoft.com","http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn":"admin2@AzureSDKTeam.onmicrosoft.com","ver":"1.0","wids":"62e90394-69f5-4237-9190-012177145e10"},"correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","description":"","eventDataId":"89d46fa2-00f4-4e20-acb3-92aeac6f8d3e","eventName":{"value":"BeginRequest","localizedValue":"Begin
+        request"},"category":{"value":"Administrative","localizedValue":"Administrative"},"httpRequest":{"clientRequestId":"a79b3190-5206-11e7-b4af-a0b3ccf7272a","clientIpAddress":"167.220.1.229","method":"PUT"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/events/89d46fa2-00f4-4e20-acb3-92aeac6f8d3e/ticks/636331542194986937","level":"Informational","resourceGroupName":"cli_test_deployment000001","resourceProviderName":{"value":"Microsoft.Resources","localizedValue":"Microsoft
+        Resources"},"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","resourceType":{"value":"Microsoft.Resources/deployments","localizedValue":"Microsoft.Resources/deployments"},"operationId":"b8232cfd-5846-4949-a2b5-60475b16d780","operationName":{"value":"Microsoft.Resources/deployments/write","localizedValue":"Microsoft.Resources/deployments/write"},"status":{"value":"Started","localizedValue":"Started"},"subStatus":{"value":"","localizedValue":""},"eventTimestamp":"2017-06-15T20:10:19.4986937Z","submissionTimestamp":"2017-06-15T20:10:30.6284676Z","subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20029']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: ['Accept-Encoding,Accept-Encoding']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b58cf52-4c90-11e7-9b16-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587046499225358060?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587040494654689172?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:23:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b58cf52-4c90-11e7-9b16-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"18048340065001902796","parameters":{"location":{"type":"String","value":"westus"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"name":{"type":"String","value":"test-lb"},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:51.7379575Z","duration":"PT8.796149S","correlationId":"c18f33be-ece9-4c12-96b9-eabd6fd111ff","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/loadBalancers/test-lb"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"6408713692666354622","parameters":{"location":{"type":"String","value":"westus"},"tags":{"type":"Object","value":{"key":"super=value"}},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"name":{"type":"String","value":"test-lb"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:21.4099596Z","duration":"PT1.4012558S","correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"}]}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:23:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['1206']
+      cache-control: [no-cache]
+      content-length: ['1393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [network lb show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
-          msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          msrest_azure/0.4.7 networkmanagementclient/1.0.0rc3 Azure-SDK-For-Python
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae78895c-4c90-11e7-adda-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb?api-version=2017-03-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"18048340065001902796","parameters":{"location":{"type":"String","value":"westus"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"name":{"type":"String","value":"test-lb"},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:51.7379575Z","duration":"PT8.796149S","correlationId":"c18f33be-ece9-4c12-96b9-eabd6fd111ff","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/loadBalancers/test-lb"}]}}]}'}
+    body: {string: "{\r\n  \"name\": \"test-lb\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb\"\
+        ,\r\n  \"etag\": \"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westus\"\
+        ,\r\n  \"tags\": {\r\n    \"key\": \"super=value\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"5dfd3e9a-ce5b-431e-be12-87e156d8ea66\",\r\n    \"frontendIPConfigurations\"\
+        : [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n        \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\
+        ,\r\n        \"etag\": \"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1\"\
+        \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\"\
+        : [\r\n      {\r\n        \"name\": \"bepool1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool1\"\
+        ,\r\n        \"etag\": \"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        \r\n        }\r\n      },\r\n      {\r\n        \"name\": \"bepool2\",\r\n\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb/backendAddressPools/bepool2\"\
+        ,\r\n        \"etag\": \"W/\\\"deb1081f-8468-4ee2-89a3-00e28114da5d\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        \r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n\
+        \    \"probes\": [],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\"\
+        : [],\r\n    \"inboundNatPools\": []\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:23:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['1218']
+      cache-control: [no-cache]
+      content-length: ['2420']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:50 GMT']
+      etag: [W/"deb1081f-8468-4ee2-89a3-00e28114da5d"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aeb3b476-4c90-11e7-ba4f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"18048340065001902796","parameters":{"location":{"type":"String","value":"westus"},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"name":{"type":"String","value":"test-lb"},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:51.7379575Z","duration":"PT8.796149S","correlationId":"c18f33be-ece9-4c12-96b9-eabd6fd111ff","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/loadBalancers/test-lb"}]}}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"6408713692666354622","parameters":{"location":{"type":"String","value":"westus"},"tags":{"type":"Object","value":{"key":"super=value"}},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"name":{"type":"String","value":"test-lb"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:21.4099596Z","duration":"PT1.4012558S","correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"}]}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:23:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['1206']
+      cache-control: [no-cache]
+      content-length: ['1405']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
           msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+          AZURECLI/2.0.9+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aeea1dd2-4c90-11e7-a097-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-deployment-test/deployments/mock-deployment/operations?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment/operations/62E23BA3072F9A59","operationId":"62E23BA3072F9A59","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:49.7320302Z","duration":"PT3.1487534S","trackingId":"25239975-d954-465b-897a-708ab8de526f","serviceRequestId":"1d49c05c-2558-47e1-84ac-d104ba980e53","statusCode":"Created","targetResource":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"test-lb"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azure-cli-deployment-test/providers/Microsoft.Resources/deployments/azure-cli-deployment/operations/08587046499225358060","operationId":"08587046499225358060","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2017-06-08T21:22:51.4958641Z","duration":"PT1.3552308S","trackingId":"52533323-6355-43b1-b5ca-d54f37c55fea","statusCode":"OK","statusMessage":null}}]}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment","name":"azure-cli-deployment","properties":{"templateHash":"6408713692666354622","parameters":{"location":{"type":"String","value":"westus"},"tags":{"type":"Object","value":{"key":"super=value"}},"privateIPAllocationMethod":{"type":"String","value":"Dynamic"},"name":{"type":"String","value":"test-lb"},"backendAddressPools":{"type":"Array","value":[{"name":"bepool1"},{"name":"bepool2"}]},"subnetId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:21.4099596Z","duration":"PT1.4012558S","correlationId":"b8232cfd-5846-4949-a2b5-60475b16d780","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb"}]}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Jun 2017 21:23:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['1272']
+      cache-control: [no-cache]
+      content-length: ['1393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group deployment operation list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001/deployments/mock-deployment/operations?api-version=2017-05-10
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/operations/BDF6DEB6CF066808","operationId":"BDF6DEB6CF066808","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:21.2323261Z","duration":"PT0.4173229S","trackingId":"54c6f4d1-3680-4636-a172-e3a85ddb5f91","serviceRequestId":"f01a0be4-f105-42e3-af90-e63ad09c45fb","statusCode":"Created","targetResource":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Network/loadBalancers/test-lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"test-lb"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-deployment/operations/08587040494654689172","operationId":"08587040494654689172","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2017-06-15T20:10:21.3811157Z","duration":"PT0.1108897S","trackingId":"5504e6a1-ff15-47b0-8cb8-cf4cf0e4321a","statusCode":"OK","statusMessage":null}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1404']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 15 Jun 2017 20:10:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.7
+          msrest_azure/0.4.7 resourcemanagementclient/1.1.0rc1 Azure-SDK-For-Python
+          AZURECLI/2.0.9+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_deployment000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 15 Jun 2017 20:10:52 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGREVQTE9ZTUVOVFAzQzdCQlVVNUVPU0tPV0ZNMlE0QzRLTXxGQTIwQkM5MDBBMzBFRDFCLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      retry-after: ['15']
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-resource/tests/test-params.json
+++ b/src/command_modules/azure-cli-resource/tests/test-params.json
@@ -10,6 +10,11 @@
     },
     "privateIPAllocationMethod": {
       "value": "Dynamic"
+    },
+    "tags": {
+      "value": {
+        "key": "super=value"
+      }
     }
   }
 }

--- a/src/command_modules/azure-cli-resource/tests/test-template.json
+++ b/src/command_modules/azure-cli-resource/tests/test-template.json
@@ -16,6 +16,9 @@
     },
     "backendAddressPools": {
       "type": "array"
+    },
+    "tags": {
+      "type": "object"
     }
   },
   "resources": [
@@ -38,6 +41,7 @@
         ],
         "backendAddressPools": "[parameters('backendAddressPools')]"
       },
+      "tags": "[parameters('tags')]",
       "type": "Microsoft.Network/loadBalancers"
     }
   ]

--- a/src/command_modules/azure-cli-resource/tests/test_custom.py
+++ b/src/command_modules/azure-cli-resource/tests/test_custom.py
@@ -176,7 +176,7 @@ class TestCustom(unittest.TestCase):
             {
                 "parameter_list": [['{"foo": "bar"}', '{"foo": "baz"}']],
                 "expected": {"foo": "baz"},
-            },
+            }
         ]
 
         for test in tests:


### PR DESCRIPTION
Fixes #3729.

Ensures that `--parameters <JSON String>` or `--parameters @<file>` no longer are ignored if the contents contain an = sign.  Enhances existing test to protect against regressions for this scenario.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
