### PR TITLE
[ARM] Add `--ids` support to resource commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -89,11 +89,27 @@ def deployment_validate_table_format(result):
     return result
 
 
-def _build_parent_string(kwargs):
+def _populate_alternate_kwargs(kwargs):
+    """ Translates the parsed arguments into a format used by generic ARM commands
+    such as the resource and lock commands. """
     parent = ''
     has_child = all(kwargs[x] is not None for x in ['child_name', 'child_type'])
     has_grandchild = all(kwargs[x] is not None for x in ['grandchild_name', 'grandchild_type'])
-    return parent
+    resource_namespace = kwargs['namespace']
+    resource_type = kwargs['grandchild_type'] or kwargs['child_type'] or kwargs['type']
+    resource_name = kwargs['grandchild_name'] or kwargs['child_name'] or kwargs['name']
+    if has_grandchild:
+        parent = '{type}/{name}/providers/{child_namespace}/{child_type}/{child_name}/providers/{grandchild_namespace}'.format(**kwargs)  # pylint: disable=line-too-long
+    elif has_child:
+        parent = '{type}/{name}/providers/{child_namespace}'.format(**kwargs)
+    parent = parent.replace('providers/None', '')
+    parent = '{}/'.format(parent) if parent and not parent.endswith('/') else parent
+
+    kwargs['resource_parent'] = parent
+    kwargs['resource_namespace'] = resource_namespace
+    kwargs['resource_type'] = resource_type
+    kwargs['resource_name'] = resource_name
+    return kwargs
 
 
 def resource_id(**kwargs):
@@ -136,21 +152,23 @@ def parse_resource_id(rid):
         - subscription          Subscription id
         - resource_group        Name of resource group
         - namespace             Namespace for the resource provider (i.e. Microsoft.Compute)
-        - type                  Type of the resource (i.e. virtualMachines)
-        - name                  Name of the resource (or parent if child_name is also specified)
+        - type                  Type of the root resource (i.e. virtualMachines)
+        - name                  Name of the root resource
         - child_namespace       Namespace for the child resoure (optional)
         - child_type            Type of the child resource
         - child_name            Name of the child resource
         - grandchild_namespace  Namespace for the grandchild resource (optional)
         - grandchild_type       Type of the grandchild resource
         - grandchild_name       Name of the grandchild resource
-        - parent                Computed helper of everything between the namespace and right-most
-                                resource type and name.
+        - resource_parent       Computed parent in the following pattern: providers/{namespace}/{parent}/{type}/{name}
+        - resource_namespace    Same as namespace. Note that this may be different than the target resource's namespace.
+        - resource_type         Type of the target resource (not the parent)
+        - resource_name         Name of the target resource (not the parent)
     '''
     m = regex.match(rid)
     if m:
         result = m.groupdict()
-        result['parent'] = _build_parent_string(result)
+        result = _populate_alternate_kwargs(result)
     else:
         result = dict(name=rid)
 
@@ -223,7 +241,8 @@ def add_id_parameters(command_table):
         return SplitAction
 
     def command_loaded_handler(command):
-        if 'name' not in [arg.id_part for arg in command.arguments.values() if arg.id_part]:
+        id_parts = [arg.id_part for arg in command.arguments.values() if arg.id_part]
+        if 'name' not in id_parts and 'resource_name' not in id_parts:
             # Only commands with a resource name are candidates for an id parameter
             return
         if command.name.split()[-1] == 'create':

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -91,6 +91,8 @@ def deployment_validate_table_format(result):
 
 def _build_parent_string(kwargs):
     parent = ''
+    has_child = all(kwargs[x] is not None for x in ['child_name', 'child_type'])
+    has_grandchild = all(kwargs[x] is not None for x in ['grandchild_name', 'grandchild_type'])
     return parent
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_arm.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_arm.py
@@ -10,88 +10,151 @@ from azure.cli.core.commands.arm import parse_resource_id
 
 class TestARM(unittest.TestCase):
     def test_resource_parse(self):
-        tests = [{
-            'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
-                           '/Microsoft.Storage/storageAccounts/foo/providers'
-                           '/Microsoft.Authorization/locks/bar',
-            'expected': {
-                'name': 'foo',
-                'type': 'storageAccounts',
-                'namespace': 'Microsoft.Storage',
-                'child_name': 'bar',
-                'child_namespace': 'Microsoft.Authorization',
-                'child_type': 'locks',
-                'resource_group': 'testgroup',
-                'subscription': 'fakesub',
-            }
-        }, {
-            'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
-                           '/Microsoft.Storage/storageAccounts/foo'
-                           '/locks/bar',
-            'expected': {
-                'name': 'foo',
-                'type': 'storageAccounts',
-                'namespace': 'Microsoft.Storage',
-                'child_name': 'bar',
-                'child_type': 'locks',
-                'resource_group': 'testgroup',
-                'subscription': 'fakesub',
-            }
-        }, {
-            'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
-                           '/Microsoft.Storage/storageAccounts/foo',
-            'expected': {
-                'name': 'foo',
-                'type': 'storageAccounts',
-                'namespace': 'Microsoft.Storage',
-                'resource_group': 'testgroup',
-                'subscription': 'fakesub',
-            }
-        }, {
-            'resource_id': '/subscriptions/fakesub/providers/Microsoft.Authorization'
-                           '/locks/foo',
-            'expected': {
-                'name': 'foo',
-                'type': 'locks',
-                'namespace': 'Microsoft.Authorization',
-                'subscription': 'fakesub',
-            }
-        }, {
-            'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
-                           '/Microsoft.Storage/storageAccounts/foo/providers'
-                           '/Microsoft.Authorization/locks/bar/nets/gc',
-            'expected': {
-                'name': 'foo',
-                'type': 'storageAccounts',
-                'namespace': 'Microsoft.Storage',
-                'child_name': 'bar',
-                'child_namespace': 'Microsoft.Authorization',
-                'child_type': 'locks',
-                'grandchild_name': 'gc',
-                'grandchild_type': 'nets',
-                'resource_group': 'testgroup',
-                'subscription': 'fakesub',
-            }
-        }, {
-            'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
-                           '/Microsoft.Storage/storageAccounts/foo'
-                           '/locks/bar/nets/gc',
-            'expected': {
-                'name': 'foo',
-                'type': 'storageAccounts',
-                'namespace': 'Microsoft.Storage',
-                'child_name': 'bar',
-                'child_type': 'locks',
-                'grandchild_name': 'gc',
-                'grandchild_type': 'nets',
-                'resource_group': 'testgroup',
-                'subscription': 'fakesub',
-            }
-        }]
 
+        tests = [
+            {
+                'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
+                               '/Microsoft.Storage/storageAccounts/foo/providers'
+                               '/Microsoft.Authorization/locks/bar',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'storageAccounts',
+                    'namespace': 'Microsoft.Storage',
+                    'child_name': 'bar',
+                    'child_namespace': 'Microsoft.Authorization',
+                    'child_type': 'locks',
+                    'resource_group': 'testgroup',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
+                               '/Microsoft.Storage/storageAccounts/foo'
+                               '/locks/bar',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'storageAccounts',
+                    'namespace': 'Microsoft.Storage',
+                    'child_name': 'bar',
+                    'child_type': 'locks',
+                    'resource_group': 'testgroup',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
+                               '/Microsoft.Storage/storageAccounts/foo',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'storageAccounts',
+                    'namespace': 'Microsoft.Storage',
+                    'resource_group': 'testgroup',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/fakesub/providers/Microsoft.Authorization'
+                               '/locks/foo',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'locks',
+                    'namespace': 'Microsoft.Authorization',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
+                               '/Microsoft.Storage/storageAccounts/foo/providers'
+                               '/Microsoft.Authorization/locks/bar/nets/gc',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'storageAccounts',
+                    'namespace': 'Microsoft.Storage',
+                    'child_name': 'bar',
+                    'child_namespace': 'Microsoft.Authorization',
+                    'child_type': 'locks',
+                    'grandchild_name': 'gc',
+                    'grandchild_type': 'nets',
+                    'resource_group': 'testgroup',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
+                               '/Microsoft.Storage/storageAccounts/foo'
+                               '/locks/bar/nets/gc',
+                'expected': {
+                    'name': 'foo',
+                    'type': 'storageAccounts',
+                    'namespace': 'Microsoft.Storage',
+                    'child_name': 'bar',
+                    'child_type': 'locks',
+                    'grandchild_name': 'gc',
+                    'grandchild_type': 'nets',
+                    'resource_group': 'testgroup',
+                    'subscription': 'fakesub',
+                }
+            },
+            {
+                'resource_id': '/subscriptions/mySub/resourceGroups/myRg/providers/'
+                               'Microsoft.Provider1/resourceType1/name1',
+                'expected': {
+                    'subscription': 'mySub',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.Provider1',
+                    'type': 'resourceType1',
+                    'name': 'name1',
+                    'resource_parent': '',
+                    'resource_namespace': 'Microsoft.Provider1',
+                    'resource_type': 'resourceType1',
+                    'resource_name': 'name1'
+                }
+            },
+            {
+                'resource_id': '/subscriptions/mySub/resourceGroups/myRg/providers/'
+                               'Microsoft.Provider1/resourceType1/name1/resourceType2/name2',
+                'expected': {
+                    'subscription': 'mySub',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.Provider1',
+                    'type': 'resourceType1',
+                    'name': 'name1',
+                    'child_namespace': None,
+                    'child_type': 'resourceType2',
+                    'child_name': 'name2',
+                    'resource_parent': 'resourceType1/name1/',
+                    'resource_namespace': 'Microsoft.Provider1',
+                    'resource_type': 'resourceType2',
+                    'resource_name': 'name2'
+                }
+            },
+            {
+                'resource_id': '/subscriptions/mySub/resourceGroups/myRg/providers/'
+                               'Microsoft.Provider1/resourceType1/name1/providers/'
+                               'Microsoft.Provider2/resourceType2/name2',
+                'expected': {
+                    'subscription': 'mySub',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.Provider1',
+                    'type': 'resourceType1',
+                    'name': 'name1',
+                    'child_namespace': 'Microsoft.Provider2',
+                    'child_type': 'resourceType2',
+                    'child_name': 'name2',
+                    'resource_parent': 'resourceType1/name1/providers/Microsoft.Provider2/',
+                    'resource_namespace': 'Microsoft.Provider1',
+                    'resource_type': 'resourceType2',
+                    'resource_name': 'name2'
+                }
+            }
+        ]
         for test in tests:
-            resource = parse_resource_id(test['resource_id'])
-            self.assertDictEqual(resource, test['expected'])
+            kwargs = parse_resource_id(test['resource_id'])
+            for key in test['expected']:
+                try:
+                    self.assertEqual(kwargs[key], test['expected'][key])
+                except KeyError:
+                    self.assertTrue(key not in kwargs and test['expected'][key] is None)
 
 
 if __name__ == "__main__":

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -11,6 +11,7 @@ unreleased
 2.0.9 (2017-06-21)
 ++++++++++++++++++
 * `group deployment create`: Fixes issue where some parameter files were no longer recognized using @<file> syntax.
+* `resource` commands: Support `--ids` argument.
 
 
 2.0.8 (2017-06-13)

--- a/src/command_modules/azure-cli-resource/HISTORY.rst
+++ b/src/command_modules/azure-cli-resource/HISTORY.rst
@@ -11,7 +11,7 @@ unreleased
 2.0.9 (2017-06-21)
 ++++++++++++++++++
 * `group deployment create`: Fixes issue where some parameter files were no longer recognized using @<file> syntax.
-* `resource` commands: Support `--ids` argument.
+* `resource\managedapp` commands: Support `--ids` argument.
 
 
 2.0.8 (2017-06-13)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -28,17 +28,19 @@ resource_parent_type = CliArgumentType(required=False, options_list=('--parent',
                                        help="The parent path (Ex: 'resA/myA/resB/myB')")
 _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''
 register_cli_argument('resource', 'no_wait', no_wait_type)
-register_cli_argument('resource', 'resource_name', resource_name_type, id_part='name')
-register_cli_argument('resource', 'api_version', help='The api version of the resource (omit for latest)', required=False)
 register_cli_argument('resource', 'resource_id', ignore_type)
-register_cli_argument('resource', 'resource_provider_namespace', resource_namespace_type, id_part='namespace')
-register_cli_argument('resource', 'resource_type', arg_type=resource_type_type, completer=get_resource_types_completion_list, id_part='type')
-register_cli_argument('resource', 'parent_resource_path', resource_parent_type, id_part='parent')
+register_cli_argument('resource', 'resource_name', resource_name_type, id_part='resource_name')
+register_cli_argument('resource', 'api_version', help='The api version of the resource (omit for latest)', required=False)
+register_cli_argument('resource', 'resource_provider_namespace', resource_namespace_type, id_part='resource_namespace')
+register_cli_argument('resource', 'resource_type', arg_type=resource_type_type, completer=get_resource_types_completion_list, id_part='resource_type')
+register_cli_argument('resource', 'parent_resource_path', resource_parent_type, id_part='resource_parent')
 register_cli_argument('resource', 'tag', tag_type)
 register_cli_argument('resource', 'tags', tags_type)
 
 register_cli_argument('resource list', 'name', resource_name_type)
 register_cli_argument('resource move', 'ids', nargs='+')
+
+register_cli_argument('resource create', 'resource_id', options_list=['--id'], help='Resource ID.', action=None)
 register_cli_argument('resource create', 'properties', options_list=('--properties', '-p'),
                       help='a JSON-formatted string containing resource properties')
 register_cli_argument('resource create', 'is_full_object', action='store_true',

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -102,16 +102,17 @@ register_cli_argument('lock', 'resource_type', arg_type=resource_type_type,
                       completer=get_resource_types_completion_list,)
 register_cli_argument('lock', 'resource_name', options_list=('--resource-name'))
 
-register_cli_argument('managedapp', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group of the managed application')
-register_cli_argument('managedapp', 'appliance_name', options_list=('--name', '-n'))
-register_cli_argument('managedapp', 'managedapp_id', options_list=('--id',), help='The managed application resource ID')
-register_cli_argument('managedapp definition', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group of the managed application definition')
-register_cli_argument('managedapp definition', 'appliance_definition_name', options_list=('--name', '-n'))
-register_cli_argument('managedapp definition', 'managedapp_definition_id', options_list=('--id',), help='The managed application definition resource ID')
+register_cli_argument('managedapp', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group of the managed application', id_part='resource_group')
+register_cli_argument('managedapp', 'appliance_name', options_list=('--name', '-n'), id_part='name')
+
+register_cli_argument('managedapp definition', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group of the managed application definition', id_part='resource_group')
+register_cli_argument('managedapp definition', 'appliance_definition_name', options_list=('--name', '-n'), id_part='name')
+
 register_cli_argument('managedapp create', 'name', options_list=('--name', '-n'), help='name of the new managed application', completer=None)
 register_cli_argument('managedapp create', 'location', help='the managed application location')
 register_cli_argument('managedapp create', 'managedapp_definition_id', options_list=('--managedapp-definition-id', '-d'), help='the full qualified managed application definition id')
 register_cli_argument('managedapp create', 'managedby_resource_group_id', options_list=('--managed-rg-id', '-m'), help='the resource group managed by the managed application')
 register_cli_argument('managedapp create', 'parameters', help='JSON formatted string or a path to a file with such content', type=file_type)
+
 register_cli_argument('managedapp definition create', 'lock_level', **enum_choice_list(ApplianceLockLevel))
 register_cli_argument('managedapp definition create', 'authorizations', options_list=('--authorizations', '-a'), nargs='+', help="space separated authorization pairs in a format of <principalId>:<roleDefinitionId>")

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -28,15 +28,15 @@ resource_parent_type = CliArgumentType(required=False, options_list=('--parent',
                                        help="The parent path (Ex: 'resA/myA/resB/myB')")
 _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''
 register_cli_argument('resource', 'no_wait', no_wait_type)
-register_cli_argument('resource', 'resource_name', resource_name_type)
+register_cli_argument('resource', 'resource_name', resource_name_type, id_part='name')
 register_cli_argument('resource', 'api_version', help='The api version of the resource (omit for latest)', required=False)
-register_cli_argument('resource', 'resource_id', options_list=('--id',), help='Resource ID')
-register_cli_argument('resource', 'resource_provider_namespace', resource_namespace_type)
-register_cli_argument('resource', 'resource_type', arg_type=resource_type_type,
-                      completer=get_resource_types_completion_list)
-register_cli_argument('resource', 'parent_resource_path', resource_parent_type)
+register_cli_argument('resource', 'resource_id', ignore_type)
+register_cli_argument('resource', 'resource_provider_namespace', resource_namespace_type, id_part='namespace')
+register_cli_argument('resource', 'resource_type', arg_type=resource_type_type, completer=get_resource_types_completion_list, id_part='type')
+register_cli_argument('resource', 'parent_resource_path', resource_parent_type, id_part='parent')
 register_cli_argument('resource', 'tag', tag_type)
 register_cli_argument('resource', 'tags', tags_type)
+
 register_cli_argument('resource list', 'name', resource_name_type)
 register_cli_argument('resource move', 'ids', nargs='+')
 register_cli_argument('resource create', 'properties', options_list=('--properties', '-p'),

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -464,10 +464,10 @@ def create_resource(properties,
 
 def show_resource(resource_group_name=None,
                   resource_provider_namespace=None, parent_resource_path=None, resource_type=None,
-                  resource_name=None, resource_id=None, api_version=None):
+                  resource_name=None, api_version=None):
     res = _ResourceUtils(resource_group_name, resource_provider_namespace,
                          parent_resource_path, resource_type, resource_name,
-                         resource_id, api_version)
+                         None, api_version)
     return res.get_resource()
 
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -127,32 +127,22 @@ def create_appliance(resource_group_name,
     return racf.appliances.create_or_update(resource_group_name, appliance_name, appliance)
 
 
-def show_appliance(resource_group_name=None, appliance_name=None, managedapp_id=None):
+def show_appliance(resource_group_name=None, appliance_name=None):
     """ Gets a managed application.
     :param str resource_group_name:the resource group name
     :param str appliance_name:the managed application name
     """
     racf = _resource_managedapps_client_factory()
-    if managedapp_id:
-        appliance = racf.appliances.get_by_id(managedapp_id)
-    else:
-        appliance = racf.appliances.get(resource_group_name, appliance_name)
-    return appliance
+    return racf.appliances.get(resource_group_name, appliance_name)
 
 
-def show_appliancedefinition(resource_group_name=None, appliance_definition_name=None,
-                             managedapp_definition_id=None):
+def show_appliancedefinition(resource_group_name=None, appliance_definition_name=None):
     """ Gets a managed application definition.
     :param str resource_group_name:the resource group name
     :param str appliance_definition_name:the managed application definition name
     """
     racf = _resource_managedapps_client_factory()
-    if managedapp_definition_id:
-        appliancedef = racf.appliance_definitions.get_by_id(managedapp_definition_id)
-    else:
-        appliancedef = racf.appliance_definitions.get(resource_group_name,
-                                                      appliance_definition_name)
-    return appliancedef
+    return racf.appliance_definitions.get(resource_group_name, appliance_definition_name)
 
 
 def create_appliancedefinition(resource_group_name,

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/latest/test_resource_id_scenario.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/latest/test_resource_id_scenario.yaml
@@ -6,14 +6,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec0c01c6-5abe-11e7-b706-a0b3ccf7272a]
+      x-ms-client-request-id: [0a86900f-5b58-11e7-89b1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -102,14 +102,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:29:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:45:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -118,88 +118,89 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec32143a-5abe-11e7-8e6a-a0b3ccf7272a]
+      x-ms-client-request-id: [0ab4cc00-5b58-11e7-9ecd-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_vnet\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"f5d4eb4b-063a-4324-97c2-013049130c1e\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_vnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
+        ,\r\n  \"etag\": \"W/\\\"7c10dcea-b13e-4712-abd8-710b1d0a9298\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"32a82309-5b4c-4cbb-8f9b-f308b611d454\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ac063eb5-d7d2-4875-a6c9-e2414ef51a14\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"cli_test_resource_id_subnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n        \"etag\": \"W/\\\"f5d4eb4b-063a-4324-97c2-013049130c1e\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"7c10dcea-b13e-4712-abd8-710b1d0a9298\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:29:31 GMT']
-      ETag: [W/"f5d4eb4b-063a-4324-97c2-013049130c1e"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['1164']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:45:34 GMT']
+      etag: [W/"7c10dcea-b13e-4712-abd8-710b1d0a9298"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"tag-vnet": ""}, "location": "westus", "properties": {"addressSpace":
-      {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name": "cli_test_resource_id_subnet",
-      "etag": "W/\"f5d4eb4b-063a-4324-97c2-013049130c1e\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet",
-      "properties": {"addressPrefix": "10.0.0.0/24", "provisioningState": "Succeeded"}}],
-      "provisioningState": "Succeeded", "virtualNetworkPeerings": [], "dhcpOptions":
-      {"dnsServers": []}, "resourceGuid": "32a82309-5b4c-4cbb-8f9b-f308b611d454"}}'
+    body: !!python/unicode '{"location": "westus", "properties": {"subnets": [{"etag":
+      "W/\"7c10dcea-b13e-4712-abd8-710b1d0a9298\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet",
+      "name": "cli_test_resource_id_subnet", "properties": {"addressPrefix": "10.0.0.0/24",
+      "provisioningState": "Succeeded"}}], "dhcpOptions": {"dnsServers": []}, "virtualNetworkPeerings":
+      [], "provisioningState": "Succeeded", "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+      "resourceGuid": "ac063eb5-d7d2-4875-a6c9-e2414ef51a14"}, "tags": {"tag-vnet":
+      ""}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['672']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec5a56b0-5abe-11e7-ab50-a0b3ccf7272a]
+      x-ms-client-request-id: [0ae35611-5b58-11e7-af12-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_vnet\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_vnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
+        ,\r\n  \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {\r\n    \"tag-vnet\": \"\"\r\n  },\r\n  \"properties\":\
         \ {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"32a82309-5b4c-4cbb-8f9b-f308b611d454\",\r\n    \"addressSpace\": {\r\n\
+        \ \"ac063eb5-d7d2-4875-a6c9-e2414ef51a14\",\r\n    \"addressSpace\": {\r\n\
         \      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n  \
         \  },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n\
         \    \"subnets\": [\r\n      {\r\n        \"name\": \"cli_test_resource_id_subnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n        \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/009aac68-8e9e-494b-aa47-915063660257?api-version=2017-06-01']
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:29:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/03038adf-9a2b-4d18-a959-9916c5349945?api-version=2017-06-01']
+      cache-control: [no-cache]
       content-length: ['1188']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:45:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -208,25 +209,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec5a56b0-5abe-11e7-ab50-a0b3ccf7272a]
+      x-ms-client-request-id: [0ae35611-5b58-11e7-af12-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/009aac68-8e9e-494b-aa47-915063660257?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/03038adf-9a2b-4d18-a959-9916c5349945?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -235,40 +236,40 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec5a56b0-5abe-11e7-ab50-a0b3ccf7272a]
+      x-ms-client-request-id: [0ae35611-5b58-11e7-af12-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_vnet\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_vnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
+        ,\r\n  \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {\r\n    \"tag-vnet\": \"\"\r\n  },\r\n  \"properties\":\
         \ {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"32a82309-5b4c-4cbb-8f9b-f308b611d454\",\r\n    \"addressSpace\": {\r\n\
+        \ \"ac063eb5-d7d2-4875-a6c9-e2414ef51a14\",\r\n    \"addressSpace\": {\r\n\
         \      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n  \
         \  },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n\
         \    \"subnets\": [\r\n      {\r\n        \"name\": \"cli_test_resource_id_subnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n        \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:01 GMT']
-      ETag: [W/"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['1188']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:06 GMT']
+      etag: [W/"01f834e9-47ff-4517-801a-b121472c3922"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -277,14 +278,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff2e964a-5abe-11e7-a229-a0b3ccf7272a]
+      x-ms-client-request-id: [1dadab5e-5b58-11e7-861e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -373,14 +374,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -389,40 +390,40 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff5a2dcc-5abe-11e7-8e42-a0b3ccf7272a]
+      x-ms-client-request-id: [1dc949ae-5b58-11e7-92c4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_vnet\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_vnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet\"\
+        ,\r\n  \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {\r\n    \"tag-vnet\": \"\"\r\n  },\r\n  \"properties\":\
         \ {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"32a82309-5b4c-4cbb-8f9b-f308b611d454\",\r\n    \"addressSpace\": {\r\n\
+        \ \"ac063eb5-d7d2-4875-a6c9-e2414ef51a14\",\r\n    \"addressSpace\": {\r\n\
         \      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n  \
         \  },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n\
         \    \"subnets\": [\r\n      {\r\n        \"name\": \"cli_test_resource_id_subnet\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n        \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"addressPrefix\": \"10.0.0.0/24\"\r\n        }\r\n      }\r\
         \n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:03 GMT']
-      ETag: [W/"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['1188']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:07 GMT']
+      etag: [W/"01f834e9-47ff-4517-801a-b121472c3922"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -431,14 +432,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff86ea08-5abe-11e7-ae05-a0b3ccf7272a]
+      x-ms-client-request-id: [1e00111e-5b58-11e7-b01f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -527,14 +528,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -543,30 +544,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ffb0531e-5abe-11e7-8a87-a0b3ccf7272a]
+      x-ms-client-request-id: [1e1cc0e1-5b58-11e7-81f5-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_subnet\",\r\n  \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_subnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
+        ,\r\n  \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/24\"\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:03 GMT']
-      ETag: [W/"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['414']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:07 GMT']
+      etag: [W/"01f834e9-47ff-4517-801a-b121472c3922"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -575,14 +576,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fffe5a10-5abe-11e7-b5a3-a0b3ccf7272a]
+      x-ms-client-request-id: [1e633fc0-5b58-11e7-8e1c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -671,14 +672,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -687,30 +688,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [00313c9c-5abf-11e7-8fff-a0b3ccf7272a]
+      x-ms-client-request-id: [1ebea630-5b58-11e7-9106-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_subnet\",\r\n  \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_subnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
+        ,\r\n  \"etag\": \"W/\\\"01f834e9-47ff-4517-801a-b121472c3922\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/24\"\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:04 GMT']
-      ETag: [W/"0705dda9-52b7-4c94-a3d9-7a89eedb3ce4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['414']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:08 GMT']
+      etag: [W/"01f834e9-47ff-4517-801a-b121472c3922"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -719,14 +720,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [005abc8c-5abf-11e7-9ff0-a0b3ccf7272a]
+      x-ms-client-request-id: [1ef8c900-5b58-11e7-9475-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -815,49 +816,50 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"addressPrefix": "10.0.0.0/22", "provisioningState": "Succeeded"}}'
+    body: !!python/unicode '{"properties": {"addressPrefix": "10.0.0.0/22", "provisioningState":
+      "Succeeded"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['82']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0087c62c-5abf-11e7-812e-a0b3ccf7272a]
+      x-ms-client-request-id: [1f166321-5b58-11e7-bf98-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_subnet\",\r\n  \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"af0d67d4-c3d0-4a74-a893-de7d89c02ea2\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_subnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
+        ,\r\n  \"etag\": \"W/\\\"abc64358-638b-4a66-8750-3bfaf4973aee\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/22\"\r\n  }\r\n}"}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d79bf952-ab74-4df5-8da9-87fbad066d77?api-version=2017-06-01']
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['3']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/5dac3b35-523a-4430-8b53-3734e81795e9?api-version=2017-06-01']
+      cache-control: [no-cache]
       content-length: ['413']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['3']
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -866,25 +868,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0087c62c-5abf-11e7-812e-a0b3ccf7272a]
+      x-ms-client-request-id: [1f166321-5b58-11e7-bf98-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d79bf952-ab74-4df5-8da9-87fbad066d77?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5dac3b35-523a-4430-8b53-3734e81795e9?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -893,30 +895,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0087c62c-5abf-11e7-812e-a0b3ccf7272a]
+      x-ms-client-request-id: [1f166321-5b58-11e7-bf98-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"name\": \"cli_test_resource_id_subnet\",\r\n  \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
-        ,\r\n  \"etag\": \"W/\\\"a100415c-5d78-49d0-a7e1-f84eae7196ec\\\"\",\r\n \
+    body: {string: !!python/unicode "{\r\n  \"name\": \"cli_test_resource_id_subnet\"\
+        ,\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet\"\
+        ,\r\n  \"etag\": \"W/\\\"35571a0a-ff89-4cb7-a13f-a0b810ed1187\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         addressPrefix\": \"10.0.0.0/22\"\r\n  }\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:08 GMT']
-      ETag: [W/"a100415c-5d78-49d0-a7e1-f84eae7196ec"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['414']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:12 GMT']
+      etag: [W/"35571a0a-ff89-4cb7-a13f-a0b810ed1187"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -925,14 +927,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [032bbd9a-5abf-11e7-9bfd-a0b3ccf7272a]
+      x-ms-client-request-id: [21b773cf-5b58-11e7-8e74-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -1021,14 +1023,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1038,26 +1040,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0355d5f6-5abf-11e7-acd0-a0b3ccf7272a]
+      x-ms-client-request-id: [21d7cd0f-5b58-11e7-af6f-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet/subnets/cli_test_resource_id_subnet?api-version=2017-06-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d4b1f59b-cdfd-4d42-9d64-976b90df773b?api-version=2017-06-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 26 Jun 2017 22:30:09 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/d4b1f59b-cdfd-4d42-9d64-976b90df773b?api-version=2017-06-01']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1a77cf7d-ea92-4d75-8742-979d8f530d4f?api-version=2017-06-01']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Tue, 27 Jun 2017 16:46:14 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/1a77cf7d-ea92-4d75-8742-979d8f530d4f?api-version=2017-06-01']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1066,25 +1068,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0355d5f6-5abf-11e7-acd0-a0b3ccf7272a]
+      x-ms-client-request-id: [21d7cd0f-5b58-11e7-af6f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d4b1f59b-cdfd-4d42-9d64-976b90df773b?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1a77cf7d-ea92-4d75-8742-979d8f530d4f?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1093,14 +1095,14 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0a3fc8d0-5abf-11e7-b971-a0b3ccf7272a]
+      x-ms-client-request-id: [28e119de-5b58-11e7-a465-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -1189,14 +1191,14 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"],"capabilities":"None"},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"serviceTunnelServices","locations":[],"apiVersions":["2017-06-01","2017-04-01"]}],"registrationState":"Registered"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['15217']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1206,26 +1208,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0a62fc8a-5abf-11e7-bd10-a0b3ccf7272a]
+      x-ms-client-request-id: [28ffc570-5b58-11e7-841d-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_id/providers/Microsoft.Network/virtualNetworks/cli_test_resource_id_vnet?api-version=2017-06-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4fe22460-ef06-46d0-be81-04703696e087?api-version=2017-06-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 26 Jun 2017 22:30:21 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/4fe22460-ef06-46d0-be81-04703696e087?api-version=2017-06-01']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/e731803e-b6dd-4c5a-95a1-841a46938f2f?api-version=2017-06-01']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Tue, 27 Jun 2017 16:46:25 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/e731803e-b6dd-4c5a-95a1-841a46938f2f?api-version=2017-06-01']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1234,24 +1236,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
           msrest_azure/0.4.9 resourcemanagementclient/1.1.0 Azure-SDK-For-Python AZURECLI/TEST/2.0.10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0a62fc8a-5abf-11e7-bd10-a0b3ccf7272a]
+      x-ms-client-request-id: [28ffc570-5b58-11e7-841d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4fe22460-ef06-46d0-be81-04703696e087?api-version=2017-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e731803e-b6dd-4c5a-95a1-841a46938f2f?api-version=2017-06-01
   response:
-    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Jun 2017 22:30:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['29']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 27 Jun 2017 16:46:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
@@ -518,7 +518,7 @@ class PolicyScenarioTest(ScenarioTest):
 class ManagedAppDefinitionScenarioTest(ScenarioTest):
     @ResourceGroupPreparer()
     def test_managedappdef(self, resource_group):
-        location = 'eastus2euap'
+        location = 'westcentralus'
         appdef_name = 'testappdefname'
         appdef_display_name = 'test_appdef_123'
         appdef_description = 'test_appdef_123'
@@ -528,7 +528,7 @@ class ManagedAppDefinitionScenarioTest(ScenarioTest):
 
         # create a managedapp definition
         create_cmd = 'managedapp definition create -n {} --package-file-uri {} --display-name {} --description {} -l {} -a {} --lock-level {} -g {}'
-        self.cmd(create_cmd.format(appdef_name, packageUri, appdef_display_name, appdef_description, location, auth, lock, resource_group), checks=[
+        appdef = self.cmd(create_cmd.format(appdef_name, packageUri, appdef_display_name, appdef_description, location, auth, lock, resource_group), checks=[
             JCheck('name', appdef_name),
             JCheck('displayName', appdef_display_name),
             JCheck('description', appdef_description),
@@ -538,7 +538,7 @@ class ManagedAppDefinitionScenarioTest(ScenarioTest):
             JCheck('artifacts[0].type', 'Template'),
             JCheck('artifacts[1].name', 'CreateUiDefinition'),
             JCheck('artifacts[1].type', 'Custom')
-        ])
+        ]).get_output_in_json()
 
         # list and show it
         list_cmd = 'managedapp definition list -g {}'
@@ -546,8 +546,8 @@ class ManagedAppDefinitionScenarioTest(ScenarioTest):
             JCheck('[0].name', appdef_name)
         ])
 
-        show_cmd = 'managedapp definition show -g {} -n {}'
-        self.cmd(show_cmd.format(resource_group, appdef_name), checks=[
+        show_cmd = 'managedapp definition show --ids {}'
+        self.cmd(show_cmd.format(appdef['id']), checks=[
             JCheck('name', appdef_name),
             JCheck('displayName', appdef_display_name),
             JCheck('description', appdef_description),
@@ -567,7 +567,7 @@ class ManagedAppDefinitionScenarioTest(ScenarioTest):
 class ManagedAppScenarioTest(ScenarioTest):
     @ResourceGroupPreparer()
     def test_managedapp(self, resource_group):
-        location = 'eastus2euap'
+        location = 'westcentralus'
         appdef_name = 'testappdefname'
         appdef_display_name = 'test_appdef_123'
         appdef_description = 'test_appdef_123'
@@ -582,18 +582,18 @@ class ManagedAppScenarioTest(ScenarioTest):
 
         # create a managedapp
         managedapp_name = 'mymanagedapp'
-        managedapp_loc = 'eastus2euap'
+        managedapp_loc = 'westcentralus'
         managedapp_kind = 'servicecatalog'
         newrg = self.create_random_name('climanagedapp', 25)
         managedrg = '/subscriptions/{}/resourceGroups/{}'.format(managedappdef['id'].split("/")[2], newrg)
         create_cmd = 'managedapp create -n {} -g {} -l {} --kind {} -m {} -d {}'
-        self.cmd(create_cmd.format(managedapp_name, resource_group, managedapp_loc, managedapp_kind, managedrg, managedappdef['id']), checks=[
+        app = self.cmd(create_cmd.format(managedapp_name, resource_group, managedapp_loc, managedapp_kind, managedrg, managedappdef['id']), checks=[
             JCheck('name', managedapp_name),
             JCheck('type', 'Microsoft.Solutions/appliances'),
             JCheck('kind', 'servicecatalog'),
             JCheck('managedResourceGroupId', managedrg),
             JCheck('applianceDefinitionId', managedappdef['id'])
-        ])
+        ]).get_output_in_json()
 
         # list and show
         list_byrg_cmd = 'managedapp list -g {}'
@@ -601,8 +601,8 @@ class ManagedAppScenarioTest(ScenarioTest):
             JCheck('[0].name', managedapp_name)
         ])
 
-        show_cmd = 'managedapp show -g {} -n {}'
-        self.cmd(show_cmd.format(resource_group, managedapp_name), checks=[
+        show_cmd = 'managedapp show --ids {}'
+        self.cmd(show_cmd.format(app['id']), checks=[
             JCheck('name', managedapp_name),
             JCheck('type', 'Microsoft.Solutions/appliances'),
             JCheck('kind', 'servicecatalog'),


### PR DESCRIPTION
Partially addresses #3479.

Enhances the parse_resource_id code to yield parameters that conform to the syntax required by the resource commands.

`providers/{resource_namespace}/{resource_parent}/{resource_type}/{resource_name}`

Note that this results in some bizarre behavior:

`providers/Microsoft.Network/virtualNetworks/vnet1/providers/Microsoft.Authorization/locks/lock1`

parses into the following:
```
resource_namespace: Microsoft.Network
resource_parent: virtualNetworks/vnet1/providers/Microsoft.Authoriation/
resource_type: locks
resource_name: lock1
```

So the namespace doesn't match the actual target resource's type at all. This wonky format required is what is required to use the SDK. 

Adds additional unit tests to prevent regressions in this parsing. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [X] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
