### PR TITLE
Fix "az cdn endpoint purge" command example in documentation

### DIFF
--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
@@ -127,7 +127,7 @@ helps['cdn endpoint purge'] = """
     examples:
         - name: Purge content for Javascript and CSS styles
           text: >
-            az cdn endpoint load -g group -n endpoint --profile-name profile-name --content-paths \\
+            az cdn endpoint purge -g group -n endpoint --profile-name profile-name --content-paths \\
                 '/scripts/app.js' '/styles/*'
 """
 


### PR DESCRIPTION
Fix copy-paste typo and replace `load` with `purge` command in "Purge content for Javascript and CSS styles" example.