### PR TITLE
Touch up pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -28,7 +28,7 @@ min-similarity-lines=10
 # The invalid-name checker must be **enabled** for these hints to be used.
 include-naming-hint=yes
 
-module-name-hint=lowercase (short; underscores are discouraged)
+module-name-hint=lowercase (keep short; underscores are discouraged)
 const-name-hint=UPPER_CASE_WITH_UNDERSCORES
 class-name-hint=CapitalizedWords
 class-attribute-name-hint=lower_case_with_underscores

--- a/pylintrc
+++ b/pylintrc
@@ -1,12 +1,9 @@
 [MESSAGES CONTROL]
-# For all codes, run 'pylint --list-msgs' or go to 'http://pylint-messages.wikidot.com/all-codes'
-# C0111 Missing docstring 
-# C0103 Invalid %s name "%s"
-# I0011 Warning locally suppressed using disable-msg
-# W0511 fixme
-# R0401 Cyclic import (because of https://github.com/PyCQA/pylint/issues/850)
-# R0913 Too many arguments - Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
-disable=C0111,C0103,I0011,W0511,R0401,R0913
+# For all codes, run 'pylint --list-msgs' or go to 'https://pylint.readthedocs.io/en/latest/reference_guide/features.html'
+# locally-disabled: Warning locally suppressed using disable-msg
+# cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
+# too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
+disable=missing-docstring,invalid-name,locally-disabled,fixme,cyclic-import,too-many-arguments
 
 [FORMAT]
 max-line-length=120

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@
 # locally-disabled: Warning locally suppressed using disable-msg
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
-disable=missing-docstring,invalid-name,locally-disabled,fixme,cyclic-import,too-many-arguments
+disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name
 
 [FORMAT]
 max-line-length=120
@@ -21,3 +21,20 @@ max-branches=20
 [SIMILARITIES]
 min-similarity-lines=10
 
+[BASIC]
+# Naming hints based on PEP 8 (https://www.python.org/dev/peps/pep-0008/#naming-conventions).
+# Consider these guidelines and not hard rules. Read PEP 8 for more details.
+
+# The invalid-name checker must be **enabled** for these hints to be used.
+include-naming-hint=yes
+
+module-name-hint=lowercase (short; underscores are discouraged)
+const-name-hint=UPPER_CASE_WITH_UNDERSCORES
+class-name-hint=CapitalizedWords
+class-attribute-name-hint=lower_case_with_underscores
+attr-name-hint=lower_case_with_underscores
+method-name-hint=lower_case_with_underscores
+function-name-hint=lower_case_with_underscores
+argument-name-hint=lower_case_with_underscores
+variable-name-hint=lower_case_with_underscores
+inlinevar-name-hint=lower_case_with_underscores (short is OK)


### PR DESCRIPTION
This PR does two things. One, it switches from pylint's cryptic codes for checkers to their short names which are much easier to reason about.

Two, I added naming hints (which are off by default due to `invalid-name` being disabled). At PyCon US 2017 I talked with @troydai about adding a few things to this pylintrc to help promote its use within Microsoft and this change is (currently) it.