### PR TITLE
vm image create: improve doc and error messages for the --source argument 

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
+++++++++++++++++++
+* vm: makes image create's '--source' argument mandatory, also improves the clarity of the help 
+
 2.0.9 (2017-06-21)
 ++++++++++++++++++
 * vm/vmss: lower thread number used for 'vm image list --all' to avoid exceeding the OS opened file limits  

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -2,10 +2,6 @@
 
 Release History
 ===============
-(unreleased)
-++++++++++++++++++
-* vm: makes image create's '--source' argument mandatory, also improves the clarity of the help 
-
 2.0.9 (2017-06-21)
 ++++++++++++++++++
 * vm/vmss: lower thread number used for 'vm image list --all' to avoid exceeding the OS opened file limits  

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -10,7 +10,7 @@ from azure.mgmt.compute.models import (CachingTypes,
                                        UpgradeMode)
 from azure.mgmt.storage.models import SkuName
 
-from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
+from azure.cli.core.commands import register_cli_argument, CliArgumentType
 from azure.cli.core.commands.validators import \
     (get_default_location_from_resource_group, validate_file_or_dict)
 from azure.cli.core.commands.parameters import \
@@ -291,8 +291,8 @@ register_cli_argument('image create', 'data_disks', ignore_type)
 register_cli_argument('image create', 'data_snapshots', ignore_type)
 
 for scope in ['disk', 'snapshot']:
-    register_extra_cli_argument(scope + ' create', 'source', validator=process_disk_or_snapshot_create_namespace,
-                                help='source from the same region, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
+    register_cli_argument(scope + ' create', 'source', validator=process_disk_or_snapshot_create_namespace,
+                          help='source to create the disk/snapshot from, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
     register_cli_argument(scope, 'source_blob_uri', ignore_type)
     register_cli_argument(scope, 'source_disk', ignore_type)
     register_cli_argument(scope, 'source_snapshot', ignore_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -278,9 +278,9 @@ register_cli_argument('image', 'image_name', arg_type=name_arg_type, id_part='na
 register_cli_argument('image create', 'name', arg_type=name_arg_type, help='new image name')
 
 # here we collpase all difference image sources to under 2 common arguments --os-disk-source --data-disk-sources
-register_extra_cli_argument('image create', 'source', validator=process_image_create_namespace,
+register_cli_argument('image create', 'source', validator=process_image_create_namespace,
                             help='OS disk source of the new image, including a virtual machine id or name, os disk blob uri, managed os disk id or name, or os snapshot id or name')
-register_extra_cli_argument('image create', 'data_disk_sources', nargs='+',
+register_cli_argument('image create', 'data_disk_sources', nargs='+',
                             help='space separated 1 or more data disk sources, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
 register_cli_argument('image create', 'source_virtual_machine', ignore_type)
 register_cli_argument('image create', 'os_blob_uri', ignore_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -279,9 +279,9 @@ register_cli_argument('image create', 'name', arg_type=name_arg_type, help='new 
 
 # here we collpase all difference image sources to under 2 common arguments --os-disk-source --data-disk-sources
 register_cli_argument('image create', 'source', validator=process_image_create_namespace,
-                            help='OS disk source of the new image, including a virtual machine id or name, os disk blob uri, managed os disk id or name, or os snapshot id or name')
+                      help='OS disk source from the same region, including a virtual machine id or name, os disk blob uri, managed os disk id or name, or os snapshot id or name')
 register_cli_argument('image create', 'data_disk_sources', nargs='+',
-                            help='space separated 1 or more data disk sources, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
+                      help='space separated 1 or more data disk sources, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
 register_cli_argument('image create', 'source_virtual_machine', ignore_type)
 register_cli_argument('image create', 'os_blob_uri', ignore_type)
 register_cli_argument('image create', 'os_disk', ignore_type)
@@ -292,7 +292,7 @@ register_cli_argument('image create', 'data_snapshots', ignore_type)
 
 for scope in ['disk', 'snapshot']:
     register_extra_cli_argument(scope + ' create', 'source', validator=process_disk_or_snapshot_create_namespace,
-                                help='source to create the disk from, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
+                                help='source from the same region, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
     register_cli_argument(scope, 'source_blob_uri', ignore_type)
     register_cli_argument(scope, 'source_disk', ignore_type)
     register_cli_argument(scope, 'source_snapshot', ignore_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -279,9 +279,9 @@ register_cli_argument('image create', 'name', arg_type=name_arg_type, help='new 
 
 # here we collpase all difference image sources to under 2 common arguments --os-disk-source --data-disk-sources
 register_extra_cli_argument('image create', 'source', validator=process_image_create_namespace,
-                            help='OS disk source of the new image, including a virtual machine id or name, sas uri to a os disk blob, managed os disk id or name, or os snapshot id or name')
+                            help='OS disk source of the new image, including a virtual machine id or name, os disk blob uri, managed os disk id or name, or os snapshot id or name')
 register_extra_cli_argument('image create', 'data_disk_sources', nargs='+',
-                            help='space separated 1 or more data disk sources, including sas uri to a blob, managed disk id or name, or snapshot id or name')
+                            help='space separated 1 or more data disk sources, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
 register_cli_argument('image create', 'source_virtual_machine', ignore_type)
 register_cli_argument('image create', 'os_blob_uri', ignore_type)
 register_cli_argument('image create', 'os_disk', ignore_type)
@@ -292,7 +292,7 @@ register_cli_argument('image create', 'data_snapshots', ignore_type)
 
 for scope in ['disk', 'snapshot']:
     register_extra_cli_argument(scope + ' create', 'source', validator=process_disk_or_snapshot_create_namespace,
-                                help='source to create the disk from, including a sas blob uri to a blob, managed disk id or name, or snapshot id or name')
+                                help='source to create the disk from, including unmanaged blob uri, managed disk id or name, or snapshot id or name')
     register_cli_argument(scope, 'source_blob_uri', ignore_type)
     register_cli_argument(scope, 'source_disk', ignore_type)
     register_cli_argument(scope, 'source_snapshot', ignore_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -473,7 +473,7 @@ def list_images(resource_group_name=None):
     return client.images.list()
 
 
-def create_image(resource_group_name, name, source, os_type=None, # pylint: disable=too-many-locals
+def create_image(resource_group_name, name, source, os_type=None,  # pylint: disable=too-many-locals
                  location=None, data_disk_sources=None,  # pylint: disable=unused-argument
                  # below are generated internally from 'source' and 'data_disk_sources'
                  source_virtual_machine=None,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -473,8 +473,8 @@ def list_images(resource_group_name=None):
     return client.images.list()
 
 
-def create_image(resource_group_name, name, os_type=None, location=None,  # pylint: disable=too-many-locals
-                 source=None, data_disk_sources=None,  # pylint: disable=unused-argument
+def create_image(resource_group_name, name, source, os_type=None, # pylint: disable=too-many-locals
+                 location=None, data_disk_sources=None,  # pylint: disable=unused-argument
                  # below are generated internally from 'source' and 'data_disk_sources'
                  source_virtual_machine=None,
                  os_blob_uri=None, data_blob_uris=None,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -473,8 +473,7 @@ def list_images(resource_group_name=None):
     return client.images.list()
 
 
-def create_image(resource_group_name, name, source, os_type=None,  # pylint: disable=too-many-locals
-                 location=None, data_disk_sources=None,  # pylint: disable=unused-argument
+def create_image(resource_group_name, name, source, os_type=None, data_disk_sources=None, location=None,  # pylint: disable=too-many-locals,unused-argument
                  # below are generated internally from 'source' and 'data_disk_sources'
                  source_virtual_machine=None,
                  os_blob_uri=None, data_blob_uris=None,


### PR DESCRIPTION
Fix #3572 
1. Remove the `sas` term from the help text for the `blob uri`. Sas uri is not supported as image/disk/snapshot source 
2. Call out `same region` on the `--source` argument . #3809 was logged to track server bad error
3. Make `--source` mandatory. Honestly, I don't remember why I used `register_extra_cli_argument` on a custom command, but now i am removing it

No new test coverage is needed. The main production code change is to make `--source` mandatory, a petty simple one. 


- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
