### PR TITLE
update seperator in the history.rst of azure-cli-core

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,11 +3,11 @@
 Release History
 ===============
 2.0.10 (2017-06-21)
-^^^^^^^^^^^^^^^^^^
+++++++++++++++++++
 * Fix deployment progress exceptions
 
 2.0.9 (2017-06-14)
-^^^^^^^^^^^^^^^^^^
+++++++++++++++++++
 * use arm endpoint from the current cloud to create subscription client
 
 2.0.8 (2017-06-13)

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 2.0.10 (2017-06-21)
-++++++++++++++++++
++++++++++++++++++++
 * Fix deployment progress exceptions
 
 2.0.9 (2017-06-14)


### PR DESCRIPTION
To get CI's readme validating task pass

- [N/A ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ N/A] Each command and parameter has a meaningful description.
- [ N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
