### PR TITLE
Replace dependencies of LiveTest with LiveScenarioTest

### DIFF
--- a/doc/recording_vcr_tests.md
+++ b/doc/recording_vcr_tests.md
@@ -50,7 +50,7 @@ When recording file is missing, the test framework will execute the test in live
 export AZURE_TEST_RUN_LIVE='True'
 ```
 
-Also, you can author tests which are for live test only. Just derive the test class from [LiveTest].
+Also, you can author tests which are for live test only. Just derive the test class from [LiveScenarioTest].
 
 ### Rebase recordings
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py
@@ -3,18 +3,18 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import LiveTest, live_only, record_only, get_sha1_hash
+from azure_devtools.scenario_tests import live_only, record_only, get_sha1_hash
 
-from .base import ScenarioTest
-from .preparers import (StorageAccountPreparer, ResourceGroupPreparer,
-                        RoleBasedServicePrincipalPreparer, KeyVaultPreparer)
+from .base import ScenarioTest, LiveScenarioTest
+from .preparers import (StorageAccountPreparer, ResourceGroupPreparer, RoleBasedServicePrincipalPreparer,
+                        KeyVaultPreparer)
 from .exceptions import CliTestError
-from .checkers import (JMESPathCheck, JMESPathCheckExists, JMESPathCheckGreaterThan, NoneCheck,
-                       StringCheck, StringContainCheck)
+from .checkers import (JMESPathCheck, JMESPathCheckExists, JMESPathCheckGreaterThan, NoneCheck, StringCheck,
+                       StringContainCheck)
 from .decorators import api_version_constraint
 from .utilities import get_active_api_profile, create_random_name
 
-__all__ = ['ScenarioTest', 'LiveTest', 'ResourceGroupPreparer', 'StorageAccountPreparer',
+__all__ = ['ScenarioTest', 'LiveScenarioTest', 'ResourceGroupPreparer', 'StorageAccountPreparer',
            'RoleBasedServicePrincipalPreparer', 'CliTestError', 'JMESPathCheck', 'JMESPathCheckExists', 'NoneCheck',
            'live_only', 'record_only', 'StringCheck', 'StringContainCheck', 'get_sha1_hash', 'KeyVaultPreparer',
            'JMESPathCheckGreaterThan', 'api_version_constraint', 'get_active_api_profile', 'create_random_name']

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -10,15 +10,10 @@ import shlex
 import logging
 import inspect
 
-from azure_devtools.scenario_tests import (
-    ReplayableTest,
-    SubscriptionRecordingProcessor, OAuthRequestResponsesFilter,
-    GeneralNameReplacer, LargeRequestBodyProcessor,
-    LargeResponseBodyProcessor, LargeResponseBodyReplacer,
-    DeploymentNameReplacer,
-    patch_time_sleep_api,
-    create_random_name,
-)
+from azure_devtools.scenario_tests import (IntegrationTestBase, ReplayableTest, SubscriptionRecordingProcessor,
+                                           OAuthRequestResponsesFilter, GeneralNameReplacer, LargeRequestBodyProcessor,
+                                           LargeResponseBodyProcessor, LargeResponseBodyReplacer, live_only,
+                                           DeploymentNameReplacer, patch_time_sleep_api, create_random_name)
 
 from azure_devtools.scenario_tests.const import MOCKED_SUBSCRIPTION_ID, ENV_SKIP_ASSERT
 
@@ -76,6 +71,13 @@ class ScenarioTest(ReplayableTest):
 
         return moniker
 
+    @classmethod
+    def cmd(cls, command, checks=None, expect_failure=False):
+        return execute(command, expect_failure=expect_failure).assert_with_checks(checks)
+
+
+@live_only()
+class LiveScenarioTest(IntegrationTestBase):
     @classmethod
     def cmd(cls, command, checks=None, expect_failure=False):
         return execute(command, expect_failure=expect_failure).assert_with_checks(checks)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
@@ -10,17 +10,16 @@ import tempfile
 import time
 import unittest
 
-from azure.cli.testsdk import \
-    (LiveTest, ResourceGroupPreparer, KeyVaultPreparer, JMESPathCheck as JMESPathCheckV2)
+from azure.cli.testsdk import (LiveScenarioTest, ResourceGroupPreparer, KeyVaultPreparer,
+                               JMESPathCheck as JMESPathCheckV2)
 import azure.cli.core.azlogging as azlogging
-from azure.cli.testsdk.vcr_test_base import VCRTestBase, JMESPathCheck, \
-    ResourceGroupVCRTestBase, NoneCheck, MOCKED_SUBSCRIPTION_ID
+from azure.cli.testsdk.vcr_test_base import (VCRTestBase, JMESPathCheck, ResourceGroupVCRTestBase, NoneCheck,
+                                             MOCKED_SUBSCRIPTION_ID)
 
 logger = azlogging.get_az_logger(__name__)
 
 
-class RbacSPSecretScenarioTest(LiveTest):
-
+class RbacSPSecretScenarioTest(LiveScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_create_rbac_sp_minimal')
     def test_create_for_rbac_with_secret(self, resource_group):
 
@@ -54,8 +53,7 @@ class RbacSPSecretScenarioTest(LiveTest):
             self.cmd('ad app delete --id {}'.format(sp_name))
 
 
-class RbacSPCertScenarioTest(LiveTest):
-
+class RbacSPCertScenarioTest(LiveScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_create_rbac_sp_with_cert')
     def test_create_for_rbac_with_cert(self, resource_group):
 
@@ -76,8 +74,7 @@ class RbacSPCertScenarioTest(LiveTest):
             self.cmd('ad app delete --id {}'.format(sp_name), checks=NoneCheck())
 
 
-class RbacSPKeyVaultScenarioTest(LiveTest):
-
+class RbacSPKeyVaultScenarioTest(LiveScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_sp_with_kv_new_cert')
     @KeyVaultPreparer()
     def test_create_for_rbac_with_new_kv_cert(self, resource_group, key_vault):
@@ -183,7 +180,7 @@ class RoleAssignmentScenarioTest(ResourceGroupVCRTestBase):
         self.user = 'testuser1@azuresdkteam.onmicrosoft.com'
 
     def set_up(self):
-        super().set_up()
+        super(RoleAssignmentScenarioTest, self).set_up()
         self.cmd(
             'ad user create --display-name tester123 --password Test123456789 --user-principal-name {}'.format(
                 self.user), None)
@@ -192,7 +189,7 @@ class RoleAssignmentScenarioTest(ResourceGroupVCRTestBase):
 
     def tear_down(self):
         self.cmd('ad user delete --upn-or-object-id {}'.format(self.user), None)
-        super().tear_down()
+        super(RoleAssignmentScenarioTest, self).tear_down()
 
     def test_role_assignment_scenario(self):
         if self.playback:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_batch_operations.py
@@ -4,12 +4,11 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-from azure.cli.testsdk import (LiveTest, StorageAccountPreparer, ResourceGroupPreparer,
-                               JMESPathCheck)
+from azure.cli.testsdk import LiveScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, JMESPathCheck
 from .storage_test_util import StorageScenarioMixin, StorageTestFilesPreparer
 
 
-class StorageBatchOperationScenarios(StorageScenarioMixin, LiveTest):
+class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
     @StorageTestFilesPreparer()

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_blob_copy_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_blob_copy_scenarios.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import (LiveTest, ResourceGroupPreparer, StorageAccountPreparer)
+from azure.cli.testsdk import LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 from .storage_test_util import StorageScenarioMixin
 
 
-class StorageBlobCopyTests(StorageScenarioMixin, LiveTest):
+class StorageBlobCopyTests(StorageScenarioMixin, LiveScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='source_account')
     @StorageAccountPreparer(parameter_name='target_account')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_blob_live_scenarios.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage_blob_live_scenarios.py
@@ -4,13 +4,13 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-from azure.cli.testsdk import (LiveTest, ResourceGroupPreparer, StorageAccountPreparer,
+from azure.cli.testsdk import (LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer,
                                JMESPathCheck, api_version_constraint)
 from azure.cli.core.profiles import ResourceType
 
 
 @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2016-12-01')
-class StorageBlobUploadLiveTests(LiveTest):
+class StorageBlobUploadLiveTests(LiveScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
     def test_storage_blob_upload_128mb_file(self, resource_group, storage_account):


### PR DESCRIPTION
After moving to the devtools, the original LiveTest stop working because
of the missing cmd function. The newly created LiveScenarioTest will
take over its place. The LiveTest will be eventually removed from the
devtools package since the live_only decorator is sufficent.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
