### PR TITLE
support generate sdk auth info

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -384,10 +384,14 @@ class Profile(object):
                 raise CLIError('SDK Auth file is only applicable on service principals')
 
         result[_TENANT_ID] = account[_TENANT_ID]
-        endpoint_mappings = {
-            'active_directory': 'activeDirectoryEndpointUrl',
-            'resource_manager': 'resourceManagerEndpointUrl',
-        }
+        endpoint_mappings = OrderedDict()  # use OrderedDict to control the output sequence
+        endpoint_mappings['active_directory'] = 'activeDirectoryEndpointUrl'
+        endpoint_mappings['resource_manager'] = 'resourceManagerEndpointUrl'
+        endpoint_mappings['active_directory_graph_resource_id'] = 'activeDirectoryGraphResourceId'
+        endpoint_mappings['sql_management'] = 'sqlManagementEndpointUrl'
+        endpoint_mappings['gallery'] = 'galleryEndpointUrl'
+        endpoint_mappings['management'] = 'managementEndpointUrl'
+
         for e in endpoint_mappings:
             result[endpoint_mappings[e]] = getattr(CLOUD.endpoints, e)
         return result

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -360,7 +360,7 @@ class Profile(object):
 
         # is the credential created through command like 'create-for-rbac'?
         result = OrderedDict()
-        if bool(name) and bool(password):
+        if name and password:
             result['clientId'] = name
             if password:
                 result['clientSecret'] = password

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -354,36 +354,42 @@ class Profile(object):
                 str(account[_SUBSCRIPTION_ID]),
                 str(account[_TENANT_ID]))
 
-    # per ask from java sdk
-    def get_expanded_subscription_info(self, subscription_id=None, name=None, password=None):
+    def get_sp_auth_info(self, subscription_id=None, name=None, password=None, cert_file=None):
+        from collections import OrderedDict
         account = self.get_subscription(subscription_id)
 
         # is the credential created through command like 'create-for-rbac'?
+        result = OrderedDict()
         if bool(name) and bool(password):
-            result = {}
-            result[_SUBSCRIPTION_ID] = subscription_id or account[_SUBSCRIPTION_ID]
-            result['client'] = name
-            result['password'] = password
-            result[_TENANT_ID] = account[_TENANT_ID]
-            result[_ENVIRONMENT_NAME] = CLOUD.name
-            result['subscriptionName'] = account[_SUBSCRIPTION_NAME]
+            result['clientId'] = name
+            if password:
+                result['clientSecret'] = password
+            else:
+                result['clientCertificate'] = cert_file
+            result['subscriptionId'] = subscription_id or account[_SUBSCRIPTION_ID]
         else:  # has logged in through cli
-            result = deepcopy(account)
             user_type = account[_USER_ENTITY].get(_USER_TYPE)
             if user_type == _SERVICE_PRINCIPAL:
-                result['client'] = account[_USER_ENTITY][_USER_NAME]
-                result['password'] = self._creds_cache.retrieve_secret_of_service_principal(
-                    account[_USER_ENTITY][_USER_NAME])
+                result['clientId'] = account[_USER_ENTITY][_USER_NAME]
+                sp_auth = ServicePrincipalAuth(self._creds_cache.retrieve_secret_of_service_principal(
+                    account[_USER_ENTITY][_USER_NAME]))
+                secret = getattr(sp_auth, 'secret', None)
+                if secret:
+                    result['clientSecret'] = secret
+                else:
+                    # we can output 'clientCertificateThumbprint' if asked
+                    result['clientCertificate'] = sp_auth.certificate_file
+                result['subscriptionId'] = account[_SUBSCRIPTION_ID]
             else:
-                result['userName'] = account[_USER_ENTITY][_USER_NAME]
+                raise CLIError('SDK Auth file is only applicable on service principals')
 
-            result.pop(_STATE)
-            result.pop(_USER_ENTITY)
-            result.pop(_IS_DEFAULT_SUBSCRIPTION)
-            result['subscriptionName'] = result.pop(_SUBSCRIPTION_NAME)
-
-        result['subscriptionId'] = result.pop('id')
-        result['endpoints'] = CLOUD.endpoints
+        result[_TENANT_ID] = account[_TENANT_ID]
+        endpoint_mappings = {
+            'active_directory': 'activeDirectoryEndpointUrl',
+            'resource_manager': 'resourceManagerEndpointUrl',
+        }
+        for e in endpoint_mappings:
+            result[endpoint_mappings[e]] = getattr(CLOUD.endpoints, e)
         return result
 
     def get_installation_id(self):

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(Unreleased)
+++++++++++++++++++
+account show: support output in SDK auth file format
+
 2.0.7 (2017-06-21)
 ++++++++++++++++++
 * No changes.

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-import argparse
 from azure.cli.core.commands import register_cli_argument
 from .custom import load_subscriptions
 
@@ -28,4 +27,4 @@ register_cli_argument('logout', 'username', help='account user, if missing, logo
 
 register_cli_argument('account', 'subscription', options_list=('--subscription', '-s'), help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
-register_cli_argument('account show', 'expanded_view', action='store_true', help=argparse.SUPPRESS)  # supress because this is being deprecated
+register_cli_argument('account show', 'show_auth_for_sdk', options_list=('--sdk-auth',), action='store_true', help='output result in compatible with Azure SDK auth file')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -39,6 +39,7 @@ def show_subscription(subscription=None, show_auth_for_sdk=None):
     if not show_auth_for_sdk:
         return profile.get_subscription(subscription)
 
+    # sdk-auth file should be in json format all the time, hence the print
     print(json.dumps(profile.get_sp_auth_info(subscription), indent=2))
 
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -33,14 +33,13 @@ def list_subscriptions(all=False):  # pylint: disable=redefined-builtin
     return subscriptions
 
 
-def show_subscription(subscription=None, expanded_view=None):
+def show_subscription(subscription=None, show_auth_for_sdk=None):
+    import json
     profile = Profile()
-    if not expanded_view:
+    if not show_auth_for_sdk:
         return profile.get_subscription(subscription)
 
-    logger.warning("'--expanded-view' is deprecating and will be removed in a future release. You can get the same "
-                   "information using 'az cloud show'")
-    return profile.get_expanded_subscription_info(subscription)
+    print(json.dumps(profile.get_sp_auth_info(subscription), indent=2))
 
 
 def get_access_token(subscription=None, resource=None):

--- a/src/command_modules/azure-cli-role/HISTORY.rst
+++ b/src/command_modules/azure-cli-role/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
+++++++++++++++++++
+create-for-rbac: support output in SDK auth file format
+
 2.0.7 (2017-06-21)
 ++++++++++++++++++
 * No changes.

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-import argparse
 from azure.cli.core.commands import CliArgumentType
 from azure.cli.core.commands import register_cli_argument
 from azure.cli.core.commands.parameters import enum_choice_list
@@ -33,7 +32,7 @@ register_cli_argument('ad sp create', 'identifier', options_list=('--id',), help
 register_cli_argument('ad sp create-for-rbac', 'scopes', nargs='+')
 register_cli_argument('ad sp create-for-rbac', 'role', completer=get_role_definition_name_completion_list)
 register_cli_argument('ad sp create-for-rbac', 'skip_assignment', action='store_true', help='do not create default assignment')
-register_cli_argument('ad sp create-for-rbac', 'expanded_view', action='store_true', help=argparse.SUPPRESS)
+register_cli_argument('ad sp create-for-rbac', 'show_auth_for_sdk', options_list='--sdk-auth', action='store_true', help='output result in compatible with Azure SDK auth file')
 
 for item in ['create-for-rbac', 'reset-credentials']:
     register_cli_argument('ad sp {}'.format(item), 'name', name_arg_type)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -672,6 +672,7 @@ def create_service_principal_for_rbac(
         profile = Profile()
         result = profile.get_sp_auth_info(scopes[0].split('/')[2] if scopes else None,
                                           app_id, password, cert_file)
+        # sdk-auth file should be in json format all the time, hence the print
         print(json.dumps(result, indent=2))
         return
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -579,7 +579,7 @@ def create_service_principal_for_rbac(
         name=None, password=None, years=None,
         create_cert=False, cert=None,
         scopes=None, role='Contributor',
-        expanded_view=None, skip_assignment=False, keyvault=None):
+        show_auth_for_sdk=None, skip_assignment=False, keyvault=None):
     import time
     import pytz
 
@@ -666,26 +666,27 @@ def create_service_principal_for_rbac(
                                            ex.response.headers)  # pylint: disable=no-member
                     raise
 
-    if expanded_view:
-        logger.warning("'--expanded-view' is deprecating and will be removed in a future release. "
-                       "You can get the same information using 'az cloud show'")
+    if show_auth_for_sdk:
+        import json
         from azure.cli.core._profile import Profile
         profile = Profile()
-        result = profile.get_expanded_subscription_info(scopes[0].split('/')[2] if scopes else None,
-                                                        app_id, password)
-    else:
-        result = {
-            'appId': app_id,
-            'password': password,
-            'name': name,
-            'displayName': app_display_name,
-            'tenant': graph_client.config.tenant_id
-        }
-        if cert_file:
-            logger.warning(
-                "Please copy %s to a safe place. When run 'az login' provide the file path to the --password argument",
-                cert_file)
-            result['fileWithCertAndPrivateKey'] = cert_file
+        result = profile.get_sp_auth_info(scopes[0].split('/')[2] if scopes else None,
+                                          app_id, password, cert_file)
+        print(json.dumps(result, indent=2))
+        return
+
+    result = {
+        'appId': app_id,
+        'password': password,
+        'name': name,
+        'displayName': app_display_name,
+        'tenant': graph_client.config.tenant_id
+    }
+    if cert_file:
+        logger.warning(
+            "Please copy %s to a safe place. When run 'az login' provide the file path to the --password argument",
+            cert_file)
+        result['fileWithCertAndPrivateKey'] = cert_file
     return result
 
 


### PR DESCRIPTION
//cc: @mayurid @jianghaolu @selvasingh
Per our discussion and following mail exchange
```bash
(env) D:\sdk\azure-cli>az ad sp create-for-rbac -n yugangwdelete --sdk-auth
{
  "clientId": "56dc7894-2cb8-40d8-9a29-fdc8b6c66xxx",
  "clientSecret": "2457b4e1-1e42-4cd8-98f2-3e510a502xxx",
  "subscriptionId": "0b1f6471-1bf0-4dda-aec3-cb9272f09xxx",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9xxx",
  "resourceManagerEndpointUrl": "https://management.azure.com/",
  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com"
}
```
### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
