### PR TITLE
vm: remove dead code and move 'paramiko' dependency to azure-cli-core

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -58,6 +58,7 @@ DEPENDENCIES = [
     'jmespath',
     'msrest>=0.4.4',
     'msrestazure>=0.4.7',
+    'paramiko',
     'pip',
     'pygments',
     'pyopenssl>=16.2',  # https://github.com/pyca/pyopenssl/issues/568

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -726,47 +726,6 @@ def validate_ssh_key(namespace):
     namespace.ssh_key_value = content
 
 
-def _generate_ssh_keys(private_key_filepath, public_key_filepath):
-    import paramiko
-
-    ssh_dir, _ = os.path.split(private_key_filepath)
-    if not os.path.exists(ssh_dir):
-        os.makedirs(ssh_dir)
-        os.chmod(ssh_dir, 0o700)
-
-    key = paramiko.RSAKey.generate(2048)
-    key.write_private_key_file(private_key_filepath)
-    os.chmod(private_key_filepath, 0o600)
-
-    with open(public_key_filepath, 'w') as public_key_file:
-        public_key = '%s %s' % (key.get_name(), key.get_base64())
-        public_key_file.write(public_key)
-    os.chmod(public_key_filepath, 0o644)
-
-    return public_key
-
-
-def _is_valid_ssh_rsa_public_key(openssh_pubkey):
-    # http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
-    # A "good enough" check is to see if the key starts with the correct header.
-    import struct
-    try:
-        from base64 import decodebytes as base64_decode
-    except ImportError:
-        # deprecated and redirected to decodebytes in Python 3
-        from base64 import decodestring as base64_decode
-    parts = openssh_pubkey.split()
-    if len(parts) < 2:
-        return False
-    key_type = parts[0]
-    key_string = parts[1]
-
-    data = base64_decode(key_string.encode())  # pylint:disable=deprecated-method
-    int_len = 4
-    str_len = struct.unpack('>I', data[:int_len])[0]  # this should return 7
-    return data[int_len:int_len + str_len] == key_type.encode()
-
-
 def process_vm_create_namespace(namespace):
     get_default_location_from_resource_group(namespace)
     _validate_vm_create_storage_profile(namespace)

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -37,8 +37,7 @@ DEPENDENCIES = [
     'azure-mgmt-network==1.0.0rc3',
     'azure-mgmt-resource==1.1.0rc1',
     'azure-multiapi-storage==0.1.0',
-    'azure-cli-core',
-    'paramiko'
+    'azure-cli-core'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
A bit clean up after #3105 was merged. Since ssh key gen was moved to azure-cli-core, the `paramiko` should become its dependency, and vm command module no longer needs it

//CC: @brendandburns , @troydai 

### General Guidelines

- [ na] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ na] Each command and parameter has a meaningful description.
- [ na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
