### PR TITLE
Refactor LICENSE.txt to make GitHub happy.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,21 @@
-Azure CLI
+The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation
+Copyright (c) Microsoft Corporation. All rights reserved.
 
-All rights reserved. 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-MIT License
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
GitHub parses LICENSE files strictly and doesn't recognize this one as MIT due to its first line. This makes it conform, which enables a nifty link to the user's rights and responsibilities as shown here:
![screen shot 2017-06-28 at 12 33 00 pm](https://user-images.githubusercontent.com/73019/27654003-160062e4-5bfe-11e7-8455-e4b2db08774d.png)
![screen shot 2017-06-28 at 12 33 17 pm](https://user-images.githubusercontent.com/73019/27654006-1a10a1b4-5bfe-11e7-9faa-6c4911f77bfb.png)
I copied this MIT license from [Azure/draft](https://github.com/Azure/draft) which we recently got approved, so I know CELA is ok with this formatting.