### PR TITLE
Removing resizing from loops to affect performance for interactive in python2.7

### DIFF
--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -32,7 +32,7 @@ import azclishell.configuration
 from azclishell.az_lexer import AzLexer, ExampleLexer, ToolbarLexer
 from azclishell.command_tree import in_tree
 from azclishell.frequency_heuristic import DISPLAY_TIME
-from azclishell.gather_commands import add_random_new_lines
+from azclishell.gather_commands import add_new_lines
 from azclishell.key_bindings import registry, get_section, sub_section
 from azclishell.layout import create_layout, create_tutorial_layout, set_scope
 from azclishell.progress import progress_view
@@ -397,7 +397,7 @@ class Shell(object):
                 eventloop=create_eventloop())
             example_cli.buffers['example_line'].reset(
                 initial_document=Document(u'{}\n'.format(
-                    add_random_new_lines(example)))
+                    add_new_lines(example)))
             )
             while start_index < len(text.split()):
                 if self.default_command:

--- a/src/command_modules/azure-cli-interactive/azclishell/gather_commands.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/gather_commands.py
@@ -27,11 +27,10 @@ GLOBAL_PARAM = list(GLOBAL_PARAM_DESCRIPTIONS.keys())
 
 
 def _get_window_columns():
-    _, columns = get_window_dim()
-    return columns
+    _, col = get_window_dim()
+    return col
 
-
-def add_random_new_lines(long_phrase, line_min=None, tolerance=TOLERANCE):
+def add_new_lines(long_phrase, line_min=None, tolerance=TOLERANCE):
     """ not everything fits on the screen, based on the size, add newlines """
     if line_min is None:
         line_min = math.floor(int(_get_window_columns()) / 2 - 15)
@@ -110,6 +109,8 @@ class GatherCommands(object):
         """ gathers from the files in a way that is convienent to use """
         command_file = CONFIGURATION.get_help_files()
         cache_path = os.path.join(azclishell.configuration.get_config_dir(), 'cache')
+        cols = _get_window_columns()
+
         with open(os.path.join(cache_path, command_file), 'r') as help_file:
             data = json.load(help_file)
 
@@ -128,15 +129,14 @@ class GatherCommands(object):
                 branch = branch.get_child(word, branch.children)
 
             description = data[command]['help']
-            self.descrip[command] = add_random_new_lines(description)
+            self.descrip[command] = add_new_lines(description, line_min=int(cols) - 2 * TOLERANCE)
 
             if 'examples' in data[command]:
                 examples = []
-                cols = _get_window_columns()
                 for example in data[command]['examples']:
                     examples.append([
-                        add_random_new_lines(example[0], line_min=int(cols) - 2 * TOLERANCE),
-                        add_random_new_lines(example[1], line_min=int(cols) - 2 * TOLERANCE)])
+                        add_new_lines(example[0], line_min=int(cols) - 2 * TOLERANCE),
+                        add_new_lines(example[1], line_min=int(cols) - 2 * TOLERANCE)])
                 self.command_example[command] = examples
 
             all_params = []
@@ -156,9 +156,10 @@ class GatherCommands(object):
                             self.same_param_doubles[param_double] = par
 
                         self.param_descript[command + " " + par] =  \
-                            add_random_new_lines(
+                            add_new_lines(
                                 data[command]['parameters'][param]['required'] +
-                                " " + data[command]['parameters'][param]['help'])
+                                " " + data[command]['parameters'][param]['help'],
+                                line_min=int(cols) - 2 * TOLERANCE)
                         if par not in self.completable_param:
                             self.completable_param.append(par)
                         all_params.append(par)

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_gather.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_gather.py
@@ -5,7 +5,7 @@
 
 import unittest
 import six
-from azclishell.gather_commands import add_random_new_lines as nl
+from azclishell.gather_commands import add_new_lines as nl
 
 
 class GatherTest(unittest.TestCase):


### PR DESCRIPTION
Uses cached values for terminal size so performance change isn't noticeable
---

This checklist is used to make sure that common guidelines for a pull request are followed.


