### PR TITLE
Removed sql server create --identity param.

### DIFF
--- a/src/command_modules/azure-cli-sql/HISTORY.rst
+++ b/src/command_modules/azure-cli-sql/HISTORY.rst
@@ -3,12 +3,19 @@
 Release History
 ===============
 
+unreleased
+++++++++++++++++++
+
+* Removed broken az sql server create --identity parameter.
+
 2.0.6 (2017-06-21)
 ++++++++++++++++++
+
 * az sql server create/update command output no longer show administratorLoginPassword values.
 
 2.0.5 (2017-06-13)
 ++++++++++++++++++
+
 * Added az sql db list-editions and az sql elastic-pool list-editions commands.
 
 2.0.4 (2017-05-30)

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
@@ -572,13 +572,16 @@ with ParametersContext(command='sql server create') as c:
     # Both administrator_login and administrator_login_password are required for server creation.
     # However these two parameters are given default value in the create_or_update function
     # signature, therefore, they can't be automatically converted to requirement arguments.
-    c.expand('parameters', Server, group_name='Authentication', patches={
+    c.expand('parameters', Server, patches={
         'administrator_login': patch_arg_make_required,
         'administrator_login_password': patch_arg_make_required
     })
 
     # 12.0 is the only server version allowed and it's already the default.
     c.ignore('version')
+
+    # Identity will be handled with its own parameter.
+    c.ignore('identity')
 
 
 with ParametersContext(command='sql server update') as c:


### PR DESCRIPTION
This param was not intentionally added and is unusable. A different param which sets server identity will be added in a separate change.

Additionally removed 'Authentication' arg group from sql server create because it was confusingly applied to all args, not just authentication-related args.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
