### PR TITLE
test: add progress specific tests for vm & deployment create

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+from contextlib import contextmanager
 
 from azure_devtools.scenario_tests import create_random_name as create_random_name_base
 
@@ -34,3 +35,29 @@ def get_active_api_profile():
     except CloudNotRegisteredException:
         init_known_clouds()
         return get_active_cloud().profile
+
+
+@contextmanager
+def force_progress_logging():
+    from six import StringIO
+    import logging
+    from azure.cli.core.commands import logger as cmd_logger
+
+    # register a progress logger handler to get the content to verify
+    test_io = StringIO()
+    test_handler = logging.StreamHandler(test_io)
+    cmd_logger.addHandler(test_handler)
+    old_cmd_level = cmd_logger.level
+    cmd_logger.setLevel(logging.INFO)
+
+    # this tells progress logger we are under verbose, so should log
+    az_logger = logging.getLogger('az')
+    old_az_level = az_logger.handlers[0].level
+    az_logger.handlers[0].level = logging.INFO
+
+    yield test_io
+
+    # restore old logging level and unplug the test handler
+    cmd_logger.removeHandler(test_handler)
+    cmd_logger.setLevel(old_cmd_level)
+    az_logger.handlers[0].level = old_az_level

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
@@ -339,7 +339,6 @@ class DeploymentTest(ScenarioTest):
         ])
 
 
-
 class DeploymentLiveTest(LiveScenarioTest):
     @ResourceGroupPreparer()
     def test_group_deployment_progress(self, resource_group):

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
@@ -7,7 +7,8 @@ import os
 import time
 import unittest
 
-from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, JMESPathCheck as JCheck, create_random_name)
+from azure.cli.testsdk import (ScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
+                               JMESPathCheck as JCheck, create_random_name)
 # AZURE CLI RESOURCE TEST DEFINITIONS
 from azure.cli.testsdk.vcr_test_base import (VCRTestBase, JMESPathCheck, NoneCheck,
                                              BooleanCheck,
@@ -336,6 +337,30 @@ class DeploymentTest(ScenarioTest):
             JCheck('length([])', 2),
             JCheck('[0].resourceGroup', resource_group)
         ])
+
+
+
+class DeploymentLiveTest(LiveScenarioTest):
+    @ResourceGroupPreparer()
+    def test_group_deployment_progress(self, resource_group):
+        from azure.cli.testsdk.utilities import force_progress_logging
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        template_file = os.path.join(curr_dir, 'test-template.json').replace('\\', '\\\\')
+        parameters_file = os.path.join(curr_dir, 'test-params.json').replace('\\', '\\\\')
+        object_file = os.path.join(curr_dir, 'test-object.json').replace('\\', '\\\\')
+        deployment_name = 'azure-cli-deployment2'
+
+        subnet_id = self.cmd('network vnet create -g {} -n vnet1 --subnet-name subnet1'.format(resource_group)).get_output_in_json()['newVNet']['subnets'][0]['id']
+
+        with force_progress_logging() as test_io:
+            self.cmd('group deployment create --verbose -g {} -n {} --template-file {} --parameters @"{}" --parameters subnetId="{}" --parameters backendAddressPools=@"{}"'.format(
+                resource_group, deployment_name, template_file, parameters_file, subnet_id, object_file))
+
+        # very the progress
+        lines = test_io.getvalue().splitlines()
+        for l in lines:
+            self.assertTrue(l.split(':')[0] in ['Accepted', 'Succeeded'])
+        self.assertTrue('Succeeded: {} (Microsoft.Resources/deployments)'.format(deployment_name), lines)
 
 
 class DeploymentnoWaitTest(ResourceGroupVCRTestBase):


### PR DESCRIPTION
Fix #3804
1. Have to make the tests live only as under playback the tests run too fast and timing based progress logic doesn't have a chance to get involved.
2. A bit surprising (and pain) that I had to write non trivial code to force the verbose logging so the test can get the progress output to verify. Let me know if can be simplified
