### PR TITLE
Remove marker options from blob, container, and share list commands

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+unreleased
+++++++++++
+* Remove --marker option from storage blob list, storage container list, and storage share list commands. The change is a part of the solution to issue #3745. This is technically a breaking change. However since the removed options never works, the impact is limited.
+
 2.0.10 (2017-07-07)
 +++++++++++++++++++
 * minor fixes

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -344,6 +344,7 @@ with CommandContext('storage blob list') as c:
               help='Specifies additional datasets to include: (c)opy-info, (m)etadata, (s)napshots. Can be combined.',
               validator=validate_included_datasets)
     c.reg_arg('num_results', type=int)
+    c.reg_arg('marker', ignore_type)  # https://github.com/Azure/azure-cli/issues/3745
 
 for item in ['download', 'upload']:
     register_cli_argument('storage blob {}'.format(item), 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter())
@@ -473,6 +474,8 @@ register_cli_argument('storage container policy', 'policy_name', options_list=('
 for item in ['create', 'delete', 'list', 'show', 'update']:
     register_extra_cli_argument('storage container policy {}'.format(item), 'lease_id', options_list=('--lease-id',), help='The container lease ID.')
 
+register_cli_argument('storage container list', 'marker', ignore_type)  # https://github.com/Azure/azure-cli/issues/3745
+
 register_cli_argument('storage share', 'share_name', share_name_type, options_list=('--name', '-n'))
 
 register_cli_argument('storage share exists', 'directory_name', ignore_type)
@@ -480,6 +483,8 @@ register_cli_argument('storage share exists', 'file_name', ignore_type)
 
 register_cli_argument('storage share policy', 'container_name', share_name_type)
 register_cli_argument('storage share policy', 'policy_name', options_list=('--name', '-n'), help='The stored access policy name.', completer=get_storage_acl_name_completion_list(FileService, 'container_name', 'get_share_acl'))
+
+register_cli_argument('storage share list', 'marker', ignore_type)  # https://github.com/Azure/azure-cli/issues/3745
 
 register_cli_argument('storage directory', 'directory_name', directory_type, options_list=('--name', '-n'))
 


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-cli/issues/3745

The marker option never works in the CLI context because the commands never return the marker value when --num-results is specified. A fix is being worked to improve overall paging mechanism in CLI. In the meantime, this option is removed to reduce confusing.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
