### PR TITLE
Fix Nic creation issue in stack

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1,4 +1,4 @@
-# --------------------------------------------------------------------------------------------
+﻿# --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
@@ -1134,14 +1134,20 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
                public_ip_address=None, virtual_network_name=None, enable_accelerated_networking=None):
     client = _network_client_factory().network_interfaces
     NetworkInterface = get_sdk(ResourceType.MGMT_NETWORK, 'NetworkInterface', mod='models')
+    
+    network_interface_args = {}
+    if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
+        network_interface_args['enable_accelerated_networking'] = enable_accelerated_networking
+
     NetworkInterfaceDnsSettings = get_sdk(
         ResourceType.MGMT_NETWORK,
         'NetworkInterfaceDnsSettings', mod='models')
 
     dns_settings = NetworkInterfaceDnsSettings(internal_dns_name_label=internal_dns_name_label,
                                                dns_servers=dns_servers or [])
+
     nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding,
-                           dns_settings=dns_settings, enable_accelerated_networking=enable_accelerated_networking)
+                           dns_settings=dns_settings, **network_interface_args)
 
     if network_security_group:
         nic.network_security_group = NetworkSecurityGroup(id=network_security_group)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1142,7 +1142,7 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
     dns_settings = NetworkInterfaceDnsSettings(internal_dns_name_label=internal_dns_name_label,
                                                dns_servers=dns_servers or [])
 
-    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding, 
+    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding,
                            dns_settings=dns_settings)
 
     if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1142,7 +1142,8 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
     dns_settings = NetworkInterfaceDnsSettings(internal_dns_name_label=internal_dns_name_label,
                                                dns_servers=dns_servers or [])
 
-    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding, dns_settings=dns_settings)
+    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding, 
+                           dns_settings=dns_settings)
 
     if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
         nic.enable_accelerated_networking = enable_accelerated_networking

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1135,10 +1135,6 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
     client = _network_client_factory().network_interfaces
     NetworkInterface = get_sdk(ResourceType.MGMT_NETWORK, 'NetworkInterface', mod='models')
 
-    network_interface_args = {}
-    if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
-        network_interface_args['enable_accelerated_networking'] = enable_accelerated_networking
-
     NetworkInterfaceDnsSettings = get_sdk(
         ResourceType.MGMT_NETWORK,
         'NetworkInterfaceDnsSettings', mod='models')
@@ -1146,8 +1142,10 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
     dns_settings = NetworkInterfaceDnsSettings(internal_dns_name_label=internal_dns_name_label,
                                                dns_servers=dns_servers or [])
 
-    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding,
-                           dns_settings=dns_settings, **network_interface_args)
+    nic = NetworkInterface(location=location, tags=tags, enable_ip_forwarding=enable_ip_forwarding, dns_settings=dns_settings)
+
+    if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
+        nic.enable_accelerated_networking = enable_accelerated_networking
 
     if network_security_group:
         nic.network_security_group = NetworkSecurityGroup(id=network_security_group)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1134,7 +1134,7 @@ def create_nic(resource_group_name, network_interface_name, subnet, location=Non
                public_ip_address=None, virtual_network_name=None, enable_accelerated_networking=None):
     client = _network_client_factory().network_interfaces
     NetworkInterface = get_sdk(ResourceType.MGMT_NETWORK, 'NetworkInterface', mod='models')
-    
+
     network_interface_args = {}
     if supported_api_version(ResourceType.MGMT_NETWORK, min_api='2016-09-01'):
         network_interface_args['enable_accelerated_networking'] = enable_accelerated_networking


### PR DESCRIPTION
Nic creation in Azure Stack failed because network api supported by stack doesn't recognize `'enable_accelerated_networking' `argument for nic creation. This fix adds a check for supported api version.

Closes  #4007 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
