### PR TITLE
Remove 'container' from blacklisted mods

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -39,7 +39,7 @@ DEFAULT_QUERY_TIME_RANGE = 3600000
 
 CONFIRM_PARAM_NAME = 'yes'
 
-BLACKLISTED_MODS = ['context', 'container', 'shell', 'documentdb']
+BLACKLISTED_MODS = ['context', 'shell', 'documentdb']
 
 
 class VersionConstraint(object):


### PR DESCRIPTION
This PR is going to add 'container' command module to azure cli to support container instance commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
