### PR TITLE
vm: handle the case when an extension's type could be None

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -751,7 +751,7 @@ def _get_extension_instance_name(instance_view, publisher, extension_type_name,
     full_type_name = '.'.join([publisher, extension_type_name])
     if instance_view.extensions:
         ext = next((x for x in instance_view.extensions
-                    if x.type.lower() == full_type_name.lower()), None)
+                    if x.type and (x.type.lower() == full_type_name.lower())), None)
         if ext:
             extension_instance_name = ext.name
     return extension_instance_name

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_custom_vm_commands.py
@@ -356,6 +356,18 @@ class Test_Vm_Custom(unittest.TestCase):
         # assert
         self.assertEqual(result, 'extension1')
 
+    def test_get_extension_instance_name_when_type_none(self):
+        instance_view = mock.MagicMock()
+        extension = mock.MagicMock()
+        extension.type = None
+        instance_view.extensions = [extension]
+
+        # action
+        result = _get_extension_instance_name(instance_view, 'na', 'extension-name')
+
+        # assert
+        self.assertEqual(result, 'extension-name')
+
 
 class FakedVM(object):  # pylint: disable=too-few-public-methods
     def __init__(self, nics=None, disks=None, os_disk=None):


### PR DESCRIPTION
Fix #3995 Fix #3936 
I couldn't reproduce this even I de-allocated the VM, but the 2 issues had stack traces both pointing out the `type` could be unavailable, so I am still fixing it

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
