### PR TITLE
output sdk auth info for service principals with certificates

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
++++++++++++++++++++
+* output sdk auth info for service principals with certificates
+
 2.0.11 (2017-07-07)
 +++++++++++++++++++
 * minor fixes

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -428,7 +428,7 @@ class Profile(object):
 
         # is the credential created through command like 'create-for-rbac'?
         result = OrderedDict()
-        if name and password:
+        if name and (password or cert_file):
             result['clientId'] = name
             if password:
                 result['clientSecret'] = password

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -247,6 +247,24 @@ class Test_Profile(unittest.TestCase):
         self.assertEqual('https://login.microsoftonline.com', extended_info['activeDirectoryEndpointUrl'])
         self.assertEqual('https://management.azure.com/', extended_info['resourceManagerEndpointUrl'])
 
+    def test_get_auth_info_for_newly_created_service_principal(self):
+        storage_mock = {'subscriptions': []}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        consolidated = Profile._normalize_properties(self.user1,
+                                                     [self.subscription1],
+                                                     False)
+        profile._set_subscriptions(consolidated)
+        # action
+        extended_info = profile.get_sp_auth_info(name='1234', cert_file='/tmp/123.pem')
+        # assert
+        self.assertEqual(self.id1.split('/')[-1], extended_info['subscriptionId'])
+        self.assertEqual(self.tenant_id, extended_info['tenantId'])
+        self.assertEqual('1234', extended_info['clientId'])
+        self.assertEqual('/tmp/123.pem', extended_info['clientCertificate'])
+        self.assertIsNone(extended_info.get('clientSecret', None))
+        self.assertEqual('https://login.microsoftonline.com', extended_info['activeDirectoryEndpointUrl'])
+        self.assertEqual('https://management.azure.com/', extended_info['resourceManagerEndpointUrl'])
+
     @mock.patch('adal.AuthenticationContext', autospec=True)
     def test_create_account_without_subscriptions_thru_service_principal(self, mock_auth_context):
         mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -250,9 +250,7 @@ class Test_Profile(unittest.TestCase):
     def test_get_auth_info_for_newly_created_service_principal(self):
         storage_mock = {'subscriptions': []}
         profile = Profile(storage_mock, use_global_creds_cache=False)
-        consolidated = Profile._normalize_properties(self.user1,
-                                                     [self.subscription1],
-                                                     False)
+        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
         profile._set_subscriptions(consolidated)
         # action
         extended_info = profile.get_sp_auth_info(name='1234', cert_file='/tmp/123.pem')


### PR DESCRIPTION
//cc:@jianghaolu


### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
