### PR TITLE
doc: update 'resource create' command's example to create an api app

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -235,12 +235,12 @@ helps['resource create'] = """
     type: command
     short-summary: create a resource.
     examples:
-       - name: Create a resource by providing a full resource object json. Note, you can also use `@<file>` to load from a json file.
+       - name: Create a resource, such as an API App, by providing a full resource object json. Note, you can also use `@<file>` to load from a json file.
          text: >
-            az resource create -g myRG -n myPlan --resource-type Microsoft.web/serverFarms --is-full-object --properties "{ \\"location\\":\\"westus\\",\\"sku\\":{\\"name\\":\\"B1\\",\\"tier\\":\\"BASIC\\"}}"
-       - name: Create a resource by only providing resource properties
+            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties "{\\"kind\\":\\"api\\", \\"location\\":\\"West US\\", \\"properties\\":{\\"serverFarmId\\":\\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1\\"}}"
+       - name: Create a resource, such as a Web App, by only providing resource properties
          text: >
-            az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties "{\\"serverFarmId\\":\\"myPlan\\"}"
+            az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties "{\\"serverFarmId\\":\\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1\\"}"
 """
 
 helps['resource update'] = """


### PR DESCRIPTION
To help out #2866, while appservice team has no immediate plans to add strong typed commands. The old
 example creates an app service plan which is less meaningful since we have strong typed commands for that already.

- [na] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
