### PR TITLE
Specify Linux distro on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: trusty
 python:
   - "2.7"
   - "3.5"


### PR DESCRIPTION
Addresses the warnings we see on Travis CI.
(not urgent for this release)

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming