### PR TITLE
account list: add '--refresh' to sycn up the latest subscriptions from server

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -437,7 +437,7 @@ class Profile(object):
             if user_name in refreshed_list:
                 continue
             refreshed_list.add(user_name)
-            is_service_principal = (s[_USER_ENTITY][_USER_NAME] == _SERVICE_PRINCIPAL)
+            is_service_principal = (s[_USER_ENTITY][_USER_TYPE] == _SERVICE_PRINCIPAL)
             tenant = s[_TENANT_ID]
             subscriptions = []
             try:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -264,7 +264,7 @@ class Profile(object):
         # use deepcopy as we don't want to persist these changes to file.
         return deepcopy(consolidated)
 
-    def _set_subscriptions(self, new_subscriptions):
+    def _set_subscriptions(self, new_subscriptions, merge=True):
         existing_ones = self.load_cached_subscriptions(all_clouds=True)
         active_one = next((x for x in existing_ones if x.get(_IS_DEFAULT_SUBSCRIPTION)), None)
         active_subscription_id = active_one[_SUBSCRIPTION_ID] if active_one else None
@@ -272,27 +272,31 @@ class Profile(object):
         default_sub_id = None
 
         # merge with existing ones
-        dic = collections.OrderedDict((x[_SUBSCRIPTION_ID], x) for x in existing_ones)
+        if merge:
+            dic = collections.OrderedDict((x[_SUBSCRIPTION_ID], x) for x in existing_ones)
+        else:
+            dic = collections.OrderedDict()
+
         dic.update((x[_SUBSCRIPTION_ID], x) for x in new_subscriptions)
         subscriptions = list(dic.values())
+        if subscriptions:
+            if active_one:
+                new_active_one = next(
+                    (x for x in new_subscriptions if x[_SUBSCRIPTION_ID] == active_subscription_id),
+                    None)
 
-        if active_one:
-            new_active_one = next(
-                (x for x in new_subscriptions if x[_SUBSCRIPTION_ID] == active_subscription_id),
-                None)
+                for s in subscriptions:
+                    s[_IS_DEFAULT_SUBSCRIPTION] = False
 
-            for s in subscriptions:
-                s[_IS_DEFAULT_SUBSCRIPTION] = False
-
-            if not new_active_one:
+                if not new_active_one:
+                    new_active_one = Profile._pick_working_subscription(new_subscriptions)
+            else:
                 new_active_one = Profile._pick_working_subscription(new_subscriptions)
-        else:
-            new_active_one = Profile._pick_working_subscription(new_subscriptions)
 
-        new_active_one[_IS_DEFAULT_SUBSCRIPTION] = True
-        default_sub_id = new_active_one[_SUBSCRIPTION_ID]
+            new_active_one[_IS_DEFAULT_SUBSCRIPTION] = True
+            default_sub_id = new_active_one[_SUBSCRIPTION_ID]
 
-        set_cloud_subscription(active_cloud.name, default_sub_id)
+            set_cloud_subscription(active_cloud.name, default_sub_id)
         self._storage[_SUBSCRIPTIONS] = subscriptions
 
     @staticmethod
@@ -423,13 +427,15 @@ class Profile(object):
                 str(account[_SUBSCRIPTION_ID]),
                 str(account[_TENANT_ID]))
 
-    def refresh_accounts(self):
+    def refresh_accounts(self, subscription_finder=None):
         subscriptions = self.load_cached_subscriptions()
         to_refresh = [s for s in subscriptions if s[_SUBSCRIPTION_NAME] != _MSI_ACCOUNT_NAME]
+        not_to_refresh = [s for s in subscriptions if s not in to_refresh]
 
         from azure.cli.core._debug import allow_debug_adal_connection
         allow_debug_adal_connection()
-        subscription_finder = SubscriptionFinder(self.auth_ctx_factory, self._creds_cache.adal_token_cache)
+        subscription_finder = subscription_finder or SubscriptionFinder(self.auth_ctx_factory,
+                                                                        self._creds_cache.adal_token_cache)
         refreshed_list = set()
         result = []
         for s in to_refresh:
@@ -446,12 +452,13 @@ class Profile(object):
                     subscriptions = subscription_finder.find_from_service_principal_id(user_name, sp_auth, tenant,
                                                                                        self._ad_resource_uri)
                 else:
-                    subscriptions = subscription_finder.find_from_user_account(user_name, None, tenant,
+                    subscriptions = subscription_finder.find_from_user_account(user_name, None, None,
                                                                                self._ad_resource_uri)
             except Exception as ex:  # pylint: disable=broad-except
                 logger.warning("Refreshing for '%s' failed for an error '%s'. The existing accounts are not modified. "
                                "You can run 'az login' later to explictly refresh them", user_name, ex)
-                pass
+                result += deepcopy([r for r in to_refresh if r[_USER_ENTITY][_USER_NAME] == user_name])
+                continue
 
             if not subscriptions:
                 if s[_SUBSCRIPTION_NAME] == _TENANT_LEVEL_ACCOUNT_NAME:
@@ -470,7 +477,8 @@ class Profile(object):
         if self._creds_cache.adal_token_cache.has_state_changed:
             self._creds_cache.persist_cached_creds()
 
-        self._set_subscriptions(result)
+        result = result + not_to_refresh
+        self._set_subscriptions(result, merge=False)
 
     def get_sp_auth_info(self, subscription_id=None, name=None, password=None, cert_file=None):
         from collections import OrderedDict

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -462,9 +462,7 @@ class Profile(object):
 
             if not subscriptions:
                 if s[_SUBSCRIPTION_NAME] == _TENANT_LEVEL_ACCOUNT_NAME:
-                    t_list = [s.tenant_id for s in subscriptions]
-                    bare_tenants = [t for t in subscription_finder.tenants if t not in t_list]
-                    subscriptions = Profile._build_tenant_level_accounts(bare_tenants)
+                    subscriptions = Profile._build_tenant_level_accounts([s[_TENANT_ID]])
 
                 if not subscriptions:
                     continue

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -455,8 +455,8 @@ class Profile(object):
                     subscriptions = subscription_finder.find_from_user_account(user_name, None, None,
                                                                                self._ad_resource_uri)
             except Exception as ex:  # pylint: disable=broad-except
-                logger.warning("Refreshing for '%s' failed for an error '%s'. The existing accounts are not modified. "
-                               "You can run 'az login' later to explictly refresh them", user_name, ex)
+                logger.warning("Refreshing for '%s' failed with an error '%s'. The existing accounts were not "
+                               "modified. You can run 'az login' later to explictly refresh them", user_name, ex)
                 result += deepcopy([r for r in to_refresh if r[_USER_ENTITY][_USER_NAME] == user_name])
                 continue
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -9,6 +9,8 @@ import os
 import unittest
 import mock
 
+from copy import deepcopy
+
 from adal import AdalError
 from azure.mgmt.resource.subscriptions.models import (SubscriptionState, Subscription,
                                                       SubscriptionPolicies, SpendingLimit)
@@ -884,13 +886,13 @@ class Test_Profile(unittest.TestCase):
     def test_refresh_accounts_one_user_account(self, mock_auth_context):
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock, use_global_creds_cache=False)
-        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        consolidated = Profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         profile._set_subscriptions(consolidated)
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
         mock_auth_context.acquire_token.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
-        mock_arm_client.subscriptions.list.return_value = [self.subscription1, self.subscription2]
+        mock_arm_client.subscriptions.list.return_value = deepcopy([self.subscription1, self.subscription2])
         finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
                                     None,
                                     lambda _: mock_arm_client)
@@ -909,7 +911,7 @@ class Test_Profile(unittest.TestCase):
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock, use_global_creds_cache=False)
         sp_subscription1 = SubscriptionStub('sp-sub/3', 'foo-subname', self.state1, 'foo_tenant.onmicrosoft.com')
-        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        consolidated = Profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         consolidated += Profile._normalize_properties('http://foo', [sp_subscription1], True)
         profile._set_subscriptions(consolidated)
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
@@ -917,7 +919,7 @@ class Test_Profile(unittest.TestCase):
         mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
-        mock_arm_client.subscriptions.list.side_effect = [[self.subscription1], [self.subscription2, sp_subscription1]]
+        mock_arm_client.subscriptions.list.side_effect = deepcopy([[self.subscription1], [self.subscription2, sp_subscription1]])
         finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
                                     None,
                                     lambda _: mock_arm_client)
@@ -938,7 +940,7 @@ class Test_Profile(unittest.TestCase):
     def test_refresh_accounts_with_nothing(self, mock_auth_context):
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock, use_global_creds_cache=False)
-        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        consolidated = Profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False)
         profile._set_subscriptions(consolidated)
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
         mock_auth_context.acquire_token.return_value = self.token_entry1

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -880,6 +880,81 @@ class Test_Profile(unittest.TestCase):
         mock_auth_context.acquire_token_with_client_certificate.assert_called_once_with(
             mgmt_resource, 'my app', mock.ANY, mock.ANY)
 
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_refresh_accounts_one_user_account(self, mock_auth_context):
+        storage_mock = {'subscriptions': None}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        profile._set_subscriptions(consolidated)
+        mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
+        mock_auth_context.acquire_token.return_value = self.token_entry1
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_arm_client.subscriptions.list.return_value = [self.subscription1, self.subscription2]
+        finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
+                                    None,
+                                    lambda _: mock_arm_client)
+        # action
+        profile.refresh_accounts(finder)
+
+        # assert
+        result = storage_mock['subscriptions']
+        self.assertEqual(2, len(result))
+        self.assertEqual(self.id1.split('/')[-1], result[0]['id'])
+        self.assertEqual(self.id2.split('/')[-1], result[1]['id'])
+        self.assertTrue(result[0]['isDefault'])
+
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_refresh_accounts_one_user_account_one_sp_account(self, mock_auth_context):
+        storage_mock = {'subscriptions': None}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        sp_subscription1 = SubscriptionStub('sp-sub/3', 'foo-subname', self.state1, 'foo_tenant.onmicrosoft.com')
+        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        consolidated += Profile._normalize_properties('http://foo', [sp_subscription1], True)
+        profile._set_subscriptions(consolidated)
+        mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
+        mock_auth_context.acquire_token.return_value = self.token_entry1
+        mock_auth_context.acquire_token_with_client_credentials.return_value = self.token_entry1
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_arm_client.subscriptions.list.side_effect = [[self.subscription1], [self.subscription2, sp_subscription1]]
+        finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
+                                    None,
+                                    lambda _: mock_arm_client)
+        profile._creds_cache.retrieve_secret_of_service_principal = lambda _: 'verySecret'
+        profile._creds_cache.flush_to_disk = lambda _: ''
+        # action
+        profile.refresh_accounts(finder)
+
+        # assert
+        result = storage_mock['subscriptions']
+        self.assertEqual(3, len(result))
+        self.assertEqual(self.id1.split('/')[-1], result[0]['id'])
+        self.assertEqual(self.id2.split('/')[-1], result[1]['id'])
+        self.assertEqual('3', result[2]['id'])
+        self.assertTrue(result[0]['isDefault'])
+
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    def test_refresh_accounts_with_nothing(self, mock_auth_context):
+        storage_mock = {'subscriptions': None}
+        profile = Profile(storage_mock, use_global_creds_cache=False)
+        consolidated = Profile._normalize_properties(self.user1, [self.subscription1], False)
+        profile._set_subscriptions(consolidated)
+        mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1
+        mock_auth_context.acquire_token.return_value = self.token_entry1
+        mock_arm_client = mock.MagicMock()
+        mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
+        mock_arm_client.subscriptions.list.return_value = []
+        finder = SubscriptionFinder(lambda _, _2: mock_auth_context,
+                                    None,
+                                    lambda _: mock_arm_client)
+        # action
+        profile.refresh_accounts(finder)
+
+        # assert
+        result = storage_mock['subscriptions']
+        self.assertEqual(0, len(result))
+
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     def test_credscache_load_tokens_and_sp_creds_with_secret(self, mock_read_file):
         test_sp = {

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+(unreleased)
++++++++++++++++++++
+* account list: add `--refresh` to sycn up the latest subscriptions from server
+
 2.0.9 (2017-07-27)
 ++++++++++++++++++
 support login inside a VM with a managed identity

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -27,4 +27,5 @@ register_cli_argument('logout', 'username', help='account user, if missing, logo
 
 register_cli_argument('account', 'subscription', options_list=('--subscription', '-s'), help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'all', help="List all subscriptions, rather just 'Enabled' ones", action='store_true')
+register_cli_argument('account list', 'refresh', help="retrieve up to date subscriptions from server", action='store_true')
 register_cli_argument('account show', 'show_auth_for_sdk', options_list=('--sdk-auth',), action='store_true', help='output result in compatible with Azure SDK auth file')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -14,15 +14,17 @@ from azure.cli.core.cloud import get_active_cloud
 logger = get_az_logger(__name__)
 
 
-def load_subscriptions(all_clouds=False):
+def load_subscriptions(all_clouds=False, refresh=False):
     profile = Profile()
+    if refresh:
+        subscriptions = profile.refresh_accounts()
     subscriptions = profile.load_cached_subscriptions(all_clouds)
     return subscriptions
 
 
-def list_subscriptions(all=False):  # pylint: disable=redefined-builtin
+def list_subscriptions(all=False, refresh=False):  # pylint: disable=redefined-builtin
     """List the imported subscriptions."""
-    subscriptions = load_subscriptions(all_clouds=all)
+    subscriptions = load_subscriptions(all_clouds=all, refresh=refresh)
     if not subscriptions:
         logger.warning('Please run "az login" to access your accounts.')
     for sub in subscriptions:


### PR DESCRIPTION
Fix #919 

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
