### PR TITLE
Fix dep. check after azure-common release

### DIFF
--- a/scripts/automation/tests/verify_dependencies.py
+++ b/scripts/automation/tests/verify_dependencies.py
@@ -12,9 +12,8 @@ import sys
 
 ALLOWED_ERRORS = [
     "has requirement requests~=2.14.1, but you have requests 2.",
-    "has requirement azure-common[autorest]==1.1.4, but you have azure-common 1.1.6.",
-    "has requirement azure-common[autorest]==1.1.4, but you have azure-common 1.1.7.",
-    "has requirement azure-common~=1.1.5, but you have azure-common 1.1.4."
+    "has requirement azure-common[autorest]==1.1.4, but you have azure-common 1.1.",
+    "has requirement azure-common~=1.1.5, but you have azure-common 1.1."
 ]
 
 def verify_dependencies():


### PR DESCRIPTION
Now we check just MAJOY and MINOR version
