### PR TITLE
[Test] Make `run_tests --test` parameter work cross platform

### DIFF
--- a/scripts/automation/tests/run.py
+++ b/scripts/automation/tests/run.py
@@ -21,11 +21,11 @@ def get_unittest_runner(tests):
             print('When --test is given, no more than 1 module can be selected.')
             return False
 
-        module_path = module_paths[0][len(os.path.join(get_repo_root(), 'src/')):]
+        module_path = module_paths[0][len(os.path.join(get_repo_root(), 'src' + os.sep)):]
         if module_path.startswith('command_modules'):
-            module_path = module_path.split('/', 2)[-1].replace('/', '.')
+            module_path = module_path.split(os.sep, 2)[-1].replace(os.sep, '.')
         else:
-            module_path = module_path.split('/', 1)[-1].replace('/', '.')
+            module_path = module_path.split(os.sep, 1)[-1].replace(os.sep, '.')
 
         try:
             import unittest


### PR DESCRIPTION
Previously only work on Linux.  With this change, it will also work on Windows.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [N/A] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
