### PR TITLE
[ACR] Fix an issue with authentication when refresh token is not available

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -407,7 +407,9 @@ class Profile(object):
         if user_type == _USER:
             _, _, token_entry = self._creds_cache.retrieve_token_for_user(
                 username_or_sp_id, account[_TENANT_ID], resource)
-            return None, token_entry[_REFRESH_TOKEN], token_entry[_ACCESS_TOKEN], str(account[_TENANT_ID])
+            refresh_token = token_entry[_REFRESH_TOKEN] if _REFRESH_TOKEN in token_entry else None
+            access_token = token_entry[_ACCESS_TOKEN] if _ACCESS_TOKEN in token_entry else None
+            return None, refresh_token, access_token, str(account[_TENANT_ID])
 
         sp_secret = self._creds_cache.retrieve_secret_of_service_principal(username_or_sp_id)
         return username_or_sp_id, sp_secret, None, str(account[_TENANT_ID])

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -407,9 +407,7 @@ class Profile(object):
         if user_type == _USER:
             _, _, token_entry = self._creds_cache.retrieve_token_for_user(
                 username_or_sp_id, account[_TENANT_ID], resource)
-            refresh_token = token_entry[_REFRESH_TOKEN] if _REFRESH_TOKEN in token_entry else None
-            access_token = token_entry[_ACCESS_TOKEN] if _ACCESS_TOKEN in token_entry else None
-            return None, refresh_token, access_token, str(account[_TENANT_ID])
+            return None, token_entry.get(_REFRESH_TOKEN), token_entry[_ACCESS_TOKEN], str(account[_TENANT_ID])
 
         sp_secret = self._creds_cache.retrieve_secret_of_service_principal(username_or_sp_id)
         return username_or_sp_id, sp_secret, None, str(account[_TENANT_ID])

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
@@ -47,8 +47,8 @@ def _get_login_token(login_server, only_refresh_token=True, repository=None):
     sp_id, refresh, access, tenant = profile.get_refresh_token()
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-    if sp_id is None:
-        if refresh is None:
+    if not sp_id:
+        if not refresh:
             content = {
                 'grant_type': 'access_token',
                 'service': params['service'],

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_docker_utils.py
@@ -48,13 +48,21 @@ def _get_login_token(login_server, only_refresh_token=True, repository=None):
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
     if sp_id is None:
-        content = {
-            'grant_type': 'access_token_refresh_token',
-            'service': params['service'],
-            'tenant': tenant,
-            'access_token': access,
-            'refresh_token': refresh
-        }
+        if refresh is None:
+            content = {
+                'grant_type': 'access_token',
+                'service': params['service'],
+                'tenant': tenant,
+                'access_token': access
+            }
+        else:
+            content = {
+                'grant_type': 'access_token_refresh_token',
+                'service': params['service'],
+                'tenant': tenant,
+                'access_token': access,
+                'refresh_token': refresh
+            }
     else:
         content = {
             'grant_type': 'spn',

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -257,15 +257,15 @@ def acr_login(registry_name, resource_group_name=None, username=None, password=N
                 password = get_login_refresh_token(login_server)
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning("AAD authentication failed with message: %s", str(e))
-    else:
-        # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
-        if not password:
-            try:
-                cred = acr_credential_show(registry_name)
-                username = cred.username
-                password = cred.passwords[0].value
-            except Exception as e:  # pylint: disable=broad-except
-                logger.warning("Admin user authentication failed with message: %s", str(e))
+
+    # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
+    if not password:
+        try:
+            cred = acr_credential_show(registry_name)
+            username = cred.username
+            password = cred.passwords[0].value
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Admin user authentication failed with message: %s", str(e))
 
     # 4. if we still don't have credentials, prompt the user
     if not password:

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
@@ -163,19 +163,19 @@ def _validate_user_credentials(registry_name,
             logger.warning("Unable to authenticate using AAD tokens: %s", str(e))
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("AAD authentication failed with message: %s", str(e))
-    else:
-        # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
-        try:
-            cred = acr_credential_show(registry_name)
-            username = cred.username
-            password = cred.passwords[0].value
-            return request_method(login_server, path, username, password, result_index)
-        except NotFound as e:
-            raise CLIError(str(e))
-        except Unauthorized as e:
-            logger.warning("Unable to authenticate using admin login credentials: %s", str(e))
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning("Admin user authentication failed with message: %s", str(e))
+
+    # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
+    try:
+        cred = acr_credential_show(registry_name)
+        username = cred.username
+        password = cred.passwords[0].value
+        return request_method(login_server, path, username, password, result_index)
+    except NotFound as e:
+        raise CLIError(str(e))
+    except Unauthorized as e:
+        logger.warning("Unable to authenticate using admin login credentials: %s", str(e))
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning("Admin user authentication failed with message: %s", str(e))
 
     # 4. if we still don't have credentials, prompt the user
     try:


### PR DESCRIPTION
 - Fallback to authenticate with access token if refresh token is not available (such as in cloud console).
 - Always fallback to admin user authentication if all preceding operations failed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
