### PR TITLE
Allow equals sign in an environment variable value

### DIFF
--- a/src/command_modules/azure-cli-container/HISTORY.rst
+++ b/src/command_modules/azure-cli-container/HISTORY.rst
@@ -1,5 +1,10 @@
 .. :changelog:
 
+unreleased
+----------
+
+* container create: Fixes issue where equals sign was not allowed inside an environment variable.
+
 Release History
 ===============
 

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
@@ -20,7 +20,7 @@ OS_TYPES = ['Windows', 'Linux']
 def environment_variables_format(value):
     """Space separated values in 'key=value' format."""
     try:
-        env_name, env_value = value.split('=')
+        env_name, env_value = value.split('=', 1)
     except ValueError:
         message = ("Incorrectly formatted enviroment settings. "
                    "Argmuent values should be in the format a=b c=d")

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/tests/test_container_commands.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/tests/test_container_commands.py
@@ -19,7 +19,7 @@ class AzureContainerInstanceScenarioTest(ScenarioTest):
         cpu = 1
         memory = 1
         command = '"/bin/sh -c \'while true; do echo hello; sleep 20; done\'"'
-        env = 'KEY1=VALUE1 KEY2=VALUE2'
+        env = 'KEY1=VALUE1 KEY2=FOO=BAR='
 
         create_cmd = 'container create -g {} -n {} --image {} --os-type {} --ip-address {} --port {} ' \
             '--cpu {} --memory {} --command-line {} -e {}'.format(resource_group,


### PR DESCRIPTION
Fixes #4142.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ x ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ x ] Each command and parameter has a meaningful description.
- [ x ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
