### PR TITLE
[Network] Fix error - unexpected keyword argument 'sa_data_size_kilobyes'

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -8,6 +8,7 @@ unreleased
 * `lb`: fixed issue where the certain child resource names did not resolve correctly when omitted
 * `application-gateway {subresource} delete`: Fixed issue where `--no-wait` was not honored.
 * `application-gateway http-settings update`: Fix issue where `--connection-draining-timeout` could not be turned off.
+* `[Network] Fix error - unexpected keyword argument 'sa_data_size_kilobyes'` : Fix where `az network vpn-connection ipsec-policy add` unexpected keyword argument 'sa_data_size_kilobyes'
 
 2.0.11 (2017-07-27)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1677,7 +1677,7 @@ def add_vpn_conn_ipsec_policy(resource_group_name, connection_name,
     ncf = _network_client_factory().virtual_network_gateway_connections
     conn = ncf.get(resource_group_name, connection_name)
     new_policy = IpsecPolicy(sa_life_time_seconds=sa_life_time_seconds,
-                             sa_data_size_kilobyes=sa_data_size_kilobytes,
+                             sa_data_size_kilobytes=sa_data_size_kilobytes,
                              ipsec_encryption=ipsec_encryption,
                              ipsec_integrity=ipsec_integrity,
                              ike_encryption=ike_encryption,


### PR DESCRIPTION
spelling mistake kilobyes updated to kilobytes 

causing the following error when users runs -- az network vpn-connection ipsec-policy add 
__init__() got an unexpected keyword argument 'sa_data_size_kilobyes'
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/core/application.py", line 211, in execute
    result = expanded_arg.func(params)
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/core/commands/__init__.py", line 351, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/core/commands/__init__.py", line 550, in _execute_command
    reraise(*sys.exc_info())
  File "/usr/local/lib/python3.5/dist-packages/six.py", line 686, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/core/commands/__init__.py", line 527, in _execute_command
    result = op(client, **kwargs) if client else op(**kwargs)
  File "/usr/local/lib/python3.5/dist-packages/azure/cli/command_modules/network/custom.py", line 1682, in add_vpn_conn_ipsec_policy
    pfs_group=pfs_group)
TypeError: __init__() got an unexpected keyword argument 'sa_data_size_kilobyes'

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
