### PR TITLE
[ACR] Add support to pipe docker password using --password-stdin option

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from subprocess import call, PIPE
-
 from azure.cli.core.commands import LongRunningOperation
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core.util import CLIError
@@ -226,17 +224,26 @@ def acr_update_set(client,
     return client.update(resource_group_name, registry_name, parameters)
 
 
-def acr_login(registry_name, resource_group_name=None, username=None, password=None):
+def acr_login(registry_name,  # pylint: disable=too-many-statements
+              resource_group_name=None,
+              username=None,
+              password=None):
     """Login to a container registry through Docker.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     :param str username: The username used to log into the container registry
     :param str password: The password used to log into the container registry
     """
+    from subprocess import PIPE, Popen
+    _DOCKER_NOT_AVAILABLE = "Please verify whether docker is installed and running properly"
+
     try:
-        call(["docker", "ps"], stdout=PIPE, stderr=PIPE)
+        p = Popen(["docker", "ps"], stdout=PIPE, stderr=PIPE)
+        returncode = p.wait()
+        if returncode:
+            raise CLIError(_DOCKER_NOT_AVAILABLE)
     except:
-        raise CLIError("Please verify whether docker is installed and running properly")
+        raise CLIError(_DOCKER_NOT_AVAILABLE)
 
     registry, _ = get_registry_by_name(registry_name, resource_group_name)
     sku_tier = registry.sku.tier
@@ -277,10 +284,27 @@ def acr_login(registry_name, resource_group_name=None, username=None, password=N
                 'Unable to authenticate using AAD or admin login credentials. ' +
                 'Please specify both username and password in non-interactive mode.')
 
-    call(["docker", "login",
-          "--username", username,
-          "--password", password,
-          login_server])
+    use_password_stdin = False
+    try:
+        p = Popen(["docker", "login", "--help"], stdout=PIPE, stderr=PIPE)
+        stdout, _ = p.communicate()
+        if b'--password-stdin' in stdout:
+            use_password_stdin = True
+    except:
+        raise CLIError(_DOCKER_NOT_AVAILABLE)
+
+    if use_password_stdin:
+        p = Popen(["docker", "login",
+                   "--username", username,
+                   "--password-stdin",
+                   login_server], stdin=PIPE)
+        p.communicate(input=password.encode())
+    else:
+        p = Popen(["docker", "login",
+                   "--username", username,
+                   "--password", password,
+                   login_server])
+        p.wait()
 
 
 def acr_show_usage(registry_name, resource_group_name=None):


### PR DESCRIPTION
Newer versions of `docker` added a new `--password-stdin` option for docker login to take the password from stdin, so that the OS won't log the password, but now it also complains when `--password` option is used.
```
az acr login -n MyRegistry
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
```
This change is to use `--password-stdin` option if possible.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
