### PR TITLE
az vmss list-instance-public-ips should be made available to 2017-03-09-profile

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -267,11 +267,11 @@ cli_command(__name__, 'vmss stop', custom_path.format('stop_vmss'), no_wait_para
 cli_command(__name__, 'vmss restart', custom_path.format('restart_vmss'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss start', custom_path.format('start_vmss'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss update-instances', custom_path.format('update_vmss_instances'), no_wait_param='no_wait')
-cli_command(__name__, 'vmss reimage', custom_path.format('reimage_vmss'), no_wait_param='no_wait')
+if supported_api_version(ResourceType.MGMT_COMPUTE, min_api='2017-03-30'):
+    cli_command(__name__, 'vmss reimage', custom_path.format('reimage_vmss'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss scale', custom_path.format('scale_vmss'), no_wait_param='no_wait')
 cli_command(__name__, 'vmss list-instance-connection-info', custom_path.format('list_vmss_instance_connection_info'))
-if supported_api_version(ResourceType.MGMT_COMPUTE, min_api='2017-03-30'):
-    cli_command(__name__, 'vmss list-instance-public-ips', custom_path.format('list_vmss_instance_public_ips'))
+cli_command(__name__, 'vmss list-instance-public-ips', custom_path.format('list_vmss_instance_public_ips'))
 
 # VM Size
 cli_command(__name__, 'vm list-sizes', mgmt_path.format('virtual_machine_sizes_operations', 'VirtualMachineSizesOperations', 'list'), cf_vm_sizes)


### PR DESCRIPTION
az vmss list-instance-public-ips should be made available to 2017-03-09-profile
and az vmss reimage command should be available only to latest
It closes #4239 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
