### PR TITLE
vm/vmss create: don't throw when failed to retrieve the image to extract out the plan information

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 unreleased
 +++++++++++++++++++
+* `vm/vmss create`: don't throw when failed to retrieve the image to extract out the plan information 
 * `vmss create`: fix a crash when create a scaleset with an internal LB
 * `vm availability-set create`: Fix issue where --no-wait argument did not work.
 

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 unreleased
 +++++++++++++++++++
-* `vm/vmss create`: don't throw when failed to retrieve the image to extract out the plan information 
+* `vm/vmss create`: fix issue where the command would throw an error if unable to extract plan information from an image. 
 * `vmss create`: fix a crash when create a scaleset with an internal LB
 * `vm availability-set create`: Fix issue where --no-wait argument did not work.
 


### PR DESCRIPTION
Fix #4262 
### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
