### PR TITLE
[IOT] Fix for iot hub policy delete, deleting all policies.

### DIFF
--- a/src/command_modules/azure-cli-iot/HISTORY.rst
+++ b/src/command_modules/azure-cli-iot/HISTORY.rst
@@ -2,7 +2,7 @@
 
 Release History
 ===============
-0.1.11 (2017-08-18)
+unreleased
 +++++++++++++++++++
 * revisit of bug 3934 -- policy creation no longer clears existing policies.
 

--- a/src/command_modules/azure-cli-iot/HISTORY.rst
+++ b/src/command_modules/azure-cli-iot/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.1.11 (2017-08-18)
++++++++++++++++++++
+* revisit of bug 3934 -- policy creation no longer clears existing policies.
 
 0.1.10 (2017-07-27)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-iot/HISTORY.rst
+++ b/src/command_modules/azure-cli-iot/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 unreleased
-+++++++++++++++++++
++++++++++++++++
 * revisit of bug 3934 -- policy creation no longer clears existing policies.
 
 0.1.10 (2017-07-27)

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -150,7 +150,8 @@ def iot_hub_policy_create(client, hub_name, policy_name, permissions, resource_g
 def iot_hub_policy_delete(client, hub_name, policy_name, resource_group_name=None):
     hub = iot_hub_get(client, hub_name, resource_group_name)
     policies = iot_hub_policy_list(client, hub_name, hub.resourcegroup)
-    if not _is_policy_existed(policies, policy_name):
+    import copy
+    if not _is_policy_existed(copy.deepcopy(policies), policy_name):
         raise CLIError('Policy {0} not found.'.format(policy_name))
     updated_policies = [p for p in policies if p.key_name.lower() != policy_name.lower()]
     hub.properties.authorization_policies = updated_policies

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -148,9 +148,9 @@ def iot_hub_policy_create(client, hub_name, policy_name, permissions, resource_g
 
 
 def iot_hub_policy_delete(client, hub_name, policy_name, resource_group_name=None):
+    import copy
     hub = iot_hub_get(client, hub_name, resource_group_name)
     policies = iot_hub_policy_list(client, hub_name, hub.resourcegroup)
-    import copy
     if not _is_policy_existed(copy.deepcopy(policies), policy_name):
         raise CLIError('Policy {0} not found.'.format(policy_name))
     updated_policies = [p for p in policies if p.key_name.lower() != policy_name.lower()]

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/latest/test_iot_hub.yaml
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/latest/test_iot_hub.yaml
@@ -1,32 +1,32 @@
 interactions:
 - request:
-    body: '{"Name": "iot-hub-for-test"}'
+    body: !!python/unicode '{"Name": "iot-hub-for-test"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9ff3162c-cb35-11e6-bc69-40a8f04ffd53]
+      x-ms-client-request-id: [5c86bf9e-8459-11e7-962d-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2016-02-03
   response:
-    body: {string: '{"nameAvailable":true,"reason":"Invalid","message":null}'}
+    body: {string: !!python/unicode '{"nameAvailable":true,"reason":"Invalid","message":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:36:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['56']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:08:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -35,51 +35,53 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0ea8746-cb35-11e6-a6d8-40a8f04ffd53]
+      x-ms-client-request-id: [5cbc2780-8459-11e7-9c06-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/iot-hub-test-rg?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg","name":"iot-hub-test-rg","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg","name":"iot-hub-test-rg","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:36:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['220']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:08:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1}, "resourcegroup":
-      "iot-hub-test-rg", "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584"}'
+    body: !!python/unicode '{"resourcegroup": "iot-hub-test-rg", "sku": {"capacity":
+      1, "name": "S1"}, "subscriptionid": "5bd5a5c2-9d8f-4223-b911-5c58cf39aedd",
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['160']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","properties":{"state":"Activating","provisioningState":"Accepted","enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","properties":{"state":"Activating","provisioningState":"Accepted","enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo']
-      Cache-Control: [no-cache]
-      Content-Length: ['689']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:36:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo']
+      cache-control: [no-cache]
+      content-length: ['668']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:08:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['4999']
     status: {code: 201, message: Created}
 - request:
@@ -89,25 +91,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Running"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:37:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:08:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -116,25 +118,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Running"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:37:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:09:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -143,25 +145,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Running"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:38:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:09:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -170,25 +172,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Running"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:38:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -197,133 +199,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTJmODBlYjAtNzJkZi00ZDJmLTkyNzEtMmI0MzA1Y2YwYjBk?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:39:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:39:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:40:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:40:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Succeeded"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -332,25 +226,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
+      x-ms-client-request-id: [5ce6b9f0-8459-11e7-bfee-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:16 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1873']
+      cache-control: [no-cache]
+      content-length: ['1854']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -359,25 +253,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4e7ff802-cb36-11e6-8787-40a8f04ffd53]
+      x-ms-client-request-id: [b96aa7e1-8459-11e7-8e9e-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:18 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
+      cache-control: [no-cache]
+      content-length: ['3749']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -387,83 +283,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4ef41c80-cb36-11e6-9e40-40a8f04ffd53]
+      x-ms-client-request-id: [b99169c0-8459-11e7-be5b-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [501b976e-cb36-11e6-b9a3-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51283a30-cb36-11e6-855d-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -473,25 +312,55 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [526ec5c8-cb36-11e6-9c76-40a8f04ffd53]
+      x-ms-client-request-id: [b9ba758f-8459-11e7-946a-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
+      cache-control: [no-cache]
+      content-length: ['1866']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b9ef4130-8459-11e7-8b56-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -500,349 +369,99 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [536c6878-cb36-11e6-93f2-40a8f04ffd53]
+      x-ms-client-request-id: [ba195e70-8459-11e7-808c-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
+      cache-control: [no-cache]
+      content-length: ['3749']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
-      "etag": "AAAAAACS9jQ=", "sku": {"name": "S1", "capacity": 1}, "properties":
-      {"eventHubEndpoints": {"operationsMonitoringEvents": {"partitionCount": 4, "retentionTimeInDays":
-      1}, "events": {"partitionCount": 4, "retentionTimeInDays": 1}}, "enableFileUploadNotifications":
-      false, "operationsMonitoringProperties": {"events": {"C2DCommands": "None",
-      "Connections": "None", "FileUploadOperations": "None", "None": "None", "Routes":
-      "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
-      "None"}}, "features": "None", "messagingEndpoints": {"fileNotifications": {"ttlAsIso8601":
-      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}}, "cloudToDevice":
-      {"feedback": {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601":
-      "PT1M"}, "maxDeliveryCount": 10, "defaultTtlAsIso8601": "PT1H"}, "ipFilterRules":
-      [], "storageEndpoints": {"$default": {"connectionString": "", "sasTtlAsIso8601":
-      "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ba4613c0-8459-11e7-ac5d-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3749']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"resourcegroup": "iot-hub-test-rg", "sku": {"capacity":
+      1, "name": "S1"}, "etag": "AAAAAAEWr4w=", "location": "westus", "tags": {},
+      "subscriptionid": "5bd5a5c2-9d8f-4223-b911-5c58cf39aedd", "properties": {"messagingEndpoints":
+      {"fileNotifications": {"ttlAsIso8601": "PT1H", "lockDurationAsIso8601": "PT1M",
+      "maxDeliveryCount": 10}}, "operationsMonitoringProperties": {"events": {"None":
+      "None", "C2DCommands": "None", "DeviceIdentityOperations": "None", "Connections":
+      "None", "Routes": "None", "DeviceTelemetry": "Error, Information", "FileUploadOperations":
+      "None"}}, "ipFilterRules": [], "features": "None", "cloudToDevice": {"defaultTtlAsIso8601":
+      "PT1H", "feedback": {"ttlAsIso8601": "PT1H", "lockDurationAsIso8601": "PT1M",
+      "maxDeliveryCount": 10}, "maxDeliveryCount": 10}, "eventHubEndpoints": {"operationsMonitoringEvents":
+      {"partitionCount": 4, "retentionTimeInDays": 1}, "events": {"partitionCount":
+      4, "retentionTimeInDays": 1}}, "enableFileUploadNotifications": false, "storageEndpoints":
+      {"$default": {"sasTtlAsIso8601": "PT1H", "containerName": "", "connectionString":
+      ""}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1096']
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9jQ=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr4w=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
+      x-ms-client-request-id: [ba6e3530-8459-11e7-b7fe-9cb6d0dafd06]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr4w=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjNhZTgyOGUtZjhmOS00NDcwLWI5OTYtNzdhMzI1MzUyMWQz?api-version=2016-02-03&asyncinfo']
-      Cache-Control: [no-cache]
-      Content-Length: ['2443']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:41:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['4998']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9jQ=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjNhZTgyOGUtZjhmOS00NDcwLWI5OTYtNzdhMzI1MzUyMWQz?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Succeeded"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['22']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9jQ=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1887']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [694120a8-cb36-11e6-b0b3-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6a0edfd0-cb36-11e6-8977-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6ae872c8-cb36-11e6-a23d-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6b5b37d4-cb36-11e6-8a4b-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/skus?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S1","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S2","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S3","tier":"Standard"},"capacity":{"minimum":1,"maximum":10,"default":1,"scaleType":"Manual"}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['475']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6c2c7010-cb36-11e6-b9cc-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6ca0f95e-cb36-11e6-b71f-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['905']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
-      "etag": "AAAAAACS9p0=", "sku": {"name": "S1", "capacity": 1}, "properties":
-      {"authorizationPolicies": [{"rights": "RegistryWrite, ServiceConnect, DeviceConnect",
-      "keyName": "iothubowner", "primaryKey": "B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=",
-      "secondaryKey": "90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI="}, {"rights":
-      "ServiceConnect", "keyName": "service", "primaryKey": "7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=",
-      "secondaryKey": "DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o="}, {"rights":
-      "DeviceConnect", "keyName": "device", "primaryKey": "uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=",
-      "secondaryKey": "WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q="}, {"rights":
-      "RegistryRead", "keyName": "registryRead", "primaryKey": "tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=",
-      "secondaryKey": "9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI="}, {"rights":
-      "RegistryWrite", "keyName": "registryReadWrite", "primaryKey": "mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=",
-      "secondaryKey": "hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ="}, {"rights":
-      "RegistryWrite, ServiceConnect, DeviceConnect", "keyName": "test_policy"}],
-      "enableFileUploadNotifications": false, "operationsMonitoringProperties": {"events":
-      {"C2DCommands": "None", "Connections": "None", "FileUploadOperations": "None",
-      "None": "None", "Routes": "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
-      "None"}}, "features": "None", "eventHubEndpoints": {"operationsMonitoringEvents":
-      {"partitionCount": 4, "retentionTimeInDays": 1}, "events": {"partitionCount":
-      4, "retentionTimeInDays": 1}}, "cloudToDevice": {"feedback": {"ttlAsIso8601":
-      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}, "maxDeliveryCount":
-      10, "defaultTtlAsIso8601": "PT1H"}, "messagingEndpoints": {"fileNotifications":
-      {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}},
-      "ipFilterRules": [], "storageEndpoints": {"$default": {"connectionString": "",
-      "sasTtlAsIso8601": "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2143']
-      Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9p0=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
-  response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo']
-      Cache-Control: [no-cache]
-      Content-Length: ['2647']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzdjMjJhYWMtY2ZhOS00NDc2LWFkZmYtOTRmYzJiYzcwYWNj?api-version=2016-02-03&asyncinfo']
+      cache-control: [no-cache]
+      content-length: ['2445']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:10:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['4999']
     status: {code: 201, message: Created}
 - request:
@@ -852,54 +471,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9p0=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr4w=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+      x-ms-client-request-id: [ba6e3530-8459-11e7-b7fe-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzdjMjJhYWMtY2ZhOS00NDc2LWFkZmYtOTRmYzJiYzcwYWNj?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:42:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9p0=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Succeeded"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -908,27 +499,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9p0=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr4w=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+      x-ms-client-request-id: [ba6e3530-8459-11e7-b7fe-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:16 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1887']
+      cache-control: [no-cache]
+      content-length: ['1868']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -937,26 +528,143 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9645cfa2-cb36-11e6-819f-40a8f04ffd53]
+      x-ms-client-request-id: [cd79640f-8459-11e7-a832-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cda296f0-8459-11e7-a9d1-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1880']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cdce13c0-8459-11e7-b74c-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ce0920f0-8459-11e7-a33b-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/skus?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S1","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S2","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S3","tier":"Standard"},"capacity":{"minimum":1,"maximum":10,"default":1,"scaleType":"Manual"}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['475']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ce5ee20f-8459-11e7-95f4-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -966,199 +674,84 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [972e443e-cb36-11e6-9a9a-40a8f04ffd53]
+      x-ms-client-request-id: [ce8b704f-8459-11e7-a734-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}]}'}
+    body: {string: !!python/unicode '{"value":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1109']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      cache-control: [no-cache]
+      content-length: ['905']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9867b4f8-cb36-11e6-bffc-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [98f83b9c-cb36-11e6-a211-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/test_policy/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9a39f888-cb36-11e6-9072-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9b23c99e-cb36-11e6-a5f2-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1109']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
-      "etag": "AAAAAACS9sM=", "sku": {"name": "S1", "capacity": 1}, "properties":
-      {"authorizationPolicies": [{"rights": "RegistryWrite, ServiceConnect, DeviceConnect",
-      "keyName": "iothubowner", "primaryKey": "B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=",
-      "secondaryKey": "90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI="}, {"rights":
-      "ServiceConnect", "keyName": "service", "primaryKey": "7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=",
-      "secondaryKey": "DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o="}, {"rights":
-      "DeviceConnect", "keyName": "device", "primaryKey": "uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=",
-      "secondaryKey": "WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q="}, {"rights":
-      "RegistryRead", "keyName": "registryRead", "primaryKey": "tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=",
-      "secondaryKey": "9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI="}, {"rights":
-      "RegistryWrite", "keyName": "registryReadWrite", "primaryKey": "mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=",
-      "secondaryKey": "hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ="}], "enableFileUploadNotifications":
-      false, "operationsMonitoringProperties": {"events": {"C2DCommands": "None",
-      "Connections": "None", "FileUploadOperations": "None", "None": "None", "Routes":
+    body: !!python/unicode '{"resourcegroup": "iot-hub-test-rg", "sku": {"capacity":
+      1, "name": "S1"}, "etag": "AAAAAAEWr5Y=", "location": "westus", "tags": {},
+      "subscriptionid": "5bd5a5c2-9d8f-4223-b911-5c58cf39aedd", "properties": {"messagingEndpoints":
+      {"fileNotifications": {"ttlAsIso8601": "PT1H", "lockDurationAsIso8601": "PT1M",
+      "maxDeliveryCount": 10}}, "operationsMonitoringProperties": {"events": {"None":
       "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
-      "None"}}, "features": "None", "eventHubEndpoints": {"operationsMonitoringEvents":
-      {"partitionCount": 4, "retentionTimeInDays": 1}, "events": {"partitionCount":
-      4, "retentionTimeInDays": 1}}, "cloudToDevice": {"feedback": {"ttlAsIso8601":
-      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}, "maxDeliveryCount":
-      10, "defaultTtlAsIso8601": "PT1H"}, "messagingEndpoints": {"fileNotifications":
-      {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}},
-      "ipFilterRules": [], "storageEndpoints": {"$default": {"connectionString": "",
-      "sasTtlAsIso8601": "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
+      "None", "Connections": "None", "Routes": "None", "C2DCommands": "None", "FileUploadOperations":
+      "None"}}, "cloudToDevice": {"defaultTtlAsIso8601": "PT1H", "feedback": {"ttlAsIso8601":
+      "PT1H", "lockDurationAsIso8601": "PT1M", "maxDeliveryCount": 10}, "maxDeliveryCount":
+      10}, "authorizationPolicies": [{"secondaryKey": "5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=",
+      "keyName": "iothubowner", "primaryKey": "lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=",
+      "rights": "RegistryWrite, ServiceConnect, DeviceConnect"}, {"secondaryKey":
+      "bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=", "keyName": "service", "primaryKey":
+      "KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=", "rights": "ServiceConnect"},
+      {"secondaryKey": "MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=", "keyName":
+      "device", "primaryKey": "dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=", "rights":
+      "DeviceConnect"}, {"secondaryKey": "Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=",
+      "keyName": "registryRead", "primaryKey": "LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=",
+      "rights": "RegistryRead"}, {"secondaryKey": "Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=",
+      "keyName": "registryReadWrite", "primaryKey": "oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=",
+      "rights": "RegistryWrite"}, {"keyName": "test_policy", "rights": "RegistryWrite,
+      ServiceConnect, DeviceConnect"}], "features": "None", "ipFilterRules": [], "eventHubEndpoints":
+      {"operationsMonitoringEvents": {"partitionCount": 4, "retentionTimeInDays":
+      1}, "events": {"partitionCount": 4, "retentionTimeInDays": 1}}, "enableFileUploadNotifications":
+      false, "storageEndpoints": {"$default": {"sasTtlAsIso8601": "PT1H", "containerName":
+      "", "connectionString": ""}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2057']
+      Content-Length: ['2143']
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9sM=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr5Y=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+      x-ms-client-request-id: [ceb629cf-8459-11e7-b9e5-9cb6d0dafd06]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr5Y=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"None","FileUploadOperations":"None"}},"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"A+HbZwSD5o8dt5QQ6NjuO2JGwIRLq3EaYpZK+uHIVMA=","secondaryKey":"+WBw9eyth4froBx4mgSBX94GcW2krM3QRK0GXz9By10=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjU3NTNmNTktNDg5Mi00ZTcwLTk1YmItNGE3ZWY3Y2NkZTYy?api-version=2016-02-03&asyncinfo']
-      Cache-Control: [no-cache]
-      Content-Length: ['2443']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:43:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['4998']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTZjNDFhYjEtNWM4ZS00ODZlLWExMWMtNTY4Y2IwMzY2ODc5?api-version=2016-02-03&asyncinfo']
+      cache-control: [no-cache]
+      content-length: ['2649']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:11:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['4999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1167,26 +760,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9sM=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr5Y=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+      x-ms-client-request-id: [ceb629cf-8459-11e7-b9e5-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjU3NTNmNTktNDg5Mi00ZTcwLTk1YmItNGE3ZWY3Y2NkZTYy?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OTZjNDFhYjEtNWM4ZS00ODZlLWExMWMtNTY4Y2IwMzY2ODc5?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Succeeded"}'}
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1195,27 +788,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      IF-MATCH: [AAAAAACS9sM=]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr5Y=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+      x-ms-client-request-id: [ceb629cf-8459-11e7-b9e5-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr7U=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"None","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1887']
+      cache-control: [no-cache]
+      content-length: ['1868']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1224,26 +817,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b28749c0-cb36-11e6-8bd7-40a8f04ffd53]
+      x-ms-client-request-id: [e2d25380-8459-11e7-99cb-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr7U=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"None","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1253,26 +848,580 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b392ae5c-cb36-11e6-990b-40a8f04ffd53]
+      x-ms-client-request-id: [e346e740-8459-11e7-9b38-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}]}'}
+    body: {string: !!python/unicode '{"value":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"A+HbZwSD5o8dt5QQ6NjuO2JGwIRLq3EaYpZK+uHIVMA=","secondaryKey":"+WBw9eyth4froBx4mgSBX94GcW2krM3QRK0GXz9By10=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}]}'}
     headers:
-      Cache-Control: [no-cache]
+      cache-control: [no-cache]
+      content-length: ['1109']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e3930b70-8459-11e7-b043-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr7U=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"None","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e3ce3fae-8459-11e7-b818-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/test_policy/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"test_policy","primaryKey":"A+HbZwSD5o8dt5QQ6NjuO2JGwIRLq3EaYpZK+uHIVMA=","secondaryKey":"+WBw9eyth4froBx4mgSBX94GcW2krM3QRK0GXz9By10=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e4393680-8459-11e7-b293-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr7U=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"None","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e49400ae-8459-11e7-85a0-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"A+HbZwSD5o8dt5QQ6NjuO2JGwIRLq3EaYpZK+uHIVMA=","secondaryKey":"+WBw9eyth4froBx4mgSBX94GcW2krM3QRK0GXz9By10=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1109']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e50d284f-8459-11e7-89c9-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"A+HbZwSD5o8dt5QQ6NjuO2JGwIRLq3EaYpZK+uHIVMA=","secondaryKey":"+WBw9eyth4froBx4mgSBX94GcW2krM3QRK0GXz9By10=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1109']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"resourcegroup": "iot-hub-test-rg", "sku": {"capacity":
+      1, "name": "S1"}, "etag": "AAAAAAEWr7U=", "location": "westus", "tags": {},
+      "subscriptionid": "5bd5a5c2-9d8f-4223-b911-5c58cf39aedd", "properties": {"messagingEndpoints":
+      {"fileNotifications": {"ttlAsIso8601": "PT1H", "lockDurationAsIso8601": "PT1M",
+      "maxDeliveryCount": 10}}, "operationsMonitoringProperties": {"events": {"None":
+      "None", "C2DCommands": "None", "DeviceIdentityOperations": "None", "Connections":
+      "None", "Routes": "None", "DeviceTelemetry": "Error, Information", "FileUploadOperations":
+      "None"}}, "cloudToDevice": {"defaultTtlAsIso8601": "PT1H", "feedback": {"ttlAsIso8601":
+      "PT1H", "lockDurationAsIso8601": "PT1M", "maxDeliveryCount": 10}, "maxDeliveryCount":
+      10}, "authorizationPolicies": [{"secondaryKey": "5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=",
+      "keyName": "iothubowner", "primaryKey": "lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=",
+      "rights": "RegistryWrite, ServiceConnect, DeviceConnect"}, {"secondaryKey":
+      "bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=", "keyName": "service", "primaryKey":
+      "KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=", "rights": "ServiceConnect"},
+      {"secondaryKey": "MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=", "keyName":
+      "device", "primaryKey": "dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=", "rights":
+      "DeviceConnect"}, {"secondaryKey": "Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=",
+      "keyName": "registryRead", "primaryKey": "LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=",
+      "rights": "RegistryRead"}, {"secondaryKey": "Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=",
+      "keyName": "registryReadWrite", "primaryKey": "oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=",
+      "rights": "RegistryWrite"}], "features": "None", "ipFilterRules": [], "eventHubEndpoints":
+      {"operationsMonitoringEvents": {"partitionCount": 4, "retentionTimeInDays":
+      1}, "events": {"partitionCount": 4, "retentionTimeInDays": 1}}, "enableFileUploadNotifications":
+      false, "storageEndpoints": {"$default": {"sasTtlAsIso8601": "PT1H", "containerName":
+      "", "connectionString": ""}}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2057']
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr7U=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e54db3c0-8459-11e7-8ecb-9cb6d0dafd06]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr7U=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/YTg0MTkxY2EtOWM3Zi00ZTdlLWJhMTMtMDlmNDllMGFlYzA4?api-version=2016-02-03&asyncinfo']
+      cache-control: [no-cache]
+      content-length: ['2445']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['4999']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr7U=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e54db3c0-8459-11e7-8ecb-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/YTg0MTkxY2EtOWM3Zi00ZTdlLWJhMTMtMDlmNDllMGFlYzA4?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [!!python/unicode 'AAAAAAEWr7U=']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e54db3c0-8459-11e7-8ecb-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1868']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f97a5830-8459-11e7-a499-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f9df3480-8459-11e7-b45a-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"KlSk6vna4JMdfVdrgPHbNMnyD44Kmq2+o9kfBNIjjWc=","secondaryKey":"bpxznTvMhXyAqUzJ/YuXZIMnSrt8ftSEQ2IqsNY1Z04=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"dY6Tzek2yQVKopXeoXI8kiTVYBEFHoieJInvuUbf76w=","secondaryKey":"MxzqhdiO4Tz5h6Q7UmhKj1ZDir+RK9m7NIbm2s5U+mE=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"LjgNpp6v56g2W1eCqyfHeK5b60JIYRDokDgiJbVIz8I=","secondaryKey":"Mdfu+3Kyu0ti1pWt4duQpN4MzJn5j+r6W6qwKzkrs1A=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oTlgQAQPr2+EzxU8dfc2kabGCmlpmPyNZLHuqGeH0+Y=","secondaryKey":"Kxgv9556n4FxVAHRe3y8obPWK6GOOperbIl5M2iKUs8=","rights":"RegistryWrite"}]}'}
+    headers:
+      cache-control: [no-cache]
       content-length: ['905']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa53530f-8459-11e7-9e4f-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa94a1cf-8459-11e7-bf92-9cb6d0dafd06]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['175']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fbc29a80-8459-11e7-a466-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fc08a42e-8459-11e7-974b-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['175']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fc46978f-8459-11e7-b937-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fc6d5970-8459-11e7-9941-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":["$Default","cg1"]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fca420de-8459-11e7-9e7a-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fccabbb0-8459-11e7-9e89-9cb6d0dafd06]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 18 Aug 2017 21:12:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
@@ -1282,55 +1431,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b52a97ac-cb36-11e6-9269-40a8f04ffd53]
+      x-ms-client-request-id: [fd29f2b0-8459-11e7-8b3f-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b60a1e7e-cb36-11e6-9d83-40a8f04ffd53]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
-  response:
-    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['175']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1339,217 +1461,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9f3140a-cb36-11e6-b8d8-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [baedee82-cb36-11e6-a36e-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
-  response:
-    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['175']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bc300f2c-cb36-11e6-bdee-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bd0b30dc-cb36-11e6-9ef1-40a8f04ffd53]
+      x-ms-client-request-id: [fd61f29e-8459-11e7-a760-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
   response:
-    body: {string: '{"value":["$Default","cg1"]}'}
+    body: {string: !!python/unicode '{"value":["$Default"]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['28']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bdde9a7e-cb36-11e6-8ba4-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [beb83da8-cb36-11e6-96f3-40a8f04ffd53]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 26 Dec 2016 06:44:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c026283e-cb36-11e6-a4e4-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c097b370-cb36-11e6-88cc-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
-  response:
-    body: {string: '{"value":["$Default"]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1558,26 +1488,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c14f4fa4-cb36-11e6-ae8d-40a8f04ffd53]
+      x-ms-client-request-id: [fda479e1-8459-11e7-9a09-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1586,25 +1518,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c1bf4d3e-cb36-11e6-834a-40a8f04ffd53]
+      x-ms-client-request-id: [fdcb89e1-8459-11e7-b632-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/jobs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[]}'}
+    body: {string: !!python/unicode '{"value":[]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1613,26 +1545,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c288beae-cb36-11e6-97b3-40a8f04ffd53]
+      x-ms-client-request-id: [fe10a930-8459-11e7-8607-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1641,26 +1575,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c3919b2e-cb36-11e6-b955-40a8f04ffd53]
+      x-ms-client-request-id: [fe491e4f-8459-11e7-ac54-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/jobs/fake-job?api-version=2016-02-03
   response:
-    body: {string: '{"Code":"JobNotFound","HttpStatusCode":"NotFound","Message":"Job
+    body: {string: !!python/unicode '{"Code":"JobNotFound","HttpStatusCode":"NotFound","Message":"Job
         not found with ID ''fake-job''. If you contact a support representative please
-        include this correlation identifier: 1cd77bf7-e618-4198-abfc-d677e3daeb31,
-        timestamp: 2016-12-26 06:44:36Z, errorcode: IH404011."}'}
+        include this correlation identifier: 87bb73f4-d986-4780-b78b-8bcf3f8c496f,
+        timestamp: 2017-08-18 21:12:55Z, errorcode: IH404011."}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['272']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      cache-control: [no-cache]
+      content-length: ['272']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1669,26 +1603,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c46e1c14-cb36-11e6-9aa8-40a8f04ffd53]
+      x-ms-client-request-id: [0163cbcf-845a-11e7-b39e-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1698,27 +1634,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c4e1db54-cb36-11e6-80dc-40a8f04ffd53]
+      x-ms-client-request-id: [01a6c840-845a-11e7-b8a2-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:37 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1728,21 +1664,21 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c546845c-cb36-11e6-b222-40a8f04ffd53]
+      x-ms-client-request-id: [01e0c400-845a-11e7-8594-9cb6d0dafd06]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/jobs/fake-job?api-version=2016-11-14
   response:
-    body: {string: '{"Message":"ErrorCode:JobNotFound;NotFound","ExceptionMessage":"Tracking
-        ID:4620d5f90d8345e0a1fe257830757c02-G:9-TimeStamp:12/26/2016 06:44:39"}'}
+    body: {string: !!python/unicode '{"Message":"ErrorCode:JobNotFound;NotFound","ExceptionMessage":"Tracking
+        ID:c26acdd954e24a1d8d570b917dbdb7ac-G:9-TimeStamp:08/18/2017 21:12:58"}'}
     headers:
-      Content-Length: ['144']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:39 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['144']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:58 GMT']
       iothub-errorcode: [JobNotFound]
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1751,26 +1687,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c66d8cfa-cb36-11e6-b265-40a8f04ffd53]
+      x-ms-client-request-id: [0207fb0f-845a-11e7-b651-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1780,50 +1718,50 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c6e07346-cb36-11e6-9c4f-40a8f04ffd53]
+      x-ms-client-request-id: [022ebcf0-845a-11e7-90a8-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:12:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
-    body: '{"deviceId": "test-device-1"}'
+    body: !!python/unicode '{"deviceId": "test-device-1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c742d598-cb36-11e6-990f-40a8f04ffd53]
+      x-ms-client-request-id: [025e586e-845a-11e7-9f03-9cb6d0dafd06]
     method: PUT
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
     headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:43 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['543']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:01 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1832,26 +1770,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c884abd4-cb36-11e6-844f-40a8f04ffd53]
+      x-ms-client-request-id: [05583780-845a-11e7-8a8f-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1861,52 +1801,52 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c8f95ad8-cb36-11e6-876d-40a8f04ffd53]
+      x-ms-client-request-id: [0581b880-845a-11e7-a4f0-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
-    body: '{"authentication": {"x509Thumbprint": {"secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087",
-      "primaryThumbprint": "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C"}}, "deviceId":
-      "test-device-2"}'
+    body: !!python/unicode '{"authentication": {"x509Thumbprint": {"primaryThumbprint":
+      "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C", "secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087"}},
+      "deviceId": "test-device-2"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['201']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [c95d9fde-cb36-11e6-a8b4-40a8f04ffd53]
+      x-ms-client-request-id: [05a7de21-845a-11e7-8414-9cb6d0dafd06]
     method: PUT
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
     headers:
-      Content-Length: ['535']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:44 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['535']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:03 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1915,26 +1855,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ca7bc712-cb36-11e6-97bc-40a8f04ffd53]
+      x-ms-client-request-id: [05df41cf-845a-11e7-9476-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1944,106 +1886,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [caeded1e-cb36-11e6-b800-40a8f04ffd53]
+      x-ms-client-request-id: [060678de-845a-11e7-90b2-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cb4dad3e-cb36-11e6-a367-40a8f04ffd53]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
-    headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cc51e07e-cb36-11e6-a780-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ccc2eb0c-cb36-11e6-a6ed-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -2053,20 +1915,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd22d780-cb36-11e6-a08a-40a8f04ffd53]
+      x-ms-client-request-id: [066ae000-845a-11e7-8477-9cb6d0dafd06]
     method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
     headers:
-      Content-Length: ['535']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['543']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:03 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2075,26 +1937,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce28abe2-cb36-11e6-9e1d-40a8f04ffd53]
+      x-ms-client-request-id: [068ee2c0-845a-11e7-b0bd-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2104,27 +1968,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce996f14-cb36-11e6-834f-40a8f04ffd53]
+      x-ms-client-request-id: [06c13d61-845a-11e7-8d02-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2133,71 +1997,50 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [cefa46f4-cb36-11e6-a9d8-40a8f04ffd53]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
-  response:
-    body: {string: '[{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
-    headers:
-      Content-Length: ['1081']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:55 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cf9b9330-cb36-11e6-ba54-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cffb58fa-cb36-11e6-b249-40a8f04ffd53]
+      x-ms-client-request-id: [06e73bf0-845a-11e7-8727-9cb6d0dafd06]
     method: GET
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
     headers:
-      Content-Length: ['535']
+      content-length: ['535']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:05 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:01 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [070f846e-845a-11e7-bba9-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2207,26 +2050,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d27b4980-cb36-11e6-9eef-40a8f04ffd53]
+      x-ms-client-request-id: [073730b0-845a-11e7-aef6-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:44:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
@@ -2236,48 +2079,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d2db48e6-cb36-11e6-983b-40a8f04ffd53]
+      x-ms-client-request-id: [07730130-845a-11e7-b257-9cb6d0dafd06]
     method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
   response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    body: {string: !!python/unicode '[{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
     headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:00 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d3da4612-cb36-11e6-bdc6-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      content-length: ['1081']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:04 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2287,27 +2101,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d44b8b66-cb36-11e6-ac81-40a8f04ffd53]
+      x-ms-client-request-id: [079b49b0-845a-11e7-a9c4-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2316,48 +2130,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d4ac1076-cb36-11e6-8c32-40a8f04ffd53]
+      x-ms-client-request-id: [07c3b940-845a-11e7-bddf-9cb6d0dafd06]
     method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
     headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d59f688a-cb36-11e6-8ac8-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      content-length: ['535']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:07 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2367,26 +2153,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d613c512-cb36-11e6-964b-40a8f04ffd53]
+      x-ms-client-request-id: [07d98b30-845a-11e7-ba15-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
@@ -2396,20 +2182,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d6745e5a-cb36-11e6-9bfc-40a8f04ffd53]
+      x-ms-client-request-id: [08029700-845a-11e7-ad10-9cb6d0dafd06]
     method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
     headers:
-      Content-Length: ['535']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['543']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:05 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2418,26 +2204,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d7164968-cb36-11e6-9488-40a8f04ffd53]
+      x-ms-client-request-id: [083c1d8f-845a-11e7-95ea-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2447,35 +2235,199 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d78969dc-cb36-11e6-a886-40a8f04ffd53]
+      x-ms-client-request-id: [087ca900-845a-11e7-8992-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 - request:
-    body: '{"lastActivityTime": "0001-01-01T00:00:00.000Z", "connectionState": "Disconnected",
-      "status": "enabled", "etag": "MA==", "authentication": {"symmetricKey": {},
-      "x509Thumbprint": {"secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087",
-      "primaryThumbprint": "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C"}}, "connectionStateUpdatedTime":
-      "0001-01-01T00:00:00.000Z", "cloudToDeviceMessageCount": 0, "statusUpdatedTime":
-      "0001-01-01T00:00:00.000Z", "statusReason": "TestReason", "deviceId": "test-device-2"}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [08a7d7b0-845a-11e7-83a5-9cb6d0dafd06]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+  response:
+    body: {string: !!python/unicode '{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    headers:
+      content-length: ['543']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:06 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [08c94261-845a-11e7-8a9f-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [08f61ec0-845a-11e7-af96-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [091f78ae-845a-11e7-9070-9cb6d0dafd06]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+  response:
+    body: {string: !!python/unicode '{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    headers:
+      content-length: ['535']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:09 GMT']
+      etag: ['"MA=="']
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0947c130-845a-11e7-b2d3-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0971904f-845a-11e7-8aa5-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"status": "enabled", "connectionState": "Disconnected",
+      "authentication": {"symmetricKey": {}, "x509Thumbprint": {"primaryThumbprint":
+      "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C", "secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087"}},
+      "etag": "MA==", "lastActivityTime": "0001-01-01T00:00:00.000Z", "statusUpdatedTime":
+      "0001-01-01T00:00:00.000Z", "connectionStateUpdatedTime": "0001-01-01T00:00:00.000Z",
+      "cloudToDeviceMessageCount": 0, "statusReason": "TestReason", "deviceId": "test-device-2"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2483,20 +2435,20 @@ interactions:
       Content-Length: ['510']
       Content-Type: [application/json; charset=utf-8]
       If-Match: ['*']
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d7e98fa6-cb36-11e6-9da6-40a8f04ffd53]
+      x-ms-client-request-id: [099c70de-845a-11e7-b7f6-9cb6d0dafd06]
     method: PUT
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: !!python/unicode '{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
     headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:10 GMT']
-      ETag: ['"MQ=="']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['543']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:10 GMT']
+      etag: ['"MQ=="']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2505,26 +2457,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d8e92f86-cb36-11e6-b9d4-40a8f04ffd53]
+      x-ms-client-request-id: [09caaccf-845a-11e7-9b97-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2534,127 +2488,129 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d959e29e-cb36-11e6-a203-40a8f04ffd53]
+      x-ms-client-request-id: [09f90fcf-845a-11e7-85dd-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d9ba19d0-cb36-11e6-832d-40a8f04ffd53]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
-  response:
-    body: {string: '[{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
-    headers:
-      Content-Length: ['1089']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [daac874c-cb36-11e6-9a8d-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [db1ec890-cb36-11e6-b4a2-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
-    body: '"Ping from Azure CLI"'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0a23c94f-845a-11e7-9e2b-9cb6d0dafd06]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
+  response:
+    body: {string: !!python/unicode '[{"deviceId":"test-device-2","generationId":"636386875828047813","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636386875811187073","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GoP46hrRclg0vLNUaEnXuzW/WkJ8A7uC6nm3EheDHXs=","secondaryKey":"oG+dMsXp9TD8kClRKzmuU0IfRvLFYgNeNueo1uNAy+w="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
+    headers:
+      content-length: ['1089']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:11 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0a43d470-845a-11e7-8ceb-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0a745a4f-845a-11e7-8b8c-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '"Ping from Azure CLI"'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['21']
       Content-Type: [application/octet-stream]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [db7e6164-cb36-11e6-8b3b-40a8f04ffd53]
+      x-ms-client-request-id: [0aa6b4f0-845a-11e7-a51b-9cb6d0dafd06]
     method: POST
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/events?api-version=2016-11-14
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-Length: ['0']
-      Date: ['Mon, 26 Dec 2016 06:45:18 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['0']
+      date: ['Fri, 18 Aug 2017 21:13:11 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -2663,26 +2619,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [dc9f53b8-cb36-11e6-9610-40a8f04ffd53]
+      x-ms-client-request-id: [0ae6f240-845a-11e7-92d1-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:16 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2692,27 +2650,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd108c1a-cb36-11e6-bf7f-40a8f04ffd53]
+      x-ms-client-request-id: [0b2de64f-845a-11e7-b762-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2722,18 +2680,18 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       IotHub-MessageLockTimeout: ['60']
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd71310a-cb36-11e6-975d-40a8f04ffd53]
+      x-ms-client-request-id: [0b56a400-845a-11e7-833d-9cb6d0dafd06]
     method: GET
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound?api-version=2016-11-14
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-Length: ['0']
-      Date: ['Mon, 26 Dec 2016 06:45:17 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['0']
+      date: ['Fri, 18 Aug 2017 21:13:13 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -2742,26 +2700,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [de6fb742-cb36-11e6-90ab-40a8f04ffd53]
+      x-ms-client-request-id: [0b826ef0-845a-11e7-b312-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2771,382 +2731,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [df605d00-cb36-11e6-ab85-40a8f04ffd53]
+      x-ms-client-request-id: [0bfb486e-845a-11e7-9111-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e03713f6-cb36-11e6-b59b-40a8f04ffd53]
-    method: DELETE
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14
-  response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"9e761689f9a14c5dba683db29f11e001-G:0-TimeStamp:12/26/2016
-        06:45:25\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:25.0059132Z\"}","ExceptionMessage":""}'}
-    headers:
-      Content-Length: ['229']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:24 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-      iothub-errorcode: [DeviceMessageLockLost]
-    status: {code: 412, message: Precondition Failed}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e1363bd0-cb36-11e6-80f9-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e1c958ae-cb36-11e6-842e-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e2a63d8c-cb36-11e6-ad81-40a8f04ffd53]
-    method: DELETE
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14&reject=
-  response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"6133673abe134adb8c41668061603d8a-G:7-TimeStamp:12/26/2016
-        06:45:26\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:26.6951274Z\"}","ExceptionMessage":""}'}
-    headers:
-      Content-Length: ['229']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:26 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-      iothub-errorcode: [DeviceMessageLockLost]
-    status: {code: 412, message: Precondition Failed}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e3a881f4-cb36-11e6-99af-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e43abbca-cb36-11e6-b49b-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e49a6a5c-cb36-11e6-9bf4-40a8f04ffd53]
-    method: POST
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000/abandon?api-version=2016-11-14
-  response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"5e4b6095b0d44c209b9b166ad89142f6-G:4-TimeStamp:12/26/2016
-        06:45:32\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:32.9772581Z\"}","ExceptionMessage":""}'}
-    headers:
-      Content-Length: ['229']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:32 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-      iothub-errorcode: [DeviceMessageLockLost]
-    status: {code: 412, message: Precondition Failed}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e5ab6c36-cb36-11e6-b977-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e621cf34-cb36-11e6-8862-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/quotaMetrics?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"Name":"TotalMessages","CurrentValue":0,"MaxValue":400000},{"Name":"TotalDeviceCount","CurrentValue":2,"MaxValue":500000}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['134']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e70a83da-cb36-11e6-b121-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e785204a-cb36-11e6-9ae1-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubStats?api-version=2016-02-03
-  response:
-    body: {string: '{"totalDeviceCount":0,"enabledDeviceCount":0,"disabledDeviceCount":0}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['69']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e84a61f6-cb36-11e6-9b7a-40a8f04ffd53]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:37 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e8bd5f5e-cb36-11e6-bd20-40a8f04ffd53]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -3157,20 +2761,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      If-Match: ['*']
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e98f5c46-cb36-11e6-abd0-40a8f04ffd53]
+      x-ms-client-request-id: [0c2565b0-845a-11e7-b3a9-9cb6d0dafd06]
     method: DELETE
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode '{"Message":"{\"errorCode\":412002,\"trackingId\":\"cd101492109d48dc907bae17dfed671d-G:6-TimeStamp:08/18/2017
+        21:13:14\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2017-08-18T21:13:14.1165268Z\"}","ExceptionMessage":""}'}
     headers:
-      Content-Length: ['0']
-      Date: ['Mon, 26 Dec 2016 06:45:39 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 204, message: No Content}
+      content-length: ['229']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:13 GMT']
+      iothub-errorcode: [DeviceMessageLockLost]
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 412, message: Precondition Failed}
 - request:
     body: null
     headers:
@@ -3178,26 +2784,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eabf0c08-cb36-11e6-a9b7-40a8f04ffd53]
+      x-ms-client-request-id: [0c50e280-845a-11e7-8fde-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -3207,26 +2815,390 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb329648-cb36-11e6-9527-40a8f04ffd53]
+      x-ms-client-request-id: [0c7b9c00-845a-11e7-8096-9cb6d0dafd06]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0ca6f1c0-845a-11e7-acba-9cb6d0dafd06]
+    method: DELETE
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14&reject=
+  response:
+    body: {string: !!python/unicode '{"Message":"{\"errorCode\":412002,\"trackingId\":\"edf4829a78d746ebb4e8dcb1bd63edf3-G:2-TimeStamp:08/18/2017
+        21:13:13\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2017-08-18T21:13:13.7183393Z\"}","ExceptionMessage":""}'}
+    headers:
+      content-length: ['229']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:13 GMT']
+      iothub-errorcode: [DeviceMessageLockLost]
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 412, message: Precondition Failed}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0cd18430-845a-11e7-98c3-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0cfeaeb0-845a-11e7-8873-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0d27e18f-845a-11e7-bd9b-9cb6d0dafd06]
+    method: POST
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000/abandon?api-version=2016-11-14
+  response:
+    body: {string: !!python/unicode '{"Message":"{\"errorCode\":412002,\"trackingId\":\"b8624d0be8f449afb2bcf224308ddcec-G:6-TimeStamp:08/18/2017
+        21:13:15\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2017-08-18T21:13:15.7476465Z\"}","ExceptionMessage":""}'}
+    headers:
+      content-length: ['229']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:15 GMT']
+      iothub-errorcode: [DeviceMessageLockLost]
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 412, message: Precondition Failed}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0d4b962e-845a-11e7-985d-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0d784b80-845a-11e7-9f83-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/quotaMetrics?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"Name":"TotalMessages","CurrentValue":0,"MaxValue":400000},{"Name":"TotalDeviceCount","CurrentValue":0,"MaxValue":500000}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['134']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0db7775e-845a-11e7-ba93-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0de5b34f-845a-11e7-b7e4-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubStats?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"totalDeviceCount":0,"enabledDeviceCount":0,"disabledDeviceCount":0}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['69']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0fe9246e-845a-11e7-b648-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1014531e-845a-11e7-b9cd-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      If-Match: ['*']
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [104fae70-845a-11e7-9048-9cb6d0dafd06]
+    method: DELETE
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-length: ['0']
+      date: ['Fri, 18 Aug 2017 21:13:22 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10917261-845a-11e7-9106-9cb6d0dafd06]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10bd3d4f-845a-11e7-854e-9cb6d0dafd06]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: !!python/unicode '{"keyName":"iothubowner","primaryKey":"lbzYVkXcbwvfH0o/9+hahT6RPSVDqxlNvcRYOI9uejs=","secondaryKey":"5MNo7vsXXDoyCW+nBzGAOfAIrZM40qURB7mz/MAtN3g=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['203']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
@@ -3238,18 +3210,18 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       If-Match: ['*']
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb972e66-cb36-11e6-9a84-40a8f04ffd53]
+      x-ms-client-request-id: [1101241e-845a-11e7-8c1c-9cb6d0dafd06]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-Length: ['0']
-      Date: ['Mon, 26 Dec 2016 06:45:44 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
+      content-length: ['0']
+      date: ['Fri, 18 Aug 2017 21:13:22 GMT']
+      server: [Microsoft-HTTPAPI/2.0]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -3258,26 +3230,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ec9fc2b0-cb36-11e6-80c9-40a8f04ffd53]
+      x-ms-client-request-id: [112cc800-845a-11e7-a53b-9cb6d0dafd06]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
-        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/IoT/providers/Microsoft.Devices/IotHubs/PaymaunHub","name":"PaymaunHub","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"IoT","etag":"AAAAAAEWqXY=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","C2DCommands":"Error,
+        Information","FileUploadOperations":"Error"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"PaymaunHub.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":2,"partitionIds":["0","1"],"path":"paymaunhub-operationmonitoring","endpoint":"sb://iothub-ns-paymaunhub-167309-c06055ec8c.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"DefaultEndpointsProtocol=https;AccountName=iothubstor;AccountKey=****","containerName":"testcontainer"}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":true,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"5bd5a5c2-9d8f-4223-b911-5c58cf39aedd","resourcegroup":"iot-hub-test-rg","etag":"AAAAAAEWr74=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","C2DCommands":"None","DeviceIdentityOperations":"None","Connections":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","FileUploadOperations":"None"}},"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-203811-5151495961.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1899']
+      cache-control: [no-cache]
+      content-length: ['3763']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -3287,27 +3261,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+      x-ms-client-request-id: [1166c3c0-845a-11e7-ab09-9cb6d0dafd06]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: 'null'}
+    body: {string: !!python/unicode 'null'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo']
-      Cache-Control: [no-cache]
-      Content-Length: ['4']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:45:46 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03']
-      Pragma: [no-cache]
-      Retry-After: ['15']
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OWYxNjJkZDctZWNlNS00MTkzLTgzMjgtMzI2ZmRlNTM2NDEw?api-version=2016-02-03&asyncinfo']
+      cache-control: [no-cache]
+      content-length: ['4']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:24 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/5bd5a5c2-9d8f-4223-b911-5c58cf39aedd/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OWYxNjJkZDctZWNlNS00MTkzLTgzMjgtMzI2ZmRlNTM2NDEw?api-version=2016-02-03']
+      pragma: [no-cache]
+      retry-after: ['15']
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -3316,25 +3290,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+      x-ms-client-request-id: [1166c3c0-845a-11e7-ab09-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OWYxNjJkZDctZWNlNS00MTkzLTgzMjgtMzI2ZmRlNTM2NDEw?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"status":"Running"}'}
+    body: {string: !!python/unicode '{"status":"Running"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:46:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:13:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -3343,23 +3317,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 iothubclient/0.2.2 Azure-SDK-For-Python AZURECLI/TEST/2.0.13+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+      x-ms-client-request-id: [1166c3c0-845a-11e7-ab09-9cb6d0dafd06]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OWYxNjJkZDctZWNlNS00MTkzLTgzMjgtMzI2ZmRlNTM2NDEw?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Devices/IotHubs/iot-hub-for-test''
-        under resource group ''iot-hub-test-rg'' was not found."}}'}
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['167']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 26 Dec 2016 06:46:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-failure-cause: [gateway]
-    status: {code: 404, message: Not Found}
+      cache-control: [no-cache]
+      content-length: ['22']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 18 Aug 2017 21:14:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.11+dev"
+VERSION = "0.1.10+dev"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.1.10+dev"
+VERSION = "0.1.11+dev"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
Iot hub policy delete was still deleting all policies rather
than the specified policy.

Observing the policies once seems to release the resources,
setting the desired policy list to empty [].

The fix was to pass a deepcopy of the original policy list into
_is_policy_existed to not prematurely observe the original policies.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
