### PR TITLE
[SF] Refactored 'az sf compose create' params to be automation friendly.

### DIFF
--- a/src/command_modules/azure-cli-sf/HISTORY.rst
+++ b/src/command_modules/azure-cli-sf/HISTORY.rst
@@ -2,7 +2,7 @@
 
 Release History
 ===============
-1.0.7 (2017-08-17)
+unreleased
 ++++++++++++++++++
 * Simplified registry user/pass rules for command.
 * Fixed password prompt for user even after passing in the param.

--- a/src/command_modules/azure-cli-sf/HISTORY.rst
+++ b/src/command_modules/azure-cli-sf/HISTORY.rst
@@ -2,6 +2,13 @@
 
 Release History
 ===============
+1.0.7 (2017-08-17)
+++++++++++++++++++
+* Simplified registry user/pass rules for command.
+* Fixed password prompt for user even after passing in the param.
+* Supports Null/None registry_cred.
+* Incremented history + version.
+
 1.0.6 (2017-08-11)
 ++++++++++++++++++
 * minor fixes

--- a/src/command_modules/azure-cli-sf/HISTORY.rst
+++ b/src/command_modules/azure-cli-sf/HISTORY.rst
@@ -3,11 +3,10 @@
 Release History
 ===============
 unreleased
-++++++++++++++++++
++++++++++++++++
 * Simplified registry user/pass rules for command.
 * Fixed password prompt for user even after passing in the param.
-* Supports Null/None registry_cred.
-* Incremented history + version.
+* Supports None registry_cred.
 
 1.0.6 (2017-08-11)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -30,8 +30,8 @@ az_config = AzConfig()
 logger = azlogging.get_az_logger(__name__)
 
 
-def sf_create_compose_application(client, compose_file, application_id, repo_user=None, encrypted=False,
-                                  repo_pass=None, timeout=60):
+def sf_create_compose_application(client, compose_file, application_id, registry_user=None,
+                                  registry_pass=None, encrypted=False, timeout=60):
     # We need to read from a file which makes this a custom command
     # Encrypted param to indicate a password will be prompted
     """
@@ -43,40 +43,33 @@ def sf_create_compose_application(client, compose_file, application_id, repo_use
 
     :param str compose_file: Path to the Compose file to use
 
-    :param str repo_user: Container repository user name if needed for
-    authentication
+    :param str registry_user: Username for target container registry
 
-    :param bool encrypted: If true, indicate to use an encrypted password
-    rather than prompting for a plaintext one
+    :param bool encrypted: Indicates usage of encrypted password
 
-    :param str repo_pass: Encrypted container repository password
+    :param str registry_pass: Password for target container registry
     """
     from azure.cli.core.util import read_file_content
+    from azure.cli.core.prompting import prompt
     from azure.cli.core.prompting import prompt_pass
+
     # pylint: disable=line-too-long
     from azure.servicefabric.models.create_compose_application_description import CreateComposeApplicationDescription
     from azure.servicefabric.models.repository_credential import RepositoryCredential
 
-    if (any([encrypted, repo_pass]) and
-            not all([encrypted, repo_pass, repo_user])):
-        raise CLIError(
-            "Invalid arguments: [ --application_id --file | "
-            "--application_id --file --repo_user | --application_id --file "
-            "--repo_user --encrypted --repo_pass ])"
-        )
+    if registry_user is None and registry_pass:
+        registry_user = prompt("Registry username: ",
+                               "Username for target container registry")
 
-    if repo_user:
-        plaintext_pass = prompt_pass("Container repository password: ", False,
-                                     "Password for container repository "
-                                     "containing container images")
-        repo_pass = plaintext_pass
+    if registry_pass is None and registry_user:
+        registry_pass = prompt_pass("Registry password: ", False,
+                                    "Password for target container registry")
 
-    repo_cred = RepositoryCredential(repo_user, repo_pass, encrypted)
+    registry_cred = RepositoryCredential(registry_user, registry_pass, encrypted) if registry_user and registry_pass else None
 
     file_contents = read_file_content(compose_file)
 
-    model = CreateComposeApplicationDescription(application_id, file_contents,
-                                                repo_cred)
+    model = CreateComposeApplicationDescription(application_id, file_contents, registry_cred)
 
     client.create_compose_application(model, timeout)
 

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/custom.py
@@ -57,15 +57,15 @@ def sf_create_compose_application(client, compose_file, application_id, registry
     from azure.servicefabric.models.create_compose_application_description import CreateComposeApplicationDescription
     from azure.servicefabric.models.repository_credential import RepositoryCredential
 
-    if registry_user is None and registry_pass:
-        registry_user = prompt("Registry username: ",
-                               "Username for target container registry")
+    if not registry_user and registry_pass:
+        registry_user = prompt("Registry username: ", "Username for target container registry")
 
-    if registry_pass is None and registry_user:
+    if not registry_pass and registry_user:
         registry_pass = prompt_pass("Registry password: ", False,
                                     "Password for target container registry")
 
-    registry_cred = RepositoryCredential(registry_user, registry_pass, encrypted) if registry_user and registry_pass else None
+    registry_cred = RepositoryCredential(
+        registry_user, registry_pass, encrypted) if registry_user and registry_pass else None
 
     file_contents = read_file_content(compose_file)
 

--- a/src/command_modules/azure-cli-sf/setup.py
+++ b/src/command_modules/azure-cli-sf/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "1.0.6+dev"
+VERSION = "1.0.7+dev"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/src/command_modules/azure-cli-sf/setup.py
+++ b/src/command_modules/azure-cli-sf/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "1.0.7+dev"
+VERSION = "1.0.6+dev"
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
* Simplified registry user/pass rules for command.
* Fixed password prompt for user even after passing in the
param.
* Supports None registry_cred.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
