### PR TITLE
[Release automation] Fix 'packaged release archive' creation step

### DIFF
--- a/scripts/releaser/HISTORY.rst
+++ b/scripts/releaser/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.3 (2017-08-18)
+++++++++++++++++++
+
+* Fix 'packaged release archive' creation step. We now clone the repo again after pushing tags so we can use the new tags.
+
 0.1.2 (2017-08-15)
 ++++++++++++++++++
 

--- a/scripts/releaser/release.py
+++ b/scripts/releaser/release.py
@@ -365,5 +365,8 @@ if __name__ == "__main__":
     give_chance_to_cancel('Create GitHub releases and tags')
     run_create_github_release(release_commitish_list, release_assets_dir_map)
     give_chance_to_cancel('Create Packaged Release archive')
+    # We need to clone the repo again as we've now pushed the git tags and we need them to create the packaged release.
+    # (we could do 'git pull' but this is easier and uses a clean directory just to be safe)
+    cli_repo_dir = set_up_cli_repo_dir()
     run_create_packaged_release(cli_repo_dir)
     print_status('Done.')


### PR DESCRIPTION
We now clone the repo again after pushing tags so we can use the new tags.

Before, the script would always fail at the very last step, 'Create Packaged Release archive', and I would wonder why.
It was because in order to create the packaged release (.tar.gz), we need the git tags so we need to clone the repo again **after** the github releases have been created.

I have already published 0.1.3 of the releaser Docker image so merging this code in is more of a formality.