### PR TITLE
Enable customer managed key service encryption

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+unreleased
+++++++++++
+* Enable service encryption by customer managed key
+* Breaking change: rename --encryption option to --encryption-services for az storage account create and az storage account update command.
+* Fix #4220: az storage account update encryption - syntax mismatch
+
 2.0.12 (2017-08-11)
 +++++++++++++++++++
 * Enable create storage account with system assigned identity


### PR DESCRIPTION
* Enable service encryption by customer managed key
* Breaking change: rename --encryption option to --encryption-services for az storage account create and az storage account update command.
* Fix #4220: az storage account update encryption - syntax mismatch


/cc @sptramer for the breaking change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
