### PR TITLE
vm/vmss create: remove human names from the admin name blacklist

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 unreleased
 +++++++++++++++++++
+* `vm/vmss create`: remove human names from the admin name blacklist
 * `vm/vmss create`: fix issue where the command would throw an error if unable to extract plan information from an image. 
 * `vmss create`: fix a crash when create a scaleset with an internal LB
 * `vm availability-set create`: Fix issue where --no-wait argument did not work.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -658,7 +658,7 @@ def _validate_admin_username(username, os_type):
     disallowed_user_names = [
         "administrator", "admin", "user", "user1", "test", "user2",
         "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm",
-        "admin2", "aspnet", "backup", "console", "david", "guest", "john",
+        "admin2", "aspnet", "backup", "console", "guest",
         "owner", "root", "server", "sql", "support", "support_388945a0",
         "sys", "test2", "test3", "user4", "user5"]
     if username.lower() in disallowed_user_names:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_actions.py
@@ -92,30 +92,30 @@ class TestActions(unittest.TestCase):
         err_invalid_char = r'admin user name cannot contain upper case character A-Z, special characters \/"[]:|<>+=;,?*@#()! or start with $ or -'
 
         self._verify_username_with_ex('!@#', 'linux', err_invalid_char)
-        self._verify_username_with_ex('dav[', 'linux', err_invalid_char)
-        self._verify_username_with_ex('Adavid', 'linux', err_invalid_char)
-        self._verify_username_with_ex('-ddavid', 'linux', err_invalid_char)
+        self._verify_username_with_ex('gue[', 'linux', err_invalid_char)
+        self._verify_username_with_ex('Aguest', 'linux', err_invalid_char)
+        self._verify_username_with_ex('-gguest', 'linux', err_invalid_char)
         self._verify_username_with_ex('', 'linux', 'admin user name can not be empty')
-        self._verify_username_with_ex('david', 'linux',
-                                      "This user name 'david' meets the general requirements, but is specifically disallowed for this image. Please try a different value.")
+        self._verify_username_with_ex('guest', 'linux',
+                                      "This user name 'guest' meets the general requirements, but is specifically disallowed for this image. Please try a different value.")
 
-        _validate_admin_username('d-avid1', 'linux')
-        _validate_admin_username('david1', 'linux')
-        _validate_admin_username('david1.', 'linux')
+        _validate_admin_username('g-uest1', 'linux')
+        _validate_admin_username('guest1', 'linux')
+        _validate_admin_username('guest1.', 'linux')
 
     def test_validate_admin_username_windows(self):
         # pylint: disable=line-too-long
         err_invalid_char = r'admin user name cannot contain special characters \/"[]:|<>+=;,?*@# or ends with .'
 
         self._verify_username_with_ex('!@#', 'windows', err_invalid_char)
-        self._verify_username_with_ex('dav[', 'windows', err_invalid_char)
+        self._verify_username_with_ex('gue[', 'windows', err_invalid_char)
         self._verify_username_with_ex('dddivid.', 'windows', err_invalid_char)
-        self._verify_username_with_ex('john', 'windows',
-                                      "This user name 'john' meets the general requirements, but is specifically disallowed for this image. Please try a different value.")
+        self._verify_username_with_ex('backup', 'windows',
+                                      "This user name 'backup' meets the general requirements, but is specifically disallowed for this image. Please try a different value.")
 
-        _validate_admin_username('ADAVID', 'windows')
-        _validate_admin_username('d-avid1', 'windows')
-        _validate_admin_username('david1', 'windows')
+        _validate_admin_username('AGUEST', 'windows')
+        _validate_admin_username('g-uest1', 'windows')
+        _validate_admin_username('guest1', 'windows')
 
     def test_validate_admin_password_linux(self):
         # pylint: disable=line-too-long


### PR DESCRIPTION
Fix #4257. 
Compute RP is starting to deploy the fix this week, so starting this week, David and John should be able to create vm/vmss w/o problems.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
