### PR TITLE
prevent further interactive shells in interactive mode

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -110,7 +110,8 @@ class Application(object):
             'headers': {},  # the x-ms-client-request-id is generated before a command is to execute
             'command': 'unknown',
             'completer_active': ARGCOMPLETE_ENV_NAME in os.environ,
-            'query_active': False
+            'query_active': False,
+            'interactive': False
         }
 
         # Register presence of and handlers for global parameters

--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -111,7 +111,7 @@ class Application(object):
             'command': 'unknown',
             'completer_active': ARGCOMPLETE_ENV_NAME in os.environ,
             'query_active': False,
-            'interactive': False
+            'az_interactive_active': False
         }
 
         # Register presence of and handlers for global parameters

--- a/src/command_modules/azure-cli-interactive/azclishell/__main__.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/__main__.py
@@ -26,8 +26,9 @@ import azure.cli.core.azlogging as azlogging
 
 logger = azlogging.get_az_logger(__name__)
 
+
 def main(style=None):
-    if APPLICATION.session["interactive"]:
+    if APPLICATION.session["az_interactive_active"]:
         logger.warning("You're in the interactive shell already.\n")
         return
 
@@ -76,6 +77,6 @@ def main(style=None):
         styles=style_obj,
         user_feedback=ask_feedback
     )
-    shell_app.app.session["interactive"] = True
+    shell_app.app.session["az_interactive_active"] = True
     shell_app.run()
-    shell_app.app.session["interactive"] = False
+    shell_app.app.session["az_interactive_active"] = False

--- a/src/command_modules/azure-cli-interactive/azclishell/__main__.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/__main__.py
@@ -25,6 +25,10 @@ from azure.cli.core.commands.client_factory import ENV_ADDITIONAL_USER_AGENT
 
 
 def main(style=None):
+    if APPLICATION.session["interactive"]:
+        print("You're in the interactive shell already!!\n")
+        return
+
     os.environ[ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + __version__
 
     azure_folder = cli_config_dir()
@@ -70,4 +74,6 @@ def main(style=None):
         styles=style_obj,
         user_feedback=ask_feedback
     )
+    shell_app.app.session["interactive"] = True
     shell_app.run()
+    shell_app.app.session["interactive"] = False

--- a/src/command_modules/azure-cli-interactive/azclishell/__main__.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/__main__.py
@@ -22,11 +22,13 @@ from azure.cli.core.application import APPLICATION
 from azure.cli.core._session import ACCOUNT, CONFIG, SESSION
 from azure.cli.core._environment import get_config_dir as cli_config_dir
 from azure.cli.core.commands.client_factory import ENV_ADDITIONAL_USER_AGENT
+import azure.cli.core.azlogging as azlogging
 
+logger = azlogging.get_az_logger(__name__)
 
 def main(style=None):
     if APPLICATION.session["interactive"]:
-        print("You're in the interactive shell already!!\n")
+        logger.warning("You're in the interactive shell already.\n")
         return
 
     os.environ[ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + __version__

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
@@ -7,15 +7,8 @@ import azure.cli.core.azlogging as azlogging
 
 
 logger = azlogging.get_az_logger(__name__)
-in_shell = False
+
 
 def start_shell(style=None):
-    global in_shell
-    if in_shell:
-        print("You're in the interactive shell already!!\n")
-        return
-    else:
-        in_shell = True
     from azclishell.__main__ import main
     main(style=style)
-    in_shell = False

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/custom.py
@@ -7,8 +7,15 @@ import azure.cli.core.azlogging as azlogging
 
 
 logger = azlogging.get_az_logger(__name__)
-
+in_shell = False
 
 def start_shell(style=None):
+    global in_shell
+    if in_shell:
+        print("You're in the interactive shell already!!\n")
+        return
+    else:
+        in_shell = True
     from azclishell.__main__ import main
     main(style=style)
+    in_shell = False


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/4287
---
Prevents new shell from being run in interactive mode.
If `interactive` is input in interactive mode, a message will inform user that he/she is already in the shell.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [na ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na ] Each command and parameter has a meaningful description.
- [na ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
