### PR TITLE
Enable set blob tier

### DIFF
--- a/src/command_modules/azure-cli-storage/HISTORY.rst
+++ b/src/command_modules/azure-cli-storage/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 unreleased
 ++++++++++
+* Enable set blob tier
 * `storage account create/update`: Add `--bypass` and `--default-action` arguments to support service tunneling.
 * `storage account network-rule`: Added commands to add VNET rules and IP based rules.
 * Enable service encryption by customer managed key

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
@@ -3,18 +3,18 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from azure.cli.core.profiles import supported_api_version
 from azure.cli.core.commands import create_command, command_table
 from ._validators import validate_client_parameters
 
 
-def cli_storage_data_plane_command(name, operation, client_factory,
-                                   transform=None, table_transformer=None, exception_handler=None,
-                                   resource_type=None, min_api=None, max_api=None):
+def cli_storage_data_plane_command(name, operation, client_factory, transform=None, table_transformer=None,
+                                   exception_handler=None, resource_type=None, max_api=None, min_api=None):
     """ Registers an Azure CLI Storage Data Plane command. These commands always include the
     four parameters which can be used to obtain a storage client: account-name, account-key,
     connection-string, and sas-token. """
-    if resource_type and (min_api or max_api):
-        from azure.cli.core.profiles import supported_api_version
+
+    if resource_type and (max_api or min_api):
         if not supported_api_version(resource_type, min_api=min_api, max_api=max_api):
             return
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_format.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_format.py
@@ -53,6 +53,7 @@ def transform_blob_output(result):
     return build_table_output(result, [
         ('Name', 'name'),
         ('Blob Type', 'properties.blobType'),
+        ('Blob Tier', 'properties.blobTier'),
         ('Length', 'properties.contentLength'),
         ('Content Type', 'properties.contentSettings.contentType'),
         ('Last Modified', 'properties.lastModified')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -197,6 +197,12 @@ helps['storage blob service-properties'] = """
     type: group
     short-summary: Manage storage blob service properties.
 """
+helps['storage blob set-tier'] = """
+    type: command
+    short-summary: Sets the block or page blob tiers on the blob.
+    long-summary:  For block blob this command only supports block blob on standard storage accounts.
+                   For page blob, this command only supports for page blobs on premium accounts.
+"""
 helps['storage blob copy start-batch'] = """
     type: command
     short-summary: Copy multiple blobs or files to a blob container.

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -98,7 +98,8 @@ cli_storage_data_plane_command('storage container policy create', custom_path + 
 cli_storage_data_plane_command('storage container policy delete', custom_path + 'delete_acl_policy', factory)
 cli_storage_data_plane_command('storage container policy show', custom_path + 'get_acl_policy', factory, exception_handler=_dont_fail_not_exist)
 cli_storage_data_plane_command('storage container policy list', custom_path + 'list_acl_policies', factory, table_transformer=transform_acl_list_output)
-cli_storage_data_plane_command('storage container policy update', custom_path + 'set_acl_policy', factory)
+cli_storage_data_plane_command('storage container policy update', custom_path + 'set_acl_policy', factory,
+                               resource_type=ResourceType.DATA_STORAGE, min_api='2017-04-17')
 
 # blob commands
 cli_storage_data_plane_command('storage blob list', block_blob_path + 'list_blobs', factory, transform=transform_storage_list_output, table_transformer=transform_blob_output)
@@ -124,6 +125,7 @@ cli_storage_data_plane_command('storage blob copy start-batch', 'azure.cli.comma
 cli_storage_data_plane_command('storage blob copy cancel', block_blob_path + 'abort_copy_blob', factory)
 cli_storage_data_plane_command('storage blob upload-batch', 'azure.cli.command_modules.storage.blob#storage_blob_upload_batch', factory)
 cli_storage_data_plane_command('storage blob download-batch', 'azure.cli.command_modules.storage.blob#storage_blob_download_batch', factory)
+cli_storage_data_plane_command('storage blob set-tier', custom_path + 'set_blob_tier', factory)
 
 # page blob commands
 cli_storage_data_plane_command('storage blob incremental-copy start',

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -199,12 +199,10 @@ def show_storage_account_connection_string(
 
 
 @transfer_doc(BlockBlobService.create_blob_from_path)
-def upload_blob(  # pylint: disable=too-many-locals
-        client, container_name, blob_name, file_path, blob_type=None,
-        content_settings=None, metadata=None, validate_content=False, maxsize_condition=None,
-        max_connections=2, lease_id=None, if_modified_since=None,
-        if_unmodified_since=None, if_match=None, if_none_match=None, timeout=None):
-    '''Upload a blob to a container.'''
+def upload_blob(client, container_name, blob_name, file_path, blob_type=None, content_settings=None, metadata=None,
+                validate_content=False, maxsize_condition=None, max_connections=2, lease_id=None, tier=None,
+                if_modified_since=None, if_unmodified_since=None, if_match=None, if_none_match=None, timeout=None):
+    """Upload a blob to a container."""
 
     def upload_append_blob():
         if not client.exists(container_name, blob_name):
@@ -258,6 +256,9 @@ def upload_blob(  # pylint: disable=too-many-locals
             'timeout': timeout
         }
 
+        if supported_api_version(ResourceType.DATA_STORAGE, min_api='2017-04-17') and tier:
+            create_blob_args['premium_page_blob_tier'] = tier
+
         if supported_api_version(ResourceType.DATA_STORAGE, min_api='2016-05-31'):
             create_blob_args['validate_content'] = validate_content
 
@@ -269,6 +270,17 @@ def upload_blob(  # pylint: disable=too-many-locals
         'page': upload_block_blob  # same implementation
     }
     return type_func[blob_type]()
+
+
+def set_blob_tier(client, container_name, blob_name, tier, blob_type='block', timeout=None):
+    if blob_type == 'block':
+        return client.set_standard_blob_tier(container_name=container_name, blob_name=blob_name,
+                                             standard_blob_tier=tier, timeout=timeout)
+    elif blob_type == 'page':
+        return client.set_premium_page_blob_tier(container_name=container_name, blob_name=blob_name,
+                                                 premium_page_blob_tier=tier, timeout=timeout)
+    else:
+        raise ValueError('Blob tier is only applicable to block or page blob.')
 
 
 def _get_service_container_type(client):
@@ -348,7 +360,7 @@ def set_acl_policy(client, container_name, policy_name, start=None, expiry=None,
 
 
 def delete_acl_policy(client, container_name, policy_name, **kwargs):
-    ''' Delete a stored access policy on a containing object '''
+    """ Delete a stored access policy on a containing object """
     acl = _get_acl(client, container_name, **kwargs)
     del acl[policy_name]
     if hasattr(acl, 'public_access'):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/util.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/util.py
@@ -131,3 +131,7 @@ def _pattern_has_wildcards(p):
 
 def _match_path(pattern, *args):
     return fnmatch(os.path.join(*args), pattern) if pattern else True
+
+
+def get_blob_tier_names(model):
+    return [v for v in dir(get_sdk(ResourceType.DATA_STORAGE, 'blob.models#' + model)) if not v.startswith('_')]

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -30,7 +30,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-multiapi-storage==0.1.2',
+    'azure-multiapi-storage==0.1.3',
     'azure-mgmt-storage==1.2.0',
     'azure-cli-core',
 ]

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -37,7 +37,7 @@ DEPENDENCIES = [
     'azure-keyvault==0.3.4',
     'azure-mgmt-network==1.4.0',
     'azure-mgmt-resource==1.1.0',
-    'azure-multiapi-storage==0.1.2',
+    'azure-multiapi-storage==0.1.3',
     'azure-cli-core'
 ]
 


### PR DESCRIPTION
```
10:24 $ az storage blob set-tier -h

Command
    az storage blob set-tier: Sets the block or page blob tiers on the blob.
        For block blob this command only supports block blob on standard storage accounts. For page
        blob, this command only supports for page blobs on premium accounts.

Arguments
    --container-name -c [Required]: The container name.
    --name -n           [Required]: The blob name.
    --tier              [Required]: The tier value to set the blob to.
    --timeout                     : The timeout parameter is expressed in seconds. This method may
                                    make multiple calls to the Azure service and the timeout will
                                    apply to each call individually.
    --type -t                     : The blob's type.  Allowed values: block, page.  Default: block.

Storage Account Arguments
    --account-key                 : Storage account key. Must be used in conjunction with storage
                                    account name. Environment variable: AZURE_STORAGE_KEY.
    --account-name                : Storage account name. Must be used in conjunction with either
                                    storage account key or a SAS token. Environment variable:
                                    AZURE_STORAGE_ACCOUNT.
    --connection-string           : Storage account connection string. Environment variable:
                                    AZURE_STORAGE_CONNECTION_STRING.
    --sas-token                   : A Shared Access Signature (SAS). Must be used in conjunction
                                    with storage account name. Environment variable:
                                    AZURE_STORAGE_SAS_TOKEN.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: table.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.

10:24 $ az storage blob upload -h

Command
    az storage blob upload: Upload a specified file to a storage blob.
        Creates a new blob from a file path, or updates the content of an existing blob, with
        automatic chunking and progress notifications.

Arguments
    --container-name -c [Required]: The container name.
    --file -f           [Required]: Path of the file to upload as the blob content.
    --name -n           [Required]: The blob name.
    --content-cache-control       : The cache control string.
    --content-disposition         : Conveys additional information about how to process the response
                                    payload, and can also be used to attach additional metadata.
    --content-encoding            : The content encoding type.
    --content-language            : The content language.
    --content-md5                 : The content's MD5 hash.
    --content-type                : The content MIME type.
    --lease-id                    : Required if the blob has an active lease.
    --max-connections             : Maximum number of parallel connections to use when the blob size
                                    exceeds 64MB.  Default: 2.
    --maxsize-condition           : The max length in bytes permitted for an append blob.
    --metadata                    : Metadata in space-separated key=value pairs. This overwrites any
                                    existing metadata.
    --tier                        : A page blob tier value to set the blob to. The tier correlates
                                    to the size of the blob and number of allowed IOPS. This is only
                                    applicable to page blobs on premium storage accounts.  Allowed
                                    values: P10, P20, P30, P4, P40, P50, P6, P60.
    --timeout                     : Request timeout in seconds. Applies to each call to the service.
    --type -t                     : Defaults to 'page' for *.vhd files, or 'block' otherwise.
                                    Allowed values: append, block, page.
    --validate-content            : Specifies that an MD5 hash shall be calculated for each chunk of
                                    the blob and verified by the service when the chunk has arrived.

Pre-condition Arguments
    --if-match                    : An ETag value, or the wildcard character (*). Specify this
                                    header to perform the operation only if the resource's ETag
                                    matches the value specified.
    --if-modified-since           : Alter only if modified since supplied UTC datetime
                                    (Y-m-d'T'H:M'Z').
    --if-none-match               : An ETag value, or the wildcard character (*). Specify this
                                    header to perform the operation only if the resource's ETag does
                                    not match the value specified. Specify the wildcard character
                                    (*) to perform the operation only if the resource does not
                                    exist, and fail the operation if it does exist.
    --if-unmodified-since         : Alter only if unmodified since supplied UTC datetime
                                    (Y-m-d'T'H:M'Z').

Storage Account Arguments
    --account-key                 : Storage account key. Must be used in conjunction with storage
                                    account name. Environment variable: AZURE_STORAGE_KEY.
    --account-name                : Storage account name. Must be used in conjunction with either
                                    storage account key or a SAS token. Environment variable:
                                    AZURE_STORAGE_ACCOUNT.
    --connection-string           : Storage account connection string. Environment variable:
                                    AZURE_STORAGE_CONNECTION_STRING.
    --sas-token                   : A Shared Access Signature (SAS). Must be used in conjunction
                                    with storage account name. Environment variable:
                                    AZURE_STORAGE_SAS_TOKEN.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: table.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Upload to a blob with all required fields.
        az storage blob upload -f /path/to/file -c MyContainer -n MyBlob

```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
