### PR TITLE
Fix pythonPath reference in .vscode/launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath": "${config.python.pythonPath}",
+            "pythonPath": "${config:python.pythonPath}",
             "program": "${workspaceRoot}/src/azure-cli/azure/cli/__main__.py",
             "cwd": "${workspaceRoot}",
             "args": [
@@ -23,7 +23,7 @@
             "type": "python",
             "request": "launch",
             "stopOnEntry": true,
-            "pythonPath": "${config.python.pythonPath}",
+            "pythonPath": "${config:python.pythonPath}",
             "program": "${workspaceRoot}/src/azure-cli/azure/cli/__main__.py",
             "cwd": "${workspaceRoot}",
             "args": [


### PR DESCRIPTION
I was trying to debug some `az` changes in VSCode, but hitting [F5] gave me this:
![screen shot 2017-08-24 at 1 37 40 pm](https://user-images.githubusercontent.com/73019/29685049-73e6cc2c-88d1-11e7-8853-982c8e1f4341.png)
Indeed, this agrees with [current VSCode docs](https://code.visualstudio.com/docs/editor/debugging#_variable-substitution) on how to reference the `config`.

I can't tell when this syntax changed, but swapping the `.` for `:` in two places in launch.json allows debugging to proceed with VSCode 1.15.1.