### PR TITLE
msi: simplify the login experience

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -571,7 +571,7 @@ class Profile(object):
         while True:
             err = None
             try:
-                result = requests.post(request_uri, data=payload)
+                result = requests.post(request_uri, data=payload, headers={'Metadata':True})
                 logger.debug("MSI: Retrieving a token from %s, with payload %s", request_uri, payload)
                 if result.status_code != 200:
                     err = result.text

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -541,7 +541,7 @@ class Profile(object):
         while True:
             err = None
             try:
-                result = requests.post(request_uri, data=payload, headers={'Metadata':'true'})
+                result = requests.post(request_uri, data=payload, headers={'Metadata': 'true'})
                 logger.debug("MSI: Retrieving a token from %s, with payload %s", request_uri, payload)
                 if result.status_code != 200:
                     err = result.text

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -249,7 +249,7 @@ class Profile(object):
         s.state = StateType.enabled
         return s
 
-    def find_subscriptions_in_vm_with_identity(self, msi_port):
+    def find_subscriptions_in_vm_with_msi(self, msi_port):
         import jwt
         _, token, _ = Profile.get_msi_token(CLOUD.endpoints.active_directory_resource_id, msi_port)
         logger.info('MSI: token was retrieved. Now trying to initialize local accounts...')
@@ -258,7 +258,7 @@ class Profile(object):
 
         subscription_finder = SubscriptionFinder(self.auth_ctx_factory, None)
         subscriptions = subscription_finder.find_from_raw_token(tenant, token)
-        consolidated = Profile._normalize_properties(str(msi_port), subscriptions, is_service_principal=False)
+        consolidated = Profile._normalize_properties(msi_port, subscriptions, is_service_principal=False)
         for s in consolidated:
             s[_SUBSCRIPTION_NAME] = _MSI_ACCOUNT_NAME  # use a special name to trigger a special token acquisition
         self._set_subscriptions(consolidated)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -562,7 +562,6 @@ class Profile(object):
         import time
         request_uri = 'http://localhost:{}/oauth2/token'.format(port)
         payload = {
-            'authority': '{}/{}'.format(aad_endpoint, tenant_id),
             'resource': resource
         }
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -570,7 +570,7 @@ class Profile(object):
         while True:
             err = None
             try:
-                result = requests.post(request_uri, data=payload, headers={'Metadata':True})
+                result = requests.post(request_uri, data=payload, headers={'Metadata':'true'})
                 logger.debug("MSI: Retrieving a token from %s, with payload %s", request_uri, payload)
                 if result.status_code != 200:
                     err = result.text

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -249,19 +249,19 @@ class Profile(object):
         s.state = StateType.enabled
         return s
 
-    def init_if_in_msi_env(self, user):
-        _, subscription_id = Profile.split_msi_user_info(user)
-        if subscription_id is None:
-            return None
-        logger.info('MSI: environment was detected. Now trying to initialize a local account...')
-        tenant_id = Profile.get_msi_tenant_id(CLOUD.endpoints.resource_manager, subscription_id)
-        s = Profile._new_account()
-        s.id = '/subscriptions/' + subscription_id
-        s.tenant_id = tenant_id
-        s.display_name = _MSI_ACCOUNT_NAME
-        consolidated = Profile._normalize_properties(user, [s], False)
+    def find_subscriptions_in_vm_with_identity(self, msi_port):
+        import jwt
+        _, token, _ = Profile.get_msi_token(CLOUD.endpoints.active_directory_resource_id, msi_port)
+        logger.info('MSI: token was retrieved. Now trying to initialize local accounts...')
+        decode = jwt.decode(token, verify=False, algorithms=['RS256'])
+        tenant = decode['tid']
+
+        subscription_finder = SubscriptionFinder(self.auth_ctx_factory, None)
+        subscriptions = subscription_finder.find_from_raw_token(tenant, token)
+        consolidated = Profile._normalize_properties(str(msi_port), subscriptions, is_service_principal=False)
+        for s in consolidated:
+            s[_SUBSCRIPTION_NAME] = _MSI_ACCOUNT_NAME  # use a special name to trigger a special token acquisition
         self._set_subscriptions(consolidated)
-        # use deepcopy as we don't want to persist these changes to file.
         return deepcopy(consolidated)
 
     def _set_subscriptions(self, new_subscriptions, merge=True):
@@ -384,8 +384,7 @@ class Profile(object):
 
         def _retrieve_token():
             if account[_SUBSCRIPTION_NAME] == _MSI_ACCOUNT_NAME:
-                port, _ = Profile.split_msi_user_info(username_or_sp_id)
-                return Profile.get_msi_token(resource, CLOUD.endpoints.active_directory, account[_TENANT_ID], port)
+                return Profile.get_msi_token(resource, account[_USER_ENTITY][_USER_NAME])
             elif user_type == _USER:
                 return self._creds_cache.retrieve_token_for_user(username_or_sp_id,
                                                                  account[_TENANT_ID], resource)
@@ -529,35 +528,7 @@ class Profile(object):
         return installation_id
 
     @staticmethod
-    def split_msi_user_info(user):
-        import uuid
-        parts = user.split('@')
-        if len(parts) == 2:
-            try:
-                uuid.UUID(parts[0])  # valid subscription id?
-                int(parts[1])  # valid port?
-                return parts[1], parts[0]
-            except ValueError:
-                pass
-        return None, None
-
-    @staticmethod
-    def get_msi_tenant_id(arm_endpoint, subscription_id):
-        import re
-        import requests
-        url = '{}/subscriptions/{}?api-version=2014-04-01'.format(arm_endpoint.rstrip('/'), subscription_id)
-        logger.debug('MSI: Retrieving tenant id by invoking GET from %s', url)
-        result = requests.get(url)
-        if result.status_code != 401:
-            raise CLIError('Failed to retrieve the tenant id of subscription {}'.format(subscription_id))
-        exp = r'.+authorization_uri="(.*?)".+'
-        r = re.match(exp, result.headers['www-authenticate'])
-        tenant_id = r.group(1).split('/')[-1]
-        logger.debug('MSI: Got tenant id: %s', tenant_id)
-        return tenant_id
-
-    @staticmethod
-    def get_msi_token(resource, aad_endpoint, tenant_id, port):
+    def get_msi_token(resource, port):
         import requests
         import time
         request_uri = 'http://localhost:{}/oauth2/token'.format(port)
@@ -649,7 +620,7 @@ class SubscriptionFinder(object):
         self.tenants = [tenant]
         return result
 
-    #  only occur inside cloud console
+    #  only occur inside cloud console or VM with identity
     def find_from_raw_token(self, tenant, token):
         # decode the token, so we know the tenant
         result = self._find_using_specific_tenant(tenant, token)

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -424,7 +424,7 @@ class Test_Profile(unittest.TestCase):
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_port = '12345'
-        test_user = test_subscription_id + '@' + test_port
+        test_user = test_port
         msi_subscription = SubscriptionStub('/subscriptions/' + test_subscription_id, 'MSI', self.state1, test_tenant_id)
         consolidated = Profile._normalize_properties(test_user,
                                                      [msi_subscription],
@@ -454,8 +454,8 @@ class Test_Profile(unittest.TestCase):
         self.assertEqual(test_token_entry['token_type'], token_type)
         self.assertEqual(test_token_entry, whole_entry)
         mock_post.assert_called_with('http://localhost:12345/oauth2/token',
-                                     {'authority': 'https://login.microsoftonline.com/{}'.format(test_tenant_id),
-                                      'resource': 'https://management.core.windows.net/'})
+                                     data={'resource': 'https://management.core.windows.net/'},
+                                     headers={'Metadata': 'true'})
 
     @mock.patch('requests.post', autospec=True)
     @mock.patch('time.sleep', autospec=True)
@@ -477,7 +477,7 @@ class Test_Profile(unittest.TestCase):
         mock_post.side_effect = [ValueError('fail'), bad_response, good_response]
 
         # action
-        token_type, token, whole_entry = Profile.get_msi_token('azure-resource', 'aad-endpoint', 'tenant-id', 12345)
+        token_type, token, whole_entry = Profile.get_msi_token('azure-resource', 12345)
 
         # assert
         self.assertEqual(test_token_entry['access_token'], token)
@@ -691,41 +691,40 @@ class Test_Profile(unittest.TestCase):
         mock_auth_context.acquire_token.assert_called_once_with(
             mgmt_resource, self.user1, mock.ANY)
 
-    @mock.patch('requests.get', autospec=True)
-    def test_init_if_in_msi_env(self, get_mock):
+    @mock.patch('requests.post', autospec=True)
+    @mock.patch('azure.cli.core.profiles._shared.get_client_class', autospec=True)
+    def test_find_subscriptions_in_vm_with_msi(self, mock_get_client_class, mock_post):
+
+        class ClientStub:
+            def __init__(self, *args, **kwargs):
+                self.subscriptions = mock.MagicMock()
+                self.subscriptions.list.return_value = [Test_Profile.subscription1]
+
+        mock_get_client_class.return_value = ClientStub
+
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock, use_global_creds_cache=False)
 
-        # setup the response for the tenant search request
-        test_subscription_id = '04b07795-8ddb-461a-bbee-02f9e1bf9999'
-        test_tenant = 'tenant1'
-        test_port = 12345
-        result = mock.MagicMock()
-        result.status_code = 401
-        headers = {
-            'www-authenticate': 'foo;authorization_uri="https://haha/{}";bar'.format(test_tenant)
+        test_token_entry = {
+            'token_type': 'Bearer',
+            'access_token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNTAzMzU0ODc2LCJuYmYiOjE1MDMzNTQ4NzYsImV4cCI6MTUwMzM1ODc3NiwiYWNyIjoiMSIsImFpbyI6IkFTUUEyLzhFQUFBQTFGL1k0VVR3bFI1Y091QXJxc1J0OU5UVVc2MGlsUHZna0daUC8xczVtdzg9IiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoyNjI4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI4YTliMTYxNy1mYzhkLTRhYTktYTQyZi05OTg2OGQzMTQ2OTkiLCI1NDgwMzkxNy00YzcxLTRkNmMtOGJkZi1iYmQ5MzEwMTBmOGMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjIzNCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1dGkiOiJuUEROYm04UFkwYUdELWhNeWxrVEFBIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.Pg4cq0MuP1uGhY_h51ZZdyUYjGDUFgTW2EfIV4DaWT9RU7GIK_Fq9VGBTTbFZA0pZrrmP-z7DlN9-U0A0nEYDoXzXvo-ACTkm9_TakfADd36YlYB5aLna-yO0B7rk5W9ANelkzUQgRfidSHtCmV6i4Ve-lOym1sH5iOcxfIjXF0Tp2y0f3zM7qCq8Cp1ZxEwz6xYIgByoxjErNXrOME5Ld1WizcsaWxTXpwxJn_Q8U2g9kXHrbYFeY2gJxF_hnfLvNKxUKUBnftmyYxZwKi0GDS0BvdJnJnsqSRSpxUx__Ra9QJkG1IaDzjZcSZPHK45T6ohK9Hk9ktZo0crVl7Tmw'
         }
-        result.headers = headers
-        get_mock.return_value = result
-        user = test_subscription_id + '@' + str(test_port)
+        encoded_test_token = json.dumps(test_token_entry).encode()
+        good_response = mock.MagicMock()
+        good_response.status_code = 200
+        good_response.content = encoded_test_token
+        mock_post.return_value = good_response
 
-        # action
-        subscriptions = profile.init_if_in_msi_env(user)
+        subscriptions = profile.find_subscriptions_in_vm_with_msi('9999')
 
         # assert
         self.assertEqual(len(subscriptions), 1)
         s = subscriptions[0]
-        self.assertEqual(s['user']['name'], test_subscription_id + '@' + str(test_port))
+        self.assertEqual(s['user']['name'], '9999')
         self.assertEqual(s['user']['type'], 'user')
         self.assertEqual(s['name'], 'MSI')
-        self.assertEqual(s['id'], test_subscription_id)
-        self.assertEqual(s['tenantId'], test_tenant)
-
-    def test_do_nothing_if_not_in_msi_env(self):
-        # verify do nothing on regular user name
-        storage_mock = {'subscriptions': None}
-        profile = Profile(storage_mock, use_global_creds_cache=False)
-        self.assertIsNone(profile.init_if_in_msi_env('foo@bar.com'))
+        self.assertEqual(s['id'], self.id1.split('/')[-1])
+        self.assertEqual(s['tenantId'], '54826b22-38d6-4fb2-bad9-b7b93a3e9c5a')
 
     @mock.patch('adal.AuthenticationContext.acquire_token_with_username_password', autospec=True)
     @mock.patch('adal.AuthenticationContext.acquire_token', autospec=True)

--- a/src/command_modules/azure-cli-profile/HISTORY.rst
+++ b/src/command_modules/azure-cli-profile/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+unreleased 
++++++++++++++++++++
+* login: expose `--msi` and `--msi-port` to login using Virtual machine's identity
+
 2.0.10 (2017-08-11)
 +++++++++++++++++++
 * account list: add `--refresh` to sycn up the latest subscriptions from server

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -20,9 +20,9 @@ helps['login'] = """
                 - name: Log in with a service principal using client certificate.
                   text: >
                     az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-                - name: Log in a VM with Managed Service Identity using default local port 50342
+                - name: Log in a VM with Managed Service Identity
                   text: >
-                    az login --msi-port
+                    az login --msi
             """
 
 helps['account'] = """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -20,9 +20,9 @@ helps['login'] = """
                 - name: Log in with a service principal using client certificate.
                   text: >
                     az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-                - name: Log in with subscription id and port number if in a VM with Managed Service Identity
+                - name: Log in a VM with Managed Service Identity using default local port 50342
                   text: >
-                    az login -u 0b1f6471-1bf0-4dda-aec3-cb9272f11111@50342
+                    az login --msi-port
             """
 
 helps['account'] = """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -20,7 +20,7 @@ helps['login'] = """
                 - name: Log in with a service principal using client certificate.
                   text: >
                     az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-                - name: Log in a VM with Managed Service Identity
+                - name: Log in using the VM’s Managed Service Identity
                   text: >
                     az login --msi
             """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -20,7 +20,7 @@ helps['login'] = """
                 - name: Log in with a service principal using client certificate.
                   text: >
                     az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-                - name: Log in using the VM’s Managed Service Identity
+                - name: Log in using the VM's Managed Service Identity
                   text: >
                     az login --msi
             """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -22,8 +22,8 @@ register_cli_argument('login', 'service_principal', action='store_true', help='T
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
 register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-register_cli_argument('login', 'msi_port', type=int, help="local port to contact for credentails to finish the login process. Only applicable in a Virual Machine with Managed Service Identity")
-
+register_cli_argument('login', 'msi', action='store_true', help="Login using the Virtual Machine's identity", arg_group='Managed Service Identity')
+register_cli_argument('login', 'msi_port', help="the port to retrieve tokens for login", arg_group='Managed Service Identity')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -22,7 +22,7 @@ register_cli_argument('login', 'service_principal', action='store_true', help='T
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
 register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-register_cli_argument('login', 'msi', action='store_true', help="Login using the Virtual Machine's identity", arg_group='Managed Service Identity')
+register_cli_argument('login', 'msi', action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
 register_cli_argument('login', 'msi_port', help="the port to retrieve tokens for login", arg_group='Managed Service Identity')
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -22,6 +22,8 @@ register_cli_argument('login', 'service_principal', action='store_true', help='T
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
 register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
+register_cli_argument('login', 'msi_port', type=int, help="local port to contact for credentails to finish the login process. Only applicable in a Virual Machine with Managed Service Identity")
+
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -84,7 +84,7 @@ def account_clear():
 
 
 def login(username=None, password=None, service_principal=None, tenant=None,
-          allow_no_subscriptions=False):
+          allow_no_subscriptions=False, msi_port=None):
     """Log in to access Azure subscriptions"""
     import os
     import re
@@ -100,6 +100,11 @@ def login(username=None, password=None, service_principal=None, tenant=None,
             return profile.find_subscriptions_in_cloud_console(re.split(';|,', console_tokens))
         else:
             raise CLIError(_CLOUD_CONSOLE_ERR_TEMPLATE.format('login'))
+
+    if msi_port:
+        if username or password or service_principal or tenant or allow_no_subscriptions:
+            raise CLIError("usage error: '--msi-port' doesn't use with other arguments")
+        return profile.find_subscriptions_in_vm_with_identity(msi_port)
 
     if username:
         if not password:

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -94,8 +94,8 @@ def login(username=None, password=None, service_principal=None, tenant=None,
     import requests
 
     # quick argument usage check
-    if (any([username, password, service_principal, tenant, allow_no_subscriptions])
-            and any([msi, not getattr(msi_port, 'is_default', None)])):
+    if (any([username, password, service_principal, tenant, allow_no_subscriptions]) and
+            any([msi, not getattr(msi_port, 'is_default', None)])):
         raise CLIError("usage error: '--msi/--msi-port' are not applicable with other arguments")
 
     interactive = False

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -288,7 +288,7 @@ def build_vm_msi_extension(vm_name, location, role_assignment_guid, port, is_lin
         'location': location,
         'dependsOn': [role_assignment_guid or 'Microsoft.Compute/virtualMachines/' + vm_name],
         'properties': {
-            'publisher': "Microsoft.ManagedIdentity",
+            'publisher': "Microsoft.ManagedIdentity.Edp",
             'type': 'ManagedIdentityExtensionFor' + ('Linux' if is_linux else 'Windows'),
             'typeHandlerVersion': extension_version,
             'autoUpgradeMinorVersion': True,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1962,7 +1962,7 @@ def create_vmss(vmss_name, resource_group_name, image,
         vmss_resource['properties']['virtualMachineProfile']['extensionProfile']["extensions"].append({
             'name': 'MSIExtension',
             'properties': {
-                'publisher': 'Microsoft.ManagedIdentity',
+                'publisher': 'Microsoft.ManagedIdentity.Edp',
                 'type': 'ManagedIdentityExtensionFor' + ('Windows' if os_type.lower() == 'windows' else 'Linux'),
                 "typeHandlerVersion": _MSI_EXTENSION_VERSION,
                 'autoUpgradeMinorVersion': True,
@@ -2098,7 +2098,7 @@ def assign_vm_identity(resource_group_name, vm_name, identity_role=DefaultStr('C
     ext_name = 'ManagedIdentityExtensionFor' + ('Linux' if _is_linux_vm(vm) else 'Windows')
     logger.info("Provisioning extension: '%s'", ext_name)
     poller = set_extension(resource_group_name, vm_name,
-                           publisher='Microsoft.ManagedIdentity',
+                           publisher='Microsoft.ManagedIdentity.Edp',
                            vm_extension_name=ext_name,
                            version=_MSI_EXTENSION_VERSION,
                            settings={'port': port})
@@ -2131,7 +2131,7 @@ def assign_vmss_identity(resource_group_name, vmss_name, identity_role=DefaultSt
                                                 else 'Windows')
     logger.info("Provisioning extension: '%s'", ext_name)
     poller = set_vmss_extension(resource_group_name, vmss_name,
-                                publisher='Microsoft.ManagedIdentity',
+                                publisher='Microsoft.ManagedIdentity.Edp',
                                 extension_name=ext_name,
                                 version=_MSI_EXTENSION_VERSION,
                                 settings={'port': port})


### PR DESCRIPTION
Support simpler login experience using VM's identity: `az login --msi`.  The `--msi-port` argument can be used if a different port was configured (very rare though).
(Mark it as `Do Not Merge` as server side change is not yet deployed, and also, the publisher of the MSI extension need to change to the official name once deployed.)

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
