### PR TITLE
[Extensions] _parse_id need to be case insensitive matching

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extensions/transform.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/transform.py
@@ -16,7 +16,7 @@ def register(application):
 def _parse_id(strid):
     parsed = {}
     parts = re.split('/', strid)
-    if not re.match('resourcegroups', parts[3], re.IGNORECASE):
+    if parts[3].lower() != 'resourcegroups':
         raise KeyError()
 
     parsed['resource-group'] = parts[4]

--- a/src/azure-cli-core/azure/cli/core/extensions/transform.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/transform.py
@@ -16,7 +16,7 @@ def register(application):
 def _parse_id(strid):
     parsed = {}
     parts = re.split('/', strid)
-    if parts[3] != 'resourceGroups':
+    if not re.match('resourcegroups', parts[3], re.IGNORECASE):
         raise KeyError()
 
     parsed['resource-group'] = parts[4]

--- a/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
@@ -24,7 +24,8 @@ class TestResourceGroupTransform(unittest.TestCase):
     def tearDown(self):
         self.io.close()
 
-    CORRECT_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"  # pylint: disable=line-too-long
+    # CORRECT_ID should match 'resourceGroups' in the path in a case insensitive way
+    CORRECT_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/resOurcegroUps/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"  # pylint: disable=line-too-long
     NON_RG_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/somethingElse/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"  # pylint: disable=line-too-long
     BOGUS_ID = "|completely-bogus-id|"
     DICT_ID = {'value': "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"}  # pylint: disable=line-too-long


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
