### PR TITLE
reenable interactive completer

### DIFF
--- a/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
@@ -76,7 +76,7 @@ def gen_dyn_completion(comp, started_param, prefix, text):
         yield Completion(completion, -len(prefix))
 
 
-def sort_completions(gen):
+def sort_completions(completions_gen):
     """ sorts the completions """
 
     def _get_weight(val):
@@ -86,10 +86,7 @@ def sort_completions(gen):
             priority = ' '  # a space has the lowest ordinance
         return priority + val.text
 
-    completions = []
-    for comp in gen:
-        completions.append(comp)
-    return sorted(completions, key=_get_weight)
+    return sorted(list(completions_gen), key=_get_weight)
 
 
 # pylint: disable=too-many-instance-attributes

--- a/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
@@ -18,8 +18,6 @@ from azure.cli.core.parser import AzCliCommandParser
 
 SELECT_SYMBOL = azclishell.configuration.SELECT_SYMBOL
 
-BLACKLISTED_COMPLETIONS = ['interactive']
-
 
 def initialize_command_table_attributes(completer):
     completer.cmdtab = FRESH_TABLE.command_table
@@ -90,8 +88,7 @@ def sort_completions(gen):
 
     completions = []
     for comp in gen:
-        if comp.text not in BLACKLISTED_COMPLETIONS:
-            completions.append(comp)
+        completions.append(comp)
     return sorted(completions, key=_get_weight)
 
 

--- a/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/az_completer.py
@@ -86,7 +86,7 @@ def sort_completions(completions_gen):
             priority = ' '  # a space has the lowest ordinance
         return priority + val.text
 
-    return sorted(list(completions_gen), key=_get_weight)
+    return sorted(completions_gen, key=_get_weight)
 
 
 # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
---
reenabled `interactive` completion in interactive mode as it is in help and is technically a valid command now.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [na ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na ] Each command and parameter has a meaningful description.
- [na ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
