### PR TITLE
MSI: disable msi login

### DIFF
--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=line-too-long
 from azure.cli.core.commands import register_cli_argument
+from azure.cli.core.commands.parameters import ignore_type
 from .custom import load_subscriptions
 
 
@@ -23,7 +24,6 @@ register_cli_argument('login', 'username', options_list=('--username', '-u'), he
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
 register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
 
-from azure.cli.core.commands.parameters import ignore_type
 register_cli_argument('login', 'msi', ignore_type)
 register_cli_argument('login', 'msi_port', ignore_type)
 # register_cli_argument('login', 'msi', action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -22,8 +22,13 @@ register_cli_argument('login', 'service_principal', action='store_true', help='T
 register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
 register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The AAD tenant, must provide when using service principals.')
 register_cli_argument('login', 'allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
-register_cli_argument('login', 'msi', action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-register_cli_argument('login', 'msi_port', help="the port to retrieve tokens for login", arg_group='Managed Service Identity')
+
+from azure.cli.core.commands.parameters import ignore_type
+register_cli_argument('login', 'msi', ignore_type)
+register_cli_argument('login', 'msi_port', ignore_type)
+# register_cli_argument('login', 'msi', action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
+# register_cli_argument('login', 'msi_port', help="the port to retrieve tokens for login", arg_group='Managed Service Identity')
+
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 


### PR DESCRIPTION
//CC: @derekbekoe, @tjprescott  @mayurid 
This is the PR to disable the msi login in case the service deployment can't go through by next Wednesday

- [na] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
