### PR TITLE
cleaned and fixed some issues with jmespath querying from last command

### DIFF
--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -501,7 +501,6 @@ class Shell(object):
             input_last = dict(self.last.result)
         else:  # list or string
             input_last = self.last.result
-            print("not dict")
         query_symbol = SELECT_SYMBOL['query']
         symbol_len = len(query_symbol)
         try:
@@ -520,7 +519,7 @@ class Shell(object):
                             return str(input_last)
                         query_result = jmespath.search(match.group(0)[symbol_len:], input_last)
                         return str(query_result)
-                    return re.sub(r'%s.*' % escaped_symbol, jmespath_query, arg)
+                    return json.dumps(re.sub(r'%s.*' % escaped_symbol, jmespath_query, arg))
                 cmd_base = ' '.join(map(sub_result, args))
                 self.cli_execute(cmd_base)
             continue_flag = True

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -516,7 +516,6 @@ class Shell(object):
                     if match.group(0) == query_symbol:
                         return str(self.last.result)
                     query_result = jmespath.search(match.group(0)[symbol_len:], self.last.result)
-                    print("query_result:", query_result)
                     return str(query_result)
 
                 def sub_result(arg):

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -513,10 +513,11 @@ class Shell(object):
             else:
                 # query, inject into cmd
                 def jmespath_query(match):
-                        if match.group(0) == query_symbol:
-                            return str(self.last.result)
-                        query_result = jmespath.search(match.group(0)[symbol_len:], self.last.result)
-                        return str(query_result)
+                    if match.group(0) == query_symbol:
+                        return str(self.last.result)
+                    query_result = jmespath.search(match.group(0)[symbol_len:], self.last.result)
+                    print("query_result:", query_result)
+                    return str(query_result)
 
                 def sub_result(arg):
                     escaped_symbol = re.escape(query_symbol)

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -86,7 +86,8 @@ def space_examples(list_examples, rows, section_value):
 
         if end < num_newline:
             example = '\n'.join(group[begin:end]) + "\n"
-        else:  # default chops top off
+        else:
+            # default chops top off
             example = '\n'.join(group[begin:]) + "\n"
             while ((section_value - 1) * len_of_excerpt) > num_newline:
                 sub_section()
@@ -151,8 +152,8 @@ class Shell(object):
         self.threads = []
         self.curr_thread = None
         self.spin_val = -1
-        self.intermediate_sleep = intermediate_sleep  # in seconds
-        self.final_sleep = final_sleep  # in seconds
+        self.intermediate_sleep = intermediate_sleep
+        self.final_sleep = final_sleep
 
     @property
     def cli(self):
@@ -258,7 +259,8 @@ class Shell(object):
             return param_descrip, example
 
         for word in text.split():
-            if word.startswith("-"):  # any parameter
+            if word.startswith("-"):
+                # any parameter
                 is_command = False
             if is_command:
                 command += str(word) + " "
@@ -447,7 +449,8 @@ class Shell(object):
 
         if cmd_stripped == "quit" or cmd_stripped == "exit":
             break_flag = True
-        elif cmd_stripped == "clear-history":  # clears the history, but only when you restart
+        elif cmd_stripped == "clear-history":
+            # clears the history, but only when you restart
             outside = True
             cmd = 'echo -n "" >' +\
                 os.path.join(
@@ -481,7 +484,8 @@ class Shell(object):
                     show_version_info_exit(self.output)
                 except SystemExit:
                     pass
-            elif "|" in cmd or ">" in cmd:  # anything I don't parse, send off
+            elif "|" in cmd or ">" in cmd:
+                # anything I don't parse, send off
                 outside = True
                 cmd = "az " + cmd
 
@@ -496,25 +500,22 @@ class Shell(object):
     def handle_jmespath_query(self, args):
         """ handles the jmespath query for injection or printing """
         continue_flag = False
-
-        if hasattr(self.last.result, '__dict__'):
-            input_last = dict(self.last.result)
-        else:  # list or string
-            input_last = self.last.result
         query_symbol = SELECT_SYMBOL['query']
         symbol_len = len(query_symbol)
         try:
-            if len(args) == 1:  # if arguments start with query_symbol, just print query result
+            if len(args) == 1:
+                # if arguments start with query_symbol, just print query result
                 if args[0] == query_symbol:
                     result = self.last.result
                 elif args[0].startswith(query_symbol):
-                    result = jmespath.search(args[0][symbol_len:], input_last)
+                    result = jmespath.search(args[0][symbol_len:], self.last.result)
                 print(json.dumps(result, sort_keys=True, indent=2), file=self.output)
-            else:  # query, inject into cmd
+            else:
+                # query, inject into cmd
                 def jmespath_query(match):
                         if match.group(0) == query_symbol:
-                            return str(input_last)
-                        query_result = jmespath.search(match.group(0)[symbol_len:], input_last)
+                            return str(self.last.result)
+                        query_result = jmespath.search(match.group(0)[symbol_len:], self.last.result)
                         return str(query_result)
 
                 def sub_result(arg):
@@ -624,7 +625,8 @@ class Shell(object):
                     OutputProducer(formatter=formatter).out(result)
                     self.last = result
 
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
+            # pylint: disable=broad-except
             self.last_exit = handle_exception(ex)
         except SystemExit as ex:
             self.last_exit = int(ex.code)
@@ -655,13 +657,15 @@ class Shell(object):
                 try:
                     document = self.cli.run(reset_current_buffer=True)
                     text = document.text
-                    if not text:  # not input
+                    if not text:
+                        # not input
                         self.set_prompt()
                         continue
                     cmd = text
                     outside = False
 
-                except AttributeError:  # when the user pressed Control D
+                except AttributeError:
+                    # when the user pressed Control D
                     break
                 else:
                     b_flag, c_flag, outside, cmd = self._special_cases(cmd, outside)
@@ -679,9 +683,11 @@ class Shell(object):
                         subprocess.Popen(cmd, shell=True).communicate()
                     else:
                         self.cli_execute(cmd)
-                        cli_telemetry.conclude()  # because I catch the sys exit, I have to push out
+                        # because I catch the sys exit, I have to push out
+                        cli_telemetry.conclude()
 
-            except (KeyboardInterrupt, ValueError):  # CTRL C
+            except (KeyboardInterrupt, ValueError):
+                # CTRL C
                 self.set_prompt()
                 continue
 

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -528,7 +528,7 @@ class Shell(object):
 
                 def sub_result(arg):
                     escaped_symbol = re.escape(query_symbol)
-                    # regex captures query symbol and all characters following it in the agument
+                    # regex captures query symbol and all characters following it in the argument
                     return json.dumps(re.sub(r'%s.*' % escaped_symbol, jmespath_query, arg))
                 cmd_base = ' '.join(map(sub_result, args))
                 self.cli_execute(cmd_base)

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -504,22 +504,23 @@ class Shell(object):
         query_symbol = SELECT_SYMBOL['query']
         symbol_len = len(query_symbol)
         try:
-            if len(args) == 1: #if arguments start with query_symbol, just print query result
+            if len(args) == 1:  # if arguments start with query_symbol, just print query result
                 if args[0] == query_symbol:
                     print(json.dumps(self.last.result, sort_keys=True, indent=2), file=self.output)
                 elif len(args) == 1 and args[0].startswith(query_symbol):
                     query = args[0][symbol_len:]
                     print(json.dumps(jmespath.search(query, input_dict), sort_keys=True, indent=2), file=self.output)
-            else: #query, inject into cmd
+            else:  # query, inject into cmd
                 def sub_result(arg):
                     escaped_symbol = re.escape(query_symbol)
+
                     def jmespath_query(match):
                         query_result = jmespath.search(match.group(0)[symbol_len:], input_dict)
                         if isinstance(query_result, list):
                             return ' '.join(query_result)
                         elif isinstance(query_result, (six.text_type, six.string_types)):
                             return query_result
-                        else: # query result is not a string or list, return invalid query message
+                        else:  # query result is not a string or list, return invalid query message
                             raise CLIError
                     return re.sub(r'%s.*' % escaped_symbol, jmespath_query, arg)
                 cmd_base = ' '.join(map(sub_result, args))

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -484,8 +484,8 @@ class Shell(object):
                 print(meaning + ": " + str(self.last_exit), file=self.output)
                 continue_flag = True
                 telemetry.track_ssg('exit code', '')
-            elif validate_contains_query(args_no_quotes, SELECT_SYMBOL['query']) and self.last and self.last.result:
-                continue_flag = self.handle_jmespath_query(args_no_quotes, continue_flag)
+            elif validate_contains_query(args, SELECT_SYMBOL['query']) and self.last and self.last.result:
+                continue_flag = self.handle_jmespath_query(args, continue_flag)
                 telemetry.track_ssg('query', '')
 
             elif args[0] == '--version' or args[0] == '-v':

--- a/src/command_modules/azure-cli-interactive/azclishell/app.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/app.py
@@ -521,7 +521,7 @@ class Shell(object):
                             return query_result
                         else: # query result is not a string or list, return invalid query message
                             raise CLIError
-                    return re.sub(r'%s\S*' % escaped_symbol, jmespath_query, arg)
+                    return re.sub(r'%s.*' % escaped_symbol, jmespath_query, arg)
                 cmd_base = ' '.join(map(sub_result, args))
                 self.cli_execute(cmd_base)
             continue_flag = True

--- a/src/command_modules/azure-cli-interactive/azclishell/configuration.py
+++ b/src/command_modules/azure-cli-interactive/azclishell/configuration.py
@@ -13,7 +13,7 @@ from six.moves import configparser
 
 SELECT_SYMBOL = {
     'outside': '#',
-    'query': '?',
+    'query': '??',
     'example': '::',
     'exit_code': '$',
     'scope': '%%',

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -86,10 +86,8 @@ class QueryInjection(unittest.TestCase):
         flag = self.shell.handle_jmespath_query(args)
         self.assertTrue(flag)
         results = self.stream.getvalue().strip().split('\n')
-        self.assertTrue(len(results) == 3)
-        self.assertEqual(results[0], 'vm show -g mygroup -n myname')
-        self.assertEqual(results[1], 'vm show -g mygroup2 -n myname2')
-        self.assertEqual(results[2], 'vm show -g mygroup3 -n myname3')
+        self.assertTrue(len(results) == 1)
+        self.assertEqual(results[0], 'vm show -g mygroup mygroup2 mygroup3 -n myname myname2 myname3')
 
     def test_quotes(self):
         # tests that it parses correctly with quotes in the command
@@ -123,7 +121,7 @@ class QueryInjection(unittest.TestCase):
 
     def test_singleton(self):
         # tests a singleton example
-        args = 'vm show -g "?group" -n "?name"'
+        args = 'vm show -g "??group" -n "??name"'
         args = parse_quotes(args)
         self.shell.last.result = {
             'group': 'mygroup',
@@ -137,11 +135,8 @@ class QueryInjection(unittest.TestCase):
 
     def test_spaces(self):
         # tests quotes with spaces
-        args = 'vm show -g "?[?group == \'mygroup\'].name"'
+        args = 'vm show -g "??[?group == \'mygroup\'].name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = [
             {
                 'group': 'mygroup',
@@ -153,17 +148,14 @@ class QueryInjection(unittest.TestCase):
             }
         ]
 
-        self.shell.handle_jmespath_query(args_no_quotes)
+        self.shell.handle_jmespath_query(args)
         results = self.stream.getvalue().split('\n')
         self.assertEqual(results[0], u'vm show -g fred')
 
     def test_spaces_with_equal(self):
         # tests quotes with spaces
-        args = 'vm show -g="?[?group == \'myg roup\'].name"'
+        args = 'vm show -g="??[?group == \'myg roup\'].name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = [
             {
                 'group': 'myg roup',
@@ -175,6 +167,6 @@ class QueryInjection(unittest.TestCase):
             }
         ]
 
-        self.shell.handle_jmespath_query(args_no_quotes)
+        self.shell.handle_jmespath_query(args)
         results = self.stream.getvalue().split('\n')
         self.assertEqual(results[0], u'vm show -g=fred')

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -45,7 +45,6 @@ class QueryInjection(unittest.TestCase):
         self.assertTrue(flag)
         self.assertEqual(self.stream.getvalue(), '\n')
 
-
     def test_print_last_command(self):
         # tests getting last command result
         args = ['??']
@@ -55,7 +54,6 @@ class QueryInjection(unittest.TestCase):
         print(repr(self.stream.getvalue()))
         self.assertEqual(self.stream.getvalue(), '{\n  \"x\": \"result\"\n}\n')
 
-
     def test_print_just_query(self):
         # tests flushing just the query
         args = ['??x']
@@ -64,7 +62,6 @@ class QueryInjection(unittest.TestCase):
         self.assertTrue(flag)
         self.assertEqual(self.stream.getvalue(), '"result"\n')
 
-    
     def test_print_list_replacement(self):
         # tests that the query replaces the values in the command
         args = '??[].group'
@@ -87,7 +84,6 @@ class QueryInjection(unittest.TestCase):
         self.assertTrue(flag)
         print(repr(self.stream.getvalue()))
         self.assertEqual(self.stream.getvalue(), '[\n  \"mygroup\",\n  \"mygroup2\",\n  \"mygroup3\"\n]\n')
-
 
     def test_string_replacement(self):
         # tests that the query replaces the values in the command

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -57,9 +57,6 @@ class QueryInjection(unittest.TestCase):
         # tests that the query replaces the values in the command
         args = 'vm show -g "??group" -n "??name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = {
             'group': 'mygroup',
             'name': 'myname'
@@ -72,9 +69,6 @@ class QueryInjection(unittest.TestCase):
         # tests that the query replaces the values in the command
         args = 'vm show -g "??[].group" -n "??[].name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = [
             {
                 'group': 'mygroup',
@@ -112,9 +106,6 @@ class QueryInjection(unittest.TestCase):
         # tests invalid query
         args = 'vm show -g "??[].group" -n "??[].name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = [
             {
                 'group': 'mygroup',
@@ -134,9 +125,6 @@ class QueryInjection(unittest.TestCase):
         # tests a singleton example
         args = 'vm show -g "?group" -n "?name"'
         args = parse_quotes(args)
-        args_no_quotes = []
-        for arg in args:
-            args_no_quotes.append(arg.strip("/'").strip('/"'))
         self.shell.last.result = {
             'group': 'mygroup',
             'name': 'myname'

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -39,14 +39,6 @@ class QueryInjection(unittest.TestCase):
         self.stream.write(cmd)
         self.stream.write(os.linesep)
 
-    def test_null(self):
-        # tests empty case
-        args = []
-        self.shell.last.result = {}
-        flag = self.shell.handle_jmespath_query(args)
-        self.assertTrue(flag)
-        self.assertEqual(self.stream.getvalue(), os.linesep)
-
     def test_print_last_command(self):
         # tests getting last command result
         args = ['??']
@@ -84,6 +76,24 @@ class QueryInjection(unittest.TestCase):
         flag = self.shell.handle_jmespath_query(args)
         self.assertTrue(flag)
         self.assertEqual(json.loads(self.stream.getvalue()), ['mygroup', 'mygroup2', 'mygroup3'])
+
+    def test_usage_error(self):
+        # tests case when multiple args but first arg starts with query
+        args = '??[].group foo bar'
+        args = parse_quotes(args)
+        self.shell.last.result = {
+            'group': 'mygroup',
+            'name': 'myname'
+        }
+        flag = self.shell.handle_jmespath_query(args)
+        self.assertTrue(flag)
+        self.assertEqual(self.stream.getvalue().strip(),
+                         "Usage Error: " + os.linesep +
+                         "1. Use ?? stand-alone to display previous result with optional filtering "
+                         "(Ex: ??[jmespath query])" +
+                         os.linesep + "OR:" + os.linesep +
+                         "2. Use ?? to query the previous result for argument values "
+                         "(Ex: group show --name ??[jmespath query])")
 
     def test_string_replacement(self):
         # tests that the query replaces the values in the command

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -5,6 +5,7 @@
 
 import unittest
 import six
+import os
 from azclishell.util import parse_quotes
 from azclishell.gather_commands import GatherCommands
 
@@ -93,8 +94,11 @@ class QueryInjection(unittest.TestCase):
         }
         flag = self.shell.handle_jmespath_query(args)
         self.assertTrue(flag)
-        results = self.stream.getvalue().split('\n')
-        self.assertEqual(results[0], u'"vm" "show" "-g" "mygroup" "-n" "myname"')
+        results = self.stream.getvalue().split(os.linesep)
+        
+        print(repr(results[0]))
+        print(repr(os.linesep))
+        self.assertEqual(results[0], '"vm" "show" "-g" "mygroup" "-n" "myname"')
 
     def test_list_replacement(self):
         # tests that the query replaces the values in the command
@@ -197,5 +201,5 @@ class QueryInjection(unittest.TestCase):
         ]
 
         self.shell.handle_jmespath_query(args)
-        results = self.stream.getvalue().split('\n')
+        results = self.stream.getvalue().split(os.linesep)
         self.assertEqual(results[0], u'"foo" "doo" "-bar=[\'fred\']"')

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/tests/test_query_injection.py
@@ -51,7 +51,6 @@ class QueryInjection(unittest.TestCase):
         self.shell.last.result = {'x': 'result'}
         flag = self.shell.handle_jmespath_query(args)
         self.assertTrue(flag)
-        print(repr(self.stream.getvalue()))
         self.assertEqual(self.stream.getvalue(), '{\n  \"x\": \"result\"\n}\n')
 
     def test_print_just_query(self):
@@ -82,7 +81,6 @@ class QueryInjection(unittest.TestCase):
         ]
         flag = self.shell.handle_jmespath_query(args)
         self.assertTrue(flag)
-        print(repr(self.stream.getvalue()))
         self.assertEqual(self.stream.getvalue(), '[\n  \"mygroup\",\n  \"mygroup2\",\n  \"mygroup3\"\n]\n')
 
     def test_string_replacement(self):


### PR DESCRIPTION
---
1) symbol for querying using last command is now `??`
2) symbol can be used in two ways: 
    a) at start of command to print out jmespath query result from the last command/s output. 
For example: 
`??` will print out the result from the last command
`??name` will print the 'name' attribute from a json object returned from last command and 
`??[].name` will print out the 'name' attributes of every json object from a json array returned from the last command
b) in the middle of your command to execute with arguments from the last command.
For example: 
`group show -n ??name` will execute `group show -n [name attribute of last json object]`
3) any objects returned from jmespath query will have its corresponding json string injected into your command. ***
4) changed tests to account for new behavior
This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [na ] The PR has modified HISTORY.rst with an appropriate description of the change (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na ] Each command and parameter has a meaningful description.
- [na ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
