### PR TITLE
Copyedit all _help.py files for consistency and correctness.

### DIFF
--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -13,22 +13,22 @@ helps['acr'] = """
 
 helps['acr credential'] = """
     type: group
-    short-summary: Manage login credentials for Azure container registries.
+    short-summary: Manage login credentials for Azure Container Registries.
     """
 
 helps['acr repository'] = """
     type: group
-    short-summary: Manage repositories for Azure container registries.
+    short-summary: Manage repositories for Azure Container Registries.
     """
 
 helps['acr webhook'] = """
     type: group
-    short-summary: Manage webhooks for Azure container registries.
+    short-summary: Manage webhooks for Azure Container Registries.
     """
 
 helps['acr check-name'] = """
     type: command
-    short-summary: Checks whether the container registry name is available for use.
+    short-summary: Checks if a container registry name is available for use.
     examples:
         - name: Check if a registry name already exists.
           text: >
@@ -70,7 +70,7 @@ helps['acr delete'] = """
 
 helps['acr show'] = """
     type: command
-    short-summary: Gets the properties of a container registry.
+    short-summary: Get the details of a container registry.
     examples:
         - name: Get the login server for a container registry.
           text: >
@@ -79,7 +79,7 @@ helps['acr show'] = """
 
 helps['acr update'] = """
     type: command
-    short-summary: Updates a container registry.
+    short-summary: Update a container registry.
     examples:
         - name: Update tags for a container registry.
           text: >
@@ -103,7 +103,7 @@ helps['acr login'] = """
 
 helps['acr show-usage'] = """
     type: command
-    short-summary: Gets the quota usages for a container registry.
+    short-summary: Get the quota usages for a container registry.
     examples:
         - name: Get the quota usages for a container registry.
           text: >
@@ -112,7 +112,7 @@ helps['acr show-usage'] = """
 
 helps['acr credential show'] = """
     type: command
-    short-summary: Gets the login credentials for a container registry.
+    short-summary: Get the login credentials for a container registry.
     examples:
         - name: Get the login credentials for a container registry.
           text: >
@@ -127,7 +127,7 @@ helps['acr credential show'] = """
 
 helps['acr credential renew'] = """
     type: command
-    short-summary: Regenerates a login credential for a container registry.
+    short-summary: Regenerate login credentials for a container registry.
     examples:
         - name: Renew the second password for a container registry.
           text: >
@@ -136,7 +136,7 @@ helps['acr credential renew'] = """
 
 helps['acr repository list'] = """
     type: command
-    short-summary: Lists repositories in a container registry.
+    short-summary: List repositories in a container registry.
     examples:
         - name: List repositories in a given container registry.
           text:
@@ -145,43 +145,43 @@ helps['acr repository list'] = """
 
 helps['acr repository show-tags'] = """
     type: command
-    short-summary: Shows tags of a given repository in a container registry.
+    short-summary: Show tags for a repository in a container registry.
     examples:
-        - name: Show tags of a given repository in a given container registry.
+        - name: Show tags of a repository in a container registry.
           text:
             az acr repository show-tags -n MyRegistry --repository MyRepository
 """
 
 helps['acr repository show-manifests'] = """
     type: command
-    short-summary: Shows manifests of a given repository in a container registry.
+    short-summary: Show manifests of a repository in a container registry.
     examples:
-        - name: Show manifests of a given repository in a given container registry.
+        - name: Show manifests of a repository in a container registry.
           text:
             az acr repository show-manifests -n MyRegistry --repository MyRepository
 """
 
 helps['acr repository delete'] = """
     type: command
-    short-summary: Deletes a repository, manifest, or tag in a container registry.
+    short-summary: Delete a repository, manifest, or tag in a container registry.
     examples:
-        - name: Delete a repository from the given container registry.
+        - name: Delete a repository from a container registry.
           text:
             az acr repository delete -n MyRegistry --repository MyRepository
-        - name: Delete a tag from the given repository. This operation does not delete the manifest referenced by the tag or associated layer data.
+        - name: Delete a tag from a repository. This does not delete the manifest referenced by the tag or any associated layer data.
           text:
             az acr repository delete -n MyRegistry --repository MyRepository --tag MyTag
-        - name: Delete the manifest referenced by a tag. This operation also deletes associated layer data and all other tags referencing the manifest.
+        - name: Delete the manifest referenced by a tag. This also deletes any associated layer data and all other tags referencing the manifest.
           text:
             az acr repository delete -n MyRegistry --repository MyRepository --tag MyTag --manifest
-        - name: Delete a manfiest from the given repository. This operation also deletes associated layer data and all tags referencing the manifest.
+        - name: Delete a manfiest from a repository. This also deletes any associated layer data and all tags referencing the manifest.
           text:
             az acr repository delete -n MyRegistry --repository MyRepository --manifest MyManifest
 """
 
 helps['acr webhook list'] = """
     type: command
-    short-summary: Lists all of the webhooks for a container registry.
+    short-summary: List all of the webhooks for a container registry.
     examples:
         - name: List webhooks and show the results in a table.
           text: >
@@ -190,19 +190,19 @@ helps['acr webhook list'] = """
 
 helps['acr webhook create'] = """
     type: command
-    short-summary: Creates a webhook for a container registry.
+    short-summary: Create a webhook for a container registry.
     examples:
-        - name: Create a webhook for a container registry that will deliver Docker push and delete events to the given service URI.
+        - name: Create a webhook for a container registry that will deliver Docker push and delete events to a service URI.
           text: >
             az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
-        - name: Create a webhook for a container registry that will deliver Docker push events to the given service URI with Basic authentication header.
+        - name: Create a webhook for a container registry that will deliver Docker push events to a service URI with a basic authentication header.
           text: >
             az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push --headers "Authorization=Basic 000000"
 """
 
 helps['acr webhook delete'] = """
     type: command
-    short-summary: Deletes a webhook from a container registry.
+    short-summary: Delete a webhook from a container registry.
     examples:
         - name: Delete a webhook from a container registry.
           text: >
@@ -211,16 +211,16 @@ helps['acr webhook delete'] = """
 
 helps['acr webhook show'] = """
     type: command
-    short-summary: Gets the properties of a webhook.
+    short-summary: Get the details of a webhook.
     examples:
-        - name: Get the properties of a webhook.
+        - name: Get the details of a webhook.
           text: >
             az acr webhook show -n MyWebhook -r MyRegistry
 """
 
 helps['acr webhook update'] = """
     type: command
-    short-summary: Updates a webhook.
+    short-summary: Update a webhook.
     examples:
         - name: Update headers for a webhook.
           text: >
@@ -235,25 +235,25 @@ helps['acr webhook update'] = """
 
 helps['acr webhook get-config'] = """
     type: command
-    short-summary: Gets the configuration of service URI and custom headers for the webhook.
+    short-summary: Get the service URI and custom headers for the webhook.
     examples:
-        - name: Get the service URI and headers for the webhook.
+        - name: Get the configuration information for a webhook. 
           text: >
             az acr webhook get-config -n MyWebhook -r MyRegistry
 """
 
 helps['acr webhook ping'] = """
     type: command
-    short-summary: Triggers a ping event to be sent to the webhook.
+    short-summary: Trigger a ping event for a webhook.
     examples:
-        - name: Triggers a ping event to be sent to the webhook.
+        - name: Trigger a ping even for a webhook.
           text: >
             az acr webhook ping -n MyWebhook -r MyRegistry
 """
 
 helps['acr webhook list-events'] = """
     type: command
-    short-summary: Lists recent events for a webhook.
+    short-summary: List recent events for a webhook.
     examples:
         - name: List recent events for a webhook.
           text: >

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -51,10 +51,10 @@ helps['acr create'] = """
     type: command
     short-summary: Creates a container registry.
     examples:
-        - name: Create a managed container registry. Applicable to Managed SKU.
+        - name: Create a managed container registry with the Standard (Preview) SKU.
           text: >
             az acr create -n MyRegistry -g MyResourceGroup --sku Managed_Standard
-        - name: Create a container registry with a new storage account. Applicable to Basic SKU.
+        - name: Create a container registry with a new storage account with the Classic SKU.
           text: >
             az acr create -n MyRegistry -g MyResourceGroup --sku Basic
 """
@@ -70,7 +70,7 @@ helps['acr delete'] = """
 
 helps['acr show'] = """
     type: command
-    short-summary: Gets the properties of the specified container registry.
+    short-summary: Gets the properties of a container registry.
     examples:
         - name: Get the login server for a container registry.
           text: >
@@ -94,16 +94,16 @@ helps['acr update'] = """
 
 helps['acr login'] = """
     type: command
-    short-summary: Login to a container registry through Docker.
+    short-summary: Log in to a container registry through Docker.
     examples:
-        - name: Login to a container registry
+        - name: Log in to a container registry
           text: >
             az acr login -n MyRegistry
 """
 
 helps['acr show-usage'] = """
     type: command
-    short-summary: Gets the quota usages for the specified container registry.
+    short-summary: Gets the quota usages for a container registry.
     examples:
         - name: Get the quota usages for a container registry.
           text: >
@@ -112,7 +112,7 @@ helps['acr show-usage'] = """
 
 helps['acr credential show'] = """
     type: command
-    short-summary: Gets the login credentials for the specified container registry.
+    short-summary: Gets the login credentials for a container registry.
     examples:
         - name: Get the login credentials for a container registry.
           text: >
@@ -120,14 +120,14 @@ helps['acr credential show'] = """
         - name: Get the username used to log into a container registry.
           text: >
             az acr credential show -n MyRegistry --query username
-        - name: Get one of the passwords used to log into a container registry.
+        - name: Get a password used to log into a container registry.
           text: >
             az acr credential show -n MyRegistry --query passwords[0].value
 """
 
 helps['acr credential renew'] = """
     type: command
-    short-summary: Regenerates one of the login credentials for the specified container registry.
+    short-summary: Regenerates a login credential for a container registry.
     examples:
         - name: Renew the second password for a container registry.
           text: >
@@ -136,7 +136,7 @@ helps['acr credential renew'] = """
 
 helps['acr repository list'] = """
     type: command
-    short-summary: Lists repositories in the specified container registry.
+    short-summary: Lists repositories in a container registry.
     examples:
         - name: List repositories in a given container registry.
           text:
@@ -145,7 +145,7 @@ helps['acr repository list'] = """
 
 helps['acr repository show-tags'] = """
     type: command
-    short-summary: Shows tags of a given repository in the specified container registry.
+    short-summary: Shows tags of a given repository in a container registry.
     examples:
         - name: Show tags of a given repository in a given container registry.
           text:
@@ -154,7 +154,7 @@ helps['acr repository show-tags'] = """
 
 helps['acr repository show-manifests'] = """
     type: command
-    short-summary: Shows manifests of a given repository in the specified container registry.
+    short-summary: Shows manifests of a given repository in a container registry.
     examples:
         - name: Show manifests of a given repository in a given container registry.
           text:
@@ -163,9 +163,9 @@ helps['acr repository show-manifests'] = """
 
 helps['acr repository delete'] = """
     type: command
-    short-summary: Deletes a repository or a manifest/tag from the given repository in the specified container registry.
+    short-summary: Deletes a repository, manifest, or tag in a container registry.
     examples:
-        - name: Delete a repository from the specified container registry.
+        - name: Delete a repository from the given container registry.
           text:
             az acr repository delete -n MyRegistry --repository MyRepository
         - name: Delete a tag from the given repository. This operation does not delete the manifest referenced by the tag or associated layer data.
@@ -181,7 +181,7 @@ helps['acr repository delete'] = """
 
 helps['acr webhook list'] = """
     type: command
-    short-summary: Lists all the webhooks for the specified container registry.
+    short-summary: Lists all of the webhooks for a container registry.
     examples:
         - name: List webhooks and show the results in a table.
           text: >
@@ -192,10 +192,10 @@ helps['acr webhook create'] = """
     type: command
     short-summary: Creates a webhook for a container registry.
     examples:
-        - name: Create a webhook for a container registry that will deliver Docker push and delete events to the specified service URI.
+        - name: Create a webhook for a container registry that will deliver Docker push and delete events to the given service URI.
           text: >
             az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
-        - name: Create a webhook for a container registry that will deliver Docker push events to the specified service URI with Basic authentication header.
+        - name: Create a webhook for a container registry that will deliver Docker push events to the given service URI with Basic authentication header.
           text: >
             az acr webhook create -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push --headers "Authorization=Basic 000000"
 """
@@ -211,9 +211,9 @@ helps['acr webhook delete'] = """
 
 helps['acr webhook show'] = """
     type: command
-    short-summary: Gets the properties of the specified webhook.
+    short-summary: Gets the properties of a webhook.
     examples:
-        - name: Get the properties of the specified webhook.
+        - name: Get the properties of a webhook.
           text: >
             az acr webhook show -n MyWebhook -r MyRegistry
 """
@@ -222,13 +222,13 @@ helps['acr webhook update'] = """
     type: command
     short-summary: Updates a webhook.
     examples:
-        - name: Update headers for a webhook
+        - name: Update headers for a webhook.
           text: >
             az acr webhook update -n MyWebhook -r MyRegistry --headers "Authorization=Basic 000000"
-        - name: Update service URI and actions for a webhook
+        - name: Update the service URI and actions for a webhook.
           text: >
             az acr webhook update -n MyWebhook -r MyRegistry --uri http://myservice.com --actions push delete
-        - name: Disable a webhook
+        - name: Disable a webhook.
           text: >
             az acr webhook update -n MyWebhook -r MyRegistry --status disabled
 """
@@ -237,7 +237,7 @@ helps['acr webhook get-config'] = """
     type: command
     short-summary: Gets the configuration of service URI and custom headers for the webhook.
     examples:
-        - name: Get service URI and headers for the webhook.
+        - name: Get the service URI and headers for the webhook.
           text: >
             az acr webhook get-config -n MyWebhook -r MyRegistry
 """
@@ -253,9 +253,9 @@ helps['acr webhook ping'] = """
 
 helps['acr webhook list-events'] = """
     type: command
-    short-summary: Lists recent events for the specified webhook.
+    short-summary: Lists recent events for a webhook.
     examples:
-        - name: List recent events for the specified webhook.
+        - name: List recent events for a webhook.
           text: >
             az acr webhook list-events -n MyWebhook -r MyRegistry
 """

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -237,7 +237,7 @@ helps['acr webhook get-config'] = """
     type: command
     short-summary: Get the service URI and custom headers for the webhook.
     examples:
-        - name: Get the configuration information for a webhook. 
+        - name: Get the configuration information for a webhook.
           text: >
             az acr webhook get-config -n MyWebhook -r MyRegistry
 """
@@ -246,7 +246,7 @@ helps['acr webhook ping'] = """
     type: command
     short-summary: Trigger a ping event for a webhook.
     examples:
-        - name: Trigger a ping even for a webhook.
+        - name: Trigger a ping event for a webhook.
           text: >
             az acr webhook ping -n MyWebhook -r MyRegistry
 """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -7,15 +7,15 @@ from azure.cli.core.help_files import helps
 
 helps['acs'] = """
      type: group
-     short-summary: Manage Azure container services.
+     short-summary: Manage Azure Container Services.
 """
 helps['acs dcos'] = """
     type: group
-    short-summary: Manage a DC/OS orchestrated Azure container service.
+    short-summary: Manage a DC/OS orchestrated Azure Container Service.
 """
 helps['acs kubernetes'] = """
     type: group
-    short-summary: Manage a Kubernetes orchestrated Azure container service.
+    short-summary: Manage a Kubernetes orchestrated Azure Container Service.
 """
 helps['acs kubernetes get-credentials'] = """
     type: command
@@ -31,18 +31,18 @@ helps['acs install-cli'] = """
 """
 helps['acs create'] = """
     type: command
-    short-summary: Create a new Azure container service cluster.
+    short-summary: Create a new Azure Container Service cluster.
     examples:
         - name: Create a default acs cluster.
           text: az acs create -g MyResourceGroup -n MyContainerService
         - name: Create a Kubernetes cluster.
           text: az acs create --orchestrator-type Kubernetes -g MyResourceGroup -n MyContainerService
-        - name: Create a Kubernetes cluster with ssh key provided.
-          text: az acs create --orchestrator-type Kubernetes -g MyResourceGroup -n MyContainerService --ssh-key-value MySSHKeyValueOrPath
-        - name: Create an acs cluster with two agent pools.
+        - name: Create a Kubernetes cluster with a an existing SSH key.
+          text: az acs create --orchestrator-type Kubernetes -g MyResourceGroup -n MyContainerService --ssh-key-value /path/to/publickey
+        - name: Create an ACS cluster with two agent pools.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2'}]"
-        - name: Create an acs cluster where the second agent pool has a vmSize specified.
+        - name: Create an ACS cluster where the second agent pool has a vmSize specified.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2','vmSize':'Standard_D2'}]"
-        - name: Create a acs cluster with agent-profiles specified from a file
+        - name: Create a ACS cluster with agent-profiles specified from a file.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles MyAgentProfiles.json
 """

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -11,15 +11,15 @@ helps['acs'] = """
 """
 helps['acs dcos'] = """
     type: group
-    short-summary: Manage a DCOS orchestrated Azure container service.
+    short-summary: Manage a DC/OS orchestrated Azure container service.
 """
 helps['acs kubernetes'] = """
     type: group
-    short-summary: Manage a Kubernetes orchestrated Azure Container service.
+    short-summary: Manage a Kubernetes orchestrated Azure container service.
 """
 helps['acs kubernetes get-credentials'] = """
     type: command
-    short-summary: Download and install credentials to access your cluster.
+    short-summary: Download and install credentials to access a cluster.
 """
 helps['acs scale'] = """
     type: command
@@ -27,19 +27,21 @@ helps['acs scale'] = """
 """
 helps['acs install-cli'] = """
     type: command
-    short-summary: Download the DCOS/Kubernetes command line.
+    short-summary: Download and install the DC/OS and Kubernetes command line for a cluster.
 """
 helps['acs create'] = """
+    type: command
+    short-summary: Create a new Azure container service cluster.
     examples:
-        - name: Create a default acs cluster
+        - name: Create a default acs cluster.
           text: az acs create -g MyResourceGroup -n MyContainerService
-        - name: Create a Kubernetes cluster
+        - name: Create a Kubernetes cluster.
           text: az acs create --orchestrator-type Kubernetes -g MyResourceGroup -n MyContainerService
-        - name: Create a Kubernetes cluster with ssh key provided
+        - name: Create a Kubernetes cluster with ssh key provided.
           text: az acs create --orchestrator-type Kubernetes -g MyResourceGroup -n MyContainerService --ssh-key-value MySSHKeyValueOrPath
-        - name: Create a acs cluster with two agent pools
+        - name: Create an acs cluster with two agent pools.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2'}]"
-        - name: Create a acs cluster with the second agent pool with vmSize specified
+        - name: Create an acs cluster where the second agent pool has a vmSize specified.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2','vmSize':'Standard_D2'}]"
         - name: Create a acs cluster with agent-profiles specified from a file
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles MyAgentProfiles.json

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_help.py
@@ -43,6 +43,6 @@ helps['acs create'] = """
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2'}]"
         - name: Create an ACS cluster where the second agent pool has a vmSize specified.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles "[{'name':'agentpool1'},{'name':'agentpool2','vmSize':'Standard_D2'}]"
-        - name: Create a ACS cluster with agent-profiles specified from a file.
+        - name: Create an ACS cluster with agent-profiles specified from a file.
           text: az acs create -g MyResourceGroup -n MyContainerService --agent-profiles MyAgentProfiles.json
 """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -7,284 +7,265 @@ from azure.cli.core.help_files import helps
 
 
 helps['appservice'] = """
-    type: group
-    short-summary: Manage your App Service plans.
+type: group
+short-summary: Manage your App Service plans.
 """
 
 helps['webapp'] = """
-    type: group
-    short-summary: Manage web apps.
+type: group
+short-summary: Manage web apps.
 """
 
 helps['webapp config'] = """
-    type: group
-    short-summary: Configure a web app.
+type: group
+short-summary: Configure a web app.
 """
 
 helps['webapp config show'] = """
-    type: command
-    short-summary: Show web app configurations.
+type: command
+short-summary: Show a web app's configuration.
 """
 
 helps['webapp config set'] = """
-    type: command
-    short-summary: create or update web app configurations.
+type: command
+short-summary: Create or update a web app's configuration.
 """
 
 helps['webapp config appsettings'] = """
-    type: group
-    short-summary: Configure web app settings.
+type: group
+short-summary: Configure web app settings.
 """
 
 helps['webapp config appsettings delete'] = """
-    type: command
-    short-summary: Delete web app settings.
+type: command
+short-summary: Delete web app settings.
 """
 
 helps['webapp config appsettings list'] = """
-    type: command
-    short-summary: Show web app settings.
+type: command
+short-summary: Show a web app's settings.
 """
 
 helps['webapp config appsettings set'] = """
-    type: command
-    short-summary: Create or update web app settings.
-    examples:
-        - name: Set the default node version for a specified web app.
-          text: >
-            az webapp config appsettings set
-            -g MyResourceGroup
-            -n MyUniqueApp
+type: command
+short-summary: Create or update a web app's settings.
+examples:
+    - name: Set the default NodeJS version for a given web app.
+      text: >
+        az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp \\
             --settings WEBSITE_NODE_DEFAULT_VERSION=6.9.1
 """
 
 helps['webapp config connection-string'] = """
-    type: group
-    short-summary: Configure web app connection strings.
+type: group
+short-summary: Manage a web app's connection strings.
 """
 
 helps['webapp config connection-string show'] = """
-    type: command
-    short-summary: Show connection strings
+type: command
+short-summary: Show a web app's connection strings.
 """
 
 helps['webapp config connection-string delete'] = """
-    type: command
-    short-summary: delete connection strings
+type: command
+short-summary: Delete a web app's connection strings.
 """
 
 helps['webapp config connection-string set'] = """
-    type: command
-    short-summary: Create or update connection strings.
-    examples:
-        - name: add a mysql connection string.
-          text: >
-            az webapp config connection-string set
-            -g MyResourceGroup
-            -n MyUniqueApp
-            -t mysql
+type: command
+short-summary: Create or update a web app's connection strings.
+examples:
+    - name: Add a mysql connection string.
+      text: >
+        az webapp config connection-string set -g MyResourceGroup -n MyUniqueApp -t mysql \\
             --settings mysql1='Server=myServer;Database=myDB;Uid=myUser;Pwd=myPwd;'
 """
 
 helps['webapp config container'] = """
-    type: group
-    short-summary: Configure container specific settings.
+type: group
+short-summary: Manage container specific settings.
 """
 
 helps['webapp config container show'] = """
-    type: command
-    short-summary: Show container settings.
+type: command
+short-summary: Show a web app container's settings.
 """
 
 helps['webapp config container set'] = """
-    type: command
-    short-summary: create or update container settings.
+type: command
+short-summary: Create or update a web app container's settings.
 """
 
 helps['webapp config container delete'] = """
-    type: command
-    short-summary: Delete container settings.
+type: command
+short-summary: Delete a web app container's settings.
 """
 
-helps['webapp config hostname'] = """
-    type: group
-    short-summary: Configure hostnames.
-"""
 
 helps['webapp config ssl'] = """
-    type: group
-    short-summary: Configure SSL certificates.
+type: group
+short-summary: Configure SSL certificates for web apps.
 """
 
 helps['webapp config ssl list'] = """
-    type: command
-    short-summary: List SSL certificates within a resource group
+type: command
+short-summary: List SSL certificates within a resource group.
 """
 
 helps['webapp config ssl bind'] = """
-    type: command
-    short-summary: Bind an SSL certificate to a web app.
+type: command
+short-summary: Bind an SSL certificate to a web app.
 """
 
 helps['webapp config ssl unbind'] = """
-    type: command
-    short-summary: Unbind an SSL certificate from a web app.
+type: command
+short-summary: Unbind an SSL certificate from a web app.
 """
 
 helps['webapp config ssl delete'] = """
-    type: command
-    short-summary: Delete an SSL certificate from a web app.
+type: command
+short-summary: Delete an SSL certificate from a resource group.
 """
 
 helps['webapp config ssl upload'] = """
-    type: command
-    short-summary: Upload an SSL certificate to a web app.
+type: command
+short-summary: Upload an SSL certificate to a resource group.
 """
 
 helps['webapp deployment'] = """
-    type: group
-    short-summary: Manage web app deployments.
+type: group
+short-summary: Manage web app deployments.
 """
-
-helps['webapp deployment source'] = """
-    type: group
-    short-summary: Manage deployment source repositories.
-"""
-
 
 helps['webapp deployment slot'] = """
-    type: group
-    short-summary: Manage web app deployment slots.
+type: group
+short-summary: Manage web app deployment slots.
 """
 
 helps['webapp deployment slot auto-swap'] = """
-    type: group
-    short-summary: Enable or disable auto-swap for a web app deployment slot.
+type: group
+short-summary: Enable or disable auto-swap for a web app deployment slot.
 """
 
 helps['webapp log'] = """
-    type: group
-    short-summary: Manage web app logs.
+type: group
+short-summary: Manage web app logs.
 """
 
 helps['webapp log config'] = """
-    type: command
-    short-summary: Configure web app logs.
+type: command
+short-summary: Configure logging for a web app.
 """
 
 helps['webapp log show'] = """
-    type: command
-    short-summary: Show web app log configurations.
+type: command
+short-summary: Show a web app's logging configuration.
 """
 
 helps['webapp log download'] = """
-    type: command
-    short-summary: Download historical logs as a zip file
-    long-summary: Might not work with Linux webs
+type: command
+short-summary: Download a web app's log history as a zip file.
+long-summary: Might not work with apps running on Linux.
 """
 
 helps['webapp log tail'] = """
-    type: command
-    short-summary: Start live tracing
-    long-summary: Might not work with Linux webs
+type: command
+short-summary: Start live log tracing for a web app.
+long-summary: Might not work with Linux webapps.
 """
 
 helps['webapp deployment'] = """
-    type: group
-    short-summary: Manage web application deployments.
+type: group
+short-summary: Manage web app deployments.
 """
 
 helps['webapp deployment list-publishing-profiles'] = """
-    type: command
-    short-summary: get publishing endpoints, credentials, database connection strings, etc
+type: command
+short-summary: Get publishing endpoints, credentials, database connection strings, and other profile elements.
 """
 
 helps['webapp deployment container'] = """
-    type: group
-    short-summary: Manage container based continuous deployment.
+type: group
+short-summary: Manage container-based continuous deployment.
 """
 
 helps['webapp deployment container config'] = """
-    type: command
-    short-summary: configure continuous deployment.
+type: command
+short-summary: Configure continuous deployment.
 """
 
 helps['webapp deployment container show-cd-url'] = """
-    type: command
-    short-summary: get the webhook url of the linux webapp you can use to configure the container repository for continuous deployment
+type: command
+short-summary: Get the webhook url which can be used to configure the container repository for continuous deployment.
 """
 
 helps['webapp deployment slot auto-swap'] = """
-    type: command
-    short-summary: Configure slot auto swap.
+type: command
+short-summary: Configure deployment slot auto swap.
 """
 
 helps['webapp deployment slot create'] = """
-    type: command
-    short-summary: Create a slot.
+type: command
+short-summary: Create a deployment slot.
 """
 
 helps['webapp deployment slot swap'] = """
-    type: command
-    short-summary: Swap slots.
-    examples:
-        - name: Swap a staging slot into production for the specified web app.
-          text: >
-            az webapp deployment slot swap
-            -g MyResourceGroup
-            -n MyUniqueApp
-            --slot staging
+type: command
+short-summary: Swap deployment slots for a web app.
+examples:
+    - name: Swap a staging slot into production for the specified web app.
+      text: >
+        az webapp deployment slot swap  -g MyResourceGroup -n MyUniqueApp --slot staging \\
             --target-slot production
 """
 
 helps['webapp deployment slot list'] = """
-    type: command
-    short-summary: List all slots.
+type: command
+short-summary: List all deployment slots.
 """
 
 helps['webapp deployment slot delete'] = """
-    type: command
-    short-summary: Delete a slot.
+type: command
+short-summary: Delete a deployment slot.
 """
 
 helps['webapp deployment user'] = """
-    type: group
-    short-summary: Manage user credentials for a deployment.
+type: group
+short-summary: Manage user credentials for deployment.
 """
 
 helps['webapp deployment user set'] = """
-    type: command
-    short-summary: Update deployment credentials.
-    long-summary: All web apps in the subscription will be impacted since all web apps share
-                  the same deployment credentials.
-    examples:
-        - name: Set FTP and git deployment credentials for all web apps.
-          text: >
-            az webapp deployment user set
-            --user-name MyUserName
+type: command
+short-summary: Update deployment credentials.
+long-summary: All function and web apps in the subscription will be impacted since all web apps share
+              the same deployment credentials.
+examples:
+    - name: Set FTP and git deployment credentials for all apps.
+      text: >
+        az webapp deployment user set --user-name MyUserName
 """
 
 helps['webapp deployment slot'] = """
-    type: group
-    short-summary: Manage deployment slots.
+type: group
+short-summary: Manage web app deployment slots.
 """
 
 helps['webapp deployment source'] = """
     type: group
-    short-summary: Manage source control systems.
+    short-summary: Manage web app deployment via source control.
 """
 
 helps['webapp deployment source config'] = """
     type: command
-    short-summary: Associate to Git or Mercurial repositories.
+    short-summary: Manage deployment from git or Mercurial repositories.
 """
 
 helps['webapp deployment source config-local-git'] = """
     type: command
-    short-summary: Enable local git.
-    long-summary: Get an endpoint to clone and later push to the web app.
+    short-summary: Deploy a web app from a local git repository.
+    long-summary: Get an endpoint to clone and later push to deploy a web app.
     examples:
-        - name: Get a git endpoint for a web app and add it as a remote.
+        - name: Get an endpoint and add it as a git remote.
           text: >
             az webapp source-control config-local-git \\
                 -g MyResourceGroup -n MyUniqueApp
@@ -295,79 +276,70 @@ helps['webapp deployment source config-local-git'] = """
 
 helps['webapp deployment source delete'] = """
     type: command
-    short-summary: Delete source control configurations.
+    short-summary: Delete a source control deployment configuration.
 """
 
 helps['webapp deployment source show'] = """
     type: command
-    short-summary: Show source control configurations.
+    short-summary: Show a source control deployment configuration.
 """
 
 helps['webapp deployment source sync'] = """
     type: command
-    short-summary: Synchronize from the source repository, only needed under manual integration mode.
+    short-summary: Synchronize from the repository. Only needed under manual integration mode.
 """
 
 helps['webapp traffic-routing'] = """
     type: group
-    short-summary: Manage traffic routings in production test.
-"""
-
-helps['webapp traffic-routing'] = """
-    type: group
-    short-summary: Manage traffic routings in production test.
+    short-summary: Manage traffic routing for web apps.
 """
 
 helps['webapp traffic-routing set'] = """
     type: command
-    short-summary: Routing some percentages of traffic to deployment slots
+    short-summary: Configure routing traffic to deployment slots.
 """
 
 helps['webapp traffic-routing show'] = """
     type: command
-    short-summary: Display the current distribution of traffic across slots
+    short-summary: Display the current distribution of traffic across slots.
 """
 
 helps['webapp traffic-routing clear'] = """
     type: command
-    short-summary: Clear the routing rules to send 100% to production
+    short-summary: Clear the routing rules and send all traffic to production.
 """
 
 helps['appservice plan'] = """
     type: group
-    short-summary: Manage App Service plans.
+    short-summary: Manage app service plans.
 """
 
 helps['appservice plan update'] = """
     type: command
-    short-summary: Update an App Service plan.
+    short-summary: Update an app service plan.
 """
 
 helps['appservice plan create'] = """
     type: command
-    short-summary: Create an App Service plan.
+    short-summary: Create an app service plan.
     examples:
-        - name: Create a basic App Service plan.
+        - name: Create a basic app service plan.
           text: >
             az appservice plan create -g MyResourceGroup -n MyPlan
-        - name: Create a standard App Service plan with with four Linux workers.
+        - name: Create a standard app service plan with with four Linux workers.
           text: >
-            az appservice plan create
-            -g MyResourceGroup
-            -n MyPlan
-            --is-linux
-            --number-of-workers 4
-            --sku S1
+            az appservice plan create -g MyResourceGroup -n MyPlan \\
+                --is-linux --number-of-workers 4 --sku S1
 """
 
 helps['appservice plan delete'] = """
     type: command
-    short-summary: Delete an App Service plan.
+    short-summary: Delete an app service plan.
 """
 
 helps['appservice plan list'] = """
     type: command
-    short-summary: List App Service plans.
+    short-summary: List app service plans.
     examples:
         - name: List all free tier App Service plans.
           text: >
@@ -376,27 +348,37 @@ helps['appservice plan list'] = """
 
 helps['appservice plan show'] = """
     type: command
-    short-summary: Get the App Service plans for a resource group or a set of resource groups.
+    short-summary: Get the app service plans for a resource group or a set of resource groups.
+"""
+
+helps['webapp config hostname'] = """
+type: group
+short-summary: Configure hostnames for a web app.
 """
 
 helps['webapp config hostname add'] = """
     type: command
-    short-summary: Bind a hostname (custom domain) to a web app.
+    short-summary: Bind a hostname to a web app.
 """
 
 helps['webapp config hostname delete'] = """
     type: command
-    short-summary: Unbind a hostname (custom domain) from a web app.
+    short-summary: Unbind a hostname from a web app.
 """
 
 helps['webapp config hostname list'] = """
     type: command
-    short-summary: List all hostname bindings.
+    short-summary: List all hostname bindings for a web app.
 """
 
 helps['webapp config hostname get-external-ip'] = """
     type: command
-    short-summary: get the ip address to configure your DNS settings for A records
+    short-summary: Get the external-facing IP address for a web app.
+"""
+
+helps['webapp config backup'] = """
+    type: group
+    short-summary: Manage backups for web apps.
 """
 
 helps['webapp config backup list'] = """
@@ -411,7 +393,7 @@ helps['webapp config backup create'] = """
 
 helps['webapp config backup show'] = """
     type: command
-    short-summary: Show the backup schedule of a web app.
+    short-summary: Show the backup schedule for a web app.
 """
 
 helps['webapp config backup update'] = """
@@ -426,25 +408,25 @@ helps['webapp config backup restore'] = """
 
 helps['webapp browse'] = """
     type: command
-    short-summary: Open the web app in a browser.
+    short-summary: Open a web app in a browser.
 """
 
 helps['webapp create'] = """
     type: command
     short-summary: Create a web app.
+    long-summary: The web app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
     examples:
-        - name: Create an empty webapp.  Name must be unique to yield a unique FQDN;
-                for example, MyUniqueApp.azurewebsites.net.
+        - name: Create a web app with the default configuration.
           text: >
-            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueApp
-        - name: Create a webapp with node 6.2 stack runtime, and local git configured for web deployment
+            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName
+        - name: Create a web app with a NodeJS 6.2 runtime and deployed from a local git repository.
           text: >
-            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueApp --runtime "node|6.2" --deployment-local-git
+            az webapp create -g MyResourceGroup -p MyPlan -n MyUniqueAppName --runtime "node|6.2" --deployment-local-git
 """
 
 helps['webapp list-runtimes'] = """
     type: command
-    short-summary: List built-in web stack runtimes you can use to create new webapps.
+    short-summary: List built-in web stack runtimes you can use to create web apps.
 """
 
 helps['webapp delete'] = """
@@ -484,28 +466,19 @@ helps['webapp stop'] = """
     short-summary: Stop a web app.
 """
 
-helps['webapp production-test'] = """
-    type: command
-    short-summary: test in production, including configuring static routings.
-"""
-
 helps['functionapp'] = """
     type: group
-    short-summary: Manage your function app.
+    short-summary: Manage function apps.
 """
 
 helps['functionapp create'] = """
     type: command
     short-summary: Create a function app.
+    long-summary: The function app's name must be able to produce a unique FQDN as AppName.azurewebsites.net.
     examples:
-        - name: Create a basic function app.  Name must be unique to yield a unique FQDN;
-                for example, MyUniqueApp.azurewebsites.net.
+        - name: Create a basic function app.
           text: >
-            az functionapp create
-            -g MyResourceGroup
-            -p MyPlan
-            -n MyUniqueApp
-            -s MyStorageAccount
+            az functionapp create -g MyResourceGroup  -p MyPlan -n MyUniqueAppName -s MyStorageAccount
 """
 
 helps['functionapp delete'] = """
@@ -545,6 +518,11 @@ helps['functionapp stop'] = """
     short-summary: Stop a function app.
 """
 
+helps['functionapp list-consumption-locations'] = """
+    type: command
+    short-summary: List available locations for running function apps.
+"""
+
 helps['functionapp config'] = """
     type: group
     short-summary: Configure a function app.
@@ -557,36 +535,36 @@ helps['functionapp config appsettings'] = """
 
 helps['functionapp config appsettings show'] = """
     type: command
-    short-summary: Show function app settings.
+    short-summary: Show settings for a function app.
 """
 
 helps['functionapp config appsettings set'] = """
     type: command
-    short-summary: Create or update function app settings.
+    short-summary: Create or update a function app's settings.
 """
 
 helps['functionapp config hostname'] = """
     type: group
-    short-summary: Configure hostnames.
+    short-summary: Configure hostnames for a function app.
 """
 helps['functionapp config hostname add'] = """
     type: command
-    short-summary: Bind a hostname (custom domain) to a function app.
+    short-summary: Bind a hostname to a function app.
 """
 
 helps['functionapp config hostname delete'] = """
     type: command
-    short-summary: Unbind a hostname (custom domain) from a function app.
+    short-summary: Unbind a hostname from a function app.
 """
 
 helps['functionapp config hostname list'] = """
     type: command
-    short-summary: List all hostname bindings.
+    short-summary: List all hostname bindings for a function app.
 """
 
 helps['functionapp config hostname get-external-ip'] = """
     type: command
-    short-summary: get the ip address to configure your DNS settings for A records
+    short-summary: Get the external-facing IP address for a function app.
 """
 
 helps['functionapp config ssl'] = """
@@ -596,7 +574,7 @@ helps['functionapp config ssl'] = """
 
 helps['functionapp config ssl list'] = """
     type: command
-    short-summary: List SSL certificates within a resource group
+    short-summary: List SSL certificates within a resource group.
 """
 
 helps['functionapp config ssl bind'] = """
@@ -611,33 +589,35 @@ helps['functionapp config ssl unbind'] = """
 
 helps['functionapp config ssl delete'] = """
     type: command
-    short-summary: Delete an SSL certificate from a function app.
+    short-summary: Delete an SSL certificate from a resource group.
 """
 
 helps['functionapp config ssl upload'] = """
     type: command
-    short-summary: Upload an SSL certificate to a function app.
+    short-summary: Upload an SSL certificate to a resource group.
 """
+
 helps['functionapp deployment'] = """
     type: group
     short-summary: Manage function app deployments.
 """
+
 helps['functionapp deployment source'] = """
     type: group
-    short-summary: Manage source control systems.
+    short-summary: Manage function app deployment via source control.
 """
 
 helps['functionapp deployment source config'] = """
     type: command
-    short-summary: Associate to Git or Mercurial repositories.
+    short-summary: Manage deployment from git or Mercurial repositories.
 """
 
 helps['functionapp deployment source config-local-git'] = """
     type: command
-    short-summary: Enable local git.
-    long-summary: Get an endpoint to clone and later push to the function app.
+    short-summary: Deploy a web app from a local git repository.
+    long-summary: Get an endpoint to clone and later push to deploy a function app.
     examples:
-        - name: Get a git endpoint for a web app and add it as a remote.
+        - name: Get an endpoint and add it as a git remote.
           text: >
             az functionapp source-control config-local-git \\
                 -g MyResourceGroup -n MyUniqueApp
@@ -648,30 +628,30 @@ helps['functionapp deployment source config-local-git'] = """
 
 helps['functionapp deployment source delete'] = """
     type: command
-    short-summary: Delete source control configurations.
+    short-summary: Delete a source control deployment configuration.
 """
 
 helps['functionapp deployment source show'] = """
     type: command
-    short-summary: Show source control configurations.
+    short-summary: Show a source control deployment configuration.
 """
 
 helps['functionapp deployment source sync'] = """
     type: command
-    short-summary: Synchronize from the source repository, only needed under manual integration mode.
+    short-summary: Synchronize from the repository. Only needed under manual integration mode.
 """
 helps['functionapp deployment user'] = """
     type: group
-    short-summary: Manage user credentials for a deployment.
+    short-summary: Manage user credentials for deployment.
 """
 
 helps['functionapp deployment user set'] = """
     type: command
     short-summary: Update deployment credentials.
-    long-summary: All function/web apps in the subscription will be impacted since all apps share
+    long-summary: All function and web apps in the subscription will be impacted since all apps share
                   the same deployment credentials.
     examples:
-        - name: Set FTP and git deployment credentials for all function/web apps.
+        - name: Set FTP and git deployment credentials for all apps.
           text: >
             az functionapp deployment user set
             --user-name MyUserName

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -260,7 +260,7 @@ helps['webapp deployment source config'] = """
 
 helps['webapp deployment source config-local-git'] = """
     type: command
-    short-summary: Get a URL for a git repository endpoint to clone and push to for web app deployment. 
+    short-summary: Get a URL for a git repository endpoint to clone and push to for web app deployment.
     examples:
         - name: Get an endpoint and add it as a git remote.
           text: >
@@ -611,7 +611,7 @@ helps['functionapp deployment source config'] = """
 
 helps['functionapp deployment source config-local-git'] = """
     type: command
-    short-summary: Get a URL for a git repository endpoint to clone and push to for function app deployment. 
+    short-summary: Get a URL for a git repository endpoint to clone and push to for function app deployment.
     examples:
         - name: Get an endpoint and add it as a git remote.
           text: >

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -8,7 +8,7 @@ from azure.cli.core.help_files import helps
 
 helps['appservice'] = """
 type: group
-short-summary: Manage your App Service plans.
+short-summary: Manage App Service plans.
 """
 
 helps['webapp'] = """
@@ -23,12 +23,12 @@ short-summary: Configure a web app.
 
 helps['webapp config show'] = """
 type: command
-short-summary: Show a web app's configuration.
+short-summary: Get the details of a web app's configuration.
 """
 
 helps['webapp config set'] = """
 type: command
-short-summary: Create or update a web app's configuration.
+short-summary: Set a web app's configuration.
 """
 
 helps['webapp config appsettings'] = """
@@ -43,17 +43,16 @@ short-summary: Delete web app settings.
 
 helps['webapp config appsettings list'] = """
 type: command
-short-summary: Show a web app's settings.
+short-summary: Get the details of a web app's settings.
 """
 
 helps['webapp config appsettings set'] = """
 type: command
-short-summary: Create or update a web app's settings.
+short-summary: Set a web app's settings.
 examples:
-    - name: Set the default NodeJS version for a given web app.
+    - name: Set the default NodeJS version to 6.9.1 for a web app.
       text: >
-        az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp \\
-            --settings WEBSITE_NODE_DEFAULT_VERSION=6.9.1
+        az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings WEBSITE_NODE_DEFAULT_VERSION=6.9.1
 """
 
 helps['webapp config connection-string'] = """
@@ -63,7 +62,7 @@ short-summary: Manage a web app's connection strings.
 
 helps['webapp config connection-string show'] = """
 type: command
-short-summary: Show a web app's connection strings.
+short-summary: Get a web app's connection strings.
 """
 
 helps['webapp config connection-string delete'] = """
@@ -73,7 +72,7 @@ short-summary: Delete a web app's connection strings.
 
 helps['webapp config connection-string set'] = """
 type: command
-short-summary: Create or update a web app's connection strings.
+short-summary: Update a web app's connection strings.
 examples:
     - name: Add a mysql connection string.
       text: >
@@ -83,24 +82,23 @@ examples:
 
 helps['webapp config container'] = """
 type: group
-short-summary: Manage container specific settings.
+short-summary: Manage web app container settings.
 """
 
 helps['webapp config container show'] = """
 type: command
-short-summary: Show a web app container's settings.
+short-summary: Get details of a web app container's settings.
 """
 
 helps['webapp config container set'] = """
 type: command
-short-summary: Create or update a web app container's settings.
+short-summary: Set a web app container's settings.
 """
 
 helps['webapp config container delete'] = """
 type: command
 short-summary: Delete a web app container's settings.
 """
-
 
 helps['webapp config ssl'] = """
 type: group
@@ -109,7 +107,7 @@ short-summary: Configure SSL certificates for web apps.
 
 helps['webapp config ssl list'] = """
 type: command
-short-summary: List SSL certificates within a resource group.
+short-summary: List SSL certificates for a web app.
 """
 
 helps['webapp config ssl bind'] = """
@@ -124,12 +122,12 @@ short-summary: Unbind an SSL certificate from a web app.
 
 helps['webapp config ssl delete'] = """
 type: command
-short-summary: Delete an SSL certificate from a resource group.
+short-summary: Delete an SSL certificate from a web app.
 """
 
 helps['webapp config ssl upload'] = """
 type: command
-short-summary: Upload an SSL certificate to a resource group.
+short-summary: Upload an SSL certificate to a web app.
 """
 
 helps['webapp deployment'] = """
@@ -159,19 +157,19 @@ short-summary: Configure logging for a web app.
 
 helps['webapp log show'] = """
 type: command
-short-summary: Show a web app's logging configuration.
+short-summary: Get the details of a web app's logging configuration.
 """
 
 helps['webapp log download'] = """
 type: command
 short-summary: Download a web app's log history as a zip file.
-long-summary: Might not work with apps running on Linux.
+long-summary: This command may not work with web apps running on Linux.
 """
 
 helps['webapp log tail'] = """
 type: command
 short-summary: Start live log tracing for a web app.
-long-summary: Might not work with Linux webapps.
+long-summary: This command may not work with web apps running on Linux.
 """
 
 helps['webapp deployment'] = """
@@ -181,7 +179,7 @@ short-summary: Manage web app deployments.
 
 helps['webapp deployment list-publishing-profiles'] = """
 type: command
-short-summary: Get publishing endpoints, credentials, database connection strings, and other profile elements.
+short-summary: Get the details for available web app deployment profiles.
 """
 
 helps['webapp deployment container'] = """
@@ -191,12 +189,12 @@ short-summary: Manage container-based continuous deployment.
 
 helps['webapp deployment container config'] = """
 type: command
-short-summary: Configure continuous deployment.
+short-summary: Configure continuous deployment via containers.
 """
 
 helps['webapp deployment container show-cd-url'] = """
 type: command
-short-summary: Get the webhook url which can be used to configure the container repository for continuous deployment.
+short-summary: Get the URL which can be used to configure webhooks for continuous deployment.
 """
 
 helps['webapp deployment slot auto-swap'] = """
@@ -211,9 +209,9 @@ short-summary: Create a deployment slot.
 
 helps['webapp deployment slot swap'] = """
 type: command
-short-summary: Swap deployment slots for a web app.
+short-summary: Change deployment slots for a web app.
 examples:
-    - name: Swap a staging slot into production for the specified web app.
+    - name: Swap a staging slot into production for the MyUniqueApp web app.
       text: >
         az webapp deployment slot swap  -g MyResourceGroup -n MyUniqueApp --slot staging \\
             --target-slot production
@@ -237,7 +235,7 @@ short-summary: Manage user credentials for deployment.
 helps['webapp deployment user set'] = """
 type: command
 short-summary: Update deployment credentials.
-long-summary: All function and web apps in the subscription will be impacted since all web apps share
+long-summary: All function and web apps in the subscription will be impacted since they share
               the same deployment credentials.
 examples:
     - name: Set FTP and git deployment credentials for all apps.
@@ -262,8 +260,7 @@ helps['webapp deployment source config'] = """
 
 helps['webapp deployment source config-local-git'] = """
     type: command
-    short-summary: Deploy a web app from a local git repository.
-    long-summary: Get an endpoint to clone and later push to deploy a web app.
+    short-summary: Get a URL for a git repository endpoint to clone and push to for web app deployment. 
     examples:
         - name: Get an endpoint and add it as a git remote.
           text: >
@@ -281,7 +278,7 @@ helps['webapp deployment source delete'] = """
 
 helps['webapp deployment source show'] = """
     type: command
-    short-summary: Show a source control deployment configuration.
+    short-summary: Get the details of a source control deployment configuration.
 """
 
 helps['webapp deployment source sync'] = """
@@ -383,7 +380,7 @@ helps['webapp config backup'] = """
 
 helps['webapp config backup list'] = """
     type: command
-    short-summary: List all backups of a web app.
+    short-summary: List backups of a web app.
 """
 
 helps['webapp config backup create'] = """
@@ -398,7 +395,7 @@ helps['webapp config backup show'] = """
 
 helps['webapp config backup update'] = """
     type: command
-    short-summary: Configure a new backup schedule.
+    short-summary: Configure a new backup schedule for a web app.
 """
 
 helps['webapp config backup restore'] = """
@@ -426,7 +423,7 @@ helps['webapp create'] = """
 
 helps['webapp list-runtimes'] = """
     type: command
-    short-summary: List built-in web stack runtimes you can use to create web apps.
+    short-summary: List available built-in stacks which can be used for web apps.
 """
 
 helps['webapp delete'] = """
@@ -458,7 +455,7 @@ helps['webapp start'] = """
 
 helps['webapp show'] = """
     type: command
-    short-summary: Show a web app.
+    short-summary: Get the details of a web app.
 """
 
 helps['webapp stop'] = """
@@ -510,7 +507,7 @@ helps['functionapp start'] = """
 
 helps['functionapp show'] = """
     type: command
-    short-summary: Show a function app.
+    short-summary: Get the details of a function app.
 """
 
 helps['functionapp stop'] = """
@@ -540,7 +537,7 @@ helps['functionapp config appsettings show'] = """
 
 helps['functionapp config appsettings set'] = """
     type: command
-    short-summary: Create or update a function app's settings.
+    short-summary: Update a function app's settings.
 """
 
 helps['functionapp config hostname'] = """
@@ -574,7 +571,7 @@ helps['functionapp config ssl'] = """
 
 helps['functionapp config ssl list'] = """
     type: command
-    short-summary: List SSL certificates within a resource group.
+    short-summary: List SSL certificates for a function app.
 """
 
 helps['functionapp config ssl bind'] = """
@@ -589,12 +586,12 @@ helps['functionapp config ssl unbind'] = """
 
 helps['functionapp config ssl delete'] = """
     type: command
-    short-summary: Delete an SSL certificate from a resource group.
+    short-summary: Delete an SSL certificate from a function app.
 """
 
 helps['functionapp config ssl upload'] = """
     type: command
-    short-summary: Upload an SSL certificate to a resource group.
+    short-summary: Upload an SSL certificate to a function app.
 """
 
 helps['functionapp deployment'] = """
@@ -614,8 +611,7 @@ helps['functionapp deployment source config'] = """
 
 helps['functionapp deployment source config-local-git'] = """
     type: command
-    short-summary: Deploy a web app from a local git repository.
-    long-summary: Get an endpoint to clone and later push to deploy a function app.
+    short-summary: Get a URL for a git repository endpoint to clone and push to for function app deployment. 
     examples:
         - name: Get an endpoint and add it as a git remote.
           text: >
@@ -633,7 +629,7 @@ helps['functionapp deployment source delete'] = """
 
 helps['functionapp deployment source show'] = """
     type: command
-    short-summary: Show a source control deployment configuration.
+    short-summary: Get the details of a source control deployment configuration.
 """
 
 helps['functionapp deployment source sync'] = """
@@ -648,7 +644,7 @@ helps['functionapp deployment user'] = """
 helps['functionapp deployment user set'] = """
     type: command
     short-summary: Update deployment credentials.
-    long-summary: All function and web apps in the subscription will be impacted since all apps share
+    long-summary: All function and web apps in the subscription will be impacted since they share
                   the same deployment credentials.
     examples:
         - name: Set FTP and git deployment credentials for all apps.

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
@@ -69,7 +69,7 @@ helps['batch application package create'] = """
 helps['batch application package activate'] = """
     type: command
     short-summary: Activates a Batch application package.
-    long-summary: This step is unnecessary if the package has already been successfully activated by the 'create' command.
+    long-summary: This step is unnecessary if the package has already been successfully activated by the `create` command.
 """
 
 helps['batch application summary'] = """
@@ -282,12 +282,12 @@ helps['batch job-schedule create'] = """
 helps['batch job-schedule set'] = """
     type: command
     short-summary: Update the properties of a job schedule.
-    long-summary: You can independently update the 'schedule' and the 'job specification', but any change to either of these entities will reset all properties in that entity.
+    long-summary: You can independently update the schedule and the job specification, but any change to either of these entities will reset all properties in that entity.
 """
 
 helps['batch job-schedule reset'] = """
     type: command
-    short-summary: Update the properties of a job schedule.  Unspecified properties which can be updated are reset to their defaults. An updated job specification only applies to new jobs.
+    short-summary: Reset the properties of a job schedule.  An updated job specification only applies to new jobs.
 """
 
 helps['batch task create'] = """
@@ -297,5 +297,5 @@ helps['batch task create'] = """
 
 helps['batch task reset'] = """
     type: command
-    short-summary: Update the properties of a Batch task. Unspecified properties which can be updated are reset to their defaults.
+    short-summary: Reset the properties of a Batch task.
 """

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_help.py
@@ -13,7 +13,7 @@ helps['batch'] = """
 
 helps['batch account'] = """
     type: group
-    short-summary: Manage your Batch accounts.
+    short-summary: Manage Azure Batch accounts.
 """
 
 helps['batch account list'] = """
@@ -28,52 +28,53 @@ helps['batch account create'] = """
 
 helps['batch account set'] = """
     type: command
-    short-summary: Update the properties of the specified Batch account. Properties that are not specified remain unchanged.
+    short-summary: Update properties for a Batch account.
 """
 
 helps['batch account autostorage-keys'] = """
     type: group
-    short-summary: Manage the access keys for the auto storage account configured for your Batch account.
+    short-summary: Manage the access keys for the auto storage account configured for a Batch account.
 """
 
 helps['batch account keys'] = """
     type: group
-    short-summary: Manage your Batch account keys.
+    short-summary: Manage Batch account keys.
 """
 
 helps['batch account login'] = """
     type: command
-    short-summary: Log in with specified Batch account through Azure Active Directory or Shared Key authentication.
+    short-summary: Log in to a Batch account through Azure Active Directory or Shared Key authentication.
 """
 
 helps['batch application'] = """
     type: group
-    short-summary: Manage your Batch applications.
+    short-summary: Manage Batch applications.
 """
 
 helps['batch application set'] = """
     type: command
-    short-summary: Update the properties of the specified application. Properties that are not specified remain unchanged.
+    short-summary: Update properties for a Batch application.
 """
 
 helps['batch application package'] = """
     type: group
-    short-summary: Manage your Batch application packages.
+    short-summary: Manage Batch application packages.
 """
 
 helps['batch application package create'] = """
     type: command
-    short-summary: Create an application package record and activate it.
+    short-summary: Create a Batch application package record and activate it.
 """
 
 helps['batch application package activate'] = """
     type: command
-    short-summary: Activates the specified application package. This step is unnecessary if the package has already been successfully activated by the 'create' command.
+    short-summary: Activates a Batch application package.
+    long-summary: This step is unnecessary if the package has already been successfully activated by the 'create' command.
 """
 
 helps['batch application summary'] = """
     type: group
-    short-summary: View a summary of your Batch application packages.
+    short-summary: View a summary of Batch application packages.
 """
 
 helps['batch location'] = """
@@ -88,77 +89,78 @@ helps['batch location quotas'] = """
 
 helps['batch certificate'] = """
     type: group
-    short-summary: Manage your Batch certificates.
+    short-summary: Manage Batch certificates.
 """
 
 helps['batch task file'] = """
     type: group
-    short-summary: Manage your Batch task files.
+    short-summary: Manage Batch task files.
 """
 
 helps['batch task file download'] = """
     type: command
-    short-summary: Download the content of the specified task file.
+    short-summary: Download the content of a Batch task file.
 """
 
 helps['batch node file'] = """
     type: group
-    short-summary: Manage your Batch compute node files.
+    short-summary: Manage Batch compute node files.
 """
 
 helps['batch node file download'] = """
     type: command
-    short-summary: Download the content of the specified node file.
+    short-summary: Download the content of the a node file.
 """
 
 helps['batch job'] = """
     type: group
-    short-summary: Manage your Batch jobs.
+    short-summary: Manage Batch jobs.
 """
 
 helps['batch job task-counts'] = """
     type: group
-    short-summary: View the number of tasks in the job and their states.
+    short-summary: View the number of tasks in a Batch job and their states.
 """
 
 helps['batch job all-statistics'] = """
     type: group
-    short-summary: View statistics of all the jobs under your Batch account.
+    short-summary: View statistics of all jobs under a Batch account.
 """
 
 helps['batch job all-statistics show'] = """
     type: command
-    short-summary: Get lifetime summary statistics for all of the jobs in the specified account. Statistics are aggregated across all jobs that have ever existed in the account, from account creation to the last update time of the statistics.
+    short-summary: Get lifetime summary statistics for all of the jobs in a Batch account.
+    long-summary: Statistics are aggregated across all jobs that have ever existed in the account, from account creation to the last update time of the statistics.
 """
 
 helps['batch job prep-release-status'] = """
     type: group
-    short-summary: View the status of your job preparation and release tasks.
+    short-summary: View the status of Batch job preparation and release tasks.
 """
 
 helps['batch job-schedule'] = """
     type: group
-    short-summary: Manage your Batch job schedules.
+    short-summary: Manage Batch job schedules.
 """
 
 helps['batch node user'] = """
     type: group
-    short-summary: Manage the user accounts of your Batch compute node.
+    short-summary: Manage the user accounts of a Batch compute node.
 """
 
 helps['batch node user create'] = """
     type: command
-    short-summary: Add a user account to the specified compute node.
+    short-summary: Add a user account to a Batch compute node.
 """
 
 helps['batch node user reset'] = """
     type: command
-    short-summary: Update the properties of a user account on the specified compute node. All updatable properties are replaced with the values specified or reset if unspecified.
+    short-summary: Update the properties of a user account on a Batch compute node. Unspecified properties which can be updated are reset to their defaults.
 """
 
 helps['batch node'] = """
     type: group
-    short-summary: Manage your Batch compute nodes.
+    short-summary: Manage Batch compute nodes.
 """
 
 helps['batch node remote-login-settings'] = """
@@ -168,7 +170,7 @@ helps['batch node remote-login-settings'] = """
 
 helps['batch node remote-desktop'] = """
     type: group
-    short-summary: Retrieve the remote desktop protocol for a Batch compute node.
+    short-summary: Retrieve the remote desktop protocol file for a Batch compute node.
 """
 
 helps['batch node scheduling'] = """
@@ -178,120 +180,122 @@ helps['batch node scheduling'] = """
 
 helps['batch pool'] = """
     type: group
-    short-summary: Manage your Batch pools.
+    short-summary: Manage Batch pools.
 """
 
 helps['batch pool os'] = """
     type: group
-    short-summary: Manage the operating system of your Batch pools.
+    short-summary: Manage the operating system of Batch pools.
 """
 
 helps['batch pool autoscale'] = """
     type: group
-    short-summary: Manage automatic scaling of your Batch pools.
+    short-summary: Manage automatic scaling of Batch pools.
 """
 
 helps['batch pool all-statistics'] = """
     type: group
-    short-summary: View statistics of all pools under your Batch account.
+    short-summary: View statistics of all pools under a Batch account.
 """
 
 helps['batch pool all-statistics show'] = """
     type: command
-    short-summary: Get lifetime summary statistics for all of the pools in the specified account. Statistics are aggregated across all pools that have ever existed in the account, from account creation to the last update time of the statistics.
+    short-summary: Get lifetime summary statistics for all of the pools in a Batch account.
+    long-summary: Statistics are aggregated across all pools that have ever existed in the account, from account creation to the last update time of the statistics.
 """
 
 helps['batch pool usage-metrics'] = """
     type: group
-    short-summary: View usage metrics of your Batch pools.
+    short-summary: View usage metrics of Batch pools.
 """
 
 helps['batch pool node-agent-skus'] = """
     type: group
-    short-summary: Retrieve node agent SKUs of pools using a Virtual Machine Configuration.
+    short-summary: Retrieve node agent SKUs of Batch pools using a Virtual Machine Configuration.
 """
 
 helps['batch task'] = """
     type: group
-    short-summary: Manage your Batch tasks.
+    short-summary: Manage Batch tasks.
 """
 
 helps['batch task subtask'] = """
     type: group
-    short-summary: Manage subtask information of your Batch task.
+    short-summary: Manage subtask information of a Batch task.
 """
 
 helps['batch certificate create'] = """
     type: command
-    short-summary: Add a certificate.
+    short-summary: Add a certificate to a Batch account.
 """
 
 helps['batch certificate delete'] = """
     type: command
-    short-summary: Delete the specified Batch certificate.
+    short-summary: Delete a certificate from a Batch account.
 """
 
 helps['batch pool create'] = """
     type: command
-    short-summary: Create a pool in the specified account. When creating a pool, choose arguments from either Cloud Services Configuration or Virtual Machine Configuration.
+    short-summary: Create a Batch pool in an account. When creating a pool, choose arguments from either Cloud Services Configuration or Virtual Machine Configuration.
 """
 
 helps['batch pool set'] = """
     type: command
-    short-summary: Update the properties of the specified pool. Properties can be updated independently, but when a property is updated in a sub-group, for example 'start task', all properties of that group are reset.
+    short-summary: Update the properties of a Batch pool. Updating a property in a subgroup will reset the unspecified properties of that group.
 """
 
 helps['batch pool reset'] = """
     type: command
-    short-summary: Update the properties of the specified pool. All updatable properties are replaced with the values specified or reset to default values if unspecified.
+    short-summary: Update the properties of a Batch pool. Unspecified properties which can be updated are reset to their defaults.
 """
 
 helps['batch pool resize'] = """
     type: command
-    short-summary: Resize (or stop resizing) the Batch pool.
+    short-summary: Resize or stop resizing a Batch pool.
 """
 
 helps['batch job create'] = """
     type: command
-    short-summary: Add a job to the specified account.
+    short-summary: Add a job to a Batch account.
 """
 
 helps['batch job list'] = """
     type: command
-    short-summary: List all of the jobs in the specified account or the specified job schedule.
+    short-summary: List all of the jobs or job schedule in a Batch account.
 """
 
 helps['batch job set'] = """
     type: command
-    short-summary: Update the properties of a job. Properties can be updated independently, but when a property is updated in a sub-group, for example 'constraints' or 'pool info', all properties of that group are reset.
+    short-summary: Update the properties of a Batch job. Updating a property in a subgroup will reset the unspecified properties of that group.
 """
 
 helps['batch job reset'] = """
     type: command
-    short-summary: Update the properties of a job. All updatable properties are replaced with the values specified or reset to default vaules if unspecified.
+    short-summary: Update the properties of a Batch job. Unspecified properties which can be updated are reset to their defaults.
 """
 
 helps['batch job-schedule create'] = """
     type: command
-    short-summary: Add a job schedule to the specified account.
+    short-summary: Add a Batch job schedule to an account.
 """
 
 helps['batch job-schedule set'] = """
     type: command
-    short-summary: Update the properties of the specified job schedule. You can independently update the 'schedule' and the 'job specification', but any change to either of these entities will reset all properties in that entity.
+    short-summary: Update the properties of a job schedule.
+    long-summary: You can independently update the 'schedule' and the 'job specification', but any change to either of these entities will reset all properties in that entity.
 """
 
 helps['batch job-schedule reset'] = """
     type: command
-    short-summary: Update the properties of the specified job schedule. All updatable properties are replaced with the values specified or reset to default values if unspecified. An updated job specification only applies to new jobs.
+    short-summary: Update the properties of a job schedule.  Unspecified properties which can be updated are reset to their defaults. An updated job specification only applies to new jobs.
 """
 
 helps['batch task create'] = """
     type: command
-    short-summary: Create a single Batch task or multiple Batch tasks.
+    short-summary: Create Batch tasks.
 """
 
 helps['batch task reset'] = """
     type: command
-    short-summary: Update the properties of the specified task. All updatable properties are replaced with the values specified or reset if unspecified.
+    short-summary: Update the properties of a Batch task. Unspecified properties which can be updated are reset to their defaults.
 """

--- a/src/command_modules/azure-cli-billing/azure/cli/command_modules/billing/_help.py
+++ b/src/command_modules/azure-cli-billing/azure/cli/command_modules/billing/_help.py
@@ -12,10 +12,10 @@ helps['billing'] = """
 
 helps['billing invoice'] = """
     type: group
-    short-summary: Get billing invoices of the subscription.
+    short-summary: Get billing invoices for a subscription.
 """
 
 helps['billing period'] = """
     type: group
-    short-summary: Get billing periods of the subscription.
+    short-summary: Get billing periods for a subscription.
 """

--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
@@ -13,7 +13,7 @@ helps['cdn'] = """
 
 helps['cdn profile'] = """
     type: group
-    short-summary: Manage CDN Profiles to define a edge network.
+    short-summary: Manage CDN profiles to define an edge network.
 """
 
 helps['cdn profile create'] = """
@@ -63,7 +63,7 @@ helps['cdn endpoint create'] = """
     type: command
     short-summary: Create a named endpoint to connect to a CDN.
     examples:
-        - name: Create an endpoint to service content for hostname over http or https.
+        - name: Create an endpoint to service content for hostname over HTTP or HTTPS.
           text: >
             az cdn endpoint create -g group -n endpoint --profile-name profile \\
                 --origin www.example.com
@@ -81,10 +81,10 @@ helps['cdn endpoint update'] = """
     type: command
     short-summary: Update a CDN endpoint to manage how content is delivered.
     examples:
-        - name: Turn off HTTP traffic for the endpoint.
+        - name: Turn off HTTP traffic for an endpoint.
           text: >
             az cdn endpoint update -g group -n endpoint --profile-name profile --no-http
-        - name: Enable content compression for the endpoint.
+        - name: Enable content compression for an endpoint.
           text: >
             az cdn endpoint update -g group -n endpoint --profile-name profile \\
                 --enable-compression
@@ -122,7 +122,7 @@ helps['cdn endpoint load'] = """
     type: command
     short-summary: Pre-load content for a CDN endpoint.
     examples:
-        - name: Pre-load content for Javascript and CSS styles.
+        - name: Pre-load Javascript and CSS content for an endpoint.
           text: >
             az cdn endpoint load -g group -n endpoint --profile-name profile-name --content-paths \\
                 '/scripts/app.js' '/styles/main.css'
@@ -130,9 +130,9 @@ helps['cdn endpoint load'] = """
 
 helps['cdn endpoint purge'] = """
     type: comman
-    short-summary: Purge preloaded content for a CDN endpoint.
+    short-summary: Purge pre-loaded content for a CDN endpoint.
     examples:
-        - name: Purge content for Javascript and CSS styles.
+        - name: Purge pre-loaded Javascript and CSS content.
           text: >
             az cdn endpoint purge -g group -n endpoint --profile-name profile-name --content-paths \\
                 '/scripts/app.js' '/styles/*'
@@ -166,7 +166,7 @@ helps['cdn custom-domain show'] = """
     type: command
     short-summary: Show details for the custom domain of a CDN.
     examples:
-        - name: Show details of a custom domain.
+        - name: Get the details of a custom domain.
           text: >
             az cdn custom-domain show -g group --endpoint-name endpoint --profile-name profile \\
                 -n domain-name

--- a/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
+++ b/src/command_modules/azure-cli-cdn/azure/cli/command_modules/cdn/_help.py
@@ -8,17 +8,17 @@ from azure.cli.core.help_files import helps
 
 helps['cdn'] = """
     type: group
-    short-summary: Manage Azure Content Delivery Networks (CDN)
+    short-summary: Manage Azure Content Delivery Networks (CDNs).
 """
 
 helps['cdn profile'] = """
     type: group
-    short-summary: Manage Azure CDN Profiles which define which CDN provider for your edge network
+    short-summary: Manage CDN Profiles to define a edge network.
 """
 
 helps['cdn profile create'] = """
     type: command
-    short-summary: Creates a new CDN profile
+    short-summary: Create a new CDN profile.
     parameters:
         - name: --sku
           type: string
@@ -26,50 +26,52 @@ helps['cdn profile create'] = """
             The pricing tier (defines a CDN provider, feature list and rate) of the CDN profile.
             Defaults to Standard_Akamai.
     examples:
-        - name: Create a CDN profile using Verizon premium CDN
+        - name: Create a CDN profile using Verizon premium CDN.
           text: >
             az cdn profile create -g group -n profile --sku Premium_Verizon
 """
 
 helps['cdn profile update'] = """
     type: command
-    short-summary: Update a CDN profile
+    short-summary: Update a CDN profile.
 """
 
 helps['cdn profile delete'] = """
     type: command
+    short-summary: Delete a CDN profile.
     examples:
-        - name: Delete a CDN profile
+        - name: Delete a CDN profile.
           text: >
             az cdn profile create -g group -n profile
 """
 
 helps['cdn profile list'] = """
     type: command
-    short-summary: List your Azure Content Delivery Network (CDN) profiles
+    short-summary: List CDN profiles.
     examples:
-        - name: List CDN profiles in a resource group
+        - name: List CDN profiles in a resource group.
           text: >
             az cdn profile list -g group
 """
 
 helps['cdn endpoint'] = """
     type: group
-    short-summary: Manage Azure CDN Endpoints which define the hostname and endpoints
+    short-summary: Manage CDN endpoints.
 """
 
 helps['cdn endpoint create'] = """
     type: command
+    short-summary: Create a named endpoint to connect to a CDN.
     examples:
-        - name: Create an endpoint to service content for hostname over http or https
+        - name: Create an endpoint to service content for hostname over http or https.
           text: >
             az cdn endpoint create -g group -n endpoint --profile-name profile \\
                 --origin www.example.com
-        - name: Create an endpoint with a custom domain origin with HTTP and HTTPS ports
+        - name: Create an endpoint with a custom domain origin with HTTP and HTTPS ports.
           text: >
             az cdn endpoint create -g group -n endpoint --profile-name profile \\
                 --origin www.example.com 88 4444
-        - name: Create an endpoint with a custom domain with compression and only HTTPS
+        - name: Create an endpoint with a custom domain with compression and only HTTPS.
           text: >
             az cdn endpoint create -g group -n endpoint --profile-name profile \\
                 --origin www.example.com --no-http --enable-compression
@@ -77,12 +79,12 @@ helps['cdn endpoint create'] = """
 
 helps['cdn endpoint update'] = """
     type: command
-    short-summary: Update a CDN endpoint to manage how content is delivered
+    short-summary: Update a CDN endpoint to manage how content is delivered.
     examples:
-        - name: Turn off HTTP traffic for the endpoint
+        - name: Turn off HTTP traffic for the endpoint.
           text: >
             az cdn endpoint update -g group -n endpoint --profile-name profile --no-http
-        - name: Enable content compression for the endpoint
+        - name: Enable content compression for the endpoint.
           text: >
             az cdn endpoint update -g group -n endpoint --profile-name profile \\
                 --enable-compression
@@ -91,41 +93,46 @@ helps['cdn endpoint update'] = """
 
 helps['cdn endpoint delete'] = """
     type: command
+    short-summary: Delete a CDN endpoint.
     examples:
-        - name: Delete a CDN endpoint
+        - name: Delete a CDN endpoint.
           text: >
             az cdn endpoint delete -g group -n endpoint --profile-name profile-name
 """
 
 helps['cdn endpoint start'] = """
     type: command
+    short-summary: Start a CDN endpoint.
     examples:
-        - name: Start a CDN endpoint
+        - name: Start a CDN endpoint.
           text: >
             az cdn endpoint start -g group -n endpoint --profile-name profile-name
 """
 
 helps['cdn endpoint stop'] = """
     type: command
+    short-summary: Stop a CDN endpoint.
     examples:
-        - name: Stop a CDN endpoint
+        - name: Stop a CDN endpoint.
           text: >
             az cdn endpoint stop -g group -n endpoint --profile-name profile-name
 """
 
 helps['cdn endpoint load'] = """
     type: command
+    short-summary: Pre-load content for a CDN endpoint.
     examples:
-        - name: Pre-load content for Javascript and CSS styles
+        - name: Pre-load content for Javascript and CSS styles.
           text: >
             az cdn endpoint load -g group -n endpoint --profile-name profile-name --content-paths \\
                 '/scripts/app.js' '/styles/main.css'
 """
 
 helps['cdn endpoint purge'] = """
-    type: command
+    type: comman
+    short-summary: Purge preloaded content for a CDN endpoint.
     examples:
-        - name: Purge content for Javascript and CSS styles
+        - name: Purge content for Javascript and CSS styles.
           text: >
             az cdn endpoint purge -g group -n endpoint --profile-name profile-name --content-paths \\
                 '/scripts/app.js' '/styles/*'
@@ -133,21 +140,23 @@ helps['cdn endpoint purge'] = """
 
 helps['cdn endpoint list'] = """
     type: command
+    short-summary: List available endpoints for a CDN.
     examples:
-        - name: List all endpoints within a given CDN profile
+        - name: List all endpoints within a given CDN profile.
           text: >
             az cdn endpoint list -g group --profile-name profile-name
 """
 
 helps['cdn custom-domain'] = """
     type: group
-    short-summary: Manage Azure CDN Custom Domains to provide custom host names for Endpoints
+    short-summary: Manage Azure CDN Custom Domains to provide custom host names for endpoints.
 """
 
 helps['cdn custom-domain delete'] = """
     type: command
+    short-summary: Delete the custom domain of a CDN.
     examples:
-        - name: Delete a custom domain
+        - name: Delete a custom domain.
           text: >
             az cdn custom-domain delete -g group --endpoint-name endpoint --profile-name profile \\
                 -n domain-name
@@ -155,8 +164,9 @@ helps['cdn custom-domain delete'] = """
 
 helps['cdn custom-domain show'] = """
     type: command
+    short-summary: Show details for the custom domain of a CDN.
     examples:
-        - name: Show details of a custom domain
+        - name: Show details of a custom domain.
           text: >
             az cdn custom-domain show -g group --endpoint-name endpoint --profile-name profile \\
                 -n domain-name
@@ -164,8 +174,7 @@ helps['cdn custom-domain show'] = """
 
 helps['cdn custom-domain create'] = """
     type: command
-    short-summary: Creates a new custom domain which provides a custom hostname for an endpoint
-        origin
+    short-summary: Create a new custom domain to provide a hostname for a CDN endpoint.
     long-summary: >
         Creates a new custom domain which must point to the hostname of the endpoint.
         For example, the custom domain hostname cdn.contoso.com would need to have a
@@ -182,7 +191,7 @@ helps['cdn custom-domain create'] = """
           type: string
           short-summary: The host name of the custom domain. Must be a domain name.
     examples:
-        - name: Create a custom domain within an endpoint and profile
+        - name: Create a custom domain within an endpoint and profile.
           text: >
             az cdn custom-domain create -g group --endpoint-name endpoint --profile-name profile \\
                 -n domain-name --hostname www.example.com
@@ -190,10 +199,10 @@ helps['cdn custom-domain create'] = """
 
 helps['cdn origin'] = """
     type: group
-    short-summary: List or show existing origins related to CDN endpoints
+    short-summary: List or show existing origins related to CDN endpoints.
 """
 
 helps['cdn edge-node'] = """
     type: group
-    short-summary: View all available edge nodes
+    short-summary: View all available CDN edge nodes.
 """

--- a/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_help.py
+++ b/src/command_modules/azure-cli-cloud/azure/cli/command_modules/cloud/_help.py
@@ -8,17 +8,17 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps['cloud'] = """
     type: group
-    short-summary: Manage the registered Azure clouds.
+    short-summary: Manage registered Azure clouds.
 """
 
 helps['cloud list'] = """
             type: command
-            short-summary: List the registered clouds.
+            short-summary: List registered clouds.
 """
 
 helps['cloud show'] = """
             type: command
-            short-summary: Show the configuration of a registered cloud.
+            short-summary: Get the details of a registered cloud.
 """
 
 helps['cloud register'] = """
@@ -39,10 +39,10 @@ helps['cloud set'] = """
 
 helps['cloud update'] = """
             type: command
-            short-summary: Update the configuration for a cloud.
+            short-summary: Update the configuration of a cloud.
 """
 
 helps['cloud list-profiles'] = """
             type: command
-            short-summary: List the profiles a given cloud supports.
+            short-summary: List the supported profiles for a cloud.
 """

--- a/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/_help.py
+++ b/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/_help.py
@@ -8,62 +8,62 @@ from azure.cli.core.help_files import helps
 
 helps['cognitiveservices'] = """
     type: group
-    short-summary: Manage Cognitive Services accounts.
+    short-summary: Manage Azure Cognitive Services accounts.
 """
 
 helps['cognitiveservices list'] = """
     type: command
-    short-summary: List all the existing cognitive services accounts under a resource group or current Azure subscription.
+    short-summary: List available Azure Cognitive Services accounts.
     examples:
-        - name: List all the cognitive services accounts in a resource group.
+        - name: List all the Cognitive Services accounts in a resource group.
           text: az cognitiveservices list -g MyResourceGroup
 """
 
 helps['cognitiveservices account'] = """
     type: group
-    short-summary: Manage and update cognitive services accounts.
+    short-summary: Manage Azure Cognitive Services accounts.
 """
 
 helps['cognitiveservices account delete'] = """
     type: command
-    short-summary: Remove a cognitive services account.
+    short-summary: Delete an Azure Cognitive Services account.
 """
 
 helps['cognitiveservices account create'] = """
     type: command
-    short-summary: Create a cognitive services account.
+    short-summary: Create an Azure Cognitive Services account.
     examples:
-        - name: Create a S0 face API cognitive services account in West Europe without confirmation required.
+        - name: Create an S0 face API Cognitive Services account in West Europe without confirmation required.
           text: az cognitiveservices create -n myresource -g myResourceGroup --kind Face --sku S0 -l WestEurope --yes
 """
 
 helps['cognitiveservices account show'] = """
     type: command
-    short-summary: Get the details of a cognitive services account.
+    short-summary: Get the details of an Azure Cognitive Services account.
 """
 
 helps['cognitiveservices account update'] = """
     type: command
-    short-summary: Update the properties of a cognitive services account.
+    short-summary: Update the properties of an Azure Cognitive Services account.
 """
 
 helps['cognitiveservices account list-skus'] = """
     type: command
-    short-summary: List the SKUs avaiable for a cognitive services account.
+    short-summary: List the SKUs avaiable for an Azure Cognitive Services account.
 """
 
 
 helps['cognitiveservices account keys'] = """
     type: group
-    short-summary: Manage the keys of a cognitive services account.
+    short-summary: Manage the keys of an Azure Cognitive Services account.
 """
 
 helps['cognitiveservices account keys regenerate'] = """
     type: command
-    short-summary: Regenerate the keys of a cognitive services account.
+    short-summary: Regenerate the keys of an Azure Cognitive Services account.
 """
 
 helps['cognitiveservices account keys list'] = """
     type: command
-    short-summary: List the keys of a cognitive services account.
+    short-summary: List the keys of an Azure Cognitive Services account.
 """

--- a/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/_help.py
+++ b/src/command_modules/azure-cli-cognitiveservices/azure/cli/command_modules/cognitiveservices/_help.py
@@ -8,20 +8,20 @@ from azure.cli.core.help_files import helps
 
 helps['cognitiveservices'] = """
     type: group
-    short-summary: Manage Cognitive Services accounts in Azure Resource Manager
+    short-summary: Manage Cognitive Services accounts.
 """
 
 helps['cognitiveservices list'] = """
     type: command
-    short-summary: list all the existing cognitive services accounts under a resource group or current azure subscription
+    short-summary: List all the existing cognitive services accounts under a resource group or current Azure subscription.
     examples:
-        - name: list all the cognitive services accounts in a resource group
+        - name: List all the cognitive services accounts in a resource group.
           text: az cognitiveservices list -g MyResourceGroup
 """
 
 helps['cognitiveservices account'] = """
     type: group
-    short-summary: Manage and update cognitive services accounts
+    short-summary: Manage and update cognitive services accounts.
 """
 
 helps['cognitiveservices account delete'] = """
@@ -33,7 +33,7 @@ helps['cognitiveservices account create'] = """
     type: command
     short-summary: Create a cognitive services account.
     examples:
-        - name: create a S0 face Api cognitive services account in West Europe without confirmation required
+        - name: Create a S0 face API cognitive services account in West Europe without confirmation required.
           text: az cognitiveservices create -n myresource -g myResourceGroup --kind Face --sku S0 -l WestEurope --yes
 """
 
@@ -49,7 +49,7 @@ helps['cognitiveservices account update'] = """
 
 helps['cognitiveservices account list-skus'] = """
     type: command
-    short-summary: List the avaiable skus of a cognitive services account.
+    short-summary: List the SKUs avaiable for a cognitive services account.
 """
 
 

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
@@ -7,6 +7,6 @@ from azure.cli.core.help_files import helps
 
 
 helps['configure'] = """
-            type: command
-            short-summary: Manage and view the Azure CLI 2.0 configuration. This command is interactive.
+        type: command
+        short-summary: Display and manage the Azure CLI 2.0 configuration. This command is interactive.
 """

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
@@ -8,5 +8,5 @@ from azure.cli.core.help_files import helps
 
 helps['configure'] = """
             type: command
-            short-summary: Configure Azure CLI 2.0 or view your configuration. The command is interactive, so just type `az configure` and respond to the prompts.
+            short-summary: Manage and view the Azure CLI 2.0 configuration. This command is interactive.
 """

--- a/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/_help.py
+++ b/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/_help.py
@@ -7,11 +7,16 @@ from azure.cli.core.help_files import helps
 
 helps['consumption'] = """
     type: group
-    short-summary: Manage Azure Consumption.
+    short-summary: Manage consumption of Azure resources.
+"""
+
+helps['consumption usage'] = """
+    type: group
+    short-summary: Inspect consumption usage.
 """
 
 helps['consumption usage list'] = """
     type: command
-    short-summary: List usage details
-    long-summary: List usage details of the subscription, in the scope of an invoice or a billing period.
+    short-summary: List consumption usage details.
+    long-summary: List usage details of the subscription, as an invoice or within a billing period.
 """

--- a/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/_help.py
+++ b/src/command_modules/azure-cli-consumption/azure/cli/command_modules/consumption/_help.py
@@ -12,11 +12,10 @@ helps['consumption'] = """
 
 helps['consumption usage'] = """
     type: group
-    short-summary: Inspect consumption usage.
+    short-summary: Inspect the usage of Azure resources.
 """
 
 helps['consumption usage list'] = """
     type: command
-    short-summary: List consumption usage details.
-    long-summary: List usage details of the subscription, as an invoice or within a billing period.
+    short-summary: Show the details of Azure resource consumption, either as an invoice or within a billing period.
 """

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -7,8 +7,7 @@ from azure.cli.core.help_files import helps
 
 helps['container'] = """
     type: group
-    short-summary: Manage Azure Container Instances.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Azure Container Instances.
 """
 
 helps['container create'] = """

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -7,7 +7,8 @@ from azure.cli.core.help_files import helps
 
 helps['container'] = """
     type: group
-    short-summary: (Preview) Manage Azure Container Instances.
+    short-summary: Manage Azure Container Instances.
+    long-summary: These commands are in preview.
 """
 
 helps['container create'] = """
@@ -42,10 +43,10 @@ helps['container list'] = """
 
 helps['container show'] = """
     type: command
-    short-summary: Show the details of a container group.
+    short-summary: Get the details of a container group.
 """
 
 helps['container logs'] = """
     type: command
-    short-summary: Examine the logs of a container group.
+    short-summary: Examine the logs for a container group.
 """

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_help.py
@@ -14,19 +14,19 @@ helps['container create'] = """
     type: command
     short-summary: Create a container group.
     examples:
-        - name: Create a container group and specify resources required.
+        - name: Create a container group with 1 core and 1Gb of memory.
           text: az container create -g MyResourceGroup --name myalpine --image alpine:latest --cpu 1 --memory 1
-        - name: Create a container group with OS type.
+        - name: Create a container group that runs Windows, with 2 cores and 3.5Gb of memory.
           text: az container create -g MyResourceGroup --name mywinapp --image winappimage:latest --os-type Windows --cpu 2 --memory 3.5
         - name: Create a container group with public IP address.
           text: az container create -g MyResourceGroup --name myalpine --image alpine:latest --ip-address public
-        - name: Create a container group with starting command line.
+        - name: Create a container group that invokes a script upon start.
           text: az container create -g MyResourceGroup --name myalpine --image alpine:latest --command-line "/bin/sh -c '/path to/myscript.sh'"
         - name: Create a container group with environment variables.
           text: az container create -g MyResourceGroup --name myalpine --image alpine:latest -e key1=value1 key2=value2
         - name: Create a container group using container image from Azure Container Registry.
           text: az container create -g MyResourceGroup --name myalpine --image myAcrRegistry.azurecr.io/alpine:latest --registry-password password
-        - name: Create a container group using container image from other private container image registry.
+        - name: Create a container group using container image from another private container image registry.
           text: az container create -g MyResourceGroup --name myapp --image myimage:latest --cpu 1 --memory 1.5 --registry-login-server myregistry.com --registry-username username --registry-password password
 """
 
@@ -47,5 +47,5 @@ helps['container show'] = """
 
 helps['container logs'] = """
     type: command
-    short-summary: Tail the log of a container group.
+    short-summary: Examine the logs of a container group.
 """

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_help.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_help.py
@@ -23,12 +23,12 @@ helps['cosmosdb collection'] = """
 
 helps['cosmosdb check-name-exists'] = """
     type: command
-    short-summary: Checks that the Azure Cosmos DB account name already exists.
+    short-summary: Checks to see if an Azure Cosmos DB account name already exists.
 """
 
 helps['cosmosdb create'] = """
     type: command
-    short-summary: Create a new Azure Cosmos DB database account.
+    short-summary: Creates a new Azure Cosmos DB database account.
 """
 
 helps['cosmosdb delete'] = """
@@ -48,30 +48,30 @@ helps['cosmosdb list'] = """
 
 helps['cosmosdb list-connection-strings'] = """
     type: command
-    short-summary: Lists the connection strings for the specified Azure Cosmos DB database account.
+    short-summary: Lists the connection strings for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb list-keys'] = """
     type: command
-    short-summary: Lists the access keys for the specified Azure Cosmos DB database account.
+    short-summary: Lists the access keys for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb list-read-only-keys'] = """
     type: command
-    short-summary: Lists the read-only access keys for the specified Azure Cosmos DB database account.
+    short-summary: Lists the read-only access keys for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb regenerate-key'] = """
     type: command
-    short-summary: Regenerates an access key for the specified Azure Cosmos DB database account.
+    short-summary: Regenerates an access key for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb show'] = """
     type: command
-    short-summary: Retrieves the properties of an existing Azure Cosmos DB database account.
+    short-summary: Retrieves the properties for an Azure Cosmos DB database account.
 """
 
 helps['cosmosdb update'] = """
     type: command
-    short-summary: Update an existing Azure Cosmos DB database account.
+    short-summary: Update an Azure Cosmos DB database account.
 """

--- a/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_help.py
+++ b/src/command_modules/azure-cli-cosmosdb/azure/cli/command_modules/cosmosdb/_help.py
@@ -23,7 +23,7 @@ helps['cosmosdb collection'] = """
 
 helps['cosmosdb check-name-exists'] = """
     type: command
-    short-summary: Checks to see if an Azure Cosmos DB account name already exists.
+    short-summary: Checks if an Azure Cosmos DB account name exists.
 """
 
 helps['cosmosdb create'] = """
@@ -33,7 +33,7 @@ helps['cosmosdb create'] = """
 
 helps['cosmosdb delete'] = """
     type: command
-    short-summary: Deletes an existing Azure Cosmos DB database account.
+    short-summary: Deletes an Azure Cosmos DB database account.
 """
 
 helps['cosmosdb failover-priority-change'] = """
@@ -43,32 +43,32 @@ helps['cosmosdb failover-priority-change'] = """
 
 helps['cosmosdb list'] = """
     type: command
-    short-summary: Lists all Azure Cosmos DB database accounts within a given resource group or subscription.
+    short-summary: List Azure Cosmos DB database accounts.
 """
 
 helps['cosmosdb list-connection-strings'] = """
     type: command
-    short-summary: Lists the connection strings for a Azure Cosmos DB database account.
+    short-summary: List the connection strings for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb list-keys'] = """
     type: command
-    short-summary: Lists the access keys for a Azure Cosmos DB database account.
+    short-summary: List the access keys for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb list-read-only-keys'] = """
     type: command
-    short-summary: Lists the read-only access keys for a Azure Cosmos DB database account.
+    short-summary: List the read-only access keys for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb regenerate-key'] = """
     type: command
-    short-summary: Regenerates an access key for a Azure Cosmos DB database account.
+    short-summary: Regenerate an access key for a Azure Cosmos DB database account.
 """
 
 helps['cosmosdb show'] = """
     type: command
-    short-summary: Retrieves the properties for an Azure Cosmos DB database account.
+    short-summary: Get the details of an Azure Cosmos DB database account.
 """
 
 helps['cosmosdb update'] = """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -8,14 +8,12 @@ from azure.cli.core.help_files import helps
 
 helps['dla'] = """
     type: group
-    short-summary: Manage Data Lake Analytics accounts, jobs, and catalogs.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics accounts, jobs, and catalogs.
 """
 
 helps['dla job'] = """
     type: group
-    short-summary: Manage Data Lake Analytics jobs.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics jobs.
 """
 
 helps['dla job submit'] = """
@@ -67,44 +65,37 @@ helps['dla job list'] = """
 
 helps['dla catalog'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalogs.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalogs.
 """
 
 helps['dla catalog database'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog databases.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog databases.
 """
 
 helps['dla catalog assembly'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog assemblies.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog assemblies.
 """
 
 helps['dla catalog external-data-source'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog external data sources.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog external data sources.
 """
 
 helps['dla catalog procedure'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog stored procedures.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog stored procedures.
 """
 
 helps['dla catalog schema'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog schemas.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog schemas.
 """
 
 helps['dla catalog table'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog tables.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog tables.
 """
 
 helps['dla catalog table list'] = """
@@ -121,14 +112,12 @@ helps['dla catalog table list'] = """
 
 helps['dla catalog table-partition'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog table partitions.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table partitions.
 """
 
 helps['dla catalog table-stats'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog table statistics.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table statistics.
 """
 
 helps['dla catalog table-stats list'] = """
@@ -148,14 +137,12 @@ helps['dla catalog table-stats list'] = """
 
 helps['dla catalog table-type'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog table types.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table types.
 """
 
 helps['dla catalog tvf'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog table valued functions.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog table valued functions.
 """
 
 helps['dla catalog tvf list'] = """
@@ -172,8 +159,7 @@ helps['dla catalog tvf list'] = """
 
 helps['dla catalog view'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog views.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog views.
 """
 
 helps['dla catalog view list'] = """
@@ -190,8 +176,7 @@ helps['dla catalog view list'] = """
 
 helps['dla catalog credential'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog credentials.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog credentials.
 """
 
 helps['dla catalog credential create'] = """
@@ -241,14 +226,12 @@ helps['dla catalog credential delete'] = """
 
 helps['dla catalog package'] = """
     type: group
-    short-summary: Manage Data Lake Analytics catalog packages.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics catalog packages.
 """
 
 helps['dla account'] = """
     type: group
-    short-summary: Manage Data Lake Analytics accounts.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics accounts.
 """
 
 helps['dla account create'] = """
@@ -307,20 +290,17 @@ helps['dla account delete'] = """
 
 helps['dla account blob-storage'] = """
     type: group
-    short-summary: Manage links between Data Lake Analytics accounts and Azure Storage.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage links between Data Lake Analytics accounts and Azure Storage.
 """
 
 helps['dla account data-lake-store'] = """
     type: group
-    short-summary: Manage links between Data Lake Analytics and Data Lake Store accounts.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage links between Data Lake Analytics and Data Lake Store accounts.
 """
 
 helps['dla account firewall'] = """
     type: group
-    short-summary: Manage Data Lake Analytics account firewall rules.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics account firewall rules.
 """
 
 helps['dla account firewall create'] = """
@@ -360,8 +340,7 @@ helps['dla account firewall delete'] = """
 
 helps['dla account compute-policy'] = """
     type: group
-    short-summary: Manage Data Lake Analytics account compute policies.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics account compute policies.
 """
 
 helps['dla account compute-policy create'] = """
@@ -417,8 +396,7 @@ helps['dla account compute-policy delete'] = """
 
 helps['dla job pipeline'] = """
     type: group
-    short-summary: Manage Data Lake Analytics job pipelines.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics job pipelines.
 """
 
 helps['dla job pipeline show'] = """
@@ -433,8 +411,7 @@ helps['dla job pipeline list'] = """
 
 helps['dla job recurrence'] = """
     type: group
-    short-summary: Manage Data Lake Analytics job recurrences.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Analytics job recurrences.
 """
 
 helps['dla job recurrence show'] = """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -8,8 +8,8 @@ from azure.cli.core.help_files import helps
 
 helps['dla'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics accounts, jobs, and catalogs.
-    long-summary: If you don't have the Data Lake Analytics component installed, add it with `az component update --add dla`. These commands are in preview.
+    short-summary: Manage Data Lake Analytics accounts, jobs, and catalogs.
+    long-summary: These commands are in preview.
 """
 
 helps['dla job'] = """
@@ -20,177 +20,178 @@ helps['dla job'] = """
 
 helps['dla job submit'] = """
     type: command
-    short-summary: submits the job to the Data Lake Analytics account.
+    short-summary: Submits a job to a Data Lake Analytics account.
     parameters:
         - name: --job-name
           type: string
-          short-summary: 'Job name for the job'
+          short-summary: 'Name for the submitted job.'
         - name: --script
           type: string
-          short-summary: 'The script to submit'
-          long-summary: This is either the script contents or use `@<file path>` to load the script from a file
+          short-summary: 'Script to submit.'
+          long-summary: This is either an inline script, or `@<file path>` to load from a file.
         - name: --runtime-version
-          short-summary: 'The runtime version to use'
+          short-summary: 'The runtime version to use.'
           long-summary: This parameter is used for explicitly overwriting the default runtime. It should only be done if you know what you are doing.
         - name: --degree-of-parallelism
-          short-summary: 'The degree of parallelism for the job'
-          long-summary: Higher values equate to more parallelism and will usually yield faster running jobs, at the cost of more AUs consumed by the job.
+          short-summary: 'The degree of parallelism for the job.'
+          long-summary: Higher values equate to more parallelism and will usually yield faster running jobs, at the cost of more AUs.
         - name: --priority
-          short-summary: 'The priority of the job'
+          short-summary: 'The priority of the job.'
           long-summary: Lower values increase the priority, with the lowest value being 1. This determines the order jobs are run in.
 
 """
 
 helps['dla job cancel'] = """
     type: command
-    short-summary: cancels the job in the Data Lake Analytics account.
+    short-summary: Cancels a Data Lake Analytics job.
 """
 
 helps['dla job show'] = """
     type: command
-    short-summary: Retrieves the job in the Data Lake Analytics account.
+    short-summary: Shows information for a Data Lake Analytics job.
 """
 
 helps['dla job wait'] = """
     type: command
-    short-summary: Waits for the job in the Data Lake Analytics account to finish, returning the job once finished
+    short-summary: Waits for a Data Lake Analytics job to finish.
+    long-summary: This command exits when the job completes.
     parameters:
         - name: --job-id
           type: string
-          short-summary: 'Job ID for the job to poll'
+          short-summary: 'Job ID to poll for completion.'
 """
 
 helps['dla job list'] = """
     type: command
-    short-summary: lists jobs in the Data Lake Analytics account.
+    short-summary: Lists Data Lake Analytics jobs.
 """
 
 helps['dla catalog'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalogs.
+    short-summary: Manage Data Lake Analytics catalogs.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog database'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog databases.
+    short-summary: Manage Data Lake Analytics catalog databases.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog assembly'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog assemblies.
+    short-summary: Manage Data Lake Analytics catalog assemblies.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog external-data-source'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog external data sources.
+    short-summary: Manage Data Lake Analytics catalog external data sources.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog procedure'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog stored procedures.
+    short-summary: Manage Data Lake Analytics catalog stored procedures.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog schema'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog schemas.
+    short-summary: Manage Data Lake Analytics catalog schemas.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog table'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog tables.
+    short-summary: Manage Data Lake Analytics catalog tables.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog table list'] = """
     type: command
-    short-summary: Lists all tables in the database or in the database and schema combination
+    short-summary: List tables in the database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database to list tables for'
+          short-summary: 'The name of the database.'
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema in the database to list tables for.'
+          short-summary: 'The schema assocated with the tables to list.'
 """
 
 helps['dla catalog table-partition'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog table partitions.
+    short-summary: Manage Data Lake Analytics catalog table partitions.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog table-stats'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog table statistics.
+    short-summary: Manage Data Lake Analytics catalog table statistics.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog table-stats list'] = """
     type: command
-    short-summary: Lists all table statistics in the database or in the database and schema or in a specific table
+    short-summary: Lists table statistics in the database, a table, or a schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database to list table statitics for'
+          short-summary: 'The name of the database.'
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema in the database to list table statistics for.'
+          short-summary: 'The schema associated with the tables to list.'
         - name: --table-name
           type: string
-          short-summary: 'The name of the table to list statistics in. --schema-name must also be specified for this parameter to be honored'
+          short-summary: 'The table to list statistics for. --schema-name must also be specified.'
 """
 
 helps['dla catalog table-type'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog table types.
+    short-summary: Manage Data Lake Analytics catalog table types.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog tvf'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog table valued functions, or TVFs.
+    short-summary: Manage Data Lake Analytics catalog table valued functions.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog tvf list'] = """
     type: command
-    short-summary: Lists all table valued functions in the database or in the database and schema combination
+    short-summary: Lists table valued functions in a database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database to list table valued functions for'
+          short-summary: 'The name of the database.'
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema in the database to list table valued functions for.'
+          short-summary: 'The name of the schema assocated with table valued functions to list.'
 """
 
 helps['dla catalog view'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog views.
+    short-summary: Manage Data Lake Analytics catalog views.
     long-summary: These commands are in preview.
 """
 
 helps['dla catalog view list'] = """
     type: command
-    short-summary: Lists all views in the database or in the database and schema combination
+    short-summary: Lists views in a database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database to list views for'
+          short-summary: 'The name of the database.'
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema in the database to list views for.'
+          short-summary: 'The name of the schema associated with the views to list.'
 """
 
 helps['dla catalog credential'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog credentials.
+    short-summary: Manage Data Lake Analytics catalog credentials.
     long-summary: These commands are in preview.
 """
 
@@ -206,12 +207,12 @@ helps['dla catalog credential create'] = """
           short-summary: 'The name of the database in which to create the credential.'
         - name: --user-name
           type: string
-          short-summary: 'The user name that will be used when authenticating with this credential'
+          short-summary: 'The user name that will be used when authenticating with this credential.'
 """
 
 helps['dla catalog credential update'] = """
     type: command
-    short-summary: Updates the catalog credential for use with an external data source.
+    short-summary: Updates a catalog credential for use with an external data source.
     parameters:
         - name: --credential-name
           type: string
@@ -221,33 +222,33 @@ helps['dla catalog credential update'] = """
           short-summary: 'The name of the database in which the credential exists.'
         - name: --user-name
           type: string
-          short-summary: "The user name associated with the credential that will have it's password updated."
+          short-summary: "The user name associated with the credential that will have its password updated."
 """
 
 helps['dla catalog credential show'] = """
     type: command
-    short-summary: Retrieves the catalog credential.
+    short-summary: Retrieves a catalog credential.
 """
 
 helps['dla catalog credential list'] = """
     type: command
-    short-summary: Lists the catalog credentials.
+    short-summary: Lists catalog credentials.
 """
 
 helps['dla catalog credential delete'] = """
     type: command
-    short-summary: deletes the catalog credential.
+    short-summary: Deletes a catalog credential.
 """
 
 helps['dla catalog package'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics catalog packages.
+    short-summary: Manage Data Lake Analytics catalog packages.
     long-summary: These commands are in preview.
 """
 
 helps['dla account'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics accounts.
+    short-summary: Manage Data Lake Analytics accounts.
     long-summary: These commands are in preview.
 """
 
@@ -257,16 +258,16 @@ helps['dla account create'] = """
     parameters:
         - name: --default-data-lake-store
           type: string
-          short-summary: 'The default Data Lake Store account to associate with the Data Lake Analytics account being created'
+          short-summary: 'The default Data Lake Store account to associate with the created account.'
         - name: --max-degree-of-parallelism
           type: int
-          short-summary: 'The maximum supported degree of parallelism for this account.'
+          short-summary: 'The maximum degree of parallelism for this account.'
         - name: --max-job-count
           type: int
-          short-summary: 'The maximum supported jobs running under the account at the same time.'
+          short-summary: 'The maximum number of concurrent jobs for this account.'
         - name: --query-store-retention
           type: int
-          short-summary: 'The number of days that job metadata is retained.'
+          short-summary: 'The number of days to retain job metadata.'
 """
 
 helps['dla account update'] = """
@@ -275,57 +276,57 @@ helps['dla account update'] = """
     parameters:
         - name: --max-degree-of-parallelism
           type: int
-          short-summary: 'The maximum supported degree of parallelism for this account.'
+          short-summary: 'The maximum degree of parallelism for this account.'
         - name: --max-job-count
           type: int
-          short-summary: 'The maximum supported jobs running under the account at the same time.'
+          short-summary: 'The maximum number of concurrent jobs for this account.'
         - name: --query-store-retention
           type: int
-          short-summary: 'Optionally enable/disable existing firewall rules.'
+          short-summary: 'The number of days to retain job metadata.'
         - name: --firewall-state
           type: string
-          short-summary: 'The number of days that job metadata is retained.'
+          short-summary: 'Enable or disable existing firewall rules.'
         - name: --allow-azure-ips
           type: string
-          short-summary: 'Optionally allow/block Azure originating IPs through the firewall.'
+          short-summary: 'Allow or block Azure originating IPs through the firewall.'
 """
 
 helps['dla account show'] = """
     type: command
-    short-summary: Retrieves the Data Lake Analytics account.
+    short-summary: Retrieves a Data Lake Analytics account.
 """
 
 helps['dla account list'] = """
     type: command
-    short-summary: Lists Data Lake Analytics accounts in a subscription or a specific resource group.
+    short-summary: Lists Data Lake Analytics accounts in a subscription or a resource group.
 """
 
 helps['dla account delete'] = """
     type: command
-    short-summary: Deletes the Data Lake Analytics account.
+    short-summary: Deletes a Data Lake Analytics account.
 """
 
 helps['dla account blob-storage'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics account linked Azure Storage.
+    short-summary: Manage Data Lake Analytics account linked Azure Storage.
     long-summary: These commands are in preview.
 """
 
 helps['dla account data-lake-store'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics account linked Data Lake Store accounts.
+    short-summary: Manage Data Lake Analytics account linked Data Lake Store accounts.
     long-summary: These commands are in preview.
 """
 
 helps['dla account firewall'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics account firewall rules.
+    short-summary: Manage Data Lake Analytics account firewall rules.
     long-summary: These commands are in preview.
 """
 
 helps['dla account firewall create'] = """
     type: command
-    short-summary: Creates a firewall rule in the Data Lake Analytics account.
+    short-summary: Creates a firewall rule in a Data Lake Analytics account.
     parameters:
         - name: --end-ip-address
           type: string
@@ -340,27 +341,27 @@ helps['dla account firewall create'] = """
 
 helps['dla account firewall update'] = """
     type: command
-    short-summary: Updates a firewall rule in the Data Lake Analytics account.
+    short-summary: Updates a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account firewall show'] = """
     type: command
-    short-summary: Retrieves a firewall rule in the Data Lake Analytics account.
+    short-summary: Retrieves a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account firewall list'] = """
     type: command
-    short-summary: Lists firewall rules in the Data Lake Analytics account.
+    short-summary: Lists firewall rules in a Data Lake Analytics account.
 """
 
 helps['dla account firewall delete'] = """
     type: command
-    short-summary: Deletes a firewall rule in the Data Lake Analytics account.
+    short-summary: Deletes a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account compute-policy'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics account compute policies.
+    short-summary: Manage Data Lake Analytics account compute policies.
     long-summary: These commands are in preview.
 """
 
@@ -402,47 +403,47 @@ helps['dla account compute-policy update'] = """
 
 helps['dla account compute-policy show'] = """
     type: command
-    short-summary: Retrieves a compute policy in the Data Lake Analytics account.
+    short-summary: Retrieves a compute policy in a Data Lake Analytics account.
 """
 
 helps['dla account compute-policy list'] = """
     type: command
-    short-summary: Lists compute policies in the Data Lake Analytics account.
+    short-summary: Lists compute policies in the a Lake Analytics account.
 """
 
 helps['dla account compute-policy delete'] = """
     type: command
-    short-summary: Deletes a compute policy in the Data Lake Analytics account.
+    short-summary: Deletes a compute policy in a Data Lake Analytics account.
 """
 
 helps['dla job pipeline'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics job pipelines.
+    short-summary: Manage Data Lake Analytics job pipelines.
     long-summary: These commands are in preview.
 """
 
 helps['dla job pipeline show'] = """
     type: command
-    short-summary: Retrieves a specific job pipeline in the Data Lake Analytics account.
+    short-summary: Retrieves a job pipeline in a Data Lake Analytics account.
 """
 
 helps['dla job pipeline list'] = """
     type: command
-    short-summary: Lists job pipelines in the Data Lake Analytics account.
+    short-summary: Lists job pipelines in a Data Lake Analytics account.
 """
 
 helps['dla job recurrence'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics job recurrences.
+    short-summary: Manage Data Lake Analytics job recurrences.
     long-summary: These commands are in preview.
 """
 
 helps['dla job recurrence show'] = """
     type: command
-    short-summary: Retrieves a specific job recurrence in the Data Lake Analytics account.
+    short-summary: Retrieves a job recurrence in a Data Lake Analytics account.
 """
 
 helps['dla job recurrence list'] = """
     type: command
-    short-summary: Lists job recurrences in the Data Lake Analytics account.
+    short-summary: Lists job recurrences in a Data Lake Analytics account.
 """

--- a/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
+++ b/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/_help.py
@@ -14,46 +14,45 @@ helps['dla'] = """
 
 helps['dla job'] = """
     type: group
-    short-summary: Commands to manage Data Lake Analytics jobs.
+    short-summary: Manage Data Lake Analytics jobs.
     long-summary: These commands are in preview.
 """
 
 helps['dla job submit'] = """
     type: command
-    short-summary: Submits a job to a Data Lake Analytics account.
+    short-summary: Submit a job to a Data Lake Analytics account.
     parameters:
         - name: --job-name
           type: string
-          short-summary: 'Name for the submitted job.'
+          short-summary: Name for the submitted job.
         - name: --script
           type: string
-          short-summary: 'Script to submit.'
-          long-summary: This is either an inline script, or `@<file path>` to load from a file.
+          short-summary: Script to submit. This may be an @{file} to load from a file.
         - name: --runtime-version
-          short-summary: 'The runtime version to use.'
+          short-summary: The runtime version to use.
           long-summary: This parameter is used for explicitly overwriting the default runtime. It should only be done if you know what you are doing.
         - name: --degree-of-parallelism
-          short-summary: 'The degree of parallelism for the job.'
+          short-summary: The degree of parallelism for the job.
           long-summary: Higher values equate to more parallelism and will usually yield faster running jobs, at the cost of more AUs.
         - name: --priority
-          short-summary: 'The priority of the job.'
+          short-summary: The priority of the job.
           long-summary: Lower values increase the priority, with the lowest value being 1. This determines the order jobs are run in.
 
 """
 
 helps['dla job cancel'] = """
     type: command
-    short-summary: Cancels a Data Lake Analytics job.
+    short-summary: Cancel a Data Lake Analytics job.
 """
 
 helps['dla job show'] = """
     type: command
-    short-summary: Shows information for a Data Lake Analytics job.
+    short-summary: Get information for a Data Lake Analytics job.
 """
 
 helps['dla job wait'] = """
     type: command
-    short-summary: Waits for a Data Lake Analytics job to finish.
+    short-summary: Wait for a Data Lake Analytics job to finish.
     long-summary: This command exits when the job completes.
     parameters:
         - name: --job-id
@@ -63,7 +62,7 @@ helps['dla job wait'] = """
 
 helps['dla job list'] = """
     type: command
-    short-summary: Lists Data Lake Analytics jobs.
+    short-summary: List Data Lake Analytics jobs.
 """
 
 helps['dla catalog'] = """
@@ -110,14 +109,14 @@ helps['dla catalog table'] = """
 
 helps['dla catalog table list'] = """
     type: command
-    short-summary: List tables in the database or schema.
+    short-summary: List tables in a database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database.'
+          short-summary: The name of the database.
         - name: --schema-name
           type: string
-          short-summary: 'The schema assocated with the tables to list.'
+          short-summary: The schema assocated with the tables to list.
 """
 
 helps['dla catalog table-partition'] = """
@@ -134,17 +133,17 @@ helps['dla catalog table-stats'] = """
 
 helps['dla catalog table-stats list'] = """
     type: command
-    short-summary: Lists table statistics in the database, a table, or a schema.
+    short-summary: List table statistics in a database, table, or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database.'
+          short-summary: The name of the database.
         - name: --schema-name
           type: string
-          short-summary: 'The schema associated with the tables to list.'
+          short-summary: The schema associated with the tables to list.
         - name: --table-name
           type: string
-          short-summary: 'The table to list statistics for. --schema-name must also be specified.'
+          short-summary: The table to list statistics for. `--schema-name` must also be specified.
 """
 
 helps['dla catalog table-type'] = """
@@ -161,14 +160,14 @@ helps['dla catalog tvf'] = """
 
 helps['dla catalog tvf list'] = """
     type: command
-    short-summary: Lists table valued functions in a database or schema.
+    short-summary: List table valued functions in a database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database.'
+          short-summary: The name of the database.
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema assocated with table valued functions to list.'
+          short-summary: The name of the schema assocated with table valued functions to list.
 """
 
 helps['dla catalog view'] = """
@@ -179,14 +178,14 @@ helps['dla catalog view'] = """
 
 helps['dla catalog view list'] = """
     type: command
-    short-summary: Lists views in a database or schema.
+    short-summary: List views in a database or schema.
     parameters:
         - name: --database-name
           type: string
-          short-summary: 'The name of the database.'
+          short-summary: The name of the database.
         - name: --schema-name
           type: string
-          short-summary: 'The name of the schema associated with the views to list.'
+          short-summary: The name of the schema associated with the views to list.
 """
 
 helps['dla catalog credential'] = """
@@ -197,47 +196,47 @@ helps['dla catalog credential'] = """
 
 helps['dla catalog credential create'] = """
     type: command
-    short-summary: Creates a new catalog credential for use with an external data source.
+    short-summary: Create a new catalog credential for use with an external data source.
     parameters:
         - name: --credential-name
           type: string
-          short-summary: 'The name of the credential.'
+          short-summary: The name of the credential.
         - name: --database-name
           type: string
-          short-summary: 'The name of the database in which to create the credential.'
+          short-summary: The name of the database in which to create the credential.
         - name: --user-name
           type: string
-          short-summary: 'The user name that will be used when authenticating with this credential.'
+          short-summary: The user name that will be used when authenticating with this credential.
 """
 
 helps['dla catalog credential update'] = """
     type: command
-    short-summary: Updates a catalog credential for use with an external data source.
+    short-summary: Update a catalog credential for use with an external data source.
     parameters:
         - name: --credential-name
           type: string
-          short-summary: 'The name of the credential to update.'
+          short-summary: The name of the credential to update.
         - name: --database-name
           type: string
-          short-summary: 'The name of the database in which the credential exists.'
+          short-summary: The name of the database in which the credential exists.
         - name: --user-name
           type: string
-          short-summary: "The user name associated with the credential that will have its password updated."
+          short-summary: The user name associated with the credential that will have its password updated.
 """
 
 helps['dla catalog credential show'] = """
     type: command
-    short-summary: Retrieves a catalog credential.
+    short-summary: Retrieve a catalog credential.
 """
 
 helps['dla catalog credential list'] = """
     type: command
-    short-summary: Lists catalog credentials.
+    short-summary: List catalog credentials.
 """
 
 helps['dla catalog credential delete'] = """
     type: command
-    short-summary: Deletes a catalog credential.
+    short-summary: Delete a catalog credential.
 """
 
 helps['dla catalog package'] = """
@@ -254,67 +253,67 @@ helps['dla account'] = """
 
 helps['dla account create'] = """
     type: command
-    short-summary: Creates a Data Lake Analytics account.
+    short-summary: Create a Data Lake Analytics account.
     parameters:
         - name: --default-data-lake-store
           type: string
-          short-summary: 'The default Data Lake Store account to associate with the created account.'
+          short-summary: The default Data Lake Store account to associate with the created account.
         - name: --max-degree-of-parallelism
           type: int
-          short-summary: 'The maximum degree of parallelism for this account.'
+          short-summary: The maximum degree of parallelism for this account.
         - name: --max-job-count
           type: int
-          short-summary: 'The maximum number of concurrent jobs for this account.'
+          short-summary: The maximum number of concurrent jobs for this account.
         - name: --query-store-retention
           type: int
-          short-summary: 'The number of days to retain job metadata.'
+          short-summary: The number of days to retain job metadata.
 """
 
 helps['dla account update'] = """
     type: command
-    short-summary: Updates a Data Lake Analytics account.
+    short-summary: Update a Data Lake Analytics account.
     parameters:
         - name: --max-degree-of-parallelism
           type: int
-          short-summary: 'The maximum degree of parallelism for this account.'
+          short-summary: The maximum degree of parallelism for this account.
         - name: --max-job-count
           type: int
-          short-summary: 'The maximum number of concurrent jobs for this account.'
+          short-summary: The maximum number of concurrent jobs for this account.
         - name: --query-store-retention
           type: int
-          short-summary: 'The number of days to retain job metadata.'
+          short-summary: The number of days to retain job metadata.
         - name: --firewall-state
           type: string
-          short-summary: 'Enable or disable existing firewall rules.'
+          short-summary: Enable or disable existing firewall rules.
         - name: --allow-azure-ips
           type: string
-          short-summary: 'Allow or block Azure originating IPs through the firewall.'
+          short-summary: Allow or block IPs originating from Azure through the firewall.
 """
 
 helps['dla account show'] = """
     type: command
-    short-summary: Retrieves a Data Lake Analytics account.
+    short-summary: Get the details of a Data Lake Analytics account.
 """
 
 helps['dla account list'] = """
     type: command
-    short-summary: Lists Data Lake Analytics accounts in a subscription or a resource group.
+    short-summary: List available Data Lake Analytics accounts.
 """
 
 helps['dla account delete'] = """
     type: command
-    short-summary: Deletes a Data Lake Analytics account.
+    short-summary: Delete a Data Lake Analytics account.
 """
 
 helps['dla account blob-storage'] = """
     type: group
-    short-summary: Manage Data Lake Analytics account linked Azure Storage.
+    short-summary: Manage links between Data Lake Analytics accounts and Azure Storage.
     long-summary: These commands are in preview.
 """
 
 helps['dla account data-lake-store'] = """
     type: group
-    short-summary: Manage Data Lake Analytics account linked Data Lake Store accounts.
+    short-summary: Manage links between Data Lake Analytics and Data Lake Store accounts.
     long-summary: These commands are in preview.
 """
 
@@ -326,37 +325,37 @@ helps['dla account firewall'] = """
 
 helps['dla account firewall create'] = """
     type: command
-    short-summary: Creates a firewall rule in a Data Lake Analytics account.
+    short-summary: Create a firewall rule in a Data Lake Analytics account.
     parameters:
         - name: --end-ip-address
           type: string
-          short-summary: 'The end of the valid IP range for the firewall rule.'
+          short-summary: The end of the valid IP range for the firewall rule.
         - name: --start-ip-address
           type: string
-          short-summary: 'The start of the valid IP range for the firewall rule.'
+          short-summary: The start of the valid IP range for the firewall rule.
         - name: --firewall-rule-name
           type: string
-          short-summary: 'The name of the firewall rule.'
+          short-summary: The name of the firewall rule.
 """
 
 helps['dla account firewall update'] = """
     type: command
-    short-summary: Updates a firewall rule in a Data Lake Analytics account.
+    short-summary: Update a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account firewall show'] = """
     type: command
-    short-summary: Retrieves a firewall rule in a Data Lake Analytics account.
+    short-summary: Retrieve a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account firewall list'] = """
     type: command
-    short-summary: Lists firewall rules in a Data Lake Analytics account.
+    short-summary: List firewall rules in a Data Lake Analytics account.
 """
 
 helps['dla account firewall delete'] = """
     type: command
-    short-summary: Deletes a firewall rule in a Data Lake Analytics account.
+    short-summary: Delete a firewall rule in a Data Lake Analytics account.
 """
 
 helps['dla account compute-policy'] = """
@@ -367,53 +366,53 @@ helps['dla account compute-policy'] = """
 
 helps['dla account compute-policy create'] = """
     type: command
-    short-summary: Creates a compute policy in the Data Lake Analytics account.
+    short-summary: Create a compute policy in the Data Lake Analytics account.
     parameters:
         - name: --max-dop-per-job
           type: int
-          short-summary: 'The maximum degree of parallelism allowed per job for this policy. At least one of --min-priority-per-job and --max-dop-per-job must be specified.'
+          short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
         - name: --min-priority-per-job
           type: int
-          short-summary: 'The minimum priority allowed per job for this policy. At least one of --min-priority-per-job and --max-dop-per-job must be specified.'
+          short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
         - name: --compute-policy-name
           type: string
-          short-summary: 'The name of the compute policy to create.'
+          short-summary: The name of the compute policy to create.
         - name: --object-id
           type: string
-          short-summary: 'The Azure Active Directory object ID of the user, group or service principal to apply the policy to.'
+          short-summary: The Azure Active Directory object ID of the user, group, or service principal to apply the policy to.
         - name: --object-type
           type: string
-          short-summary: 'The Azure Active Directory object type associated with the supplied object id.'
+          short-summary: The Azure Active Directory object type associated with the supplied object ID.
 """
 
 helps['dla account compute-policy update'] = """
     type: command
-    short-summary: Updates a compute policy in the Data Lake Analytics account.
+    short-summary: Update a compute policy in the Data Lake Analytics account.
     parameters:
         - name: --max-dop-per-job
           type: int
-          short-summary: 'The maximum degree of parallelism allowed per job for this policy. At least one of --min-priority-per-job and --max-dop-per-job must be specified.'
+          short-summary: The maximum degree of parallelism allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
         - name: --min-priority-per-job
           type: int
-          short-summary: 'The minimum priority allowed per job for this policy. At least one of --min-priority-per-job and --max-dop-per-job must be specified.'
+          short-summary: The minimum priority allowed per job for this policy. At least one of `--min-priority-per-job` and `--max-dop-per-job` must be specified.
         - name: --compute-policy-name
           type: string
-          short-summary: 'The name of the compute policy to update.'
+          short-summary: The name of the compute policy to update.
 """
 
 helps['dla account compute-policy show'] = """
     type: command
-    short-summary: Retrieves a compute policy in a Data Lake Analytics account.
+    short-summary: Retrieve a compute policy in a Data Lake Analytics account.
 """
 
 helps['dla account compute-policy list'] = """
     type: command
-    short-summary: Lists compute policies in the a Lake Analytics account.
+    short-summary: List compute policies in the a Lake Analytics account.
 """
 
 helps['dla account compute-policy delete'] = """
     type: command
-    short-summary: Deletes a compute policy in a Data Lake Analytics account.
+    short-summary: Delete a compute policy in a Data Lake Analytics account.
 """
 
 helps['dla job pipeline'] = """
@@ -424,12 +423,12 @@ helps['dla job pipeline'] = """
 
 helps['dla job pipeline show'] = """
     type: command
-    short-summary: Retrieves a job pipeline in a Data Lake Analytics account.
+    short-summary: Retrieve a job pipeline in a Data Lake Analytics account.
 """
 
 helps['dla job pipeline list'] = """
     type: command
-    short-summary: Lists job pipelines in a Data Lake Analytics account.
+    short-summary: List job pipelines in a Data Lake Analytics account.
 """
 
 helps['dla job recurrence'] = """
@@ -440,10 +439,10 @@ helps['dla job recurrence'] = """
 
 helps['dla job recurrence show'] = """
     type: command
-    short-summary: Retrieves a job recurrence in a Data Lake Analytics account.
+    short-summary: Retrieve a job recurrence in a Data Lake Analytics account.
 """
 
 helps['dla job recurrence list'] = """
     type: command
-    short-summary: Lists job recurrences in a Data Lake Analytics account.
+    short-summary: List job recurrences in a Data Lake Analytics account.
 """

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -8,14 +8,12 @@ from azure.cli.core.help_files import helps
 
 helps['dls'] = """
     type: group
-    short-summary: Manage Data Lake Store accounts and filesystems.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Store accounts and filesystems.
 """
 
 helps['dls account'] = """
     type: group
-    short-summary: Manage Data Lake Store accounts.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Store accounts.
 """
 
 helps['dls account create'] = """
@@ -63,14 +61,12 @@ helps['dls account delete'] = """
 
 helps['dls account trusted-provider'] = """
     type: group
-    short-summary: Manage Data Lake Store account trusted identity providers.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Store account trusted identity providers.
 """
 
 helps['dls account firewall'] = """
     type: group
-    short-summary: Manage Data Lake Store account firewall rules.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Data Lake Store account firewall rules.
 """
 
 helps['dls account firewall create'] = """
@@ -110,8 +106,7 @@ helps['dls account firewall delete'] = """
 
 helps['dls fs'] = """
     type: group
-    short-summary: Manage a Data Lake Store filesystem.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage a Data Lake Store filesystem.
 """
 
 helps['dls fs create'] = """
@@ -159,7 +154,7 @@ helps['dls fs upload'] = """
           short-summary: The full path in the Data Lake Store filesystem to upload the file or folder to.
         - name: --thread-count
           type: int
-          short-summary: Parallelism of the upload. Default: The number of cores in the local machine.
+          short-summary: 'Parallelism of the upload. Default: The number of cores in the local machine.'
         - name: --chunk-size
           type: int
           short-summary: Size of a chunk, in bytes.
@@ -187,7 +182,7 @@ helps['dls fs download'] = """
           short-summary: The local path where the file or folder will be downloaded to.
         - name: --thread-count
           type: int
-          short-summary: Parallelism of the download. Default: The number of cores in the local machine.
+          short-summary: 'Parallelism of the download. Default: The number of cores in the local machine.'
         - name: --chunk-size
           type: int
           short-summary: Size of a chunk, in bytes.

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -43,22 +43,22 @@ helps['dls account update'] = """
 
 helps['dls account show'] = """
     type: command
-    short-summary: Retrieves a Data Lake Store account.
+    short-summary: Get the details of a Data Lake Store account.
 """
 
 helps['dls account list'] = """
     type: command
-    short-summary: Lists Data Lake Store accounts in a subscription or resource group.
+    short-summary: Lists available Data Lake Store accounts.
 """
 
 helps['dls account enable-key-vault'] = """
     type: command
-    short-summary: Attempts to enable a user-managed Key Vault for encryption of a Data Lake Store account.
+    short-summary: Enable the use of Azure Key Vault for encryption of a Data Lake Store account.
 """
 
 helps['dls account delete'] = """
     type: command
-    short-summary: Deletes a Data Lake Store account.
+    short-summary: Delete a Data Lake Store account.
 """
 
 helps['dls account trusted-provider'] = """
@@ -95,7 +95,7 @@ helps['dls account firewall update'] = """
 
 helps['dls account firewall show'] = """
     type: command
-    short-summary: Retrieves a firewall rule in a Data Lake Store account.
+    short-summary: Get the details of a firewall rule in a Data Lake Store account.
 """
 
 helps['dls account firewall list'] = """
@@ -125,17 +125,17 @@ helps['dls fs create'] = """
 
 helps['dls fs show'] = """
     type: command
-    short-summary: Displays file or folder information in a Data Lake Store account.
+    short-summary: Get file or folder information in a Data Lake Store account.
 """
 
 helps['dls fs list'] = """
     type: command
-    short-summary: Displays the list of files and folders in a Data Lake Store account.
+    short-summary: List the files and folders in a Data Lake Store account.
 """
 
 helps['dls fs append'] = """
     type: command
-    short-summary: Appends content to a file in a Data Lake Store account.
+    short-summary: Append content to a file in a Data Lake Store account.
     parameters:
         - name: --content
           type: string
@@ -144,114 +144,114 @@ helps['dls fs append'] = """
 
 helps['dls fs delete'] = """
     type: command
-    short-summary: Deletes a file or folder in a Data Lake Store account.
+    short-summary: Delete a file or folder in a Data Lake Store account.
 """
 
 helps['dls fs upload'] = """
     type: command
-    short-summary: Uploads a file or folder to a Data Lake Store account.
+    short-summary: Upload a file or folder to a Data Lake Store account.
     parameters:
         - name: --source-path
           type: string
-          short-summary: 'The path to the file or folder to upload.'
+          short-summary: The path to the file or folder to upload.
         - name: --destination-path
           type: string
-          short-summary: 'The full path in the Data Lake Store filesystem to upload the file or folder to, in the format /path/file.txt'
+          short-summary: The full path in the Data Lake Store filesystem to upload the file or folder to.
         - name: --thread-count
           type: int
-          short-summary: 'Parallelism of the upload. The default is the number of cores in the local machine.'
+          short-summary: Parallelism of the upload. Default: The number of cores in the local machine.
         - name: --chunk-size
           type: int
-          short-summary: 'Number of bytes for a chunk.'
-          long-summary: 'Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.'
+          short-summary: Size of a chunk, in bytes.
+          long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
         - name: --buffer-size
           type: int
-          short-summary: 'Number of bytes for internal buffer.'
-          long-summary: 'A buffer cannot be bigger than a chunk and cannot be smaller than a block.'
+          short-summary: Size of the transfer buffer, in bytes.
+          long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
         - name: --block-size
           type: int
-          short-summary: 'Number of bytes for a block.'
-          long-summary: 'Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.'
+          short-summary: Size of a block, in bytes.
+          long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
 
 """
 
 helps['dls fs download'] = """
     type: command
-    short-summary: Downloads a file or folder from a Data Lake Store account to the local machine.
+    short-summary: Download a file or folder from a Data Lake Store account to the local machine.
     parameters:
         - name: --source-path
           type: string
-          short-summary: 'The full path in the Data Lake Store filesystem to download the file or folder from, in the format /path/file.txt'
+          short-summary: The full path in the Data Lake Store filesystem to download the file or folder from.
         - name: --destination-path
           type: string
-          short-summary: 'The local path where the file or folder will be downloaded to.'
+          short-summary: The local path where the file or folder will be downloaded to.
         - name: --thread-count
           type: int
-          short-summary: 'Parallelism of the download. The default is the number of cores in the local machine.'
+          short-summary: Parallelism of the download. Default: The number of cores in the local machine.
         - name: --chunk-size
           type: int
-          short-summary: 'Number of bytes for a chunk.'
-          long-summary: 'Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.'
+          short-summary: Size of a chunk, in bytes.
+          long-summary: Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.
         - name: --buffer-size
           type: int
-          short-summary: 'Number of bytes for internal buffer.'
-          long-summary: 'A buffer cannot be bigger than a chunk and cannot be smaller than a block.'
+          short-summary: Size of the transfer buffer, in bytes.
+          long-summary: A buffer cannot be bigger than a chunk and cannot be smaller than a block.
         - name: --block-size
           type: int
-          short-summary: 'Number of bytes for a block.'
-          long-summary: 'Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.'
-
+          short-summary: Size of a block, in bytes.
+          long-summary: Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.
 """
 
 helps['dls fs test'] = """
     type: command
-    short-summary: Tests for the existence of a file or folder in a Data Lake Store account.
+    short-summary: Test for the existence of a file or folder in a Data Lake Store account.
 """
 
 helps['dls fs preview'] = """
     type: command
-    short-summary: Previews the content of a file in a Data Lake Store account.
+    short-summary: Preview the content of a file in a Data Lake Store account.
     parameters:
         - name: --length
           type: long
-          short-summary: 'The amount of data to preview in bytes as a long. If not specified, will attempt to preview the full file. If the file is > 1MB --force must be specified.'
+          short-summary: The amount of data to preview in bytes.
+          long-summary: If not specified, attempts to preview the full file. If the file is > 1MB `--force` must be specified.
         - name: --offset
           type: long
-          short-summary: 'The position in bytes in the file to start the preview from.'
+          short-summary: The position in bytes to start the preview from.
 """
 
 helps['dls fs join'] = """
     type: command
-    short-summary: Joins a list of files in a Data Lake Store account into one file.
+    short-summary: Join files in a Data Lake Store account into one file.
     parameters:
         - name: --source-paths
           type: list
-          short-summary: 'The list of files in the Data Lake Store account to join.'
+          short-summary: The space-separated list of files in the Data Lake Store account to join.
         - name: --destination-path
           type: string
-          short-summary: 'The destination path in the Data Lake Store account where the result should be placed.'
+          short-summary: The destination path in the Data Lake Store account.
 """
 
 helps['dls fs move'] = """
     type: command
-    short-summary: Moves a file or folder in a Data Lake Store account.
+    short-summary: Move a file or folder in a Data Lake Store account.
     parameters:
         - name: --source-path
           type: list
-          short-summary: 'The file or folder to move.'
+          short-summary: The file or folder to move.
         - name: --destination-path
           type: string
-          short-summary: 'The destination path in the Data Lake Store account.'
+          short-summary: The destination path in the Data Lake Store account.
 """
 
 helps['dls fs set-expiry'] = """
     type: command
-    short-summary: Sets the absolute expiration time for a file.
+    short-summary: Set the expiration time for a file.
 """
 
 helps['dls fs remove-expiry'] = """
     type: command
-    short-summary: Removes the expiration time for a file.
+    short-summary: Remove the expiration time for a file.
 """
 
 helps['dls fs access'] = """
@@ -261,28 +261,28 @@ helps['dls fs access'] = """
 
 helps['dls fs access show'] = """
     type: command
-    short-summary: Displays the access control list (ACL).
+    short-summary: Display the access control list (ACL).
 """
 
 helps['dls fs access set-owner'] = """
     type: command
-    short-summary: Sets the owner information for a file or folder in a Data Lake Store account.
+    short-summary: Set the owner information for a file or folder in a Data Lake Store account.
     parameters:
         - name: --owner
           type: string
-          short-summary: 'The user Azure Active Directory object ID or user principal name to set as the owner.'
+          short-summary: The user Azure Active Directory object ID or user principal name to set as the owner.
         - name: --group
           type: string
-          short-summary: 'The group Azure Active Directory object ID or user principal name to set as the owning group.'
+          short-summary: The group Azure Active Directory object ID or user principal name to set as the owning group.
 """
 
 helps['dls fs access set-permission'] = """
     type: command
-    short-summary: Sets the permissions for a file or folder in a Data Lake Store account.
+    short-summary: Set the permissions for a file or folder in a Data Lake Store account.
     parameters:
         - name: --permission
           type: int
-          short-summary: 'The octal representation of the permissions for user, group and mask.'
+          short-summary: The octal representation of the permissions for user, group and mask.
     example:
         - name: Set full permissions for a user, read-execute permissions for a group, and execute permissions for all.
           text: az fs access set-permission --path /path/to/file.txt --permission 751
@@ -290,20 +290,20 @@ helps['dls fs access set-permission'] = """
 
 helps['dls fs access set-entry'] = """
     type: command
-    short-summary: Updates the access control list for a file or folder.
+    short-summary: Update the access control list for a file or folder.
 """
 
 helps['dls fs access set'] = """
     type: command
-    short-summary: Replaces the existing access control list for a file or folder.
+    short-summary: Replace the existing access control list for a file or folder.
 """
 
 helps['dls fs access remove-entry'] = """
     type: command
-    short-summary: Removes entries for an existing access control list of a file or folder.
+    short-summary: Remove entries for the access control list of a file or folder.
 """
 
 helps['dls fs access remove-all'] = """
     type: command
-    short-summary: Completely removes the access control list for a file or folder.
+    short-summary: Remove the access control list for a file or folder.
 """

--- a/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
+++ b/src/command_modules/azure-cli-dls/azure/cli/command_modules/dls/_help.py
@@ -8,13 +8,13 @@ from azure.cli.core.help_files import helps
 
 helps['dls'] = """
     type: group
-    short-summary: Commands to manage Data Lake Store accounts, and filesystems.
-    long-summary: If you don't have the Data Lake Store component installed, add it with `az component update --add dls`. These commands are in preview.
+    short-summary: Manage Data Lake Store accounts and filesystems.
+    long-summary: These commands are in preview.
 """
 
 helps['dls account'] = """
     type: group
-    short-summary: Commands to manage Data Lake Store accounts.
+    short-summary: Manage Data Lake Store accounts.
     long-summary: These commands are in preview.
 """
 
@@ -27,13 +27,13 @@ helps['dls account create'] = """
           short-summary: 'Name of the default group to give permissions to for freshly created files and folders in the Data Lake Store account.'
         - name: --key-vault-id
           type: string
-          short-summary: 'If the encryption type is User assigned, this is the key vault the user wishes to use.'
+          short-summary: 'Key vault for the user-assigned encryption type.'
         - name: --key-name
           type: string
-          short-summary: 'If the encryption type is User assigned, this is the key name in the key vault the user wishes to use.'
+          short-summary: 'Key name for the user-assigned encryption type.'
         - name: --key-version
           type: string
-          short-summary: 'If the encryption type is User assigned, this is the key version of the key the user wishes to use.'
+          short-summary: 'Key version for the user-assigned encryption type.'
 """
 
 helps['dls account update'] = """
@@ -43,39 +43,39 @@ helps['dls account update'] = """
 
 helps['dls account show'] = """
     type: command
-    short-summary: Retrieves the Data Lake Store account.
+    short-summary: Retrieves a Data Lake Store account.
 """
 
 helps['dls account list'] = """
     type: command
-    short-summary: Lists Data Lake Store accounts in a subscription or a specific resource group.
+    short-summary: Lists Data Lake Store accounts in a subscription or resource group.
 """
 
 helps['dls account enable-key-vault'] = """
     type: command
-    short-summary: Attempts to enable a user managed Key Vault for encryption of the specified Data Lake Store account.
+    short-summary: Attempts to enable a user-managed Key Vault for encryption of a Data Lake Store account.
 """
 
 helps['dls account delete'] = """
     type: command
-    short-summary: Deletes the Data Lake Store account.
+    short-summary: Deletes a Data Lake Store account.
 """
 
 helps['dls account trusted-provider'] = """
     type: group
-    short-summary: Commands to manage Data Lake Store account trusted identity providers.
+    short-summary: Manage Data Lake Store account trusted identity providers.
     long-summary: These commands are in preview.
 """
 
 helps['dls account firewall'] = """
     type: group
-    short-summary: Commands to manage Data Lake Store account firewall rules.
+    short-summary: Manage Data Lake Store account firewall rules.
     long-summary: These commands are in preview.
 """
 
 helps['dls account firewall create'] = """
     type: command
-    short-summary: Creates a firewall rule in the Data Lake Store account.
+    short-summary: Creates a firewall rule in a Data Lake Store account.
     parameters:
         - name: --end-ip-address
           type: string
@@ -90,52 +90,52 @@ helps['dls account firewall create'] = """
 
 helps['dls account firewall update'] = """
     type: command
-    short-summary: Updates a firewall rule in the Data Lake Store account.
+    short-summary: Updates a firewall rule in a Data Lake Store account.
 """
 
 helps['dls account firewall show'] = """
     type: command
-    short-summary: Retrieves a firewall rule in the Data Lake Store account.
+    short-summary: Retrieves a firewall rule in a Data Lake Store account.
 """
 
 helps['dls account firewall list'] = """
     type: command
-    short-summary: Lists firewall rules in the Data Lake Store account.
+    short-summary: Lists firewall rules in a Data Lake Store account.
 """
 
 helps['dls account firewall delete'] = """
     type: command
-    short-summary: Deletes a firewall rule in the Data Lake Store account.
+    short-summary: Deletes a firewall rule in a Data Lake Store account.
 """
 
 helps['dls fs'] = """
     type: group
-    short-summary: Commands to manage a Data Lake Store filesystem.
+    short-summary: Manage a Data Lake Store filesystem.
     long-summary: These commands are in preview.
 """
 
 helps['dls fs create'] = """
     type: command
-    short-summary: Creates a file or folder in the Data Lake Store account at the path.
+    short-summary: Creates a file or folder in a Data Lake Store account.
     parameters:
         - name: --content
           type: string
-          short-summary: 'Optional content for the file to contain upon creation.'
+          short-summary: 'Content for the file to contain upon creation.'
 """
 
 helps['dls fs show'] = """
     type: command
-    short-summary: displays file or folder information in the Data Lake Store account at the path.
+    short-summary: Displays file or folder information in a Data Lake Store account.
 """
 
 helps['dls fs list'] = """
     type: command
-    short-summary: displays the list of files and folder information under the folder in the Data Lake Store account.
+    short-summary: Displays the list of files and folders in a Data Lake Store account.
 """
 
 helps['dls fs append'] = """
     type: command
-    short-summary: Appends content to a file in the Data Lake Store account at the path.
+    short-summary: Appends content to a file in a Data Lake Store account.
     parameters:
         - name: --content
           type: string
@@ -144,157 +144,166 @@ helps['dls fs append'] = """
 
 helps['dls fs delete'] = """
     type: command
-    short-summary: Deletes the file or folder in the Data Lake Store account at the path.
+    short-summary: Deletes a file or folder in a Data Lake Store account.
 """
 
 helps['dls fs upload'] = """
     type: command
-    short-summary: Uploads a file or folder to the Data Lake Store account at the destination path.
+    short-summary: Uploads a file or folder to a Data Lake Store account.
     parameters:
         - name: --source-path
           type: string
-          short-summary: 'The full path to the file or folder to upload'
+          short-summary: 'The path to the file or folder to upload.'
         - name: --destination-path
           type: string
-          short-summary: 'The full path in the Data Lake Store filesystem to upload the file or folder to in the format /path/file.txt'
+          short-summary: 'The full path in the Data Lake Store filesystem to upload the file or folder to, in the format /path/file.txt'
         - name: --thread-count
           type: int
-          short-summary: 'Optionally specify the parallelism of the upload. Default is the number of cores in the local machine.'
+          short-summary: 'Parallelism of the upload. The default is the number of cores in the local machine.'
         - name: --chunk-size
           type: int
-          short-summary: 'Number of bytes for a chunk. Large files are split into chunks. Files smaller than this number will always be transferred in a single thread.'
+          short-summary: 'Number of bytes for a chunk.'
+          long-summary: 'Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.'
         - name: --buffer-size
           type: int
-          short-summary: 'Number of bytes for internal buffer. This block cannot be bigger than a chunk and cannot be smaller than a block.'
+          short-summary: 'Number of bytes for internal buffer.'
+          long-summary: 'A buffer cannot be bigger than a chunk and cannot be smaller than a block.'
         - name: --block-size
           type: int
-          short-summary: 'Number of bytes for a block. Within each chunk, we write a smaller block for each API call. This block cannot be bigger than a chunk.'
+          short-summary: 'Number of bytes for a block.'
+          long-summary: 'Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.'
 
 """
 
 helps['dls fs download'] = """
     type: command
-    short-summary: Downloads a file or folder from the Data Lake Store account to the local destination path.
+    short-summary: Downloads a file or folder from a Data Lake Store account to the local machine.
     parameters:
         - name: --source-path
           type: string
-          short-summary: 'The full path in the Data Lake Store filesystem to download the file or folder from in the format /path/file.txt'
+          short-summary: 'The full path in the Data Lake Store filesystem to download the file or folder from, in the format /path/file.txt'
         - name: --destination-path
           type: string
-          short-summary: 'The full local path where the file or folder will be downloaded to'
+          short-summary: 'The local path where the file or folder will be downloaded to.'
         - name: --thread-count
           type: int
-          short-summary: 'Optionally specify the parallelism of the download. Default is the number of cores in the local machine.'
+          short-summary: 'Parallelism of the download. The default is the number of cores in the local machine.'
         - name: --chunk-size
           type: int
-          short-summary: 'Number of bytes for a chunk. Large files are split into chunks. Files smaller than this number will always be transferred in a single thread.'
+          short-summary: 'Number of bytes for a chunk.'
+          long-summary: 'Large files are split into chunks. Files smaller than this size will always be transferred in a single thread.'
         - name: --buffer-size
           type: int
-          short-summary: 'Number of bytes for internal buffer. This block cannot be bigger than a chunk and cannot be smaller than a block.'
+          short-summary: 'Number of bytes for internal buffer.'
+          long-summary: 'A buffer cannot be bigger than a chunk and cannot be smaller than a block.'
         - name: --block-size
           type: int
-          short-summary: 'Number of bytes for a block. Within each chunk, we write a smaller block for each API call. This block cannot be bigger than a chunk.'
+          short-summary: 'Number of bytes for a block.'
+          long-summary: 'Within each chunk, a smaller block is written for each API call. A block cannot be bigger than a chunk and must be bigger than a buffer.'
 
 """
 
 helps['dls fs test'] = """
     type: command
-    short-summary: Tests the existence of the file or folder in the Data Lake Store account at the path.
+    short-summary: Tests for the existence of a file or folder in a Data Lake Store account.
 """
 
 helps['dls fs preview'] = """
     type: command
-    short-summary: Previews the content of the file in the Data Lake Store account at the path.
+    short-summary: Previews the content of a file in a Data Lake Store account.
     parameters:
         - name: --length
           type: long
-          short-summary: 'The optional amount of data to preview in bytes as a long. If not specified, will attempt to preview the full file. If the file is > 1MB --force must be specified'
+          short-summary: 'The amount of data to preview in bytes as a long. If not specified, will attempt to preview the full file. If the file is > 1MB --force must be specified.'
         - name: --offset
           type: long
-          short-summary: 'The optional position in bytes as a long in the file to start the preview from'
+          short-summary: 'The position in bytes in the file to start the preview from.'
 """
 
 helps['dls fs join'] = """
     type: command
-    short-summary: Joins the list of files in the Data Lake Store account into one file at the destination path.
+    short-summary: Joins a list of files in a Data Lake Store account into one file.
     parameters:
         - name: --source-paths
           type: list
           short-summary: 'The list of files in the Data Lake Store account to join.'
         - name: --destination-path
           type: string
-          short-summary: 'The destination path in the Data Lake Store account where the resulting joined files should be placed.'
+          short-summary: 'The destination path in the Data Lake Store account where the result should be placed.'
 """
 
 helps['dls fs move'] = """
     type: command
-    short-summary: Moves the file or folder in the Data Lake Store account to the destination path.
+    short-summary: Moves a file or folder in a Data Lake Store account.
     parameters:
         - name: --source-path
           type: list
-          short-summary: 'The file or folder to move'
+          short-summary: 'The file or folder to move.'
         - name: --destination-path
           type: string
-          short-summary: 'The destination path in the Data Lake Store account where the file or folder should be moved to.'
+          short-summary: 'The destination path in the Data Lake Store account.'
 """
 
 helps['dls fs set-expiry'] = """
     type: command
-    short-summary: Sets the absolute expiration time of the file.
+    short-summary: Sets the absolute expiration time for a file.
 """
 
 helps['dls fs remove-expiry'] = """
     type: command
-    short-summary: Removes the expiration time on a file, if any.
+    short-summary: Removes the expiration time for a file.
 """
 
 helps['dls fs access'] = """
     type: group
-    short-summary: Commands to manage a Data Lake Store filesystem access and permissions.
+    short-summary: Manage Data Lake Store filesystem access and permissions.
 """
 
 helps['dls fs access show'] = """
     type: command
-    short-summary: Displays the ACL for a given file or folder
+    short-summary: Displays the access control list (ACL).
 """
 
 helps['dls fs access set-owner'] = """
     type: command
-    short-summary: Sets the owner and or owning group for the file or folder in the Data Lake Store account.
+    short-summary: Sets the owner information for a file or folder in a Data Lake Store account.
     parameters:
         - name: --owner
           type: string
-          short-summary: 'The user AAD object ID or UPN to set as the owner. If not specified the owner remains unchanged'
+          short-summary: 'The user Azure Active Directory object ID or user principal name to set as the owner.'
         - name: --group
           type: string
-          short-summary: 'The group AAD object ID or UPN to set as the owning group. If not specified the owning group remains unchanged'
+          short-summary: 'The group Azure Active Directory object ID or user principal name to set as the owning group.'
 """
 
 helps['dls fs access set-permission'] = """
     type: command
-    short-summary: Sets the permission octal for the file or folder in the Data Lake Store account.
+    short-summary: Sets the permissions for a file or folder in a Data Lake Store account.
     parameters:
         - name: --permission
           type: int
-          short-summary: 'The octal representation of the permissions for user, group and mask (for example: 777 is full rwx for all entities)'
+          short-summary: 'The octal representation of the permissions for user, group and mask.'
+    example:
+        - name: Set full permissions for a user, read-execute permissions for a group, and execute permissions for all.
+          text: az fs access set-permission --path /path/to/file.txt --permission 751
 """
 
 helps['dls fs access set-entry'] = """
     type: command
-    short-summary: updates the existing ACL on the file or folder to include or update the entries specified
+    short-summary: Updates the access control list for a file or folder.
 """
 
 helps['dls fs access set'] = """
     type: command
-    short-summary: replaces the existing ACL on the file or folder with the specified ACL, which must contain all unnamed entries
+    short-summary: Replaces the existing access control list for a file or folder.
 """
 
 helps['dls fs access remove-entry'] = """
     type: command
-    short-summary: updates the existing ACL on the file or folder to remove the entries specified if they exist
+    short-summary: Removes entries for an existing access control list of a file or folder.
 """
 
 helps['dls fs access remove-all'] = """
     type: command
-    short-summary: completely removes the existing ACL or default ACL on the file or folder
+    short-summary: Completely removes the access control list for a file or folder.
 """

--- a/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_help.py
+++ b/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_help.py
@@ -9,17 +9,17 @@ from azure.cli.core.help_files import helps
 
 helps['eventgrid'] = """
     type: group
-    short-summary: Manage Azure EventGrid Topics and Event Subscriptions.
+    short-summary: Manage Azure Event Grid topics and subscriptions.
     """
 helps['eventgrid topic'] = """
     type: group
-    short-summary: Manage topics and their event subscriptions.
+    short-summary: Manage Azure Event Grid topics.
     """
 helps['eventgrid topic create'] = """
     type: command
     short-summary: Create a topic.
     examples:
-        - name: Create a new topic
+        - name: Create a new topic.
           text: az eventgrid topic create -g rg1 --name topic1
     """
 helps['eventgrid topic delete'] = """
@@ -28,7 +28,7 @@ helps['eventgrid topic delete'] = """
     """
 helps['eventgrid topic list'] = """
     type: command
-    short-summary: List all topics in a subscription or resource group.
+    short-summary: List topics in a subscription or resource group.
     """
 helps['eventgrid topic show'] = """
     type: command
@@ -54,11 +54,11 @@ helps['eventgrid topic event-subscription create'] = """
     type: command
     short-summary: Create a new event subscription to a topic.
     examples:
-        - name: Create a new event subscription with default filters
+        - name: Create a new event subscription with default filters.
           text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
-        - name: Create a new event subscription with a filter specifying a subject prefix
+        - name: Create a new event subscription with a filter specifying a subject prefix.
           text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
-        - name: Create a new event subscription with default filters and with additional labels
+        - name: Create a new event subscription with default filters and additional labels.
           text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --labels Finance HR
     """
 helps['eventgrid topic event-subscription delete'] = """
@@ -67,7 +67,7 @@ helps['eventgrid topic event-subscription delete'] = """
     """
 helps['eventgrid topic event-subscription list'] = """
     type: command
-    short-summary: List the event subscriptions for a topic.
+    short-summary: List event subscriptions for a topic.
     """
 helps['eventgrid topic event-subscription show'] = """
     type: command
@@ -79,37 +79,37 @@ helps['eventgrid topic event-subscription show-endpoint-url'] = """
     """
 helps['eventgrid event-subscription'] = """
     type: group
-    short-summary: Manage event subscriptions for a subscription or resource group.
+    short-summary: Manage event subscriptions.
     """
 helps['eventgrid event-subscription create'] = """
     type: command
-    short-summary: Create a new event subscription to a subscription or resource group.
+    short-summary: Create a new event subscription for a subscription or resource group.
     examples:
-        - name: Create a new event subscription to a subscription, using default filters.
+        - name: Create a new event subscription for a subscription, using default filters.
           text: az eventgrid event-subscription create --name es2 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
-        - name: Create a new event subscription to a resource group, using default filters.
+        - name: Create a new event subscription for a resource group, using default filters.
           text: az eventgrid event-subscription create -g rg1 --name es3 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
-        - name: Create a new event subscription to a subscription, with a filter specifying a subject prefix
+        - name: Create a new event subscription for a subscription, with a filter specifying a subject prefix.
           text: az eventgrid event-subscription create --name es4 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
-        - name: Create a new event subscription to a resource group, with a filter specifying a subject suffix
+        - name: Create a new event subscription for a resource group, with a filter specifying a subject suffix.
           text: az eventgrid event-subscription create -g rg2 --name es5 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-ends-with mysubject_suffix
 
     """
 helps['eventgrid event-subscription delete'] = """
     type: command
-    short-summary: Delete an event subscription for a subscription or resource group.
+    short-summary: Delete an event subscription.
     """
 helps['eventgrid event-subscription list'] = """
     type: command
-    short-summary: List the event subscriptions for a subscription or resource group.
+    short-summary: List event subscriptions.
     """
 helps['eventgrid event-subscription show'] = """
     type: command
-    short-summary: Get the properties of an event subscription for a subscription or resource group.
+    short-summary: Get properties of an event subscription.
     """
 helps['eventgrid event-subscription show-endpoint-url'] = """
     type: command
-    short-summary: Get the full endpoint URL of an event subscription for a a subscription or resource group.
+    short-summary: Get the full endpoint URL of an event subscription.
     """
 helps['eventgrid resource'] = """
     type: group
@@ -121,13 +121,13 @@ helps['eventgrid resource event-subscription'] = """
     """
 helps['eventgrid resource event-subscription create'] = """
     type: command
-    short-summary: Create a new event subscription to a resource.
+    short-summary: Create a new event subscription for a resource.
     examples:
-        - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters
+        - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters.
           text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
-        - name: Create a new event subscription to subscribe to events from an Azure Storage account, using a filter specifying a subject prefix
+        - name: Create a new event subscription to subscribe to events from an Azure Storage account, using a filter specifying a subject prefix.
           text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.Storage --resource-type storageAccounts --resource-name sa1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
-        - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters and additional labels
+        - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters and additional labels.
           text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --labels Finance HR
     """
 helps['eventgrid resource event-subscription delete'] = """

--- a/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_help.py
+++ b/src/command_modules/azure-cli-eventgrid/azure/cli/command_modules/eventgrid/_help.py
@@ -28,11 +28,11 @@ helps['eventgrid topic delete'] = """
     """
 helps['eventgrid topic list'] = """
     type: command
-    short-summary: List topics in a subscription or resource group.
+    short-summary: List available topics.
     """
 helps['eventgrid topic show'] = """
     type: command
-    short-summary: Get properties of a topic.
+    short-summary: Get the details of a topic.
     """
 helps['eventgrid topic key'] = """
     type: group
@@ -55,11 +55,19 @@ helps['eventgrid topic event-subscription create'] = """
     short-summary: Create a new event subscription to a topic.
     examples:
         - name: Create a new event subscription with default filters.
-          text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
+          text: |
+            az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
         - name: Create a new event subscription with a filter specifying a subject prefix.
-          text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
+          text: |
+            az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> \\
+                --subject-begins-with mysubject_prefix
         - name: Create a new event subscription with default filters and additional labels.
-          text: az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --labels Finance HR
+          text: |
+            az eventgrid topic event-subscription create -g rg1 --topic-name topic1 --name es1 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> \\
+                --labels Finance HR
     """
 helps['eventgrid topic event-subscription delete'] = """
     type: command
@@ -71,7 +79,7 @@ helps['eventgrid topic event-subscription list'] = """
     """
 helps['eventgrid topic event-subscription show'] = """
     type: command
-    short-summary: Get the properties of an event subscription for a topic.
+    short-summary: Get the details of an event subscription for a topic.
     """
 helps['eventgrid topic event-subscription show-endpoint-url'] = """
     type: command
@@ -83,16 +91,26 @@ helps['eventgrid event-subscription'] = """
     """
 helps['eventgrid event-subscription create'] = """
     type: command
-    short-summary: Create a new event subscription for a subscription or resource group.
+    short-summary: Create a new event subscription for an Azure subscription or resource group.
     examples:
         - name: Create a new event subscription for a subscription, using default filters.
-          text: az eventgrid event-subscription create --name es2 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
+          text: |
+            az eventgrid event-subscription create --name es2 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
         - name: Create a new event subscription for a resource group, using default filters.
-          text: az eventgrid event-subscription create -g rg1 --name es3 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
+          text: |
+            az eventgrid event-subscription create -g rg1 --name es3 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
         - name: Create a new event subscription for a subscription, with a filter specifying a subject prefix.
-          text: az eventgrid event-subscription create --name es4 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
+          text: |
+            az eventgrid event-subscription create --name es4 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> \\
+                --subject-begins-with mysubject_prefix
         - name: Create a new event subscription for a resource group, with a filter specifying a subject suffix.
-          text: az eventgrid event-subscription create -g rg2 --name es5 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-ends-with mysubject_suffix
+          text: |
+            az eventgrid event-subscription create -g rg2 --name es5 \\
+                --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> \\
+                --subject-ends-with mysubject_suffix
 
     """
 helps['eventgrid event-subscription delete'] = """
@@ -105,7 +123,7 @@ helps['eventgrid event-subscription list'] = """
     """
 helps['eventgrid event-subscription show'] = """
     type: command
-    short-summary: Get properties of an event subscription.
+    short-summary: Get the details of an event subscription.
     """
 helps['eventgrid event-subscription show-endpoint-url'] = """
     type: command
@@ -113,7 +131,7 @@ helps['eventgrid event-subscription show-endpoint-url'] = """
     """
 helps['eventgrid resource'] = """
     type: group
-    short-summary: Manage event subscriptions for a resource.
+    short-summary: Manage Azure Event Grid resources.
     """
 helps['eventgrid resource event-subscription'] = """
     type: group
@@ -124,15 +142,19 @@ helps['eventgrid resource event-subscription create'] = """
     short-summary: Create a new event subscription for a resource.
     examples:
         - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters.
-          text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
+          text: |
+            az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces \\
+                --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code>
         - name: Create a new event subscription to subscribe to events from an Azure Storage account, using a filter specifying a subject prefix.
-          text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.Storage --resource-type storageAccounts --resource-name sa1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
+          text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.Storage --resource-type storageAccounts \\
+                --resource-name sa1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --subject-begins-with mysubject_prefix
         - name: Create a new event subscription to subscribe to events from an Azure Event Hubs namespace, using default filters and additional labels.
-          text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --labels Finance HR
+          text: az eventgrid resource event-subscription create -g rg1 --provider-namespace Microsoft.EventHub --resource-type namespaces \\
+                --resource-name EHNamespace1 --name es1 --endpoint https://<yourfunction>.azurewebsites.net/api/f1?code=<code> --labels Finance HR
     """
 helps['eventgrid resource event-subscription delete'] = """
     type: command
-    short-summary: Delete an event subscription for a resource.
+    short-summary: Delete an event subscription from a resource.
     """
 helps['eventgrid resource event-subscription list'] = """
     type: command
@@ -140,7 +162,7 @@ helps['eventgrid resource event-subscription list'] = """
     """
 helps['eventgrid resource event-subscription show'] = """
     type: command
-    short-summary: Get the properties of an event subscription for a resource.
+    short-summary: Get the details of an event subscription for a resource.
     """
 helps['eventgrid resource event-subscription show-endpoint-url'] = """
     type: command
@@ -148,15 +170,15 @@ helps['eventgrid resource event-subscription show-endpoint-url'] = """
     """
 helps['eventgrid topic-type'] = """
     type: group
-    short-summary: Get information about topic types.
+    short-summary: Get details for topic types.
     """
 helps['eventgrid topic-type list'] = """
     type: command
-    short-summary: List all registered topic types.
+    short-summary: List registered topic types.
     """
 helps['eventgrid topic-type show'] = """
     type: command
-    short-summary: Get the properties of a topic type.
+    short-summary: Get the details for a topic type.
     """
 helps['eventgrid topic-type list-event-types'] = """
     type: command

--- a/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_help.py
+++ b/src/command_modules/azure-cli-find/azure/cli/command_modules/find/_help.py
@@ -7,9 +7,9 @@ from azure.cli.core.help_files import helps
 
 helps['find'] = """
     type: command
-    short-summary: Find Azure CLI commands based on a given query
+    short-summary: Find Azure CLI commands.
     examples:
-      - name: Search for things containing 'vm' or 'secret'
+      - name: Search for commands containing 'vm' or 'secret'
         text: >
             az find -q vm secret
 """

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/_help.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/_help.py
@@ -9,6 +9,5 @@ helps['interactive'] = """
             type: command
             short-summary: Start interactive mode.
             long-summary: >
-                An interactive environment that makes it easier to learn and use Azure CLI commands.
-                See https://azure.microsoft.com/en-us/blog/welcome-to-azure-cli-shell/
+                For more information on interactive mode, see: https://azure.microsoft.com/en-us/blog/welcome-to-azure-cli-shell/
             """

--- a/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/_help.py
+++ b/src/command_modules/azure-cli-interactive/azure/cli/command_modules/interactive/_help.py
@@ -7,8 +7,8 @@ from azure.cli.core.help_files import helps
 
 helps['interactive'] = """
             type: command
-            short-summary: Start the interactive experience.
+            short-summary: Start interactive mode.
             long-summary: >
                 An interactive environment that makes it easier to learn and use Azure CLI commands.
-                see https://azure.microsoft.com/en-us/blog/welcome-to-azure-cli-shell/
+                See https://azure.microsoft.com/en-us/blog/welcome-to-azure-cli-shell/
             """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -7,26 +7,23 @@ from azure.cli.core.help_files import helps
 
 helps['iot'] = """
     type: group
-    short-summary: Manage Internet of Things (IoT) assets.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Internet of Things (IoT) assets.
 """
 
 helps['iot device'] = """
     type: group
-    short-summary: Manage devices in your Azure IoT hub.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage devices in your Azure IoT hub.
 """
 
 helps['iot hub'] = """
     type: group
-    short-summary: Manage Azure IoT hubs.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Azure IoT hubs.
 """
 
 helps['iot hub create'] = """
     type: command
     short-summary: Create an Azure IoT hub.
-    long-summary: For an introduction to Azure IoT Hub, see https://docs.microsoft.com/azure/iot-hub/.
+    long-summary: 'For an introduction to Azure IoT Hub, see https://docs.microsoft.com/azure/iot-hub/'
     examples:
         - name: Create an IoT Hub with the free pricing tier F1, in the region of the resource group.
           text: >
@@ -87,8 +84,7 @@ helps['iot hub delete'] = """
 
 helps['iot hub consumer-group'] = """
     type: group
-    short-summary: Manage the event hub consumer groups of an IoT hub.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage the event hub consumer groups of an IoT hub.
 """
 
 helps['iot hub consumer-group create'] = """
@@ -120,8 +116,7 @@ helps['iot hub consumer-group delete'] = """
 
 helps['iot hub policy'] = """
     type: group
-    short-summary: Manage shared access policies of an IoT hub.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage shared access policies of an IoT hub.
 """
 
 helps['iot hub policy list'] = """
@@ -155,8 +150,7 @@ helps['iot hub list-skus'] = """
 
 helps['iot hub job'] = """
     type: group
-    short-summary: Manage jobs in an IoT hub.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage jobs in an IoT hub.
 """
 
 helps['iot hub job list'] = """
@@ -249,8 +243,7 @@ helps['iot device show-connection-string'] = """
 
 helps['iot device message'] = """
     type: group
-    short-summary: Manage IoT device messaging.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage IoT device messaging.
 """
 
 helps['iot device message send'] = """
@@ -295,11 +288,11 @@ helps['iot device message abandon'] = """
 helps['iot device export'] = """
     type: command
     short-summary: Export all the device identities in the IoT hub identity registry to an Azure Storage blob container.
-    long-summary: For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.
+    long-summary: 'For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities'
 """
 
 helps['iot device import'] = """
     type: command
     short-summary: Import, update, or delete device identities in the IoT hub identity registry from a blob.
-    long-summary: For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.
+    long-summary: 'For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities'
 """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -7,8 +7,7 @@ from azure.cli.core.help_files import helps
 
 helps['iot'] = """
     type: group
-    short-summary: Connect, monitor, and control millions of IoT assets.
-    long-summary: If you don't have the iot component installed, add it with `az component update --add iot`.
+    short-summary: Connect, monitor, and control IoT assets.
     long-summary: These commands are in preview.
 """
 
@@ -20,74 +19,75 @@ helps['iot device'] = """
 
 helps['iot hub'] = """
     type: group
-    short-summary: Manage Azure IoT Hubs.
+    short-summary: Manage Azure IoT hubs.
     long-summary: These commands are in preview.
 """
 
 helps['iot hub create'] = """
     type: command
-    short-summary: Create an Azure IoT Hub.
+    short-summary: Create an Azure IoT hub.
     long-summary: For an introduction to Azure IoT Hub, see https://docs.microsoft.com/azure/iot-hub/.
     examples:
         - name: Create an IoT Hub with the free pricing tier F1, in the region of the resource group.
           text: >
             az iot hub create --resource-group MyResourceGroup --name MyIotHub
-        - name: Create an IoT Hub with the standard pricing tier S1, in the region of the resource group.
+        - name: Create an IoT Hub with the standard pricing tier S1, in the 'westus' region.
           text: >
-            az iot hub create --resource-group MyResourceGroup --name MyIotHub --sku S1
-        - name: Create an IoT Hub with the free pricing tier F1, in the `westus` region.
-          text: >
-            az iot hub create --resource-group MyResourceGroup --name MyIotHub --location westus
+            az iot hub create --resource-group MyResourceGroup --name MyIotHub --sku S1 --location westus
 """
 
 helps['iot hub show'] = """
     type: command
-    short-summary: Show non-security metadata of an IoT Hub.
+    short-summary: Show metadata for an IoT hub.
 """
 
 helps['iot hub update'] = """
     type: command
-    short-summary: Update non-security metadata of an IoT Hub.
+    short-summary: Update metadata for an IoT hub.
     examples:
-        - name: Add an IP filter rule.
+        - name: Add a firewall filter rule to accept traffic from the IP mask 127.0.0.0/31.
           text: >
             az iot hub update --name MyIotHub --add properties.ipFilterRules filter_name=test-rule action=Accept ip_mask=127.0.0.0/31
-            az iot hub update --name MyIotHub --add properties.ipFilterRules filter_name=test-rule action=Reject ip_mask=127.0.0.0/31
 """
 
 helps['iot hub list'] = """
     type: command
-    short-summary: List IoT Hubs.
-    long-summary: If the resource group is provided, IoT Hubs in the target resource group are listed. Otherwise, IoT Hubs in your subscription are listed.
+    short-summary: List IoT hubs.
+    examples:
+        - name: List all IoT hubs in a subscription.
+          text: >
+            az iot hub list
+        - name: List all IoT hubs in the resource group 'MyGroup'
+          text: >
+            az iot hub list --resource-group MyGroup
 """
 
 helps['iot hub show-connection-string'] = """
     type: command
-    short-summary: Show the connection string of an IoT Hub.
-    long-summary: If resource group and IoT Hub name are not provided, connection strings for all IoT Hubs in your subscription are returned. If only the resource group is provided, connection strings for all IoT Hubs in the resource group are returned. If both resource group and IoT Hub name are provided, the connection string of the IoT Hub is returned.
+    short-summary: Show the connection string for IoT hubs.
     examples:
-        - name: Show the connection string of an IoT Hub using default policy (`iothubowner`) and primary key.
+        - name: Show the connection string of an IoT hub using default policy and primary key.
           text: >
             az iot hub show-connection-string --name MyIotHub
-        - name: Show the connection string of an IoT Hub using policy `service` and secondary key.
+        - name: Show the connection string of an IoT Hub using policy 'service' and secondary key.
           text: >
             az iot hub show-connection-string --name MyIotHub --policy-name service --key secondary
-        - name: Show the connection strings of all IoT Hubs in a resource group.
+        - name: Show the connection strings for all IoT hubs in a resource group.
           text: >
             az iot hub show-connection-string --resource-group MyResourceGroup
-        - name: Show the connection strings of all IoT Hubs in a subscription.
+        - name: Show the connection strings for all IoT hubs in a subscription.
           text: >
             az iot hub show-connection-string
 """
 
 helps['iot hub delete'] = """
     type: command
-    short-summary: Delete an IoT Hub.
+    short-summary: Delete an IoT hub.
 """
 
 helps['iot hub consumer-group'] = """
     type: group
-    short-summary: Manage event hub consumer groups of an IoT Hub.
+    short-summary: Manage event hub consumer groups of an IoT hub.
     long-summary: These commands are in preview.
 """
 
@@ -95,7 +95,7 @@ helps['iot hub consumer-group create'] = """
     type: command
     short-summary: Create an event hub consumer group.
     examples:
-        - name: Create a consumer group `cg1` in the default event hub endpoint `events`.
+        - name: Create a consumer group 'cg1' in the default event hub endpoint.
           text: >
             az iot hub consumer-group create --hub-name MyIotHub --name cg1
         - name: Create a consumer group `cg1` in the operation monitoring event hub endpoint `operationsMonitoringEvents`.
@@ -105,7 +105,7 @@ helps['iot hub consumer-group create'] = """
 
 helps['iot hub consumer-group list'] = """
     type: command
-    short-summary: List all event hub consumer groups.
+    short-summary: List event hub consumer groups.
 """
 
 helps['iot hub consumer-group show'] = """
@@ -120,23 +120,23 @@ helps['iot hub consumer-group delete'] = """
 
 helps['iot hub policy'] = """
     type: group
-    short-summary: Manage shared access policies of an IoT Hub.
+    short-summary: Manage shared access policies of an IoT hub.
     long-summary: These commands are in preview.
 """
 
 helps['iot hub policy list'] = """
     type: command
-    short-summary: List all shared access policies of an IoT Hub.
+    short-summary: List shared access policies of an IoT hub.
 """
 
 helps['iot hub policy show'] = """
     type: command
-    short-summary: Get a shared access policy of an IoT Hub.
+    short-summary: Get a shared access policy of an IoT hub.
 """
 
 helps['iot hub policy create'] = """
     type: command
-    short-summary: Create a new shared access policy in an IoT Hub.
+    short-summary: Create a new shared access policy in an IoT hub.
     examples:
         - name: Create a new shared access policy.
           text: >
@@ -145,48 +145,48 @@ helps['iot hub policy create'] = """
 
 helps['iot hub policy delete'] = """
     type: command
-    short-summary: Delete a shared access policy from an IoT Hub.
+    short-summary: Delete a shared access policy from an IoT hub.
 """
 
 helps['iot hub list-skus'] = """
     type: command
-    short-summary: List all valid pricing tiers.
+    short-summary: List all pricing tiers.
 """
 
 helps['iot hub job'] = """
     type: group
-    short-summary: Manage jobs in an IoT Hub.
+    short-summary: Manage jobs in an IoT hub.
     long-summary: These commands are in preview.
 """
 
 helps['iot hub job list'] = """
     type: command
-    short-summary: List all jobs in an IoT Hub.
+    short-summary: List jobs in an IoT hub.
 """
 
 helps['iot hub job show'] = """
     type: command
-    short-summary: Show a job in an IoT Hub.
+    short-summary: Show a job in an IoT hub.
 """
 
 helps['iot hub job cancel'] = """
     type: command
-    short-summary: Cancel a job in an IoT Hub.
+    short-summary: Cancel a job in an IoT hub.
 """
 
 helps['iot hub show-quota-metrics'] = """
     type: command
-    short-summary: Show quota metrics for an IoT Hub.
+    short-summary: Show quota metrics for an IoT hub.
 """
 
 helps['iot hub show-stats'] = """
     type: command
-    short-summary: Show statistics of an IoT Hub.
+    short-summary: Show statistics of an IoT hub.
 """
 
 helps['iot device create'] = """
     type: command
-    short-summary: Register a device in an IoT Hub.
+    short-summary: Register a device in an IoT hub.
     examples:
         - name: Create a device authenticating with symmetric key.
           text: >
@@ -197,22 +197,22 @@ helps['iot device create'] = """
         - name: Create a device authenticating with self-signed X.509 certificate, which is put into to the current directory.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509
-        - name: Create a device authenticating with self-signed X.509 certificate, which is valid for 100 days.
+        - name: Create a device authenticating with self-signed X.509 certificate that is valid for 100 days.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509 --valid-days 100
-        - name: Create a device authenticating with self-signed X.509 certificate, which is put into the specified directory.
+        - name: Create a device authenticating with self-signed X.509 certificate, and write the certificate to /path/to/output.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509 --output-dir /path/to/output
 """
 
 helps['iot device show'] = """
     type: command
-    short-summary: Show metadata of a device in an IoT Hub.
+    short-summary: Show metadata of a device in an IoT hub.
 """
 
 helps['iot device update'] = """
     type: command
-    short-summary: Update metadata of a device in an IoT Hub.
+    short-summary: Update metadata of a device in an IoT hub.
     examples:
         - name: Disable a device.
           text: >
@@ -221,23 +221,23 @@ helps['iot device update'] = """
 
 helps['iot device list'] = """
     type: command
-    short-summary: List devices in an IoT Hub.
+    short-summary: List devices in an IoT hub.
 """
 
 helps['iot device delete'] = """
     type: command
-    short-summary: Delete a device from an IoT Hub.
+    short-summary: Delete a device from an IoT hub.
 """
 
 helps['iot device show-connection-string'] = """
     type: command
-    short-summary: Show the connection string of devices in an IoT Hub.
+    short-summary: Show the connection string of devices in an IoT hub.
     long-summary: If the device identifier is not provided, connection strings for all devices in your IoT Hub are returned. Otherwise, the connection string of the target device is returned.
     examples:
-        - name: Show the connection string of a device in an IoT Hub using primary key.
+        - name: Show the connection string of a device in an IoT Hub using the primary key.
           text: >
             az iot device show-connection-string --hub-name MyIotHub --device-id MyDevice
-        - name: Show the connection string of a device in an IoT Hub using secondary key.
+        - name: Show the connection string of a device in an IoT Hub using the secondary key.
           text: >
             az iot device show-connection-string --hub-name MyIotHub --device-id MyDevice --key secondary
         - name: Show the connection strings of the default devices in an IoT Hub using primary key.
@@ -258,10 +258,10 @@ helps['iot device message send'] = """
     type: command
     short-summary: Send a device-to-cloud message.
     examples:
-        - name: Send a device-to-cloud message to an IoT Hub with a default message.
+        - name: Send a device-to-cloud message to an IoT hub with a default message.
           text: >
             az iot device message send --hub-name MyIotHub --device-id MyDevice
-        - name: Send a device-to-cloud message to an IoT Hub with a custom message.
+        - name: Send a device-to-cloud message to an IoT hub with a custom message.
           text: >
             az iot device message send --hub-name MyIotHub --device-id MyDevice --data "Custom Message"
 """
@@ -270,10 +270,10 @@ helps['iot device message receive'] = """
     type: command
     short-summary: Receive a cloud-to-device message.
     examples:
-        - name: Receive a cloud-to-device message from an IoT Hub with a default lock timeout.
+        - name: Receive a cloud-to-device message from an IoT hub with a default timeout.
           text: >
             az iot device message receive --hub-name MyIotHub --device-id MyDevice
-        - name: Receive a cloud-to-device message from an IoT Hub with a lock timeout of 300 seconds.
+        - name: Receive a cloud-to-device message from an IoT Hub with a timeout of 300 seconds.
           text: >
             az iot device message receive --hub-name MyIotHub --device-id MyDevice --lock-timeout 300
 """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -7,7 +7,7 @@ from azure.cli.core.help_files import helps
 
 helps['iot'] = """
     type: group
-    short-summary: Connect, monitor, and control IoT assets.
+    short-summary: Manage Internet of Things (IoT) assets.
     long-summary: These commands are in preview.
 """
 
@@ -38,7 +38,7 @@ helps['iot hub create'] = """
 
 helps['iot hub show'] = """
     type: command
-    short-summary: Show metadata for an IoT hub.
+    short-summary: Get the details of an IoT hub.
 """
 
 helps['iot hub update'] = """
@@ -64,7 +64,7 @@ helps['iot hub list'] = """
 
 helps['iot hub show-connection-string'] = """
     type: command
-    short-summary: Show the connection string for IoT hubs.
+    short-summary: Show the connection strings for an IoT hub.
     examples:
         - name: Show the connection string of an IoT hub using default policy and primary key.
           text: >
@@ -87,7 +87,7 @@ helps['iot hub delete'] = """
 
 helps['iot hub consumer-group'] = """
     type: group
-    short-summary: Manage event hub consumer groups of an IoT hub.
+    short-summary: Manage the event hub consumer groups of an IoT hub.
     long-summary: These commands are in preview.
 """
 
@@ -110,7 +110,7 @@ helps['iot hub consumer-group list'] = """
 
 helps['iot hub consumer-group show'] = """
     type: command
-    short-summary: Get an event hub consumer group.
+    short-summary: Get the details for an event hub consumer group.
 """
 
 helps['iot hub consumer-group delete'] = """
@@ -131,7 +131,7 @@ helps['iot hub policy list'] = """
 
 helps['iot hub policy show'] = """
     type: command
-    short-summary: Get a shared access policy of an IoT hub.
+    short-summary: Get the details of a shared access policy of an IoT hub.
 """
 
 helps['iot hub policy create'] = """
@@ -150,7 +150,7 @@ helps['iot hub policy delete'] = """
 
 helps['iot hub list-skus'] = """
     type: command
-    short-summary: List all pricing tiers.
+    short-summary: List available pricing tiers.
 """
 
 helps['iot hub job'] = """
@@ -161,12 +161,12 @@ helps['iot hub job'] = """
 
 helps['iot hub job list'] = """
     type: command
-    short-summary: List jobs in an IoT hub.
+    short-summary: List the jobs in an IoT hub.
 """
 
 helps['iot hub job show'] = """
     type: command
-    short-summary: Show a job in an IoT hub.
+    short-summary: Get the details of a job in an IoT hub.
 """
 
 helps['iot hub job cancel'] = """
@@ -176,43 +176,43 @@ helps['iot hub job cancel'] = """
 
 helps['iot hub show-quota-metrics'] = """
     type: command
-    short-summary: Show quota metrics for an IoT hub.
+    short-summary: Get the quota metrics for an IoT hub.
 """
 
 helps['iot hub show-stats'] = """
     type: command
-    short-summary: Show statistics of an IoT hub.
+    short-summary: Get the statistics for an IoT hub.
 """
 
 helps['iot device create'] = """
     type: command
-    short-summary: Register a device in an IoT hub.
+    short-summary: Register a device for an IoT hub.
     examples:
         - name: Create a device authenticating with symmetric key.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice
-        - name: Create a device authenticating with existing X.509 certificate.
+        - name: Create a device authenticating with an existing X.509 certificate.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509 --primary-thumbprint X.509_certificate_thumbprint
-        - name: Create a device authenticating with self-signed X.509 certificate, which is put into to the current directory.
+        - name: Create a device authenticating with a self-signed X.509 certificate, which is put into to the current directory.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509
-        - name: Create a device authenticating with self-signed X.509 certificate that is valid for 100 days.
+        - name: Create a device authenticating with a self-signed X.509 certificate that is valid for 100 days.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509 --valid-days 100
-        - name: Create a device authenticating with self-signed X.509 certificate, and write the certificate to /path/to/output.
+        - name: Create a device authenticating with a self-signed X.509 certificate, and write the certificate to /path/to/output.
           text: >
             az iot device create --hub-name MyIotHub --device-id MyDevice --x509 --output-dir /path/to/output
 """
 
 helps['iot device show'] = """
     type: command
-    short-summary: Show metadata of a device in an IoT hub.
+    short-summary: Get the details for a device in an IoT hub.
 """
 
 helps['iot device update'] = """
     type: command
-    short-summary: Update metadata of a device in an IoT hub.
+    short-summary: Update the metadata of a device in an IoT hub.
     examples:
         - name: Disable a device.
           text: >
@@ -231,8 +231,7 @@ helps['iot device delete'] = """
 
 helps['iot device show-connection-string'] = """
     type: command
-    short-summary: Show the connection string of devices in an IoT hub.
-    long-summary: If the device identifier is not provided, connection strings for all devices in your IoT Hub are returned. Otherwise, the connection string of the target device is returned.
+    short-summary: Show the connection strings for devices in an IoT hub.
     examples:
         - name: Show the connection string of a device in an IoT Hub using the primary key.
           text: >

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -9,13 +9,12 @@ from azure.cli.core.help_files import helps
 helps['keyvault'] = """
     type: group
     short-summary: Safeguard and maintain control of keys, secrets, and certificates.
-    long-summary: If you don't have the keyvault component installed, add it with `az component update --add keyvault`.
 """
 
 helps['keyvault create'] = """
     type: command
     short-summary: Create a key vault.
-    long-summary: "Default permissions are created for the current user or service principal unless the --no-self-perms flag is specified."
+    long-summary: Default permissions are created for the current user or service principal unless the --no-self-perms flag is specified.
 """
 
 helps['keyvault delete'] = """
@@ -64,40 +63,37 @@ helps['keyvault certificate download'] = """
         Download the public portion of a Key Vault certificate formatted as either PEM or DER. PEM
         formatting is the default.
     examples:
-        - name: Download a PEM and check it's fingerprint in openssl
+        - name: Download a PEM and check its fingerprint in openssl.
           text: >
-            az keyvault certificate download --vault-name vault -n cert-name -f cert.pem \n
+            az keyvault certificate download --vault-name vault -n cert-name -f cert.pem && \\
             openssl x509 -in cert.pem -inform PEM  -noout -sha1 -fingerprint
-        - name: Download a DER and check it's fingerprint in openssl
+        - name: Download a DER and check its fingerprint in openssl.
           text: >
-            az keyvault certificate download --vault-name vault -n cert-name -f cert.crt -e DER \n
+            az keyvault certificate download --vault-name vault -n cert-name -f cert.crt -e DER && \\
             openssl x509 -in cert.crt -inform DER  -noout -sha1 -fingerprint
 """
 
 helps['keyvault certificate get-default-policy'] = """
     type: command
-    short-summary: Get a default policy for a self-signed certificate
+    short-summary: Get the default policy for a self-signed certificate.
     long-summary: >
         This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
-        The default policy can also be used as a starting point to create derivative policies. \n
+        The default policy can also be used as a starting point to create derivative policies.\n
 
         Also see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
     examples:
-        - name: Create a self-signed certificate with a the default policy
+        - name: Create a self-signed certificate with the default policy
           text: >
-            az keyvault create -g group-name -n vaultname -l westus --enabled-for-deployment true \\
-              --enabled-for-template-deployment true
-
             az keyvault certificate create --vault-name vaultname -n cert1 \\
               -p "$(az keyvault certificate get-default-policy)"
 """
 
 helps['keyvault certificate create'] = """
     type: command
-    long-summary: >
+    short-summary: >
         Create a Key Vault certificate. Certificates can also be used as a secrets in provisioned virtual machines.
     examples:
-        - name: Create a self-signed certificate with a the default policy and add to a virtual machine
+        - name: Create a self-signed certificate with the default policy and add it to a virtual machine.
           text: >
             az keyvault certificate create --vault-name vaultname -n cert1 \\
               -p "$(az keyvault certificate get-default-policy)"
@@ -118,8 +114,6 @@ helps['keyvault certificate import'] = """
     examples:
         - name: Create a service principal with a certificate, add the certificate to Key Vault and provision a VM with that certificate.
           text: >
-            az group create -g my-group -l westus \n
-
             service_principal=$(az ad sp create-for-rbac --create-cert) \n
 
             cert_file=$(echo $service_principal | jq .fileWithCertAndPrivateKey -r) \n

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_help.py
@@ -14,7 +14,7 @@ helps['keyvault'] = """
 helps['keyvault create'] = """
     type: command
     short-summary: Create a key vault.
-    long-summary: Default permissions are created for the current user or service principal unless the --no-self-perms flag is specified.
+    long-summary: Default permissions are created for the current user or service principal unless the `--no-self-perms` flag is specified.
 """
 
 helps['keyvault delete'] = """
@@ -59,15 +59,14 @@ helps['keyvault certificate'] = """
 """
 
 helps['keyvault certificate download'] = """
-    long-summary: >
-        Download the public portion of a Key Vault certificate formatted as either PEM or DER. PEM
-        formatting is the default.
+    short-summary: Download the public portion of a Key Vault certificate.
+    long-summary: The certificate formatted as either PEM or DER. PEM is the default.
     examples:
-        - name: Download a PEM and check its fingerprint in openssl.
+        - name: Download a certificate as PEM and check its fingerprint in openssl.
           text: >
             az keyvault certificate download --vault-name vault -n cert-name -f cert.pem && \\
             openssl x509 -in cert.pem -inform PEM  -noout -sha1 -fingerprint
-        - name: Download a DER and check its fingerprint in openssl.
+        - name: Download a certificate as DER and check its fingerprint in openssl.
           text: >
             az keyvault certificate download --vault-name vault -n cert-name -f cert.crt -e DER && \\
             openssl x509 -in cert.crt -inform DER  -noout -sha1 -fingerprint
@@ -75,12 +74,12 @@ helps['keyvault certificate download'] = """
 
 helps['keyvault certificate get-default-policy'] = """
     type: command
-    short-summary: Get the default policy for a self-signed certificate.
+    short-summary: Get the default policy for self-signed certificates.
     long-summary: >
         This default policy can be used in conjunction with `az keyvault create` to create a self-signed certificate.
         The default policy can also be used as a starting point to create derivative policies.\n
 
-        Also see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
+        For more details, see: https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
     examples:
         - name: Create a self-signed certificate with the default policy
           text: >
@@ -90,8 +89,8 @@ helps['keyvault certificate get-default-policy'] = """
 
 helps['keyvault certificate create'] = """
     type: command
-    short-summary: >
-        Create a Key Vault certificate. Certificates can also be used as a secrets in provisioned virtual machines.
+    short-summary: Create a Key Vault certificate.
+    long-summary: Certificates can be used as a secrets for provisioned virtual machines.
     examples:
         - name: Create a self-signed certificate with the default policy and add it to a virtual machine.
           text: >

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
@@ -35,7 +35,7 @@ helps['lab vm create'] = """
                     Use `az lab formula` with the `--export-artifacts` flag to export and update artifacts, then pass
                     the results via the `--artifacts` argument.
                 - name: --size
-                  short-summary: The size of the VM to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.
+                  short-summary: 'The size of the VM to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.'
                 - name: --admin-username
                   short-summary: Username for the VM admin.
                 - name: --admin-password

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
@@ -12,81 +12,76 @@ helps['lab'] = """
             """
 helps['lab vm'] = """
             type: group
-            short-summary: Commands to manage VM in a DevTest Lab.
+            short-summary: Commands to manage a VM in a DevTest Lab.
             """
 helps['lab vm create'] = """
             type: command
-            short-summary: Command to create VM in a DevTest Lab.
+            short-summary: Command to create a VM in a DevTest Lab.
             parameters:
                 - name: --name -n
-                  short-summary: Name of the virtual machine
+                  short-summary: Name of the virtual machine.
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the Lab.
                 - name: --notes
-                  short-summary: Notes for the virtual machine
+                  short-summary: Notes for the virtual machine.
                 - name: --image
                   short-summary: The name of the operating system image (Gallery Image Name and Custom Image Name/ID).
-                                 Use az lab gallery-image list for available Gallery Images or
-                                 Use az lab custom-image list for available Custom Images
+                  long-summary:  Use 'az lab gallery-image list' for available gallery images or 'az lab custom-image list' for available custom images.
                 - name: --image-type
-                  short-summary: Type of the image. Allowed values are gallery, custom
+                  short-summary: 'Type of the image. Allowed values are: gallery, custom'
                 - name: --formula
-                  short-summary: Name of the formula. Use az lab formula list for available formulas.
-                                 Use az lab formula with --export-artifacts flag to export & update artifacts then supply
-                                 it via --artifacts argument
+                  short-summary: Name of the formula. Use 'az lab formula list' for available formulas.
+                                 Use 'az lab formula' with the --export-artifacts flag to export & update artifacts then supply
+                                 it via the --artifacts argument
                 - name: --size
-                  short-summary: The VM size to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.
-                                 Required when creating VM from gallery or custom image
+                  short-summary: The size of the VM to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.
                 - name: --admin-username
-                  short-summary: Username for the VM
+                  short-summary: Username for the VM admin.
                 - name: --admin-password
-                  short-summary: Password for the VM
+                  short-summary: Password for the VM admin.
                 - name: --ssh-key
-                  short-summary: The SSH public key or public key file path. Use --generate-ssh-keys to regen ssh keys
+                  short-summary: The SSH public key or public key file path. Use --generate-ssh-keys to generate ssh keys.
                 - name: --authentication-type
-                  short-summary: Type of authentication to use with the VM. Allowed values are password, ssh
+                  short-summary: 'Type of authentication to use with the VM. Allowed values are: password, ssh.'
                 - name: --saved-secret
-                  short-summary: Name of the saved secret to be used for authentication. When provided,
-                                 we'll use it inplace of --admin-password for password based authentication or
-                                 inplace of --ssh-key for ssh based authentication
+                  short-summary: Name of the saved secret to be used for authentication.
+                  long-summary: When this value is provided, it is used in the place of other authentication methods.
                 - name: --vnet-name
-                  short-summary: Name of the virtual network to reference an existing one in lab. If omitted, lab's existing one
-                                 VNet and subnet will be selected automatically
+                  short-summary: Name of the virtual network to add the VM to.
                 - name: --subnet
-                  short-summary: Name of the subnet to reference an existing one in lab. If omitted, lab's existing one subnet will be
-                                 selected automatically
+                  short-summary: Name of the subnet to add the VM to.
                 - name: --ip-configuration
-                  short-summary: Type of ip configuration to use with the VM. Allowed values are shared, public, private.
-                                 If omitted, will be selected based on selected vnet
+                  short-summary: 'Type of ip configuration to use for the VM. Allowed values are: shared, public, private.'
+                  long-summary: If omitted, will be selected based on the VM's vnet.
                 - name: --artifacts
-                  short-summary: JSON encoded array of artifacts to be applied. Use @{file} to load from a file
+                  short-summary: JSON encoded array of artifacts to be applied. Use @file to load from a file.
                 - name: --tags
-                  short-summary: Space separated tags in 'key[=value]' format. Use "" to clear existing tags
+                  short-summary: Space separated tags in 'key[=value]' format.
                 - name: --allow-claim
-                  short-summary: Flag indicating whether the VM will be created as a claimable VM in the lab
+                  short-summary: Flag indicating whether the VM will be created as claimable.
                 - name: --disk-type
-                  short-summary: Storage type to use for virtual machine (i.e. Standard, Premium)
+                  short-summary: Storage type to use for virtual machine.
                 - name: --expiration-date
-                  short-summary: The expiration date in UTC(YYYY-mm-dd) for VM. Ex. 2017-03-25
+                  short-summary: The expiration date in UTC(YYYY-mm-dd) for the VM.
                 - name: --generate-ssh-keys
-                  short-summary: Generate SSH public and private key files if missing
+                  short-summary: Generate SSH public and private key files if missing.
             examples:
-                - name: Create a Virtual Machine in the lab from gallery image.
+                - name: Create a Virtual Machine in the lab from a gallery image.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab from gallery image with ssh authentication.
+                - name: Create a Virtual Machine in the lab from a gallery image with ssh authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --authentication-type ssh
-                - name: Create a claimable Virtual Machine in the lab from gallery image with password authentication.
+                - name: Create a claimable Virtual Machine in the lab from a gallery image with password authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --allow-claim
-                - name: Create a windows Virtual Machine in the lab from gallery image with password authentication.
+                - name: Create a windows Virtual Machine in the lab from a gallery image with password authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Windows Server 2008 R2 SP1" --image-type gallery --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab from custom image.
+                - name: Create a Virtual Machine in the lab from a custom image.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "jenkins_custom" --image-type custom --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab with public ip configuration.
+                - name: Create a Virtual Machine in the lab with a public ip.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --ip-configuration public
                 - name: Create a Virtual Machine from a formula.
@@ -95,52 +90,52 @@ helps['lab vm create'] = """
             """
 helps['lab vm list'] = """
             type: command
-            short-summary: Command to retrieve my vms from the Azure DevTest Lab.
+            short-summary: List VMs in a Azure DevTest Lab.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --order-by
-                  short-summary: The ordering expression for the results using OData notation
+                  short-summary: The ordering expression for the results using OData notation.
                 - name: --top
-                  short-summary: The maximum number of resources to return from the operation
+                  short-summary: The maximum number of resources to return.
                 - name: --filters
-                  short-summary: The filter to apply on the operation
+                  short-summary: The filter to apply.
                 - name: --expand
-                  short-summary: Specify the expand query.
+                  short-summary: The expand query.
                 - name: --claimable
-                  short-summary: List of claimable virtual machines in the lab. Cannot be used with --filters
+                  short-summary: List only claimable virtual machines in the lab. Cannot be used with --filters
                 - name: --all
                   short-summary: List all virtual machines in the lab. Cannot be used with --filters
                 - name: --environment
-                  short-summary: Name or ID of the environment to list all virtual machines in the environment. Cannot be used with --filters
+                  short-summary: Name or ID of the environment to list virtual machines in. Cannot be used with --filters
                 - name: --object-id
-                  short-summary: Owner's object id. If omitted, we'll pick one if available
+                  short-summary: Object ID of the owner to list  virtual machines for.
             """
 helps['lab vm apply-artifacts'] = """
             type: command
-            short-summary: Command to apply artifacts to virtual machine in Azure DevTest Lab.
+            short-summary: Apply artifacts to a virtual machine in Azure DevTest Lab.
             parameters:
                 - name: --resource-group -g
-                  short-summary: Name of lab's resource group
+                  short-summary: Name of lab's resource group.
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the Lab.
                 - name: --name -n
-                  short-summary: Name of the virtual machine
+                  short-summary: Name of the virtual machine.
                 - name: --artifacts
-                  short-summary: JSON encoded array of artifacts to be applied. Use @{file} to load from a file
+                  short-summary: JSON encoded array of artifacts to be applied. Use @file to load from a file.
             """
 helps['lab vm claim'] = """
             type: command
-            short-summary: Claim a specific virtual machine or any available from the Lab.
+            short-summary: Claim a virtual machine from the Lab.
             parameters:
                 - name: --ids
                   short-summary: Space separated list of VM IDs to claim.
                 - name: --resource-group -g
-                  short-summary: Name of lab's resource group
+                  short-summary: Name of lab's resource group.
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the virtual machine
+                  short-summary: Name of the virtual machine to claim.
             examples:
                 - name: Claim any available virtual machine in the lab.
                   text: >
@@ -150,131 +145,137 @@ helps['lab vm claim'] = """
                     az lab vm claim -g MyRG --lab-name MyLab --name MyVM
                 - name: Claim multiple virtual machines in the lab using --ids.
                   text: >
-                    az lab vm claim --ids /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM1} /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM2}
+                    az lab vm claim --ids \\
+                            /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM1} \\
+                            /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM2}
             """
 helps['lab custom-image'] = """
             type: group
-            short-summary: Commands to manage custom images of a DevTest Lab.
+            short-summary: Manage custom images of a DevTest Lab.
             """
 helps['lab custom-image create'] = """
             type: command
-            short-summary: Command to create custom image in a DevTest Lab.
+            short-summary: Create a custom image in a DevTest Lab.
             parameters:
                 - name: --name -n
-                  short-summary: Name of the custom image
+                  short-summary: Name of the image.
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the Lab.
                 - name: --author
-                  short-summary: The author of the custom image
+                  short-summary: The author of the custom image.
                 - name: --description
-                  short-summary: A detailed description for the custom image
+                  short-summary: A detailed description for the custom image.
                 - name: --source-vm-id
-                  short-summary: The resource ID of a lab virtual machine in the provided lab
+                  short-summary: The resource ID of a virtual machine in the provided lab.
                 - name: --os-type
-                  short-summary: Type of the OS on which the custom image is based. Allowed values are Windows, Linux
+                  short-summary: 'Type of the OS on which the custom image is based. Allowed values are: Windows, Linux'
                 - name: --os-state
-                  short-summary: The current state of the virtual machine. For Windows virtual machines - NonSysprepped, SysprepRequested, SysprepApplied.  For Linux virtual machines - NonDeprovisioned, DeprovisionRequested, DeprovisionApplied
+                  short-summary: The current state of the virtual machine.
+                  long-summary: >
+                    For Windows virtual machines: NonSysprepped, SysprepRequested, SysprepApplied
+                    For Linux virtual machines - NonDeprovisioned, DeprovisionRequested, DeprovisionApplied
             examples:
-                - name: Create a custom image in the lab from a running Windows virtual machine without applying sysprep
+                - name: Create a custom image in the lab from a running Windows virtual machine without applying sysprep.
                   text: >
-                    az lab custom-image create --lab-name MyLab -g MyRG --name MyVM --source-vm-id "/subscriptions/mysubscription/resourcegroups/myresourcegroup/microsoft.devtestlab/labs/mylab/virtualmachines/myvirtualmachine" --os-type Windows --os-state NonSysprepped
+                    az lab custom-image create --lab-name MyLab -g MyRG --name MyVM \\
+                            --os-type Windows --os-state NonSysprepped \\
+                            --source-vm-id "/subscriptions/mysubscription/resourcegroups/myresourcegroup/microsoft.devtestlab/labs/mylab/virtualmachines/myvirtualmachine"
             """
 helps['lab gallery-image'] = """
             type: group
-            short-summary: Commands to list Azure Marketplace images allowed in a given DevTest Lab.
+            short-summary: List Azure Marketplace images allowed in a given DevTest Lab.
             """
 helps['lab artifact'] = """
             type: group
-            short-summary: Commands to manage DevTest Labs artifacts.
+            short-summary: Manage DevTest Labs artifacts.
             """
 helps['lab artifact-source'] = """
             type: group
-            short-summary: Commands to manage DevTest Lab artifact sources.
+            short-summary: Manage DevTest Lab artifact sources.
             """
 helps['lab vnet'] = """
             type: group
-            short-summary: Commands to manage Virtual Networks of a DevTest Lab.
+            short-summary: Manage Virtual Networks of a DevTest Lab.
             """
 helps['lab formula'] = """
             type: group
-            short-summary: Commands to manage formulas of a DevTest Lab.
+            short-summary: Manage formulas of a DevTest Lab.
             """
 helps['lab formula show'] = """
             type: command
-            short-summary: Commands to show formula from the Azure DevTest Lab.
+            short-summary: Show formulae from the Azure DevTest Lab.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the formula
+                  short-summary: Name of the formula.
             """
 helps['lab formula export-artifacts'] = """
             type: command
             short-summary: Export artifacts from a formula.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the formula
+                  short-summary: Name of the formula.
             """
 helps['lab secret'] = """
             type: group
-            short-summary: Commands to manage secrets of a DevTest Lab.
+            short-summary: Manage secrets of a DevTest Lab.
             """
 helps['lab secret set'] = """
             type: command
-            short-summary: Sets a secret in the DevTest Lab.
+            short-summary: Sets a secret in a DevTest Lab.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the secret
+                  short-summary: Name of the secret.
                 - name: --value
-                  short-summary: Value of the secret
+                  short-summary: Value of the secret.
             """
 helps['lab arm-template'] = """
             type: group
-            short-summary: Commands to manage ARM templates in a DevTest Lab.
+            short-summary: Manage Azure Resource Manager (ARM) templates in a DevTest Lab.
             """
 helps['lab arm-template show'] = """
             type: command
-            short-summary: Commands to show ARM templates in a DevTest Lab.
+            short-summary: Show ARM templates in a DevTest Lab.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the azure Resource Manager template
+                  short-summary: Name of the azure resource manager template.
                 - name: --resource-group -g
-                  short-summary: Name of lab's resource group
+                  short-summary: Name of lab's resource group.
                 - name: --export-parameters
-                  short-summary: Whether to export parameters template or not. This parameter template
-                                 can be used in creation of environment from this ARM template
+                  short-summary: Whether or not to export parameters template.
                 - name: --artifact-source-name
-                  short-summary: Name of the artifact source
+                  short-summary: Name of the artifact source.
             """
 helps['lab environment'] = """
             type: group
-            short-summary: Commands to manage environments in a DevTest Lab.
+            short-summary: Manage environments in a DevTest Lab.
             """
 helps['lab environment create'] = """
             type: command
             short-summary: Create an environment.
             parameters:
                 - name: --lab-name
-                  short-summary: Name of the Lab
+                  short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the environment
+                  short-summary: Name of the environment.
                 - name: --resource-group -g
-                  short-summary: Name of lab's resource group
+                  short-summary: Name of the lab's resource group.
                 - name: --arm-template
-                  short-summary: Name or ID of Azure Resource Manager template in the lab.
+                  short-summary: Name or ID of the resource manager template in the lab.
                 - name: --artifact-source-name
-                  short-summary: Name of the artifact source in the lab. Use az lab artifact-source list to see
-                                 available artifact sources
+                  short-summary: Name of the artifact source in the lab.
+                  long-summary: Use 'az lab artifact-source list' to see available artifact sources.
                 - name: --parameters
-                  short-summary: JSON encoded list of parameters. Use @{file} to load from a file
+                  short-summary: JSON encoded list of parameters. Use @file to load from a file.
                 - name: --tags
-                  short-summary: The tags of the resource
+                  short-summary: The tags for the resource.
             """
 helps['lab environment delete'] = """
             type: command

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/_help.py
@@ -8,31 +8,32 @@ from azure.cli.core.help_files import helps
 
 helps['lab'] = """
             type: group
-            short-summary: Commands to manage DevTest Labs.
+            short-summary: Manage Azure DevTest Labs.
             """
 helps['lab vm'] = """
             type: group
-            short-summary: Commands to manage a VM in a DevTest Lab.
+            short-summary: Manage VMs in an Azure DevTest Lab.
             """
 helps['lab vm create'] = """
             type: command
-            short-summary: Command to create a VM in a DevTest Lab.
+            short-summary: Create a VM in a lab.
             parameters:
                 - name: --name -n
                   short-summary: Name of the virtual machine.
                 - name: --lab-name
-                  short-summary: Name of the Lab.
+                  short-summary: Name of the lab.
                 - name: --notes
                   short-summary: Notes for the virtual machine.
                 - name: --image
-                  short-summary: The name of the operating system image (Gallery Image Name and Custom Image Name/ID).
-                  long-summary:  Use 'az lab gallery-image list' for available gallery images or 'az lab custom-image list' for available custom images.
+                  short-summary: The name of the operating system image (gallery image name or custom image name/ID).
+                  long-summary:  Use `az lab gallery-image list` for available gallery images or `az lab custom-image list` for available custom images.
                 - name: --image-type
                   short-summary: 'Type of the image. Allowed values are: gallery, custom'
                 - name: --formula
-                  short-summary: Name of the formula. Use 'az lab formula list' for available formulas.
-                                 Use 'az lab formula' with the --export-artifacts flag to export & update artifacts then supply
-                                 it via the --artifacts argument
+                  short-summary: Name of the formula. Use `az lab formula list` for available formulas.
+                  long-summary: >
+                    Use `az lab formula` with the `--export-artifacts` flag to export and update artifacts, then pass
+                    the results via the `--artifacts` argument.
                 - name: --size
                   short-summary: The size of the VM to be created. See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/ for size info.
                 - name: --admin-username
@@ -40,9 +41,9 @@ helps['lab vm create'] = """
                 - name: --admin-password
                   short-summary: Password for the VM admin.
                 - name: --ssh-key
-                  short-summary: The SSH public key or public key file path. Use --generate-ssh-keys to generate ssh keys.
+                  short-summary: The SSH public key or public key file path. Use `--generate-ssh-keys` to generate SSH keys.
                 - name: --authentication-type
-                  short-summary: 'Type of authentication to use with the VM. Allowed values are: password, ssh.'
+                  short-summary: 'Type of authentication allowed for the VM. Allowed values are: password, ssh.'
                 - name: --saved-secret
                   short-summary: Name of the saved secret to be used for authentication.
                   long-summary: When this value is provided, it is used in the place of other authentication methods.
@@ -51,14 +52,15 @@ helps['lab vm create'] = """
                 - name: --subnet
                   short-summary: Name of the subnet to add the VM to.
                 - name: --ip-configuration
-                  short-summary: 'Type of ip configuration to use for the VM. Allowed values are: shared, public, private.'
+                  short-summary: 'Type of IP configuration to use for the VM. Allowed values are: shared, public, private.'
                   long-summary: If omitted, will be selected based on the VM's vnet.
                 - name: --artifacts
-                  short-summary: JSON encoded array of artifacts to be applied. Use @file to load from a file.
+                  short-summary: JSON encoded array of artifacts to be applied. Use @{file} to load from a file.
                 - name: --tags
-                  short-summary: Space separated tags in 'key[=value]' format.
+                  short-summary: Space separated tags in `key[=value]` format.
+                  long-summary: Tags may be cleared by assigning the empty value `""` to them.
                 - name: --allow-claim
-                  short-summary: Flag indicating whether the VM will be created as claimable.
+                  short-summary: Flag indicating if the VM should be created as claimable.
                 - name: --disk-type
                   short-summary: Storage type to use for virtual machine.
                 - name: --expiration-date
@@ -66,31 +68,31 @@ helps['lab vm create'] = """
                 - name: --generate-ssh-keys
                   short-summary: Generate SSH public and private key files if missing.
             examples:
-                - name: Create a Virtual Machine in the lab from a gallery image.
+                - name: Create a VM in the lab from a gallery image.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab from a gallery image with ssh authentication.
+                - name: Create a VM in the lab from a gallery image with SSH authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --authentication-type ssh
-                - name: Create a claimable Virtual Machine in the lab from a gallery image with password authentication.
+                - name: Create a claimable VM in the lab from a gallery image with password authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --allow-claim
-                - name: Create a windows Virtual Machine in the lab from a gallery image with password authentication.
+                - name: Create a windows VM in the lab from a gallery image with password authentication.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Windows Server 2008 R2 SP1" --image-type gallery --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab from a custom image.
+                - name: Create a VM in the lab from a custom image.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "jenkins_custom" --image-type custom --size Standard_DS1_v2
-                - name: Create a Virtual Machine in the lab with a public ip.
+                - name: Create a VM in the lab with a public IP.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --image "Ubuntu Server 16.04 LTS" --image-type gallery --size Standard_DS1_v2 --ip-configuration public
-                - name: Create a Virtual Machine from a formula.
+                - name: Create a VM from a formula.
                   text: >
                     az lab vm create --lab-name MyLab -g MyRG --name MyVM --formula MyFormula --artifacts @/artifacts.json
             """
 helps['lab vm list'] = """
             type: command
-            short-summary: List VMs in a Azure DevTest Lab.
+            short-summary: List the VMs in an Azure DevTest Lab.
             parameters:
                 - name: --lab-name
                   short-summary: Name of the lab.
@@ -103,13 +105,13 @@ helps['lab vm list'] = """
                 - name: --expand
                   short-summary: The expand query.
                 - name: --claimable
-                  short-summary: List only claimable virtual machines in the lab. Cannot be used with --filters
+                  short-summary: List only claimable virtual machines in the lab. Cannot be used with `--filters`.
                 - name: --all
-                  short-summary: List all virtual machines in the lab. Cannot be used with --filters
+                  short-summary: List all virtual machines in the lab. Cannot be used with `--filters`
                 - name: --environment
-                  short-summary: Name or ID of the environment to list virtual machines in. Cannot be used with --filters
+                  short-summary: Name or ID of the environment to list virtual machines in. Cannot be used with `--filters`.
                 - name: --object-id
-                  short-summary: Object ID of the owner to list  virtual machines for.
+                  short-summary: Object ID of the owner to list VMs for.
             """
 helps['lab vm apply-artifacts'] = """
             type: command
@@ -122,7 +124,7 @@ helps['lab vm apply-artifacts'] = """
                 - name: --name -n
                   short-summary: Name of the virtual machine.
                 - name: --artifacts
-                  short-summary: JSON encoded array of artifacts to be applied. Use @file to load from a file.
+                  short-summary: JSON encoded array of artifacts to be applied. Use @{file} to load from a file.
             """
 helps['lab vm claim'] = """
             type: command
@@ -143,11 +145,11 @@ helps['lab vm claim'] = """
                 - name: Claim a specific virtual machine in the lab.
                   text: >
                     az lab vm claim -g MyRG --lab-name MyLab --name MyVM
-                - name: Claim multiple virtual machines in the lab using --ids.
-                  text: >
+                - name: Claim multiple virtual machines in the lab using `--ids`.
+                  text: |
                     az lab vm claim --ids \\
-                            /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM1} \\
-                            /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM2}
+                        /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM1} \\
+                        /subscriptions/{SubID}/resourcegroups/{MyRG}/providers/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM2}
             """
 helps['lab custom-image'] = """
             type: group
@@ -176,34 +178,34 @@ helps['lab custom-image create'] = """
                     For Linux virtual machines - NonDeprovisioned, DeprovisionRequested, DeprovisionApplied
             examples:
                 - name: Create a custom image in the lab from a running Windows virtual machine without applying sysprep.
-                  text: >
+                  text: |
                     az lab custom-image create --lab-name MyLab -g MyRG --name MyVM \\
-                            --os-type Windows --os-state NonSysprepped \\
-                            --source-vm-id "/subscriptions/mysubscription/resourcegroups/myresourcegroup/microsoft.devtestlab/labs/mylab/virtualmachines/myvirtualmachine"
-            """
+                        --os-type Windows --os-state NonSysprepped \\
+                        --source-vm-id "/subscriptions/{SubID}/resourcegroups/{MyRG}/microsoft.devtestlab/labs/{MyLab}/virtualmachines/{MyVM}"
+"""
 helps['lab gallery-image'] = """
             type: group
-            short-summary: List Azure Marketplace images allowed in a given DevTest Lab.
-            """
+            short-summary: List Azure Marketplace images allowed for a DevTest Lab.
+"""
 helps['lab artifact'] = """
             type: group
             short-summary: Manage DevTest Labs artifacts.
-            """
+"""
 helps['lab artifact-source'] = """
             type: group
             short-summary: Manage DevTest Lab artifact sources.
             """
 helps['lab vnet'] = """
             type: group
-            short-summary: Manage Virtual Networks of a DevTest Lab.
+            short-summary: Manage virtual networks of an Azure DevTest Lab.
             """
 helps['lab formula'] = """
             type: group
-            short-summary: Manage formulas of a DevTest Lab.
+            short-summary: Manage formulas for an Azure DevTest Lab.
             """
 helps['lab formula show'] = """
             type: command
-            short-summary: Show formulae from the Azure DevTest Lab.
+            short-summary: Show formulae from an Azure DevTest Lab.
             parameters:
                 - name: --lab-name
                   short-summary: Name of the lab.
@@ -221,11 +223,11 @@ helps['lab formula export-artifacts'] = """
             """
 helps['lab secret'] = """
             type: group
-            short-summary: Manage secrets of a DevTest Lab.
+            short-summary: Manage secrets of an Azure DevTest Lab.
             """
 helps['lab secret set'] = """
             type: command
-            short-summary: Sets a secret in a DevTest Lab.
+            short-summary: Set a secret for a lab.
             parameters:
                 - name: --lab-name
                   short-summary: Name of the lab.
@@ -236,16 +238,16 @@ helps['lab secret set'] = """
             """
 helps['lab arm-template'] = """
             type: group
-            short-summary: Manage Azure Resource Manager (ARM) templates in a DevTest Lab.
+            short-summary: Manage Azure Resource Manager (ARM) templates in an Azure DevTest Lab.
             """
 helps['lab arm-template show'] = """
             type: command
-            short-summary: Show ARM templates in a DevTest Lab.
+            short-summary: Get the details of an ARM template in a lab.
             parameters:
                 - name: --lab-name
                   short-summary: Name of the lab.
                 - name: --name -n
-                  short-summary: Name of the azure resource manager template.
+                  short-summary: Name of the Azure Resource Manager template.
                 - name: --resource-group -g
                   short-summary: Name of lab's resource group.
                 - name: --export-parameters
@@ -255,11 +257,11 @@ helps['lab arm-template show'] = """
             """
 helps['lab environment'] = """
             type: group
-            short-summary: Manage environments in a DevTest Lab.
+            short-summary: Manage environments for an Azure DevTest Lab.
             """
 helps['lab environment create'] = """
             type: command
-            short-summary: Create an environment.
+            short-summary: Create an environment in a lab.
             parameters:
                 - name: --lab-name
                   short-summary: Name of the lab.
@@ -268,24 +270,25 @@ helps['lab environment create'] = """
                 - name: --resource-group -g
                   short-summary: Name of the lab's resource group.
                 - name: --arm-template
-                  short-summary: Name or ID of the resource manager template in the lab.
+                  short-summary: Name or ID of the ARM template in the lab.
                 - name: --artifact-source-name
                   short-summary: Name of the artifact source in the lab.
-                  long-summary: Use 'az lab artifact-source list' to see available artifact sources.
+                  populator-commands:
+                    - az lab artifact-source list
                 - name: --parameters
-                  short-summary: JSON encoded list of parameters. Use @file to load from a file.
+                  short-summary: JSON encoded list of parameters. Use @{file} to load from a file.
                 - name: --tags
                   short-summary: The tags for the resource.
             """
 helps['lab environment delete'] = """
             type: command
-            short-summary: Delete an environment.
+            short-summary: Delete an environment from a lab.
             """
 helps['lab environment list'] = """
             type: command
-            short-summary: List environments.
+            short-summary: List environments in a lab.
             """
 helps['lab environment show'] = """
             type: command
-            short-summary: Get an environment.
+            short-summary: Get the details for an environment of a lab.
             """

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -8,16 +8,16 @@ from azure.cli.core.help_files import helps
 # pylint: disable=line-too-long, too-many-lines
 
 helps['monitor'] = """
-            type: group
-            short-summary: Commands to manage Azure Monitor service.
-            """
+    type: group
+    short-summary: Manage the Azure Monitor Service.
+"""
 
 # region Alerts
 
 helps['monitor alert'] = """
     type: group
-    short-summary: Commands to manage metric-based alert rules.
-    """
+    short-summary: Manage metric-based alert rules.
+"""
 
 helps['monitor alert create'] = """
     type: command
@@ -30,7 +30,7 @@ helps['monitor alert create'] = """
             Email:   --action email bob@contoso.com ann@contoso.com
             Webhook: --action webhook https://www.contoso.com/alert apiKey=value
             Webhook: --action webhook https://www.contoso.com/alert?apiKey=value
-            To specify multiple actions, add multiple --add-action ARGS entries.
+            To specify multiple actions, use multiple --action args.
         - name: --description
           short-summary: Free-text description of the rule. Defaults to the condition expression.
         - name: --disabled
@@ -43,10 +43,10 @@ helps['monitor alert create'] = """
         - name: --email-service-owners
           short-summary: Email the service owners if an alert is triggered.
     examples:
-        - name: Create a High CPU-based alert on a VM with no actions.
+        - name: Create a high CPU usage alert on a VM with no actions.
           text: >
             az vm alert rule create -n rule1 -g <RG> --target <VM ID> --condition "Percentage CPU > 90 avg 5m"
-        - name: Create a High CPU-based alert on a VM with email and webhook actions.
+        - name: Create a high CPU usage alert on a VM with email and webhook actions.
           text: |
             az vm alert rule create -n rule1 -g <RG> --target <VM ID> \\
                 --condition "Percentage CPU > 90 avg 5m" \\
@@ -58,16 +58,13 @@ helps['monitor alert create'] = """
 helps['monitor alert update'] = """
     type: command
     short-summary: Update a metric-based alert rule.
-    long-summary: |
-        To specify the condition:
-            --condition METRIC {>,>=,<,<=} THRESHOLD {avg,min,max,total,last} PERIOD
     parameters:
         - name: --target
           short-summary: ID of the resource to target for the alert rule.
         - name: --description
-          short-summary: Free-text description of the rule.
+          short-summary: Description of the rule.
         - name: --condition
-          short-summary: The condition expression upon which to trigger the rule.
+          short-summary: The condition expression which triggers the rule.
           long-summary: |
             Usage:   --condition "METRIC {>,>=,<,<=} THRESHOLD {avg,min,max,total,last} PERIOD"
             Example: --condition "Percentage CPU > 60 avg 1h30m"
@@ -78,7 +75,7 @@ helps['monitor alert update'] = """
             Email:   --add-action email bob@contoso.com ann@contoso.com
             Webhook: --add-action webhook https://www.contoso.com/alert apiKey=value
             Webhook: --add-action webhook https://www.contoso.com/alert?apiKey=value
-            To specify multiple actions, add multiple --add-action ARGS entries.
+            To specify multiple actions, add multiple --add-action args.
         - name: --remove-action -r
           short-summary: Remove one or more actions.
           long-summary: |
@@ -133,7 +130,7 @@ helps['monitor alert list-incidents'] = """
 
 helps['monitor metrics'] = """
     type: group
-    short-summary: Commands to view Azure resource metrics.
+    short-summary: View Azure resource metrics.
 """
 
 helps['monitor metrics list'] = """
@@ -150,15 +147,15 @@ helps['monitor metrics list-definitions'] = """
 
 helps['monitor log-profiles'] = """
             type: group
-            short-summary: Commands to manage the log profiles assigned to Azure subscription.
+            short-summary: Manage the log profiles.
             """
 helps['monitor log-profiles update'] = """
             type: command
-            short-summary: Update a log profile assigned to Azure subscription.
+            short-summary: Update a log profile.
             """
 helps['monitor diagnostic-settings'] = """
             type: group
-            short-summary: Commands to manage service diagnostic settings.
+            short-summary: Manage service diagnostic settings.
             """
 helps['monitor diagnostic-settings create'] = """
             type: command
@@ -166,38 +163,38 @@ helps['monitor diagnostic-settings create'] = """
             parameters:
                 - name: --resource-id
                   type: string
-                  short-summary: The identifier of the resource
+                  short-summary: The identifier of the resource.
                 - name: --resource-group -g
                   type: string
-                  short-summary: Name of the resource group
+                  short-summary: Name of the resource group.
                 - name: --logs
                   type: string
-                  short-summary: JSON encoded list of logs settings. Use @{file} to load from a file.
+                  short-summary: JSON encoded list of logs settings. Use @file to load from a file.
                 - name: --metrics
                   type: string
-                  short-summary: JSON encoded list of metric settings. Use @{file} to load from a file.
+                  short-summary: JSON encoded list of metric settings. Use @file to load from a file.
                 - name: --storage-account
                   type: string
-                  short-summary: Name or ID of the storage account to which you would like to send Diagnostic Logs
+                  short-summary: Name or ID of the storage account to send diagnostic logs to.
                 - name: --namespace
                   type: string
-                  short-summary: Name or ID of the Service Bus namespace
+                  short-summary: Name or ID of the Service Bus namespace.
                 - name: --rule-name
                   type: string
-                  short-summary: Name of the Service Bus authorization rule
+                  short-summary: Name of the Service Bus authorization rule.
                 - name: --workspace
                   type: string
-                  short-summary: Name or ID of the Log Analytics workspace to which you would like to send Diagnostic Logs
+                  short-summary: Name or ID of the Log Analytics workspace to send diagnostic logs to.
                 - name: --tags
                   short-summary: Space separated tags in 'key[=value]' format. Use '' to clear existing tags
             """
 helps['monitor diagnostic-settings update'] = """
             type: command
-            short-summary: Update diagnostic settings for the specified resource.
+            short-summary: Update diagnostic settings.
             """
 helps['monitor autoscale-settings'] = """
             type: group
-            short-summary: Commands to manage autoscale settings.
+            short-summary: Manage autoscale settings.
             """
 helps['monitor autoscale-settings update'] = """
             type: command
@@ -206,5 +203,5 @@ helps['monitor autoscale-settings update'] = """
 
 helps['monitor activity-log'] = """
     type: group
-    short-summary: Commands to manage activity log.
+    short-summary: Manage activity logs.
 """

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_help.py
@@ -30,16 +30,15 @@ helps['monitor alert create'] = """
             Email:   --action email bob@contoso.com ann@contoso.com
             Webhook: --action webhook https://www.contoso.com/alert apiKey=value
             Webhook: --action webhook https://www.contoso.com/alert?apiKey=value
-            To specify multiple actions, use multiple --action args.
+            Multiple actions can be specified by using more than one `--action` argument.
         - name: --description
           short-summary: Free-text description of the rule. Defaults to the condition expression.
         - name: --disabled
           short-summary: Create the rule in a disabled state.
         - name: --condition
-          short-summary: The condition expression upon which to trigger the rule.
+          short-summary: The condition which triggers the rule.
           long-summary: |
             Usage:   --condition "METRIC {>,>=,<,<=} THRESHOLD {avg,min,max,total,last} PERIOD"
-            Example: --condition "Percentage CPU > 60 avg 1h30m"
         - name: --email-service-owners
           short-summary: Email the service owners if an alert is triggered.
     examples:
@@ -75,7 +74,7 @@ helps['monitor alert update'] = """
             Email:   --add-action email bob@contoso.com ann@contoso.com
             Webhook: --add-action webhook https://www.contoso.com/alert apiKey=value
             Webhook: --add-action webhook https://www.contoso.com/alert?apiKey=value
-            To specify multiple actions, add multiple --add-action args.
+            Multiple actions can be specified by using more than one `--action` argument.
         - name: --remove-action -r
           short-summary: Remove one or more actions.
           long-summary: |
@@ -116,7 +115,7 @@ helps['monitor alert show'] = """
 
 helps['monitor alert show-incident'] = """
     type: command
-    short-summary: Show details of an alert rule incident.
+    short-summary: Get the details of an alert rule incident.
     """
 
 helps['monitor alert list-incidents'] = """
@@ -147,7 +146,7 @@ helps['monitor metrics list-definitions'] = """
 
 helps['monitor log-profiles'] = """
             type: group
-            short-summary: Manage the log profiles.
+            short-summary: Manage log profiles.
             """
 helps['monitor log-profiles update'] = """
             type: command
@@ -159,7 +158,7 @@ helps['monitor diagnostic-settings'] = """
             """
 helps['monitor diagnostic-settings create'] = """
             type: command
-            short-summary: Creates diagnostic settings for the specified resource.
+            short-summary: Create diagnostic settings for the specified resource.
             parameters:
                 - name: --resource-id
                   type: string
@@ -169,10 +168,10 @@ helps['monitor diagnostic-settings create'] = """
                   short-summary: Name of the resource group.
                 - name: --logs
                   type: string
-                  short-summary: JSON encoded list of logs settings. Use @file to load from a file.
+                  short-summary: JSON encoded list of logs settings. Use @{file} to load from a file.
                 - name: --metrics
                   type: string
-                  short-summary: JSON encoded list of metric settings. Use @file to load from a file.
+                  short-summary: JSON encoded list of metric settings. Use @{file} to load from a file.
                 - name: --storage-account
                   type: string
                   short-summary: Name or ID of the storage account to send diagnostic logs to.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -9,7 +9,7 @@ from azure.cli.core.help_files import helps
 
 helps['network'] = """
     type: group
-    short-summary: Manages Azure Network resources.
+    short-summary: Manage Azure Network resources.
 """
 
 helps['network dns'] = """
@@ -41,7 +41,7 @@ helps['network application-gateway list'] = """
 
 helps['network application-gateway show'] = """
     type: command
-    short-summary: Show details of an application gateway.
+    short-summary: Get the details of an application gateway.
 """
 
 helps['network application-gateway start'] = """
@@ -61,7 +61,7 @@ helps['network application-gateway update'] = """
 
 helps['network application-gateway show-backend-health'] = """
     type: command
-    short-summary: Show details about the backend health of an application gateway.
+    short-summary: Get information on the backend health of an application gateway.
 """
 
 helps['network application-gateway wait'] = """
@@ -82,10 +82,10 @@ helps['network application-gateway address-pool create'] = """
     short-summary: Create a backend address pool.
     examples:
         - name: Create an address pool with two endpoints.
-          text: >
+          text: |
             az network application-gateway address-pool create \\
-                    -g MyResourceGroup --gateway-name MyApplicationGateway \\
-                    -n MyAddressPool --servers 10.0.0.4 10.0.0.5
+                -g MyResourceGroup --gateway-name MyApplicationGateway \\
+                -n MyAddressPool --servers 10.0.0.4 10.0.0.5
 """
 
 helps['network application-gateway address-pool delete'] = """
@@ -100,7 +100,7 @@ helps['network application-gateway address-pool list'] = """
 
 helps['network application-gateway address-pool show'] = """
     type: command
-    short-summary: Show details of a backend address pool.
+    short-summary: Get the details for a backend address pool.
 """
 
 helps['network application-gateway address-pool update'] = """
@@ -132,7 +132,7 @@ helps['network application-gateway auth-cert list'] = """
 
 helps['network application-gateway auth-cert show'] = """
     type: command
-    short-summary: Show details of an authorization certificate.
+    short-summary: Get the details of an authorization certificate.
 """
 
 helps['network application-gateway auth-cert update'] = """
@@ -165,7 +165,7 @@ helps['network application-gateway frontend-ip list'] = """
 
 helps['network application-gateway frontend-ip show'] = """
     type: command
-    short-summary: Show details of a frontend IP address.
+    short-summary: Get the details of a frontend IP address.
 """
 
 helps['network application-gateway frontend-ip update'] = """
@@ -198,7 +198,7 @@ helps['network application-gateway frontend-port list'] = """
 
 helps['network application-gateway frontend-port show'] = """
     type: command
-    short-summary: Show details of a frontend port.
+    short-summary: Get the details for a frontend port.
 """
 
 helps['network application-gateway frontend-port update'] = """
@@ -231,7 +231,7 @@ helps['network application-gateway http-listener list'] = """
 
 helps['network application-gateway http-listener show'] = """
     type: command
-    short-summary: Show details of an HTTP listener.
+    short-summary: Get the details for an HTTP listener.
 """
 
 helps['network application-gateway http-listener update'] = """
@@ -264,7 +264,7 @@ helps['network application-gateway http-settings list'] = """
 
 helps['network application-gateway http-settings show'] = """
     type: command
-    short-summary: Show details of HTTP settings.
+    short-summary: Get the details of a gateway's HTTP settings.
 """
 
 helps['network application-gateway http-settings update'] = """
@@ -277,7 +277,7 @@ helps['network application-gateway http-settings update'] = """
 
 helps['network application-gateway probe'] = """
     type: group
-    short-summary: Use probes to gather information from a gateway and evaluate it using rules.
+    short-summary: Manage probes to gather and evaluate information on a gateway.
 """
 helps['network application-gateway probe create'] = """
     type: command
@@ -302,7 +302,7 @@ helps['network application-gateway probe list'] = """
 
 helps['network application-gateway probe show'] = """
     type: command
-    short-summary: Show details of a probe.
+    short-summary: Get the details of a probe.
 """
 
 helps['network application-gateway probe update'] = """
@@ -335,7 +335,7 @@ helps['network application-gateway redirect-config list'] = """
 
 helps['network application-gateway redirect-config show'] = """
     type: command
-    short-summary: Show details of a redirect configuration.
+    short-summary: Get the details of a redirect configuration.
 """
 
 helps['network application-gateway redirect-config update'] = """
@@ -369,7 +369,7 @@ helps['network application-gateway rule list'] = """
 
 helps['network application-gateway rule show'] = """
     type: command
-    short-summary: Show details of a rule.
+    short-summary: Get the details of a rule.
 """
 
 helps['network application-gateway rule update'] = """
@@ -401,7 +401,7 @@ helps['network application-gateway ssl-cert list'] = """
 
 helps['network application-gateway ssl-cert show'] = """
     type: command
-    short-summary: Show details of an SSL certificate.
+    short-summary: Get the details of an SSL certificate.
 """
 
 helps['network application-gateway ssl-cert update'] = """
@@ -433,7 +433,7 @@ helps['network application-gateway ssl-policy set'] = """
 
 helps['network application-gateway ssl-policy show'] = """
     type: command
-    short-summary: Show the SSL policy settings.
+    short-summary: Get the details of a gateway's SSL policy settings.
 """
 
 helps['network application-gateway ssl-policy predefined'] = """
@@ -455,8 +455,8 @@ helps['network application-gateway url-path-map create'] = """
     long-summary: >
         The map must be created with at least one rule. This command requires the creation of the
         first rule at the time the map is created. To create additional rules using different
-        address pools or HTTP settings, use the 'url-path-map rule create' command. To update the
-        rule created using this command, use the 'url-path-map rule update' command.
+        address pools or HTTP settings, use the `url-path-map rule create` command. To update the
+        rule created using this command, use the `url-path-map rule update` command.
 """
 
 helps['network application-gateway url-path-map delete'] = """
@@ -471,7 +471,7 @@ helps['network application-gateway url-path-map list'] = """
 
 helps['network application-gateway url-path-map show'] = """
     type: command
-    short-summary: Show details of a URL path map.
+    short-summary: Get the details of a URL path map.
 """
 
 helps['network application-gateway url-path-map update'] = """
@@ -518,7 +518,7 @@ helps['network application-gateway waf-config set'] = """
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rule-groups
-          short-summary: Space separated list of rule groups to disable. To disable specifc rules, use '--disabled-rules'.
+          short-summary: Space separated list of rule groups to disable. To disable individual rules, use `--disabled-rules`.
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rules
@@ -536,12 +536,13 @@ helps['network application-gateway waf-config set'] = """
 
 helps['network application-gateway waf-config show'] = """
     type: command
-    short-summary: Show the firewall configuration of a web application.
+    short-summary: Get the firewall configuration of a web application.
 """
 
 helps['network application-gateway waf-config list-rule-sets'] = """
     type: command
-    short-summary: (Preview) Lookup information on available WAF rule sets, rule groups, and rule IDs.
+    short-summary: Get information on available WAF rule sets, rule groups, and rule IDs.
+    long-summary: This command is in preview.
     parameters:
         - name: --group
           short-summary: >
@@ -585,12 +586,12 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
 for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     indef_article = 'an' if record.startswith('a') else 'a'
 
-    helps['network dns record-set {} remove-record'.format(record)] = """
+    helps['network dns record-set {0} remove-record'.format(record)] = """
         type: command
-        short-summary: Remove {} record from its set.
+        short-summary: Remove {1} {0} record from its record set.
         long-summary: >
             By default, if the last record in a set is removed, the record set is deleted. To retain the empty record set, include --keep-empty-record-set.
-    """.format(record.upper())
+    """.format(record.upper(), indef_article)
 
     helps['network dns record-set {} create'.format(record)] = """
         type: command
@@ -599,8 +600,8 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
 
     helps['network dns record-set {} delete'.format(record)] = """
         type: command
-        short-summary: Delete a {} record set and all associated records.
-    """.format(record.upper())
+        short-summary: Delete {1} {0} record set and all associated records.
+    """.format(record.upper(), indef_article)
 
     helps['network dns record-set {} list'.format(record)] = """
         type: command
@@ -609,23 +610,25 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
 
     helps['network dns record-set {} show'.format(record)] = """
         type: command
-        short-summary: Show details of {} record set.
+        short-summary: Get the details for {1} {0} record set.
         examples:
-        - name: Show information about {} {} record set.
+        - name: Show information about {1} {0} record set.
           text: >
-            az network dns record-set {} show -g MyResourceGroup -n MyRecordSet -z www.mysite.com
-    """.format(record.upper(), indef_article, record.upper(), record)
+            az network dns record-set {2} show -g MyResourceGroup -n MyRecordSet -z www.mysite.com
+    """.format(record.upper(), indef_article, record)
 
 for item in ['a', 'aaaa', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+    indef_article = 'an' if record.startswith('a') else 'a'
+    
     helps['network dns record-set {} update'.format(record)] = """
         type: command
-        short-summary: Update {} record set.
-    """.format(record.upper())
+        short-summary: Update  {} {} record set.
+    """.format(indef_article, record.upper())
 
     helps['network dns record-set {} add-record'.format(record)] = """
         type: command
-        short-summary: Add {} record.
-    """.format(record.upper())
+        short-summary: Add {} {} record.
+    """.format(indef_article, record.upper())
 
 helps['network dns record-set cname set-record'] = """
     type: command
@@ -639,7 +642,7 @@ helps['network dns record-set soa'] = """
 
 helps['network dns record-set soa show'] = """
     type: command
-    short-summary: Show details of a DNS zone's SOA record.
+    short-summary: Get the details of a DNS zone's SOA record.
 """
 
 helps['network dns record-set soa update'] = """
@@ -702,12 +705,12 @@ helps['network dns zone list'] = """
 
 helps['network dns zone show'] = """
     type: command
-    short-summary: Get DNS zone parameters. Does not show DNS records within the zone.
+    short-summary: Get a DNS zone's parameters. Does not show DNS records within the zone.
 """
 
 helps['network dns zone update'] = """
     type: command
-    short-summary: Update DNS zone properties. Does not modify DNS records within the zone.
+    short-summary: Update a DNS zone's properties. Does not modify DNS records within the zone.
     parameters:
         - name: --if-match
           short-summary: Update only if the resource with the same ETAG exists.
@@ -733,7 +736,7 @@ helps['network express-route delete'] = """
 
 helps['network express-route get-stats'] = """
     type: command
-    short-summary: Show statistics of an ExpressRoute circuit.
+    short-summary: Get the statistics for an ExpressRoute circuit.
 """
 
 helps['network express-route list'] = """
@@ -753,7 +756,7 @@ helps['network express-route list-route-tables'] = """
 
 helps['network express-route show'] = """
     type: command
-    short-summary: Show details of an ExpressRoute circuit.
+    short-summary: Get the details for an ExpressRoute circuit.
 """
 
 helps['network express-route update'] = """
@@ -791,7 +794,7 @@ helps['network express-route auth list'] = """
 
 helps['network express-route auth show'] = """
     type: command
-    short-summary: Show details for an authorization setting.
+    short-summary: Get the details of an authorization setting.
 """
 # endregion
 
@@ -819,7 +822,7 @@ helps['network express-route peering list'] = """
 
 helps['network express-route peering show'] = """
     type: command
-    short-summary: Show peering details.
+    short-summary: Get the details for an express route peering.
 """
 
 helps['network express-route peering update'] = """
@@ -859,7 +862,7 @@ helps['network lb list'] = """
 
 helps['network lb show'] = """
     type: command
-    short-summary: Show details of a load balancer.
+    short-summary: Get the details for a load balancer.
 """
 
 helps['network lb update'] = """
@@ -892,7 +895,7 @@ helps['network lb address-pool list'] = """
 
 helps['network lb address-pool show'] = """
     type: command
-    short-summary: Show details of a backend address pool.
+    short-summary: Get the details for a backend address pool.
 """
 # endregion
 
@@ -920,7 +923,7 @@ helps['network lb frontend-ip list'] = """
 
 helps['network lb frontend-ip show'] = """
     type: command
-    short-summary: Show details of a frontend IP address.
+    short-summary: Get the details of a frontend IP address.
 """
 
 helps['network lb frontend-ip update'] = """
@@ -953,7 +956,7 @@ helps['network lb inbound-nat-pool list'] = """
 
 helps['network lb inbound-nat-pool show'] = """
     type: command
-    short-summary: Show details of an inbound NAT address pool.
+    short-summary: Get the details for an inbound NAT address pool.
 """
 
 helps['network lb inbound-nat-pool update'] = """
@@ -991,7 +994,7 @@ helps['network lb inbound-nat-rule list'] = """
 
 helps['network lb inbound-nat-rule show'] = """
     type: command
-    short-summary: Show details of an inbound NAT rule.
+    short-summary: Get the details for an inbound NAT rule.
 """
 
 helps['network lb inbound-nat-rule update'] = """
@@ -1029,7 +1032,7 @@ helps['network lb probe list'] = """
 
 helps['network lb probe show'] = """
     type: command
-    short-summary: Show details for a probe.
+    short-summary: Get the details for a probe.
 """
 
 helps['network lb probe update'] = """
@@ -1049,8 +1052,9 @@ helps['network lb rule create'] = """
     type: command
     short-summary: Create a load balancing rule.
     examples:
-        - name: Create a basic load balancing rule that assigns a front-facing IP configuration
-                and port to a backend address pool and port.
+        - name: >
+            Create a basic load balancing rule that assigns a front-facing IP
+            configuration and port to a backend address pool and port.
           text: >
             az network lb rule create -g MyResourceGroup --lb-name MyLb -n MyLbRule \\
             --protocol Tcp --frontend-port 80 --backend-port 80
@@ -1068,7 +1072,7 @@ helps['network lb rule list'] = """
 
 helps['network lb rule show'] = """
     type: command
-    short-summary: Show details of a load balancing rule.
+    short-summary: Get the details of a load balancing rule.
 """
 
 helps['network lb rule update'] = """
@@ -1099,7 +1103,7 @@ helps['network local-gateway list'] = """
 """
 helps['network local-gateway show'] = """
     type: command
-    short-summary: Show details of a local VPN gateway.
+    short-summary: Get the details for a local VPN gateway.
 """
 
 helps['network local-gateway update'] = """
@@ -1157,7 +1161,7 @@ helps['network nic list'] = """
 
 helps['network nic show'] = """
     type: command
-    short-summary: Show details of a network interface.
+    short-summary: Get the details of a network interface.
     examples:
         - name: Get the internal domain name suffix for a NIC.
           text: >
@@ -1186,7 +1190,7 @@ helps['network nic ip-config create'] = """
     short-summary: Create an IP configuration.
     long-summary: >
         You must have the Microsoft.Network/AllowMultipleIpConfigurationsPerNic feature enabled for your subscription.
-        Only one configuration may be designated as the primary IP configuration per NIC, using the --make-primary flag.
+        Only one configuration may be designated as the primary IP configuration per NIC, using the `--make-primary` flag.
 """
 
 helps['network nic ip-config delete'] = """
@@ -1202,7 +1206,7 @@ helps['network nic ip-config list'] = """
 
 helps['network nic ip-config show'] = """
     type: command
-    short-summary: Show details of an IP configuration.
+    short-summary: Get the details of an IP configuration.
 """
 
 helps['network nic ip-config update'] = """
@@ -1277,7 +1281,7 @@ helps['network nsg create'] = """
 
 helps['network nsg list'] = """
     type: command
-    short-summary: Lists information about network security groups.
+    short-summary: List network security groups.
     examples:
         - name: List all NSGs in the 'westus' region.
           text: >
@@ -1286,7 +1290,7 @@ helps['network nsg list'] = """
 
 helps['network nsg show'] = """
     type: command
-    short-summary: Retrieves information about the specified network security group.
+    short-summary: Get information about a network security group.
     examples:
         - name: Get basic information about an NSG.
           text: >
@@ -1299,7 +1303,6 @@ helps['network nsg show'] = """
 helps['network nsg rule create'] = """
     type: command
     short-summary: Create a network security group rule.
-    long-summary: By default, the source address and port are '*', and the destination address is '*:80'.
     examples:
         - name: Create a basic "Allow" NSG rule with the highest priority.
           text: >
@@ -1324,7 +1327,7 @@ helps['network nsg rule list'] = """
 
 helps['network nsg rule show'] = """
     type: command
-    short-summary: Show details of a network security group rule.
+    short-summary: Get the details for a network security group rule.
 """
 
 helps['network nsg rule update'] = """
@@ -1376,7 +1379,7 @@ helps['network public-ip list'] = """
 
 helps['network public-ip show'] = """
     type: command
-    short-summary: Show details of a public IP address.
+    short-summary: Get the details of a public IP address.
     examples:
         - name: Get information about a public IP resource.
           text: >
@@ -1420,7 +1423,7 @@ helps['network route-table list'] = """
 
 helps['network route-table show'] = """
     type: command
-    short-summary: Show details of a route table.
+    short-summary: Get the details for a route table.
 """
 
 helps['network route-table update'] = """
@@ -1450,7 +1453,7 @@ helps['network route-table route list'] = """
 
 helps['network route-table route show'] = """
     type: command
-    short-summary: Show details of a route in a route table.
+    short-summary: Get the details of a route in a route table.
 """
 
 helps['network route-table route update'] = """
@@ -1464,7 +1467,8 @@ helps['network route-table route update'] = """
 
 helps['network route-filter'] = """
     type: group
-    short-summary: (Preview) Manage route filters.
+    short-summary: Manage route filters.
+    long-summary: These commands are in preview.
 """
 
 helps['network route-filter create'] = """
@@ -1484,7 +1488,7 @@ helps['network route-filter list'] = """
 
 helps['network route-filter show'] = """
     type: command
-    short-summary: Show details of a route filter.
+    short-summary: Get the details of a route filter.
 """
 
 helps['network route-filter update'] = """
@@ -1494,7 +1498,8 @@ helps['network route-filter update'] = """
 
 helps['network route-filter rule'] = """
     type: group
-    short-summary: (Preview) Manage rules in a route filter.
+    short-summary: Manage rules in a route filter.
+    long-summary: These commands are in preview.
 """
 
 helps['network route-filter rule create'] = """
@@ -1503,9 +1508,11 @@ helps['network route-filter rule create'] = """
     parameters:
         - name: --communities
           short-summary: |
-                Space separated list of BGP community values to filter on.
+                Space separated list of border gateway protocol (BGP) community values to filter on.
           populator-commands:
             - az network route-filter rule list-service-communities
+    examples:
+        text: 
 """
 
 helps['network route-filter rule delete'] = """
@@ -1520,7 +1527,7 @@ helps['network route-filter rule list'] = """
 
 helps['network route-filter rule show'] = """
     type: command
-    short-summary: Show details of a rule in a route filter.
+    short-summary: Get the details of a rule in a route filter.
 """
 
 helps['network route-filter rule update'] = """
@@ -1569,7 +1576,7 @@ helps['network traffic-manager profile list'] = """
 
 helps['network traffic-manager profile show'] = """
     type: command
-    short-summary: Show details of a profile.
+    short-summary: Get the details for a profile.
 """
 
 helps['network traffic-manager profile update'] = """
@@ -1599,7 +1606,7 @@ helps['network traffic-manager endpoint list'] = """
 
 helps['network traffic-manager endpoint show'] = """
     type: command
-    short-summary: Show details of an endpoint.
+    short-summary: Get the details for an endpoint.
 """
 
 helps['network traffic-manager endpoint update'] = """
@@ -1617,7 +1624,7 @@ helps['network vnet'] = """
 
 helps['network vnet check-ip-address'] = """
     type: command
-    short-summary: Check whether a private IP address is available for use.
+    short-summary: Check if a private IP address is available for use.
 """
 
 helps['network vnet create'] = """
@@ -1649,7 +1656,7 @@ helps['network vnet list'] = """
 
 helps['network vnet show'] = """
     type: command
-    short-summary: Show details on a virtual network.
+    short-summary: Get the details of a virtual network.
 """
 
 helps['network vnet update'] = """
@@ -1730,7 +1737,7 @@ helps['network vnet peering list'] = """
 
 helps['network vnet peering show'] = """
     type: command
-    short-summary: Show details of a peering.
+    short-summary: Get the details of a peering.
 """
 
 helps['network vnet peering update'] = """
@@ -1763,7 +1770,7 @@ helps['network vpn-connection list'] = """
 
 helps['network vpn-connection show'] = """
     type: command
-    short-summary: Show details of a VPN connection.
+    short-summary: Get the details of a VPN connection.
 """
 
 helps['network vpn-connection update'] = """
@@ -1787,7 +1794,7 @@ helps['network vpn-connection shared-key reset'] = """
 
 helps['network vpn-connection shared-key show'] = """
     type: command
-    short-summary: Show a VPN connection shared key.
+    short-summary: Retrieve a VPN connection shared key.
 """
 
 helps['network vpn-connection shared-key update'] = """
@@ -1854,7 +1861,7 @@ helps['network vnet-gateway reset'] = """
 
 helps['network vnet-gateway show'] = """
     type: command
-    short-summary: Show details of a virtual network gateway.
+    short-summary: Get the details for a virtual network gateway.
 """
 
 helps['network vnet-gateway update'] = """
@@ -1921,7 +1928,8 @@ helps['network vnet-gateway root-cert delete'] = """
 # region Network Watcher
 helps['network watcher'] = """
     type: group
-    short-summary: (Preview) Commands to manage Network Watcher.
+    short-summary: Manage the Azure Network Watcher.
+    long-summary: These commands are in preview.
 """
 
 helps['network watcher list'] = """
@@ -1945,7 +1953,8 @@ helps['network watcher configure'] = """
 
 helps['network watcher troubleshooting'] = """
     type: group
-    short-summary: (Preview) Commands to manage Network Watcher troubleshooting sessions.
+    short-summary: Manage Network Watcher troubleshooting sessions.
+    long-summary: These commands are in preview.
 """
 
 helps['network watcher troubleshooting start'] = """
@@ -1962,7 +1971,7 @@ helps['network watcher troubleshooting start'] = """
 
 helps['network watcher troubleshooting show'] = """
     type: command
-    short-summary: Show results of the last troubleshooting operation.
+    short-summary: Get the results of the last troubleshooting operation.
 """
 
 helps['network watcher test-ip-flow'] = """
@@ -1984,8 +1993,7 @@ helps['network watcher test-ip-flow'] = """
 
 helps['network watcher test-connectivity'] = """
     type: command
-    short-summary: Test whether a direct TCP connection can be established between a Virtual
-        Machine and a given endpoint.
+    short-summary: Test if a direct TCP connection can be established between a Virtual Machine and a given endpoint.
     parameters:
         - name: --source-resource
           short-summary: Name or ID of the resource from which to originate traffic.
@@ -2003,18 +2011,18 @@ helps['network watcher test-connectivity'] = """
 
 helps['network watcher show-next-hop'] = """
     type: command
-    short-summary: Show information on the 'next hop' for a VM.
+    short-summary: Get information on the 'next hop' for a VM.
     long-summary: Requires that Network Watcher is enabled for the region in which the VM is located.
 """
 
 helps['network watcher show-security-group-view'] = """
     type: command
-    short-summary: Show detailed security information on a VM for the currently configured network security group.
+    short-summary: Get detailed security information on a VM for the currently configured network security group.
 """
 
 helps['network watcher show-topology'] = """
     type: command
-    short-summary: Show the network topology for a resource group.
+    short-summary: Get the network topology of a resource group.
     parameters:
         - name: --resource-group -g
           short-summary: The name of the target resource group to perform topology on.
@@ -2026,10 +2034,10 @@ helps['network watcher show-topology'] = """
 
 helps['network watcher packet-capture'] = """
     type: group
-    short-summary: (Preview) Commands to manage packet capture sessions on VMs.
+    short-summary: Manage packet capture sessions on VMs.
     long-summary: |
-        Requires that Network Watcher is enabled for the region in which the VM is located
-        and that the AzureNetworkWatcherExtension is enabled on the VM.
+        These commands are in preview, and require that both Azure Network Watcher is enabled for the
+        VM's region and that AzureNetworkWatcherExtension is enabled on the VM.
 """
 
 helps['network watcher packet-capture create'] = """
@@ -2060,7 +2068,8 @@ helps['network watcher packet-capture create'] = """
 
 helps['network watcher flow-log'] = """
     type: group
-    short-summary: (Preview) Commands to manage network security group flow logging.
+    short-summary: Manage network security group flow logging.
+    long-summary: These commands are in preview.
 """
 
 helps['network watcher flow-log configure'] = """
@@ -2079,7 +2088,7 @@ helps['network watcher flow-log configure'] = """
 
 helps['network watcher flow-log show'] = """
     type: command
-    short-summary: Show flow log configuration for a network security group.
+    short-summary: Get the flow log configuration for a network security group.
 """
 
 # endregion

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -14,14 +14,14 @@ helps['network'] = """
 
 helps['network dns'] = """
     type: group
-    short-summary: Host your DNS domain in Azure.
+    short-summary: Manage DNS domains in Azure.
 """
 
 # region Application Gateway
 
 helps['network application-gateway'] = """
     type: group
-    short-summary: Provides application-level routing and load balancing services.
+    short-summary: Manage application-level routing and load balancing services.
 """
 
 helps['network application-gateway create'] = """
@@ -81,13 +81,11 @@ helps['network application-gateway address-pool create'] = """
     type: command
     short-summary: Create a backend address pool.
     examples:
-        - name: Create an address pool with two endpoints specified by IP.
+        - name: Create an address pool with two endpoints.
           text: >
-            az network application-gateway address-pool create
-            -g MyResourceGroup
-            --gateway-name MyApplicationGateway
-            -n MyAddressPool
-            --servers 10.0.0.4 10.0.0.5
+            az network application-gateway address-pool create \\
+                    -g MyResourceGroup --gateway-name MyApplicationGateway \\
+                    -n MyAddressPool --servers 10.0.0.4 10.0.0.5
 """
 
 helps['network application-gateway address-pool delete'] = """
@@ -279,7 +277,7 @@ helps['network application-gateway http-settings update'] = """
 
 helps['network application-gateway probe'] = """
     type: group
-    short-summary: Use probes to gather information, such as utilization, and then evaluate it by using rules.
+    short-summary: Use probes to gather information from a gateway and evaluate it using rules.
 """
 helps['network application-gateway probe create'] = """
     type: command
@@ -287,13 +285,9 @@ helps['network application-gateway probe create'] = """
     examples:
         - name: Create an application gateway probe.
           text: >
-            az network application-gateway probe create
-            -g MyResourceGroup
-            -n MyProbe
-            --protocol Https
-            --gateway-name MyApplicationGateway
-            --host 127.0.0.1
-            --path /path/to/probe
+            az network application-gateway probe create -g MyResourceGroup -n MyProbe \\
+                    --protocol https --gateway-name MyApplicationGateway \\
+                    --host 127.0.0.1 --path /path/to/probe
 """
 
 helps['network application-gateway probe delete'] = """
@@ -444,7 +438,7 @@ helps['network application-gateway ssl-policy show'] = """
 
 helps['network application-gateway ssl-policy predefined'] = """
     type: group
-    short-summary: Information on predefined SSL policies.
+    short-summary: Get information on predefined SSL policies.
 """
 
 # endregion
@@ -460,8 +454,8 @@ helps['network application-gateway url-path-map create'] = """
     short-summary: Create a URL path map.
     long-summary: >
         The map must be created with at least one rule. This command requires the creation of the
-        first rule at the time the map is created. To create additional rules (using different
-        address pools or HTTP settings) use the 'url-path-map rule create' command. To update the
+        first rule at the time the map is created. To create additional rules using different
+        address pools or HTTP settings, use the 'url-path-map rule create' command. To update the
         rule created using this command, use the 'url-path-map rule update' command.
 """
 
@@ -508,7 +502,7 @@ helps['network application-gateway url-path-map rule delete'] = """
 helps['network application-gateway waf-config'] = """
     type: group
     short-summary: Configure the settings of a web application firewall.
-    long-summary: This command is only applicable to application gateways with SKU type of WAF.
+    long-summary: This command is only applicable to application gateways with an SKU type of WAF.
 """
 
 helps['network application-gateway waf-config set'] = """
@@ -524,8 +518,7 @@ helps['network application-gateway waf-config set'] = """
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rule-groups
-          short-summary: Space separated list of rule groups to disable. This disables the entire group.
-            To disable specifc rules, use '--disabled-rules'.
+          short-summary: Space separated list of rule groups to disable. To disable specifc rules, use '--disabled-rules'.
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
         - name: --disabled-rules
@@ -533,9 +526,12 @@ helps['network application-gateway waf-config set'] = """
           populator-commands:
           - az network application-gateway waf-config list-rule-sets
     examples:
-        - name: Disable two rules for validation of request body parsing and SQL Injection
+        - name: Disable rules for validation of request body parsing and SQL injection.
           text: >
-            az network application-gateway waf-config set -g MyResourceGroup -n MyGatewayName --enabled true --rule-set-type OWASP --rule-set-version 3.0 --disabled-rules 920130 920140 --disabled-rule-groups REQUEST-942-APPLICATION-ATTACK-SQLI
+            az network application-gateway waf-config set -g MyResourceGroup -n MyGatewayName \\
+                    --enabled true --rule-set-type OWASP --rule-set-version 3.0 \\
+                    --disabled-rules 920130 920140 \\
+                    --disabled-rule-groups REQUEST-942-APPLICATION-ATTACK-SQLI
 """
 
 helps['network application-gateway waf-config show'] = """
@@ -545,10 +541,10 @@ helps['network application-gateway waf-config show'] = """
 
 helps['network application-gateway waf-config list-rule-sets'] = """
     type: command
-    short-summary: (PREVIEW) Lookup information on available WAF rule sets, rule groups, and rule IDs.
+    short-summary: (Preview) Lookup information on available WAF rule sets, rule groups, and rule IDs.
     parameters:
         - name: --group
-          short-summary:
+          short-summary: >
             List rules for the specified rule group. Use '*' to list rules for all groups.
             Omit to suppress listing individual rules.
         - name: --type
@@ -587,9 +583,11 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     """.format(record.upper())
 
 for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+    indef_article = 'an' if record.startswith('a') else 'a'
+
     helps['network dns record-set {} remove-record'.format(record)] = """
         type: command
-        short-summary: Remove {} record from its record set.
+        short-summary: Remove {} record from its set.
         long-summary: >
             By default, if the last record in a set is removed, the record set is deleted. To retain the empty record set, include --keep-empty-record-set.
     """.format(record.upper())
@@ -601,7 +599,7 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
 
     helps['network dns record-set {} delete'.format(record)] = """
         type: command
-        short-summary: Delete a {} record set and all records within.
+        short-summary: Delete a {} record set and all associated records.
     """.format(record.upper())
 
     helps['network dns record-set {} list'.format(record)] = """
@@ -613,10 +611,10 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
         type: command
         short-summary: Show details of {} record set.
         examples:
-        - name: Show information about an A record set.
+        - name: Show information about {} {} record set.
           text: >
-            az network dns record-set a show -g MyResourceGroup -n MyRecordSet -z www.mysite.com
-    """.format(record.upper())
+            az network dns record-set {} show -g MyResourceGroup -n MyRecordSet -z www.mysite.com
+    """.format(record.upper(), indef_article, record.upper(), record)
 
 for item in ['a', 'aaaa', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     helps['network dns record-set {} update'.format(record)] = """
@@ -636,17 +634,17 @@ helps['network dns record-set cname set-record'] = """
 
 helps['network dns record-set soa'] = """
     type: group
-    short-summary: Manage DNS zone SOA record.
+    short-summary: Manage a DNS zone's SOA record.
 """
 
 helps['network dns record-set soa show'] = """
     type: command
-    short-summary: Show details of the DNS zone's SOA record.
+    short-summary: Show details of a DNS zone's SOA record.
 """
 
 helps['network dns record-set soa update'] = """
     type: command
-    short-summary: Update properties of the zone's SOA record.
+    short-summary: Update properties of a zone's SOA record.
 """
 
 helps['network dns record-set list'] = """
@@ -655,10 +653,7 @@ helps['network dns record-set list'] = """
     examples:
         - name: List all "@" record sets within this zone.
           text: >
-            az network dns record-set list
-            -g MyResourceGroup
-            -z www.mysite.com
-            --query "[?name=='@']"
+            az network dns record-set list -g MyResourceGroup -z www.mysite.com --query "[?name=='@']"
 """
 
 # endregion
@@ -674,9 +669,9 @@ helps['network dns zone create'] = """
     short-summary: Create a DNS zone.
     parameters:
         - name: --if-none-match
-          short-summary: Create a DNS zone only if one doesn't exist that matches the given one.
+          short-summary: Only create a DNS zone if one doesn't exist that matches the given name.
     examples:
-        - name: Create DNS zone for a specific fully qualified domain name.
+        - name: Create a DNS zone using a fully qualified domain name.
           text: >
             az network dns zone create -g MyResourceGroup -n www.mysite.com
 """
@@ -684,8 +679,6 @@ helps['network dns zone create'] = """
 helps['network dns zone delete'] = """
     type: command
     short-summary: Delete a DNS zone and all associated records.
-    long-summary: |
-        WARNING: This operation cannot be undone.
 """
 
 helps['network dns zone export'] = """
@@ -699,10 +692,7 @@ helps['network dns zone import'] = """
     examples:
         - name: Import a local zone file into a DNS zone resource.
           text: >
-            az network dns zone import
-            -g MyResourceGroup
-            -n MyZone
-            -f /path/to/zone/file
+            az network dns zone import -g MyResourceGroup -n MyZone -f /path/to/zone/file
 """
 
 helps['network dns zone list'] = """
@@ -753,7 +743,7 @@ helps['network express-route list'] = """
 
 helps['network express-route list-arp-tables'] = """
     type: command
-    short-summary: List the currently advertised ARP table of an ExpressRoute circuit.
+    short-summary: List the currently advertised address resolution protocol (ARP) table of an ExpressRoute circuit.
 """
 
 helps['network express-route list-route-tables'] = """
@@ -801,7 +791,7 @@ helps['network express-route auth list'] = """
 
 helps['network express-route auth show'] = """
     type: command
-    short-summary: Show details of an authorization setting.
+    short-summary: Show details for an authorization setting.
 """
 # endregion
 
@@ -842,7 +832,7 @@ helps['network express-route peering update'] = """
 
 helps['network lb'] = """
     type: group
-    short-summary: Use a load balancer to deliver high availability and network performance to your applications.
+    short-summary: Manage and configure load balancers.
 """
 
 helps['network lb create'] = """
@@ -854,11 +844,7 @@ helps['network lb create'] = """
             az network lb create -g MyResourceGroup -n MyLb
         - name: Create a load balancer on a specific virtual network and subnet.
           text: >
-            az network lb create
-            -g MyResourceGroup
-            -n MyLb
-            --vnet-name MyVnet
-            --subnet MySubnet
+            az network lb create -g MyResourceGroup -n MyLb --vnet-name MyVnet --subnet MySubnet
 """
 
 helps['network lb delete'] = """
@@ -989,8 +975,8 @@ helps['network lb inbound-nat-rule create'] = """
     examples:
         - name: Create a basic inbound NAT rule for port 80.
           text: >
-            az network lb inbound-nat-rule create -g MyResourceGroup --lb-name MyLb -n MyNatRule
-            --protocol Tcp --frontend-port 80 --backend-port 80
+            az network lb inbound-nat-rule create -g MyResourceGroup --lb-name MyLb -n MyNatRule \\
+                    --protocol Tcp --frontend-port 80 --backend-port 80
 """
 
 helps['network lb inbound-nat-rule delete'] = """
@@ -1027,13 +1013,8 @@ helps['network lb probe create'] = """
     examples:
         - name: Create a probe on a load balancer over HTTP and port 80.
           text: >
-            az network lb probe create
-            -g MyResourceGroup
-            --lb-name MyLb
-            -n MyProbe
-            --protocol Http
-            --port 80
-            --path /
+            az network lb probe create -g MyResourceGroup --lb-name MyLb -n MyProbe \\
+                    --protocol http --port 80 --path /
 """
 
 helps['network lb probe delete'] = """
@@ -1048,7 +1029,7 @@ helps['network lb probe list'] = """
 
 helps['network lb probe show'] = """
     type: command
-    short-summary: Show details of a probe.
+    short-summary: Show details for a probe.
 """
 
 helps['network lb probe update'] = """
@@ -1071,7 +1052,7 @@ helps['network lb rule create'] = """
         - name: Create a basic load balancing rule that assigns a front-facing IP configuration
                 and port to a backend address pool and port.
           text: >
-            az network lb rule create -g MyResourceGroup --lb-name MyLb -n MyLbRule
+            az network lb rule create -g MyResourceGroup --lb-name MyLb -n MyLbRule \\
             --protocol Tcp --frontend-port 80 --backend-port 80
 """
 
@@ -1150,21 +1131,12 @@ helps['network nic create'] = """
     examples:
         - name: Create a network interface for a specified subnet on a specified virtual network.
           text: >
-            az network nic create
-            -g MyResourceGroup
-            --vnet-name MyVnet
-            --subnet MySubnet
-            -n MyNic
-        - name: Create a network interface for a specified subnet on a specified virtual network which allows
-                IP forwarding subject to the specified NSG.
+            az network nic create -g MyResourceGroup --vnet-name MyVnet --subnet MySubnet -n MyNic
+        - name: Create a network interface for a specified subnet on a virtual network which allows
+                IP forwarding subject to a network security group.
           text: >
-            az network nic create
-            -g MyResourceGroup
-            --vnet-name MyVnet
-            --subnet MySubnet
-            -n MyNic
-            --ip-forwarding
-            --network-security-group MyNsg
+            az network nic create -g MyResourceGroup --vnet-name MyVnet --subnet MySubnet -n MyNic \\
+                --ip-forwarding --network-security-group MyNsg
 """
 
 helps['network nic delete'] = """
@@ -1189,22 +1161,16 @@ helps['network nic show'] = """
     examples:
         - name: Get the internal domain name suffix for a NIC.
           text: >
-            az network nic show
-            -g MyResourceGroup
-            -n MyNic
-            --query "dnsSettings.internalDomainNameSuffix"
+            az network nic show -g MyResourceGroup -n MyNic --query "dnsSettings.internalDomainNameSuffix"
 """
 
 helps['network nic update'] = """
     type: command
     short-summary: Update a network interface.
     examples:
-        - name: Update a network interface to use a different NSG.
+        - name: Update a network interface to use a different network security group.
           text: >
-            az network nic update
-            -g MyResourceGroup
-            -n MyNic
-            --network-security-group MyNsg
+            az network nic update -g MyResourceGroup -n MyNic --network-security-group MyNsg
 """
 # endregion
 
@@ -1218,7 +1184,9 @@ helps['network nic ip-config'] = """
 helps['network nic ip-config create'] = """
     type: command
     short-summary: Create an IP configuration.
-    long-summary: You must have the Microsoft.Network/AllowMultipleIpConfigurationsPerNic feature enabled for your subscription. Only one configuration may be designated as the primary IP configuration per NIC, using the --make-primary flag.
+    long-summary: >
+        You must have the Microsoft.Network/AllowMultipleIpConfigurationsPerNic feature enabled for your subscription.
+        Only one configuration may be designated as the primary IP configuration per NIC, using the --make-primary flag.
 """
 
 helps['network nic ip-config delete'] = """
@@ -1241,20 +1209,12 @@ helps['network nic ip-config update'] = """
     type: command
     short-summary: Update an IP configuration.
     examples:
-        - name: Update the NIC to use a new private IP address.
+        - name: Update a NIC to use a new private IP address.
           text: >
-            az network nic ip-config update
-            -g MyResourceGroup
-            --nic-name MyNic
-            -n MyIpConfig
-            --private-ip-address 10.0.0.9
-        - name: Make this IP configuration the default for the supplied NIC.
+            az network nic ip-config update -g MyResourceGroup --nic-name MyNic -n MyIpConfig --private-ip-address 10.0.0.9
+        - name: Make an IP configuration the default for the supplied NIC.
           text: >
-            az network nic ip-config update
-            -g MyResourceGroup
-            --nic-name MyNic
-            -n MyIpConfig
-            --make-primary
+            az network nic ip-config update -g MyResourceGroup --nic-name MyNic -n MyIpConfig --make-primary
 """
 # endregion
 
@@ -1298,12 +1258,12 @@ helps['network nic ip-config inbound-nat-rule remove'] = """
 
 helps['network nsg'] = """
     type: group
-    short-summary: Manage Azure Network Security Groups.
+    short-summary: Manage Azure Network Security Groups (NSGs).
 """
 
 helps['network nsg rule'] = """
     type: group
-    short-summary: Manage NSG rules.
+    short-summary: Manage network security group rules.
 """
 
 helps['network nsg create'] = """
@@ -1312,17 +1272,14 @@ helps['network nsg create'] = """
     examples:
         - name: Create an NSG with some tags.
           text: >
-            az network nsg create
-            -g MyResourceGroup
-            -n MyNsg
-            --tags super_secure no_80 no_22
+            az network nsg create -g MyResourceGroup -n MyNsg --tags super_secure no_80 no_22
 """
 
 helps['network nsg list'] = """
     type: command
     short-summary: Lists information about network security groups.
     examples:
-        - name: List all NSGs for a specific region (for example, West US).
+        - name: List all NSGs in the 'westus' region.
           text: >
             az network nsg list --query "[?location=='westus']"
 """
@@ -1336,66 +1293,47 @@ helps['network nsg show'] = """
             az network nsg show -g MyResourceGroup -n MyNsg
         - name: Get basic information about all default NSG rules with "Allow" access.
           text: >
-            az network nsg show
-            -g MyResourceGroup
-            -n MyNsg
-            --query "defaultSecurityRules[?access=='Allow']"
+            az network nsg show -g MyResourceGroup -n MyNsg --query "defaultSecurityRules[?access=='Allow']"
 """
 
 helps['network nsg rule create'] = """
     type: command
-    short-summary: Create an NSG rule.
+    short-summary: Create a network security group rule.
+    long-summary: By default, the source address and port are '*', and the destination address is '*:80'.
     examples:
-        - name: Create a basic "Allow" NSG rule with the highest priority (that is, 100).  By default, source address
-                and port are "*" and destination address is "*:80".
+        - name: Create a basic "Allow" NSG rule with the highest priority.
           text: >
-            az network nsg rule create
-            -g MyResourceGroup
-            --nsg-name MyNsg
-            -n MyNsgRule
-            --priority 100
-        - name: Create a "Deny" rule over TCP for a specific IP address range with the lowest priority (that is, 4096).
+            az network nsg rule create -g MyResourceGroup --nsg-name MyNsg -n MyNsgRule --priority 100
+        - name: Create a "Deny" rule over TCP for a specific IP address range with the lowest priority.
           text: >
-            az network nsg rule create
-            -g MyResourceGroup
-            --nsg-name MyNsg
-            -n MyNsgRule
-            --priority 4096
-            --source-address-prefixes 208.130.28/24
-            --source-port-ranges 80
-            --destination-address-prefixes *
-            --destination-port-ranges 80
-            --access Deny
-            --protocol Tcp
-            --description "Deny from specific IP address range on 80."
+            az network nsg rule create -g MyResourceGroup --nsg-name MyNsg -n MyNsgRule --priority 4096 \\
+                    --source-address-prefixes 208.130.28/24 --source-port-ranges 80 \\
+                    --destination-address-prefixes * --destination-port-ranges 80 --access Deny \\
+                    --protocol Tcp --description "Deny from specific IP address range on 80."
 """
 
 helps['network nsg rule delete'] = """
     type: command
-    short-summary: Delete an NSG rule.
+    short-summary: Delete a network security group rule.
 """
 
 helps['network nsg rule list'] = """
     type: command
-    short-summary: List all rules in an NSG.
+    short-summary: List all rules in a network security group.
 """
 
 helps['network nsg rule show'] = """
     type: command
-    short-summary: Show details of an NSG rule.
+    short-summary: Show details of a network security group rule.
 """
 
 helps['network nsg rule update'] = """
     type: command
-    short-summary: Update an NSG rule.
+    short-summary: Update a network security group rule.
     examples:
         - name: Update an NSG rule with a new wildcard destination address prefix.
           text: >
-            az network nsg rule update
-            -g MyResourceGroup
-            --nsg-name MyNsg
-            -n MyNsgRule
-            --destination-address-prefix *
+            az network nsg rule update -g MyResourceGroup --nsg-name MyNsg -n MyNsgRule --destination-address-prefix *
 """
 
 # endregion
@@ -1414,14 +1352,9 @@ helps['network public-ip create'] = """
         - name: Create a basic public IP resource.
           text: >
             az network public-ip create -g MyResourceGroup -n MyIp
-        - name: Create a static public IP resource for a DNS name label
-                (for example, MyLabel.westus.cloudapp.azure.com).
+        - name: Create a static public IP resource for a DNS name label.
           text: >
-            az network public-ip create
-            -g MyResourceGroup
-            -n MyIp
-            --dns-name MyLabel
-            --allocation-method Static
+            az network public-ip create -g MyResourceGroup -n MyIp --dns-name MyLabel --allocation-method Static
 """
 
 helps['network public-ip delete'] = """
@@ -1436,11 +1369,9 @@ helps['network public-ip list'] = """
         - name: List all public IPs in a resource group.
           text: >
             az network public-ip list -g MyResourceGroup
-        - name: List all public IPs for a domain name label (for example `MyLabel.eastus.cloudapp.azure.com`).
+        - name: List all public IPs for a domain name label.
           text: >
-            az network public-ip list
-            -g MyResourceGroup
-            --query "[?dnsSettings.domainNameLabel=='MyLabel']"
+            az network public-ip list -g MyResourceGroup --query "[?dnsSettings.domainNameLabel=='MyLabel']"
 """
 
 helps['network public-ip show'] = """
@@ -1450,27 +1381,18 @@ helps['network public-ip show'] = """
         - name: Get information about a public IP resource.
           text: >
             az network public-ip show -g MyResourceGroup -n MyIp
-        - name: Get FQDN and IP address for a public IP resource.
+        - name: Get the FQDN and IP address for a public IP resource.
           text: >
-            az network public-ip show
-            -g MyResourceGroup
-            -n MyIp
-            --query "{ fqdn:dnsSettings.fqdn, address: ipAddress }"
+            az network public-ip show -g MyResourceGroup -n MyIp --query "{ fqdn:dnsSettings.fqdn, address: ipAddress }"
 """
 
 helps['network public-ip update'] = """
     type: command
     short-summary: Update a public IP address.
     examples:
-        - name: Update a public IP resource with a DNS name label
-                (for example, MyLabel.westus.cloudapp.azure.com) and
-                static allocation.
+        - name: Update a public IP resource with a DNS name label and static allocation.
           text: >
-            az network public-ip update
-            -g MyResourceGroup
-            -n MyIp
-            --dns-name MyLabel
-            --allocation-method Static
+            az network public-ip update -g MyResourceGroup -n MyIp --dns-name MyLabel --allocation-method Static
 """
 # endregion
 
@@ -1542,7 +1464,7 @@ helps['network route-table route update'] = """
 
 helps['network route-filter'] = """
     type: group
-    short-summary: (PREVIEW) Manage route filters.
+    short-summary: (Preview) Manage route filters.
 """
 
 helps['network route-filter create'] = """
@@ -1572,7 +1494,7 @@ helps['network route-filter update'] = """
 
 helps['network route-filter rule'] = """
     type: group
-    short-summary: (PREVIEW) Manage rules in a route filter.
+    short-summary: (Preview) Manage rules in a route filter.
 """
 
 helps['network route-filter rule create'] = """
@@ -1581,7 +1503,7 @@ helps['network route-filter rule create'] = """
     parameters:
         - name: --communities
           short-summary: |
-                Space separated list of BGP community values to filter on. (e.g.: 12076:5010)
+                Space separated list of BGP community values to filter on.
           populator-commands:
             - az network route-filter rule list-service-communities
 """
@@ -1612,17 +1534,17 @@ helps['network route-filter rule update'] = """
 
 helps['network traffic-manager'] = """
     type: group
-    short-summary: Route incoming traffic for high performance and availability.
+    short-summary: Manage the routing of incoming traffic.
 """
 
 helps['network traffic-manager endpoint'] = """
     type: group
-    short-summary: Manage Traffic Manager end points.
+    short-summary: Manage traffic manager end points.
 """
 
 helps['network traffic-manager profile'] = """
     type: group
-    short-summary: Manage Traffic Manager profiles.
+    short-summary: Manage traffic manager profiles.
 """
 
 helps['network traffic-manager profile check-dns'] = """
@@ -1708,12 +1630,7 @@ helps['network vnet create'] = """
             az network vnet create -g MyResourceGroup -n MyVnet
         - name: Create a virtual network with a specific address prefix and one subnet.
           text: >
-            az network vnet create
-            -g MyResourceGroup
-            -n MyVnet
-            --address-prefix 10.0.0.0/16
-            --subnet-name MySubnet
-            --subnet-prefix 10.0.0.0/24
+            az network vnet create -g MyResourceGroup -n MyVnet --address-prefix 10.0.0.0/16 --subnet-name MySubnet --subnet-prefix 10.0.0.0/24
 """
 
 helps['network vnet delete'] = """
@@ -1753,14 +1670,14 @@ helps['network vnet subnet create'] = """
     short-summary: Create a subnet and associate an existing NSG and route table.
     parameters:
         - name: --service-endpoints
-          short-summary: Space separated list of services for which to allow tunneling to this subnet.
+          short-summary: Space separated list of services allowed private access to this subnet.
           populator-commands:
             - az network vnet list-endpoint-services
     examples:
         - name: Create new subnet attached to an NSG with a custom route table.
           text: >
-            az network vnet subnet create -g MyResourceGroup --vnet-name MyVnet -n MySubnet
-            --address-prefix 10.0.0.0/24 --network-security-group MyNsg --route-table MyRouteTable
+            az network vnet subnet create -g MyResourceGroup --vnet-name MyVnet -n MySubnet \\
+                --address-prefix 10.0.0.0/24 --network-security-group MyNsg --route-table MyRouteTable
 """
 
 helps['network vnet subnet delete'] = """
@@ -1783,7 +1700,7 @@ helps['network vnet subnet update'] = """
     short-summary: Update a subnet.
     parameters:
         - name: --service-endpoints
-          short-summary: Space separated list of services for which to allow tunneling to this subnet.
+          short-summary: Space separated list of services allowed private access to this subnet.
           populator-commands:
             - az network vnet list-endpoint-services
 """
@@ -1917,11 +1834,7 @@ helps['network vnet-gateway create'] = """
     examples:
         - name: Create a basic virtual network gateway and associate with a public IP address.
           text: >
-            az network vnet-gateway create
-            -g MyResourceGroup
-            --vnet MyVnet
-            -n MyVnetGateway
-            --public-ip-address MyIp
+            az network vnet-gateway create -g MyResourceGroup --vnet MyVnet -n MyVnetGateway --public-ip-address MyIp
 """
 
 helps['network vnet-gateway delete'] = """
@@ -2008,7 +1921,7 @@ helps['network vnet-gateway root-cert delete'] = """
 # region Network Watcher
 helps['network watcher'] = """
     type: group
-    short-summary: (PREVIEW) Commands to manage Network Watcher.
+    short-summary: (Preview) Commands to manage Network Watcher.
 """
 
 helps['network watcher list'] = """
@@ -2032,7 +1945,7 @@ helps['network watcher configure'] = """
 
 helps['network watcher troubleshooting'] = """
     type: group
-    short-summary: (PREVIEW) Commands to manage Network Watcher troubleshooting sessions.
+    short-summary: (Preview) Commands to manage Network Watcher troubleshooting sessions.
 """
 
 helps['network watcher troubleshooting start'] = """
@@ -2044,7 +1957,7 @@ helps['network watcher troubleshooting start'] = """
         - name: --storage-account
           short-summary: Name or ID of the storage account in which to store the troubleshooting results.
         - name: --storage-path
-          short-summary: Fully qualified URI to the storage blob container at which to store the troubleshooting results.
+          short-summary: Fully qualified URI to the storage blob container in which to store the troubleshooting results.
 """
 
 helps['network watcher troubleshooting show'] = """
@@ -2054,7 +1967,7 @@ helps['network watcher troubleshooting show'] = """
 
 helps['network watcher test-ip-flow'] = """
     type: command
-    short-summary: Test IP flow to/from a VM given the currently configured NSG rules.
+    short-summary: Test IP flow to/from a VM given the currently configured network security group rules.
     long-summary: Requires that Network Watcher is enabled for the region in which the VM is located.
     parameters:
         - name: --local
@@ -2072,7 +1985,7 @@ helps['network watcher test-ip-flow'] = """
 helps['network watcher test-connectivity'] = """
     type: command
     short-summary: Test whether a direct TCP connection can be established between a Virtual
-        Machine and a given endpoint, such as another VM or an arbitrary remote server.
+        Machine and a given endpoint.
     parameters:
         - name: --source-resource
           short-summary: Name or ID of the resource from which to originate traffic.
@@ -2096,7 +2009,7 @@ helps['network watcher show-next-hop'] = """
 
 helps['network watcher show-security-group-view'] = """
     type: command
-    short-summary: Show detailed security information on a VM given the currently configured NSG.
+    short-summary: Show detailed security information on a VM for the currently configured network security group.
 """
 
 helps['network watcher show-topology'] = """
@@ -2113,7 +2026,7 @@ helps['network watcher show-topology'] = """
 
 helps['network watcher packet-capture'] = """
     type: group
-    short-summary: (PREVIEW) Commands to manage packet capture sessions on VMs.
+    short-summary: (Preview) Commands to manage packet capture sessions on VMs.
     long-summary: |
         Requires that Network Watcher is enabled for the region in which the VM is located
         and that the AzureNetworkWatcherExtension is enabled on the VM.
@@ -2130,9 +2043,9 @@ helps['network watcher packet-capture create'] = """
         - name: --time-limit
           short-summary: Maximum duration of the capture session in seconds.
         - name: --storage-account
-          short-summary: Name or ID of a storage account into which to save the packet capture.
+          short-summary: Name or ID of a storage account to save the packet capture to.
         - name: --storage-path
-          short-summary: Fully qualified URI to an existing storage container in which to store the capture file.
+          short-summary: Fully qualified URI of an existing storage container in which to store the capture file.
           long-summary: If not specified, the container 'network-watcher-logs' will be
             created if it does not exist and the capture file will be stored there.
         - name: --file-path
@@ -2147,12 +2060,12 @@ helps['network watcher packet-capture create'] = """
 
 helps['network watcher flow-log'] = """
     type: group
-    short-summary: (PREVIEW) Commands to manage NSG flow logging.
+    short-summary: (Preview) Commands to manage network security group flow logging.
 """
 
 helps['network watcher flow-log configure'] = """
     type: command
-    short-summary: Configure flow logging on a Network Security Group (NSG).
+    short-summary: Configure flow logging on a network security group.
     parameters:
         - name: --nsg
           short-summary: Name or ID of the Network Security Group to target.
@@ -2166,7 +2079,7 @@ helps['network watcher flow-log configure'] = """
 
 helps['network watcher flow-log show'] = """
     type: command
-    short-summary: Show flow log configuration for an NSG.
+    short-summary: Show flow log configuration for a network security group.
 """
 
 # endregion

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -541,8 +541,7 @@ helps['network application-gateway waf-config show'] = """
 
 helps['network application-gateway waf-config list-rule-sets'] = """
     type: command
-    short-summary: Get information on available WAF rule sets, rule groups, and rule IDs.
-    long-summary: This command is in preview.
+    short-summary: (PREVIEW) Get information on available WAF rule sets, rule groups, and rule IDs.
     parameters:
         - name: --group
           short-summary: >
@@ -619,7 +618,7 @@ for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
 
 for item in ['a', 'aaaa', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     indef_article = 'an' if record.startswith('a') else 'a'
-    
+
     helps['network dns record-set {} update'.format(record)] = """
         type: command
         short-summary: Update  {} {} record set.
@@ -1467,8 +1466,7 @@ helps['network route-table route update'] = """
 
 helps['network route-filter'] = """
     type: group
-    short-summary: Manage route filters.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage route filters.
 """
 
 helps['network route-filter create'] = """
@@ -1498,8 +1496,7 @@ helps['network route-filter update'] = """
 
 helps['network route-filter rule'] = """
     type: group
-    short-summary: Manage rules in a route filter.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage rules in a route filter.
 """
 
 helps['network route-filter rule create'] = """
@@ -1507,12 +1504,9 @@ helps['network route-filter rule create'] = """
     short-summary: Create a rule in a route filter.
     parameters:
         - name: --communities
-          short-summary: |
-                Space separated list of border gateway protocol (BGP) community values to filter on.
+          short-summary: Space separated list of border gateway protocol (BGP) community values to filter on.
           populator-commands:
             - az network route-filter rule list-service-communities
-    examples:
-        text: 
 """
 
 helps['network route-filter rule delete'] = """
@@ -1928,8 +1922,7 @@ helps['network vnet-gateway root-cert delete'] = """
 # region Network Watcher
 helps['network watcher'] = """
     type: group
-    short-summary: Manage the Azure Network Watcher.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage the Azure Network Watcher.
 """
 
 helps['network watcher list'] = """
@@ -1953,8 +1946,7 @@ helps['network watcher configure'] = """
 
 helps['network watcher troubleshooting'] = """
     type: group
-    short-summary: Manage Network Watcher troubleshooting sessions.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage Network Watcher troubleshooting sessions.
 """
 
 helps['network watcher troubleshooting start'] = """
@@ -2034,9 +2026,9 @@ helps['network watcher show-topology'] = """
 
 helps['network watcher packet-capture'] = """
     type: group
-    short-summary: Manage packet capture sessions on VMs.
+    short-summary: (PREVIEW) Manage packet capture sessions on VMs.
     long-summary: |
-        These commands are in preview, and require that both Azure Network Watcher is enabled for the
+        These commands require that both Azure Network Watcher is enabled for the
         VM's region and that AzureNetworkWatcherExtension is enabled on the VM.
 """
 
@@ -2068,8 +2060,7 @@ helps['network watcher packet-capture create'] = """
 
 helps['network watcher flow-log'] = """
     type: group
-    short-summary: Manage network security group flow logging.
-    long-summary: These commands are in preview.
+    short-summary: (PREVIEW) Manage network security group flow logging.
 """
 
 helps['network watcher flow-log configure'] = """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -40,33 +40,35 @@ helps['account clear'] = """
 
 helps['account list'] = """
     type: command
-    short-summary: Get a list of subscriptions for the account.
+    short-summary: Get a list of subscriptions for the logged in account.
 """
 
 helps['account list-locations'] = """
     type: command
-    short-summary: List supported regions of the current subscription.
+    short-summary: List supported regions for the current subscription.
 """
 
 helps['account show'] = """
     type: command
-    short-summary: Show the details of a subscription.
+    short-summary: Get the details of a subscription.
     long-summary: If no subscription is specified, shows the current subscription.
 """
 
 helps['account set'] = """
     type: command
-    short-summary: Set a subscription as the current subscription.
+    short-summary: Set a subscription to be the current active subscription.
 """
 
 helps['account show'] = """
     type: command
-    short-summary: Show the details of a subscription.
+    short-summary: Get the details of a subscription.
     long-summary: If the subscription isn't specified, shows the details of the default subscription.
 """
 
 helps['account get-access-token'] = """
     type: command
-    short-summary: Provides a token for utlilities to access Azure.
-    long-summary: The token will be valid for at least 5 minutes with the maximum at 60 minutes. If the subscription argument isn't specified, the current account is used.
+    short-summary: Get a token for utlilities to access Azure.
+    long-summary: >
+        The token will be valid for at least 5 minutes with the maximum at 60 minutes.
+        If the subscription argument isn't specified, the current account is used.
 """

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_help.py
@@ -7,27 +7,29 @@
 from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps['login'] = """
-            examples:
-                - name: Log in interactively.
-                  text: >
-                    az login
-                - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled.
-                  text: >
-                    az login -u johndoe@contoso.com -p VerySecret
-                - name: Log in with a service principal using client secret.
-                  text: >
-                    az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
-                - name: Log in with a service principal using client certificate.
-                  text: >
-                    az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-                - name: Log in using the VM's Managed Service Identity
-                  text: >
-                    az login --msi
-            """
+    type: command
+    short-summary: Log in to Azure.
+    examples:
+        - name: Log in interactively.
+          text: >
+            az login
+        - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled.
+          text: >
+            az login -u johndoe@contoso.com -p VerySecret
+        - name: Log in with a service principal using client secret.
+          text: >
+            az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
+        - name: Log in with a service principal using client certificate.
+          text: >
+            az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+        - name: Log in using a VM's managed service identity (MSI)
+          text: >
+            az login -msi
+    """
 
 helps['account'] = """
     type: group
-    short-summary: Manage subscriptions.
+    short-summary: Manage Azure subscription information.
 """
 
 helps['account clear'] = """
@@ -65,5 +67,6 @@ helps['account show'] = """
 
 helps['account get-access-token'] = """
     type: command
-    long-summary: provides the token for trusted utils to access your Azure subscriptions. The token will be valid for at least 5 minutes with the maximum at 60 minutes. If the subscription argument isn't specified, the current account is used.
+    short-summary: Provides a token for utlilities to access Azure.
+    long-summary: The token will be valid for at least 5 minutes with the maximum at 60 minutes. If the subscription argument isn't specified, the current account is used.
 """

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
@@ -13,7 +13,7 @@ def add_helps(command_group, server_type):
                 """.format(server_type)
     helps['{} server'.format(command_group)] = """
                 type: group
-                short-summary: Create, delete, restore, and manage {} servers.
+                short-summary: Manage {} servers.
                 """.format(server_type)
     helps['{} server create'.format(command_group)] = """
                 type: command
@@ -36,7 +36,10 @@ def add_helps(command_group, server_type):
                     - name: Restore 'testsvr' as 'testsvrnew'.
                       text: az {0} server restore -g testgroup -n testsvrnew --source-server testsvr --restore-point-in-time "2017-06-15T13:10:00Z"
                     - name: Restore 'testsvr2' to 'testsvrnew', where 'testsvrnew' is in a different resource group than the backup.
-                      text: az {0} server restore -g testgroup -n testsvrnew -s "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/othergroup/providers/Microsoft.DBfor{1}/servers/testsvr2" --restore-point-in-time "2017-06-15T13:10:00Z"
+                      text: |
+                        az {0} server restore -g testgroup -n testsvrnew \\
+                            -s "/subscriptions/{{SubID}}/resourceGroups/{{ResourceGroup}}/providers/Microsoft.DBfor{1}/servers/testsvr2" \\
+                            --restore-point-in-time "2017-06-15T13:10:00Z"
                 """.format(command_group, server_type)
     helps['{} server update'.format(command_group)] = """
                 type: command
@@ -53,7 +56,7 @@ def add_helps(command_group, server_type):
                 """
     helps['{} server show'.format(command_group)] = """
                 type: command
-                short-summary: Show the details for a server.
+                short-summary: Get the details of a server.
                 """
     helps['{} server list'.format(command_group)] = """
                 type: command
@@ -90,7 +93,7 @@ def add_helps(command_group, server_type):
                 """
     helps['{} server firewall-rule show'.format(command_group)] = """
                 type: command
-                short-summary: Show the details of a firewall rule.
+                short-summary: Get the details of a firewall rule.
                 """
     helps['{} server firewall-rule list'.format(command_group)] = """
                 type: command
@@ -98,7 +101,7 @@ def add_helps(command_group, server_type):
                 """
     helps['{} server configuration'.format(command_group)] = """
                 type: group
-                short-summary: Inspect and set configuration values for a server.
+                short-summary: Manage configuration values for a server.
                 """
     helps['{} server configuration set'.format(command_group)] = """
                 type: command
@@ -111,7 +114,7 @@ def add_helps(command_group, server_type):
                 """.format(command_group)
     helps['{} server configuration show'.format(command_group)] = """
                 type: command
-                short-summary: Show the configuration for a server."
+                short-summary: Get the configuration for a server."
                 """
     helps['{} server configuration list'.format(command_group)] = """
                 type: command
@@ -119,7 +122,7 @@ def add_helps(command_group, server_type):
                 """
     helps['{} server-logs'.format(command_group)] = """
                 type: group
-                short-summary: Display, download, and manage server logs.
+                short-summary: Manage server logs.
                 """
     helps['{} server-logs list'.format(command_group)] = """
                 type: command
@@ -141,7 +144,7 @@ def add_helps(command_group, server_type):
                 """.format(command_group)
     helps['{} db'.format(command_group)] = """
                 type: group
-                short-summary: Create, delete, and manage {0} databases on a server.
+                short-summary: Manage {0} databases on a server.
                 """.format(server_type)
     helps['{} db create'.format(command_group)] = """
                 type: command

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/_help.py
@@ -9,159 +9,162 @@ from azure.cli.core.help_files import helps
 def add_helps(command_group, server_type):
     helps['{}'.format(command_group)] = """
                 type: group
-                short-summary: Commands to manage %s servers.
-                """ % server_type
+                short-summary: Manage Azure Database for {} servers.
+                """.format(server_type)
     helps['{} server'.format(command_group)] = """
                 type: group
-                short-summary: Commands to manage %s servers.
-                """ % server_type
+                short-summary: Create, delete, restore, and manage {} servers.
+                """.format(server_type)
     helps['{} server create'.format(command_group)] = """
                 type: command
-                short-summary: Create an {0} server
+                short-summary: Create a server.
                 examples:
-                    - name: Create server testsvr with only required paramaters in North Europe.
+                    - name: Create a {0} server with only required paramaters in North Europe.
                       text: az {1} server create -l northeurope -g testgroup -n testsvr -u username -p password
-                    - name: Create server testsvr with specified performance tier and compute units in North Europe.
-                      text: az {1} server create -l northeurope -g testgroup -n testsvr -u username -p password --performance-tier Standard --compute-units 100
-                    - name: Create server testsvr with all paramaters
-                      text: az {1} server create -l northeurope -g testgroup -n testsvr -u username -p password --performance-tier Basic --compute-units 100 --ssl-enforcement Disabled --storage-size 51200 --tags "key=value" --version <server_version>
+                    - name: Create a {0} server with a Standard performance tier and 100 compute units in North Europe.
+                      text: az {1} server create -l northeurope -g testgroup -n testsvr -u username -p password \\
+                            --performance-tier Standard --compute-units 100
+                    - name: Create a {0} server with all paramaters set.
+                      text: az {1} server create -l northeurope -g testgroup -n testsvr -u username -p password \\
+                            --performance-tier Basic --compute-units 100 --ssl-enforcement Disabled \\
+                            --storage-size 51200 --tags "key=value" --version <server_version>
                 """.format(server_type, command_group)
     helps['{} server restore'.format(command_group)] = """
                 type: command
-                short-summary: Create a new {0} server by restoring from a server backup.
+                short-summary: Restore a server from backup.
                 examples:
-                    - name: Restore to server testsvrnew from server testsvr.
-                      text: az {1} server restore -g testgroup -n testsvrnew --source-server testsvr --restore-point-in-time "2017-06-15T13:10:00Z"
-                    - name: Restore to server testsvrnew from server testsvr2 which is in a different resource group.
-                      text: az {1} server restore -g testgroup -n testsvrnew -s "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/othergroup/providers/Microsoft.DBfor{2}/servers/testsvr2" --restore-point-in-time "2017-06-15T13:10:00Z"
-                """.format(server_type, command_group, server_type.split()[3])
+                    - name: Restore 'testsvr' as 'testsvrnew'.
+                      text: az {0} server restore -g testgroup -n testsvrnew --source-server testsvr --restore-point-in-time "2017-06-15T13:10:00Z"
+                    - name: Restore 'testsvr2' to 'testsvrnew', where 'testsvrnew' is in a different resource group than the backup.
+                      text: az {0} server restore -g testgroup -n testsvrnew -s "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/othergroup/providers/Microsoft.DBfor{1}/servers/testsvr2" --restore-point-in-time "2017-06-15T13:10:00Z"
+                """.format(command_group, server_type)
     helps['{} server update'.format(command_group)] = """
                 type: command
-                short-summary: Update an {0} server.
+                short-summary: Update a server.
                 examples:
-                    - name: Update server's compute-units to 100.
-                      text: az {1} server update -g testgroup -n testsvrnew --compute-units 100
-                    - name: Update server's tags.
-                      text: az {1} server update -g testgroup -n testsvrnew --tags "k1=v1" "k2=v2"
-                """.format(server_type, command_group)
+                    - name: Update a server's compute-units to 100.
+                      text: az {0} server update -g testgroup -n testsvrnew --compute-units 100
+                    - name: Update a server's tags.
+                      text: az {0} server update -g testgroup -n testsvrnew --tags "k1=v1" "k2=v2"
+                """.format(command_group)
     helps['{} server delete'.format(command_group)] = """
                 type: command
-                short-summary: Delete an %s server.
-                """ % server_type
+                short-summary: Delete a server.
+                """
     helps['{} server show'.format(command_group)] = """
                 type: command
-                short-summary: Show the details of an %s server.
-                """ % server_type
+                short-summary: Show the details for a server.
+                """
     helps['{} server list'.format(command_group)] = """
                 type: command
-                short-summary: List all the {0} servers belong to given resource group or subscription.
+                short-summary: List available servers.
                 examples:
-                    - name: List all servers in resource group.
-                      text: az {1} server list -g testgroup
-                    - name: List all servers in subscription.
+                    - name: List all {0} servers in a subscription.
                       text: az {1} server list
+                    - name: List all {0} servers in a resource group.
+                      text: az {1} server list -g testgroup
                 """.format(server_type, command_group)
     helps['{} server firewall-rule'.format(command_group)] = """
                 type: group
-                short-summary: Commands to manage firewall rules for an %s server
-                """ % server_type
+                short-summary: Manage firewall rules for a server.
+                """
     helps['{} server firewall-rule create'.format(command_group)] = """
                 type: command
-                short-summary: Create a firewall rule for an {0} server
+                short-summary: Create a new firewall rule for a server.
                 examples:
-                    - name: Create a firewall rule for server testsvr.
-                      text: az {1} server firewall-rule create -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.0 --end-ip-address 255.255.255.255
-                """.format(server_type, command_group)
+                    - name: Create a firewall rule allowing all connections from all IP addresses.
+                      text: az {} server firewall-rule create -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.0 --end-ip-address 255.255.255.255
+                """.format(command_group)
     helps['{} server firewall-rule update'.format(command_group)] = """
                 type: command
-                short-summary: Update a firewall rule for an {0} server
+                short-summary: Update a firewall rule.
                 examples:
-                    - name: Update firewall rule's start IP address.
-                      text: az {1} server firewall-rule update -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.1
-                    - name: Update firewall rule's start and end IP address.
-                      text: az {1} server firewall-rule update -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.1 --end-ip-address 255.255.255.254
-                """.format(server_type, command_group)
+                    - name: Update a firewall rule's start IP address.
+                      text: az {0} server firewall-rule update -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.1
+                    - name: Update a firewall rule's start and end IP address.
+                      text: az {0} server firewall-rule update -g testgroup -s testsvr -n allowall --start-ip-address 0.0.0.1 --end-ip-address 255.255.255.254
+                """.format(command_group)
     helps['{} server firewall-rule delete'.format(command_group)] = """
                 type: command
-                short-summary: Delete a firewall rule for an %s server
-                """ % server_type
+                short-summary: Delete a firewall rule.
+                """
     helps['{} server firewall-rule show'.format(command_group)] = """
                 type: command
-                short-summary: Show the details of a firewall rule for an %s server
-                """ % server_type
+                short-summary: Show the details of a firewall rule.
+                """
     helps['{} server firewall-rule list'.format(command_group)] = """
                 type: command
-                short-summary: List all the firewall rules for an %s server
-                """ % server_type
+                short-summary: List all firewall rules for a server.
+                """
     helps['{} server configuration'.format(command_group)] = """
                 type: group
-                short-summary: Commands to configure an %s server
-                """ % server_type
+                short-summary: Inspect and set configuration values for a server.
+                """
     helps['{} server configuration set'.format(command_group)] = """
                 type: command
-                short-summary: Update the configuration of an {0} server
+                short-summary: Update the configuration of a server.
                 examples:
-                    - name: Set new value for a configuration.
-                      text: az {1} server configuration set -g testgroup -s testsvr -n <config_name> --value <config_value>
-                    - name: Set configuration's value to default.
-                      text: az {1} server configuration set -g testgroup -s testsvr -n <config_name>
-                """.format(server_type, command_group)
+                    - name: Set a new configuration value.
+                      text: az {0} server configuration set -g testgroup -s testsvr -n <config_name> --value <config_value>
+                    - name: Set a configuration value to its default.
+                      text: az {0} server configuration set -g testgroup -s testsvr -n <config_name>
+                """.format(command_group)
     helps['{} server configuration show'.format(command_group)] = """
                 type: command
-                short-summary: Show the configuration of an %s server
-                """ % server_type
+                short-summary: Show the configuration for a server."
+                """
     helps['{} server configuration list'.format(command_group)] = """
                 type: command
-                short-summary: List the configurations of an %s server
-                """ % server_type
+                short-summary: List the configuration values for a server.
+                """
     helps['{} server-logs'.format(command_group)] = """
                 type: group
-                short-summary: Commands to manage %s server logs.
-                """ % server_type
+                short-summary: Display, download, and manage server logs.
+                """
     helps['{} server-logs list'.format(command_group)] = """
                 type: command
-                short-summary: List log files for {0}
+                short-summary: List log files for a server.
                 examples:
-                    - name: List logs files modified in last 72 hours (default value).
-                      text: az {1} server-logs list -g testgroup -s testsvr
-                    - name: List logs files modified in last 10 hours.
-                      text: az {1} server-logs list -g testgroup -s testsvr --file-last-written 10
-                    - name: List logs files that size not exceeds 30KB.
-                      text: az {1} server-logs list -g testgroup -s testsvr --max-file-size 30
-                """.format(server_type, command_group)
+                    - name: List log files for 'testsvr' modified in the last 72 hours (default value).
+                      text: az {0} server-logs list -g testgroup -s testsvr
+                    - name: List log files for 'testsvr' modified in the last 10 hours.
+                      text: az {0} server-logs list -g testgroup -s testsvr --file-last-written 10
+                    - name: List log files for 'testsvr' less than 30Kb in size.
+                      text: az {0} server-logs list -g testgroup -s testsvr --max-file-size 30
+                """.format(command_group)
     helps['{} server-logs download'.format(command_group)] = """
                 type: command
-                short-summary: Download log file(s) to current directory for {0}
+                short-summary: Download log files.
                 examples:
-                    - name: Download log file f1 and f2 for server testsvr.
-                      text: az {1} server-logs download -g testgroup -s testsvr -n f1.log f2.log
-                """.format(server_type, command_group)
+                    - name: Download log files f1 and f2 to the current directory from the server 'testsvr'.
+                      text: az {} server-logs download -g testgroup -s testsvr -n f1.log f2.log
+                """.format(command_group)
     helps['{} db'.format(command_group)] = """
                 type: group
-                short-summary: Commands to manage %s databases
-                """ % server_type
+                short-summary: Create, delete, and manage {0} databases on a server.
+                """.format(server_type)
     helps['{} db create'.format(command_group)] = """
                 type: command
-                short-summary: Create a database for {0}
+                short-summary: Create a {0} database.
                 examples:
-                    - name: Create database testdb in server testsvr with default parameters.
+                    - name: Create database 'testdb' in the server 'testsvr' with the default parameters.
                       text: az {1} db create -g testgroup -s testsvr -n testdb
-                    - name: Create database testdb in server testsvr with specified parameters.
+                    - name: Create database 'testdb' in server 'testsvr' with a given character set and collation rules.
                       text: az {1} db create -g testgroup -s testsvr -n testdb --charset <valid_charset> --collation <valid_collation>
                 """.format(server_type, command_group)
     helps['{} db delete'.format(command_group)] = """
                 type: command
-                short-summary: Delete a database for %s
-                """ % server_type
+                short-summary: Delete a database.
+                """
     helps['{} db show'.format(command_group)] = """
                 type: command
-                short-summary: Show the details of a database for %s
-                """ % server_type
+                short-summary: Show the details of a database.
+                """
     helps['{} db list'.format(command_group)] = """
                 type: command
-                short-summary: List the databases of an %s server
-                """ % server_type
+                short-summary: List the databases for a server.
+                """
 
 
-add_helps("mysql", "Azure Database for MySQL")
-add_helps("postgres", "Azure Database for PostgreSQL")
+add_helps("mysql", "MySQL")
+add_helps("postgres", "PostgreSQL")

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
@@ -8,32 +8,32 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps['redis'] = """
     type: group
-    short-summary: Access to a secure, dedicated redis cache for your Azure applications.
+    short-summary: Access to a secure, dedicated Redis cache for your Azure applications.
 """
 
 helps['redis export'] = """
     type: command
-    short-summary: Export data stored in a redis cache.
+    short-summary: Export data stored in a Redis cache.
 """
 
 helps['redis import-method'] = """
     type: command
-    short-summary: Import data into a redis cache.
+    short-summary: Import data into a Redis cache.
 """
 
 helps['redis update-settings'] = """
     type: command
-    short-summary: (DEPRECATED) Update the settings of a redis cache.
+    short-summary: (DEPRECATED) Update the settings of a Redis cache.
     long-summary: |
-        WARNING: This command is deprecated. Instead, use the 'update' command.
+        WARNING: This command is deprecated. Instead, use the `update` command.
 """
 
 helps['redis update'] = """
     type: command
-    short-summary: Scale or update settings of a redis cache.
+    short-summary: Scale or update settings of a Redis cache.
 """
 
 helps['redis patch-schedule'] = """
     type: group
-    short-summary: Manage redis patch schedules.
+    short-summary: Manage Redis patch schedules.
 """

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_help.py
@@ -8,8 +8,7 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps['redis'] = """
     type: group
-    short-summary: Access to a secure, dedicated cache for your Azure applications.
-    long-summary: If you don't have the redis component installed, add it with `az component update --add redis`.
+    short-summary: Access to a secure, dedicated redis cache for your Azure applications.
 """
 
 helps['redis export'] = """
@@ -26,12 +25,12 @@ helps['redis update-settings'] = """
     type: command
     short-summary: (DEPRECATED) Update the settings of a redis cache.
     long-summary: |
-        WARNING: This command is being deprecated. Please use 'update' command
+        WARNING: This command is deprecated. Instead, use the 'update' command.
 """
 
 helps['redis update'] = """
     type: command
-    short-summary: Scale or update settings of a redis cache
+    short-summary: Scale or update settings of a redis cache.
 """
 
 helps['redis patch-schedule'] = """

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -12,26 +12,26 @@ helps['managedapp'] = """
 """
 helps['managedapp definition'] = """
     type: group
-    short-summary: Create, delete, and manage applications and their definitions.
+    short-summary: Manage Azure Managed Applications.
 """
 helps['managedapp create'] = """
     type: command
-    short-summary: Creates a managed application.
+    short-summary: Create a managed application.
     examples:
-        - name: Create a managed application of kind 'ServiceCatalog'. This requires a valid managed application definition id.
-          text: >
+        - name: Create a managed application of kind 'ServiceCatalog'. This requires a valid managed application definition ID.
+          text: |
             az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind ServiceCatalog \\
-                -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" \\
-                -d "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Solutions/applianceDefinitions/myManagedAppDef"
+                -m "/subscriptions/{SubID}/resourceGroups/{ManagedRG}" \\
+                -d "/subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Solutions/applianceDefinitions/{ManagedAppDef}"
         - name: Create a managed application of kind 'MarketPlace'. This requires a valid plan, containing details about existing marketplace package like plan name, version, publisher and product.
-          text: >
+          text: |
             az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind MarketPlace \\
-                -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" \\
+                -m "/subscriptions/{SubID}/resourceGroups/myManagedRG" \\
                 --plan-name ContosoAppliance --plan-version "1.0" --plan-product "contoso-appliance" --plan-publisher Contoso
 """
 helps['managedapp definition create'] = """
     type: command
-    short-summary: Creates a managed application definition.
+    short-summary: Create a managed application definition.
     examples:
         - name: Create a managed application defintion.
           text: >
@@ -61,8 +61,7 @@ helps['lock'] = """
     parameters:
         - name: --resource-type
           type: string
-          text: >
-            The name of the resource type. Optionally, may have a provider namespace.
+          text: The name of the resource type. May have a provider namespace.
         - name: --resource-provider-namespace
           type: string
           text: The name of the resource provider.
@@ -115,7 +114,7 @@ helps['lock show'] = """
     """
 helps['lock update'] = """
     type: command
-    short-summary: Update the properties of a lock.
+    short-summary: Update a lock.
     parameters:
         - name: --notes
           type: string
@@ -221,39 +220,39 @@ helps['resource list'] = """
     type: command
     short-summary: List resources.
     examples:
-        - name: List all resource in the West US region.
+        - name: List all resources in the West US region.
           text: >
             az resource list --location westus
-        - name: List a resource with the name 'resourceName'.
+        - name: List all resources with the name 'resourceName'.
           text: >
             az resource list --name 'resourceName'
-        - name: List resources with the tag 'test'.
+        - name: List all resources with the tag 'test'.
           text: >
              az resource list --tag test
-        - name: List resources with a tag that starts with 'test'.
+        - name: List all resources with a tag that starts with 'test'.
           text: >
             az resource list --tag test*
-        - name: List resources with the tag 'test' that have the value 'example'.
+        - name: List all resources with the tag 'test' that have the value 'example'.
           text: >
             az resource list --tag test=example
 """
 
 helps['resource show'] = """
     type: command
-    short-summary: Get information about a resource.
+    short-summary: Get the details of a resource.
     examples:
         - name: Show a virtual machine resource named 'MyVm'.
           text: >
             az vm show -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
         - name: Show a web app using a resource identifier.
           text: >
-            az resource show --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
-        - name: Show a subnet in the 'microsoft.network' namespace which belongs to the virtual network 'MyVnet'.
+            az resource show --id /subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Web/sites/{MyWebapp}
+        - name: Show a subnet in the 'Microsoft.Network' namespace which belongs to the virtual network 'MyVnet'.
           text: >
-            az resource show -g MyResourceGroup -n MySubnet --namespace microsoft.network --parent virtualnetworks/MyVnet --resource-type subnets
+            az resource show -g MyResourceGroup -n MySubnet --namespace Microsoft.Network --parent virtualnetworks/MyVnet --resource-type subnets
         - name: Show a subnet using a resource identifier.
           text: >
-            az resource show --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
+            az resource show --id /subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Network/virtualNetworks/{MyVnet}/subnets/{MySubnet}
         - name: Show an application gateway path rule.
           text: >
             az resource show -g MyResourceGroup --namespace Microsoft.Network --parent applicationGateways/ag1/urlPathMaps/map1 --resource-type pathRules -n rule1
@@ -268,10 +267,10 @@ helps['resource delete'] = """
             az vm delete -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
         - name: Delete a web app using a resource identifier.
           text: >
-            az resource delete --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
+            az resource delete --id /subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Web/sites/{MyWebApp}
         - name: Delete a subnet using a resource identifier.
           text: >
-            az resource delete --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/subnets/MySubnet
+            az resource delete --id /subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Network/virtualNetworks/{MyVNET}/subnets/{MySubnet}
 """
 
 helps['resource tag'] = """
@@ -283,7 +282,7 @@ helps['resource tag'] = """
             az resource tag --tags vmlist=vm1 -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
         - name: Tag a web app with the key 'vmlist' and value 'vm1', using a resource identifier.
           text: >
-            az resource tag --tags vmlist=vm1 --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
+            az resource tag --tags vmlist=vm1 --id /subscriptions/{SubID}/resourceGroups/{MyRG}/providers/Microsoft.Web/sites/{MyWebApp}
 """
 
 helps['resource create'] = """
@@ -292,7 +291,14 @@ helps['resource create'] = """
     examples:
        - name: Create an API app by providing a full JSON configuration.
          text: |
-            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties "{\\"kind\\":\\"api\\", \\"location\\":\\"West US\\", \\"properties\\":{\\"serverFarmId\\":\\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1\\"}}"
+            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties \\
+                    '{\\
+                        "kind": "api",\\
+                        "location": "West US",\\
+                        "properties": {\\
+                            "serverFarmId": "/subscriptions/{SubID}/resourcegroups/{MyRG}/providers/Microsoft.Web/serverfarms/{MyServicePlan}"\\
+                        }\\
+                    }'
        - name: Create a resource by loading JSON configuration from a file.
          text: >
             az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties @jsonConfigFile
@@ -300,7 +306,7 @@ helps['resource create'] = """
          text: |
             az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties \\
                 { \\
-                    "serverFarmId":"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1" \\
+                    "serverFarmId":"/subscriptions/{SubID}/resourcegroups/{MyRG}/providers/Microsoft.Web/serverfarms/{MyServicePlan}" \\
                 }
 """
 
@@ -350,7 +356,7 @@ helps['group list'] = """
     type: command
     short-summary: List resource groups.
     examples:
-        - name: List all resource groups located in the  West US region.
+        - name: List all resource groups located in the West US region.
           text: >
             az group list --query "[?location=='westus']"
 """
@@ -374,7 +380,7 @@ helps['group deployment create'] = """
         - name: --parameters
           short-summary: Supply deployment parameter values.
           long-summary: >
-            Parameters may be supplied from a file using the '@<path>' syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
             It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
     examples:
         - name: Create a deployment from a remote template file, using parameters from a local JSON file.
@@ -403,7 +409,7 @@ helps['group deployment validate'] = """
         - name: --parameters
           short-summary: Supply deployment parameter values.
           long-summary: >
-            Parameters may be supplied from a file using the '@<path>' syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+            Parameters may be supplied from a file using the `@{path}` syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
             It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
 """
 helps['group deployment wait'] = """
@@ -445,7 +451,10 @@ helps['tag'] = """
 helps['resource link'] = """
     type: group
     short-summary: Manage links between resources.
-    long-summary: Linking is a feature of the Resource Manager. It enables you to declare relationships between resources even if they do not reside in the same resource group. Linking has no impact on the runtime of your resources, no impact on billing, and no impact on role-based access. It's simply a mechanism you can use to represent relationships so that tools like the tile gallery can provide a rich management experience. Your tools can inspect the links using the links API and provide custom relationship management experiences as well.
+    long-summary: >
+        Linking is a feature of the Resource Manager. It enables declaring relationships between resources even if they do not reside in the same resource group.
+        Linking has no impact on resource usage, no impact on billing, and no impact on role-based access. It allows for managing multiple resources across groups
+        as a single unit.
 """
 helps['resource link create'] = """
     type: command
@@ -476,7 +485,7 @@ helps['resource link delete'] = """
 """
 helps['resource link list'] = """
     type: command
-    short-summary: List all resource links.
+    short-summary: List resource links.
     examples:
         - name: List links, filtering with <filter-string>
           text: >
@@ -487,7 +496,7 @@ helps['resource link list'] = """
 """
 helps['resource link show'] = """
     type: command
-    short-summary: Show a resource link.
+    short-summary: Get details for a resource link.
     long-summary: A link-id is of the form /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}
     examples:
         - name: Show the <link-id> resource link.

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -8,11 +8,11 @@ from azure.cli.core.help_files import helps
 # pylint: disable=line-too-long, too-many-lines
 helps['managedapp'] = """
     type: group
-    short-summary: Manage template solutions provided and maintained by the ISV using managedapp and managedapp definitions.
+    short-summary: Manage template solutions provided and maintained by Independent Software Vendors (ISVs).
 """
 helps['managedapp definition'] = """
     type: group
-    short-summary: Manage managed application definitions.
+    short-summary: Create, delete, and manage applications and their definitions.
 """
 helps['managedapp create'] = """
     type: command
@@ -20,10 +20,14 @@ helps['managedapp create'] = """
     examples:
         - name: Create a managed application of kind 'ServiceCatalog'. This requires a valid managed application definition id.
           text: >
-            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind ServiceCatalog -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" -d "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Solutions/applianceDefinitions/myManagedAppDef"
-        - name: Create a managed application of kind 'MarketPlace'. This requires a valid plan, containing details about existing marketplace package like plan name, version, publisher and product
+            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind ServiceCatalog \\
+                -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" \\
+                -d "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Solutions/applianceDefinitions/myManagedAppDef"
+        - name: Create a managed application of kind 'MarketPlace'. This requires a valid plan, containing details about existing marketplace package like plan name, version, publisher and product.
           text: >
-            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind MarketPlace -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" --plan-name ContosoAppliance --plan-version "1.0" --plan-product "contoso-appliance" --plan-publisher Contoso
+            az managedapp create -g MyResourceGroup -n MyManagedApp -l westcentralus --kind MarketPlace \\
+                -m "/subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/myManagedRG" \\
+                --plan-name ContosoAppliance --plan-version "1.0" --plan-product "contoso-appliance" --plan-publisher Contoso
 """
 helps['managedapp definition create'] = """
     type: command
@@ -31,7 +35,9 @@ helps['managedapp definition create'] = """
     examples:
         - name: Create a managed application defintion.
           text: >
-            az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None --package-file-uri "https://path/to/myPackage.zip"
+            az managedapp definition create -g MyResourceGroup -n MyManagedAppDef -l eastus --display-name "MyManagedAppDef" \\
+                --description "My Managed App Def description" -a "myPrincipalId:myRoleId" --lock-level None \\
+                --package-file-uri "https://path/to/myPackage.zip"
 """
 helps['managedapp definition delete'] = """
     type: command
@@ -39,7 +45,7 @@ helps['managedapp definition delete'] = """
 """
 helps['managedapp definition list'] = """
     type: command
-    short-summary: Lists managed application definitions.
+    short-summary: List managed application definitions.
 """
 helps['managedapp delete'] = """
     type: command
@@ -47,7 +53,7 @@ helps['managedapp delete'] = """
 """
 helps['managedapp list'] = """
     type: command
-    short-summary: Lists managed applications by resource group, or by subscription.
+    short-summary: List managed applications.
 """
 helps['lock'] = """
     type: group
@@ -56,11 +62,10 @@ helps['lock'] = """
         - name: --resource-type
           type: string
           text: >
-            The name of the resource type (e.g. virtualMachines).
-            May have a provider namespace (e.g. Microsoft.Compute) [optional].
+            The name of the resource type. Optionally, may have a provider namespace.
         - name: --resource-provider-namespace
           type: string
-          text: The name of the resource provider (e.g. Microsoft.Compute).
+          text: The name of the resource provider.
         - name: --parent-resource-path
           type: string
           text: The path to the parent resource of the resource being locked.
@@ -71,15 +76,15 @@ helps['lock'] = """
 helps['lock create'] = """
     type: command
     short-summary: Create a lock.
-    long-summary: Locks can exist at three different scopes, (subscription, resource group and resource).
+    long-summary: 'Locks can exist at three different scopes: subscription, resource group and resource.'
     parameters:
         - name: --notes
           type: string
-          short-summary: 'Notes about this lock'
+          short-summary: Notes about this lock.
     examples:
-        - name: Create a new subscription level Read-Only lock
+        - name: Create a read-only subscription level lock.
           text: >
-            az lock create --name lockName --lock-type ReadOnly
+            az lock create --name lockName --resource-group group --lock-type ReadOnly
     """
 helps['lock delete'] = """
     type: commands
@@ -114,7 +119,7 @@ helps['lock update'] = """
     parameters:
         - name: --notes
           type: string
-          short-summary: 'Notes about this lock'
+          short-summary: Notes about this lock.
     examples:
         - name: Update a resource-group level lock with new notes and type
           text: >
@@ -134,20 +139,21 @@ helps['policy definition create'] = """
             parameters:
                 - name: --rules
                   type: string
-                  short-summary: 'JSON formatted string or a path to a file with such content'
+                  short-summary: Policy rules in JSON format, or a path to a file containing JSON rules.
             examples:
-                - name: Create a policy with following rules
+                - name: Create a read-only policy.
                   text: |
-                        {
-                            "if":
-                            {
-                                "source": "action",
-                                "equals": "Microsoft.Storage/storageAccounts/write"
-                            },
-                            "then":
-                            {
-                                "effect": "deny"
-                            }
+                    az policy definition create -n readOnlyStorage --rules \\
+                        { \\
+                            "if": \\
+                            { \\
+                                "source": "action", \\
+                                "equals": "Microsoft.Storage/storageAccounts/write" \\
+                            }, \\
+                            "then": \\
+                            { \\
+                                "effect": "deny" \\
+                            } \\
                         }
                 - name: Create a policy parameter definition with the following example
                   text: |
@@ -205,7 +211,7 @@ helps['policy assignment show'] = """
 """
 helps['policy assignment list'] = """
     type: command
-    short-summary: list resource policy assignments.
+    short-summary: List resource policy assignments.
 """
 helps['resource'] = """
     type: group
@@ -215,35 +221,34 @@ helps['resource list'] = """
     type: command
     short-summary: List resources.
     examples:
-        - name: List all resource in a region.
+        - name: List all resource in the West US region.
           text: >
             az resource list --location westus
-        - name: List resource using a name.
+        - name: List a resource with the name 'resourceName'.
           text: >
-            az resource list --name thename
-        - name: List resources using a tag.
+            az resource list --name 'resourceName'
+        - name: List resources with the tag 'test'.
           text: >
-             az resource list --tag something
-        - name: List resources using a tag with a particular prefix.
+             az resource list --tag test
+        - name: List resources with a tag that starts with 'test'.
           text: >
-            az resource list --tag some*
-        - name: List resources using a tag value.
+            az resource list --tag test*
+        - name: List resources with the tag 'test' that have the value 'example'.
           text: >
-            az resource list --tag something=else
+            az resource list --tag test=example
 """
 
 helps['resource show'] = """
     type: command
     short-summary: Get information about a resource.
-    long-summary: For example /subscriptions/0000/resourceGroups/MyResourceGroup/providers/Microsoft.Provider/ResA/MyA/ResB/MyB/resC/MyC.
     examples:
-        - name: Show a virtual machine.
+        - name: Show a virtual machine resource named 'MyVm'.
           text: >
             az vm show -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
         - name: Show a web app using a resource identifier.
           text: >
             az resource show --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
-        - name: Show a subnet.
+        - name: Show a subnet in the 'microsoft.network' namespace which belongs to the virtual network 'MyVnet'.
           text: >
             az resource show -g MyResourceGroup -n MySubnet --namespace microsoft.network --parent virtualnetworks/MyVnet --resource-type subnets
         - name: Show a subnet using a resource identifier.
@@ -256,10 +261,9 @@ helps['resource show'] = """
 
 helps['resource delete'] = """
     type: command
-    short-summary: Delete a resource. Reference the examples for help with arguments.
-    long-summary: For example, /subscriptions/0000/resourceGroups/MyResourceGroup/providers/Microsoft.Provider/ResA/MyA/ResB/MyB/ResC/MyC.
+    short-summary: Delete a resource.
     examples:
-        - name: Delete a virtual machine.
+        - name: Delete a virtual machine named 'MyVm'.
           text: >
             az vm delete -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
         - name: Delete a web app using a resource identifier.
@@ -272,13 +276,12 @@ helps['resource delete'] = """
 
 helps['resource tag'] = """
     type: command
-    short-summary: Tag a resource. Reference the examples for help with arguments.
-    long-summary: For example, /subscriptions/0000/resourceGroups/MyResourceGroup/providers/Microsoft.Provider/ResA/MyA/ResB/MyB/resC/MyC.
+    short-summary: Tag a resource.
     examples:
-        - name: Tag a virtual machine.
+        - name: Tag the virtual machine 'MyVm' with the key 'vmlist' and value 'vm1'.
           text: >
             az resource tag --tags vmlist=vm1 -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines"
-        - name: Tag a web app using a resource identifier.
+        - name: Tag a web app with the key 'vmlist' and value 'vm1', using a resource identifier.
           text: >
             az resource tag --tags vmlist=vm1 --id /subscriptions/0b1f6471-1bf0-4dda-aec3-111111111111/resourceGroups/MyResourceGroup/providers/Microsoft.Web/sites/MyWebapp
 """
@@ -287,12 +290,18 @@ helps['resource create'] = """
     type: command
     short-summary: create a resource.
     examples:
-       - name: Create a resource, such as an API App, by providing a full resource object json. Note, you can also use `@<file>` to load from a json file.
-         text: >
+       - name: Create an API app by providing a full JSON configuration.
+         text: |
             az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties "{\\"kind\\":\\"api\\", \\"location\\":\\"West US\\", \\"properties\\":{\\"serverFarmId\\":\\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1\\"}}"
-       - name: Create a resource, such as a Web App, by only providing resource properties
+       - name: Create a resource by loading JSON configuration from a file.
          text: >
-            az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties "{\\"serverFarmId\\":\\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1\\"}"
+            az resource create -g myRG -n myApiApp --resource-type Microsoft.web/sites --is-full-object --properties @jsonConfigFile
+       - name: Create a web app with the minimum required configuration information.
+         text: |
+            az resource create -g myRG -n myWeb --resource-type Microsoft.web/sites --properties \\
+                { \\
+                    "serverFarmId":"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myRG/providers/Microsoft.Web/serverfarms/appServicePlan1" \\
+                }
 """
 
 helps['resource update'] = """
@@ -302,7 +311,7 @@ helps['resource update'] = """
 
 helps['feature'] = """
     type: group
-    short-summary: Manage resource provider features, such as previews.
+    short-summary: Manage resource provider features.
 """
 
 helps['group'] = """
@@ -312,9 +321,9 @@ helps['group'] = """
 
 helps['group exists'] = """
     type: command
-    short-summary: Checks whether resource group exists.
+    short-summary: Check if a resource group exists.
     examples:
-        - name: Check group existence.
+        - name: Check if 'MyResourceGroup' exists.
           text: >
             az group exists -n MyResourceGroup
 """
@@ -323,14 +332,14 @@ helps['group create'] = """
     type: command
     short-summary: Create a new resource group.
     examples:
-        - name: Create a resource group in West US.
+        - name: Create a new resource group in the West US region.
           text: >
             az group create -l westus -n MyResourceGroup
 """
 
 helps['group delete'] = """
     type: command
-    short-summary: Delete resource group.
+    short-summary: Delete a resource group.
     examples:
         - name: Delete a resource group.
           text: >
@@ -339,9 +348,9 @@ helps['group delete'] = """
 
 helps['group list'] = """
     type: command
-    short-summary: List resource groups, optionally filtered by a tag.
+    short-summary: List resource groups.
     examples:
-        - name: List all resource groups for West US.
+        - name: List all resource groups located in the  West US region.
           text: >
             az group list --query "[?location=='westus']"
 """
@@ -365,36 +374,41 @@ helps['group deployment create'] = """
         - name: --parameters
           short-summary: Supply deployment parameter values.
           long-summary: >
-            Parameters may be supplied from a parameters file, raw JSON (which can be loaded using `@<file path>` syntax, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax (example: --parameters params.json --parameters location=westus)
+            Parameters may be supplied from a file using the '@<path>' syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
     examples:
-        - name: Create a deployment from a remote template file.
+        - name: Create a deployment from a remote template file, using parameters from a local JSON file.
           text: >
             az group deployment create -g MyResourceGroup --template-uri https://myresource/azuredeploy.json --parameters @myparameters.json
-        - name: Create a deployment from a local template file and use parameter values in a string.
+        - name: Create a deployment from a local template file, using parameters from a JSON string.
+          text: |
+            az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters \\
+                    '{ \\
+                        "location": {\\
+                            "value": "westus" \\
+                        } \\
+                    }'
+        - name: Create a deployment from a local template, using a parameter file and selectively overriding key/value pairs.
           text: >
-            az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters "{\\"location\\": {\\"value\\": \\"westus\\"}}"
-        - name: Create a deployment from a local template, use a parameter file and selectively override parameters.
-          text: >
-            az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters params.json --parameters MyValue=This MyArray=@array.json
+            az group deployment create -g MyResourceGroup --template-file azuredeploy.json --parameters @params.json --parameters MyValue=This MyArray=@array.json
 """
 helps['group deployment export'] = """
     type: command
-    short-summary: Export the template used for the specified deployment.
+    short-summary: Export the template used for a deployment.
 """
 helps['group deployment validate'] = """
     type: command
-    short-summary: Validate whether the specified template is syntactically correct and will be accepted by Azure Resource Manager.
+    short-summary: Validate whether a template is syntactically correct.
     parameters:
         - name: --parameters
           short-summary: Supply deployment parameter values.
           long-summary: >
-            Parameters may be supplied from a parameters file, raw JSON (which can be loaded using `@<file path>` syntax, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
-            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax (example: --parameters params.json --parameters location=westus)
+            Parameters may be supplied from a file using the '@<path>' syntax, a JSON string, or as <KEY=VALUE> pairs. Parameters are evaluated in order, so when a value is assigned twice, the latter value will be used.
+            It is recommended that you supply your parameters file first, and then override selectively using KEY=VALUE syntax.
 """
 helps['group deployment wait'] = """
     type: command
-    short-summary: Place the CLI in a waiting state until a condition of the deployment is met.
+    short-summary: Place the CLI in a waiting state until a deployment condition is met.
 """
 helps['group deployment operation'] = """
     type: group
@@ -438,9 +452,7 @@ helps['resource link create'] = """
     short-summary: Create a new link between resources.
     long-summary: A link-id is of the form /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}
     examples:
-        - name: Create a link from <link-id> to <resource-id> with
-                notes "some notes to explain this link"
-
+        - name: Create a link from <link-id> to <resource-id> with notes "some notes to explain this link"
           text: >
             az resource link create --link-id <link-id> --target-id <resource-id> --notes "some notes to explain this link"
 """
@@ -464,8 +476,7 @@ helps['resource link delete'] = """
 """
 helps['resource link list'] = """
     type: command
-    short-summary: List all resource links
-    long-summary: Optionally restrict to a specific scope (e.g. /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup) or filter using a filter expression.
+    short-summary: List all resource links.
     examples:
         - name: List links, filtering with <filter-string>
           text: >
@@ -476,10 +487,10 @@ helps['resource link list'] = """
 """
 helps['resource link show'] = """
     type: command
-    short-summary: Show a specific link
+    short-summary: Show a resource link.
     long-summary: A link-id is of the form /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}
     examples:
-        - name: Show a specific link, <link-id>
+        - name: Show the <link-id> resource link.
           text: >
             az resource link show --link-id <link-id>
 """

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -27,7 +27,7 @@ helps['ad sp create-for-rbac'] = """
         - name: --keyvault
           short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.
         - name: --years
-          short-summary: Number of years for which the credentials will be valid. Default: 1 year
+          short-summary: 'Number of years for which the credentials will be valid. Default: 1 year'
         - name: --scopes
           short-summary: >
             Space-separated list of scopes the service principal's role assignment applies to.

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -14,44 +14,47 @@ helps['ad sp create-for-rbac'] = """
           short-summary: Name or app URI to associate the RBAC with. If not present, a name will be generated.
         - name: --password -p
           short-summary: The password used to log in.
-          long-summary: If not present and --cert is not specified, a random password will be generated.
+          long-summary: If not present and `--cert` is not specified, a random password will be generated.
         - name: --cert
           short-summary: Certificate to use for credentials.
-          long-summary: When used with --keyvault, indicates the name of the cert to use or create.
-            Otherwise, supply a PEM or DER formatted public certificate string. Use `@<file path>` to
+          long-summary: When used with `--keyvault,` indicates the name of the cert to use or create.
+            Otherwise, supply a PEM or DER formatted public certificate string. Use `@{file}` to
             load from a file. Do not include private key info.
         - name: --create-cert
           short-summary: Create a self-signed certificate to use for the credential.
-          long-summary: Use with --keyvault to create the certificate in Key Vault. Otherwise, a
+          long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a
             certificate will be created locally.
         - name: --keyvault
           short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.
         - name: --years
-          short-summary: >
-            Number of years for which the credentials will be valid. Default: 1 year
+          short-summary: Number of years for which the credentials will be valid. Default: 1 year
         - name: --scopes
-          short-summary: Space-separated list of scopes the service principal's role assignment applies to.
+          short-summary: >
+            Space-separated list of scopes the service principal's role assignment applies to.
             Defaults to the root of the current subscription.
         - name: --role
           short-summary: Role of the service principal.
     examples:
         - name: Create with a default role assignment.
-          text: az ad sp create-for-rbac
+          text: >
+            az ad sp create-for-rbac
         - name: Create using a custom name, and with a default assignment.
-          text: az ad sp create-for-rbac -n "MyApp"
+          text: >
+            az ad sp create-for-rbac -n "MyApp"
         - name: Create without a default assignment.
-          text: az ad sp create-for-rbac --skip-assignment
+          text: >
+            az ad sp create-for-rbac --skip-assignment
         - name: Create with customized contributor assignments.
           text: |
             az ad sp create-for-rbac -n "MyApp" --role contributor \\
-                --scopes /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/MyResourceGroup \\
-                /subscriptions/11111111-2222-3333-4444-666666666666/resourceGroups/MyAnotherResourceGroup
+                --scopes /subscriptions/{SubID}/resourceGroups/{MyRG1} \\
+                /subscriptions/{SubID}/resourceGroups/{MyRG2}
         - name: Create using a self-signed certificte.
           text: az ad sp create-for-rbac --create-cert
         - name: Create using a self-signed certificate, and store it within KeyVault.
-          text: az ad sp create-for-rbac --keyvault <vault name> --cert <name> --create-cert
+          text: az ad sp create-for-rbac --keyvault MyVault --cert CertName --create-cert
         - name: Create using existing certificate in KeyVault.
-          text: az ad sp create-for-rbac --keyvault <vault name> --cert <name>
+          text: az ad sp create-for-rbac --keyvault MyVault --cert CertName
     """
 
 helps['ad sp reset-credentials'] = """
@@ -63,15 +66,15 @@ helps['ad sp reset-credentials'] = """
           short-summary: Name or app URI for the credential.
         - name: --password -p
           short-summary: The password used to log in.
-          long-summary: If not present and --cert is not specified, a random password will be generated.
+          long-summary: If not present and `--cert` is not specified, a random password will be generated.
         - name: --cert
           short-summary: Certificate to use for credentials.
-          long-summary: When using --keyvault, indicates the name of the cert to use or create.
-            Otherwise, supply a PEM or DER formatted public certificate string. Use `@<file path>` to
+          long-summary: When using `--keyvault,` indicates the name of the cert to use or create.
+            Otherwise, supply a PEM or DER formatted public certificate string. Use `@{file}` to
             load from a file. Do not include private key info.
         - name: --create-cert
           short-summary: Create a self-signed certificate to use for the credential.
-          long-summary: Use with --keyvault to create the certificate in Key Vault. Otherwise, a
+          long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a
             certificate will be created locally.
         - name: --keyvault
           short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.
@@ -92,7 +95,7 @@ helps['ad sp list'] = """
 """
 helps['ad sp show'] = """
     type: command
-    short-summary: Show information for a service principal.
+    short-summary: Get the details of a service principal.
 """
 helps['ad app delete'] = """
     type: command
@@ -108,7 +111,7 @@ helps['ad app list'] = """
 """
 helps['ad app show'] = """
     type: command
-    short-summary: Show information for an application.
+    short-summary: Get the details of an application.
 """
 helps['ad app update'] = """
     type: command
@@ -140,7 +143,7 @@ helps['role assignment delete'] = """
 helps['role assignment list'] = """
     type: command
     short-summary: List role assignments.
-    long-summary: By default, only assignments scoped to subscription will be displayed. To view assignments scoped by resource or group, use --all.
+    long-summary: By default, only assignments scoped to subscription will be displayed. To view assignments scoped by resource or group, use `--all`.
 """
 helps['role definition'] = """
     type: group
@@ -153,7 +156,7 @@ helps['role definition create'] = """
     parameters:
         - name: --role-definition
           type: string
-          short-summary: Description of a role as JSON, or an @<file> containing a JSON description.
+          short-summary: Description of a role as JSON, or a path to a file containing a JSON description.
     examples:
         - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
           text: |

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -11,12 +11,13 @@ helps['ad sp create-for-rbac'] = """
     short-summary: Create a service principal and configure its access to Azure resources.
     parameters:
         - name: --name -n
-          short-summary: Display name or an app ID URI. Command will generate one if missing.
+          short-summary: Name or app URI to associate the RBAC with. If not present, a name will be generated.
         - name: --password -p
-          short-summary: The password used to login. If missing, command will generate one.
+          short-summary: The password used to log in.
+          long-summary: If not present and --cert is not specified, a random password will be generated.
         - name: --cert
-          short-summary: Certificate to use for credentials in lieu of password.
-          long-summary: When using --keyvault, indicates the name of the cert to use or create.
+          short-summary: Certificate to use for credentials.
+          long-summary: When used with --keyvault, indicates the name of the cert to use or create.
             Otherwise, supply a PEM or DER formatted public certificate string. Use `@<file path>` to
             load from a file. Do not include private key info.
         - name: --create-cert
@@ -32,45 +33,39 @@ helps['ad sp create-for-rbac'] = """
           short-summary: Space-separated list of scopes the service principal's role assignment applies to.
             Defaults to the root of the current subscription.
         - name: --role
-          short-summary: Role the service principal has in regard to resources.
+          short-summary: Role of the service principal.
     examples:
         - name: Create with a default role assignment.
           text: az ad sp create-for-rbac
         - name: Create using a custom name, and with a default assignment.
-          text: az ad sp create-for-rbac -n "http://MyApp"
+          text: az ad sp create-for-rbac -n "MyApp"
         - name: Create without a default assignment.
           text: az ad sp create-for-rbac --skip-assignment
-        - name: Create with customized assignments
-          text: az ad sp create-for-rbac -n "http://MyApp" --role contributor --scopes /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/MyResourceGroup /subscriptions/11111111-2222-3333-4444-666666666666/resourceGroups/MyAnotherResourceGroup
-        - name: Create using self-signed certificte
+        - name: Create with customized contributor assignments.
+          text: |
+            az ad sp create-for-rbac -n "MyApp" --role contributor \\
+                --scopes /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/MyResourceGroup \\
+                /subscriptions/11111111-2222-3333-4444-666666666666/resourceGroups/MyAnotherResourceGroup
+        - name: Create using a self-signed certificte.
           text: az ad sp create-for-rbac --create-cert
-        - name: Create self-signed certificate within KeyVault
+        - name: Create using a self-signed certificate, and store it within KeyVault.
           text: az ad sp create-for-rbac --keyvault <vault name> --cert <name> --create-cert
-        - name: Create using existing certificate in KeyVault
+        - name: Create using existing certificate in KeyVault.
           text: az ad sp create-for-rbac --keyvault <vault name> --cert <name>
-        - name: Login with a service principal.
-          text: az login --service-principal -u <name> -p <password> --tenant <tenant>
-        - name: Login with self-signed certificate
-          text: az login --service-principal -u <name> -p <certificate file path> --tenant <tenant>
-        - name: Reset credentials on expiration.
-          text: az ad sp reset-credentials --name <name>
-        - name: Create extra role assignments in future.
-          text: az role assignment create --assignee <name> --role Contributor
-        - name: Revoke the service principal when done with it.
-          text: az ad app delete --id <name>
     """
 
 helps['ad sp reset-credentials'] = """
     type: command
-    short-summary: Reset service principal credentials.
-    long-summary: Use upon expiration of the existing credentials or in the even that you forget them.
+    short-summary: Reset a service principal credential.
+    long-summary: Use upon expiration of the service principal's credentials, or in the event that login credentials are lost.
     parameters:
         - name: --name -n
-          short-summary: Display name or an app ID URI.
+          short-summary: Name or app URI for the credential.
         - name: --password -p
-          short-summary: The password used to login. If missing, command will generate one.
+          short-summary: The password used to log in.
+          long-summary: If not present and --cert is not specified, a random password will be generated.
         - name: --cert
-          short-summary: Certificate to use for credentials in lieu of password.
+          short-summary: Certificate to use for credentials.
           long-summary: When using --keyvault, indicates the name of the cert to use or create.
             Otherwise, supply a PEM or DER formatted public certificate string. Use `@<file path>` to
             load from a file. Do not include private key info.
@@ -81,62 +76,61 @@ helps['ad sp reset-credentials'] = """
         - name: --keyvault
           short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.
         - name: --years
-          short-summary: >
-            Number of years for which the credentials will be valid. Default: 1 year
+          short-summary: 'Number of years for which the credentials will be valid. Default: 1 year'
 """
 helps['ad sp delete'] = """
     type: command
-    short-summary: delete a service principal and its role assignments
+    short-summary: Delete a service principal and its role assignments.
 """
 helps['ad sp create'] = """
     type: command
-    short-summary: create a service principal
+    short-summary: Create a service principal.
 """
 helps['ad sp list'] = """
     type: command
-    short-summary: list service principals, with optional filtering
+    short-summary: List service principals.
 """
 helps['ad sp show'] = """
     type: command
-    short-summary: get a service principal
+    short-summary: Show information for a service principal.
 """
 helps['ad app delete'] = """
     type: command
-    short-summary: delete an application
+    short-summary: Delete an application.
 """
 helps['ad app create'] = """
     type: command
-    short-summary: create an application
+    short-summary: Create an application.
 """
 helps['ad app list'] = """
     type: command
-    short-summary: list applications, with optional filtering
+    short-summary: List applications.
 """
 helps['ad app show'] = """
     type: command
-    short-summary: get an application
+    short-summary: Show information for an application.
 """
 helps['ad app update'] = """
     type: command
-    short-summary: update an application
+    short-summary: Update an application.
 """
 helps['ad user list'] = """
     type: command
-    short-summary: list users, with optional filtering
+    short-summary: List Azure Active Directory users.
 """
 helps['role'] = """
     type: group
-    short-summary: Use role assignments to manage access to your Azure resources.
+    short-summary: Manage user roles for access control with Azure Active Directory and service principals.
 """
 helps['role assignment'] = """
     type: group
-    short-summary: Manage role assignments
+    short-summary: Manage role assignments.
 """
 helps['role assignment create'] = """
     type: command
-    short-summary: Create a new role assignment.
+    short-summary: Create a new role assignment for a user, group, or service principal.
     examples:
-        - name: Create role assignment for a specified user, group, or service principal.
+        - name: Create role assignment for an assignee.
           text: az role assignment create --assignee sp_name --role a_role
 """
 helps['role assignment delete'] = """
@@ -159,27 +153,30 @@ helps['role definition create'] = """
     parameters:
         - name: --role-definition
           type: string
-          short-summary: 'JSON formatted string or a path to a file with such content'
+          short-summary: Description of a role as JSON, or an @<file> containing a JSON description.
     examples:
-        - name: Create a role with following definition content
+        - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
           text: |
-                {
-                    "Name": "Contoso On-call",
-                    "Description": "Can monitor compute, network and storage, and restart virtual machines",
-                    "Actions": [
-                        "Microsoft.Compute/*/read",
-                        "Microsoft.Compute/virtualMachines/start/action",
-                        "Microsoft.Compute/virtualMachines/restart/action",
-                        "Microsoft.Network/*/read",
-                        "Microsoft.Storage/*/read",
-                        "Microsoft.Authorization/*/read",
-                        "Microsoft.Resources/subscriptions/resourceGroups/read",
-                        "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
-                        "Microsoft.Insights/alertRules/*",
-                        "Microsoft.Support/*"
-                    ],
-                    "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+                az role definition create --role-definition { \\
+                    "Name": "Contoso On-call", \\
+                    "Description": "Perform VM actions and read storange and network information." \\
+                    "Actions": [ \\
+                        "Microsoft.Compute/*/read", \\
+                        "Microsoft.Compute/virtualMachines/start/action", \\
+                        "Microsoft.Compute/virtualMachines/restart/action", \\
+                        "Microsoft.Network/*/read", \\
+                        "Microsoft.Storage/*/read", \\
+                        "Microsoft.Authorization/*/read", \\
+                        "Microsoft.Resources/subscriptions/resourceGroups/read", \\
+                        "Microsoft.Resources/subscriptions/resourceGroups/resources/read", \\
+                        "Microsoft.Insights/alertRules/*", \\
+                        "Microsoft.Support/*" \\
+                    ], \\
+                    "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] \\
                 }
+        - name: Create a role from a file containing a JSON description.
+          text: >
+            az role definition create --role-definition @ad-role.json
 """
 
 helps['role definition delete'] = """
@@ -194,34 +191,6 @@ helps['role definition update'] = """
     type: command
     short-summary: Update a role definition.
 """
-helps['role definition create'] = """
-            type: command
-            parameters:
-                - name: --role-definition
-                  type: string
-                  short-summary: 'JSON formatted string or a path to a file with such content'
-            examples:
-                - name: Create a role with following definition content
-                  text: |
-                        {
-                            "Name": "Contoso On-call",
-                            "Description": "Can monitor compute, network and storage, and restart virtual machines",
-                            "Actions": [
-                                "Microsoft.Compute/*/read",
-                                "Microsoft.Compute/virtualMachines/start/action",
-                                "Microsoft.Compute/virtualMachines/restart/action",
-                                "Microsoft.Network/*/read",
-                                "Microsoft.Storage/*/read",
-                                "Microsoft.Authorization/*/read",
-                                "Microsoft.Resources/subscriptions/resourceGroups/read",
-                                "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
-                                "Microsoft.Insights/alertRules/*",
-                                "Microsoft.Support/*"
-                            ],
-                            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
-                        }
-
-            """
 helps['ad'] = """
     type: group
     short-summary: Synchronize on-premises directories and manage Azure Active Directory resources.

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_help.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_help.py
@@ -9,69 +9,65 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 
 helps["sf cluster certificate"] = """
     type: group
-    short-summary: Manage the cluster certificate
+    short-summary: Manage a cluster certificate.
 """
 
 helps["sf cluster client-certificate"] = """
     type: group
-    short-summary: Manage the client certificate of a cluster
+    short-summary: Manage the client certificate of a cluster.
 """
 
 helps["sf cluster durability"] = """
     type: group
-    short-summary: Manage the durability of a cluster
+    short-summary: Manage the durability of a cluster.
 """
 
 helps["sf cluster node"] = """
     type: group
-    short-summary: Manage the node instance of a cluster
+    short-summary: Manage the node instance of a cluster.
 """
 
 helps["sf cluster node-type"] = """
     type: group
-    short-summary: Manage the node-type of a cluster
+    short-summary: Manage the node-type of a cluster.
 """
 
 helps["sf cluster reliability"] = """
     type: group
-    short-summary: Manage the reliability of a cluster
+    short-summary: Manage the reliability of a cluster.
 """
 
 helps["sf cluster setting"] = """
     type: group
-    short-summary: Manage the cluster setting
+    short-summary: Manage a cluster's settings.
 """
 
 helps["sf cluster upgrade-type"] = """
     type: group
-    short-summary: Manage the upgrade type of the cluster
+    short-summary: Manage the upgrade type of a cluster.
 """
 
 helps["sf application certificate"] = """
     type: group
-    short-summary: Manage the certificate of the application
+    short-summary: Manage the certificate of an application.
 """
 
 helps["sf cluster list"] = """
     type: command
-    short-summary: List all the cluster resource in the same subscription
+    short-summary: List cluster resources. 
 """
 
 helps["sf cluster create"] = """
     type: command
-    short-summary: Create a new Service Fabric cluster
-    long-summary: >
-        This command uses certificates that you provide or system generated self-signed certificates to set up a new service fabric cluster.
-        It can use a default template or a custom template that you provide.
-        You have the option of specifying a folder to export the self-signed certificates to or fetching them later from the key vault.
+    short-summary: Create a new Azure Service Fabric cluster.
     examples:
-        - name: Specify only the cluster size, the cert subject name, and the OS to deploy a cluster
+        - name: Create a cluster with a given size and self-signed certificate that is downloaded locally. 
           text: >
-            az sf cluster create -g group-name -n cluster1 -l westus -size 4 --vm-password Password#1234 --certificate-output-folder c:\\Mycertificates
-        - name: Specify an existing Certificate resource in a key vault and a custom template to deploy a cluster
+            az sf cluster create -g group-name -n cluster1 -l westus -size 4 --vm-password Password#1234 --certificate-output-folder MyCertificates
+        - name: Use a keyvault certificate and custom template to deploy a cluster.
           text: >
-            az sf cluster create -g group-name -n cluster1 -l westus --template-file c:\\template.json --parameter-file c:\\parameter.json
-            --secret-identifier https://kv.vault.azure.net:443/secrets/testcertificate/56ec774dc61a462bbc645ffc9b4b225f
+            az sf cluster create -g group-name -n cluster1 -l westus --template-file template.json --parameter-file parameter.json
+            --secret-identifier https://{MyKeyVault}.vault.azure.net:443/secrets/{MyCertificate}
 
 """
 
@@ -79,10 +75,11 @@ helps["sf cluster certificate add"] = """
     type: command
     short-summary: Add a secondary cluster certificate to the cluster.
     examples:
-        - name: Add cluster certificate using secret identifier
-          text: >
-            az sf cluster certificate add -g group-name -n cluster1 --secret-identifier 'https://contoso03vault.vault.azure.net/secrets/contoso03vaultrg/7f7de9131c034172b9df37ccc549524f'
-        - name: Add cluster certificate with self-signed certificate
+        - name: Add a certificate to a  cluster using a keyvault secret identifier.
+          text: |
+            az sf cluster certificate add -g group-name -n cluster1 \\
+                --secret-identifier 'https://{MyKeyVault}.vault.azure.net/secrets/{MySecret}
+        - name: Add a self-signed certificate to a cluster.
           text: >
              az sf cluster certificate add -g group-name -n cluster1 --certificate-subject-name test.com
 
@@ -90,9 +87,9 @@ helps["sf cluster certificate add"] = """
 
 helps["sf cluster certificate remove"] = """
     type: command
-    short-summary: Remove a cluster certificate from being used for cluster security.
+    short-summary: Remove a certificate from a cluster.
     examples:
-        - name: Remove certificate by thumbprint
+        - name: Remove a certificate by thumbprint.
           text: >
             az sf cluster certificate remove -g group-name -n cluster1 --thumbprint '5F3660C715EBBDA31DB1FFDCF508302348DE8E7A'
 
@@ -100,32 +97,29 @@ helps["sf cluster certificate remove"] = """
 
 helps["sf cluster client-certificate add"] = """
     type: command
-    short-summary: Add common name or thumbprint to the cluster for client authentication purposes.
-    long-summary: >
-            Use this command to add a common name and issuer thumbprint or certificate thumbprint to the cluster,
-            so the client can use it for authentication.
+    short-summary: Add a common name or certificate thumbprint to the cluster for client authentication.
     examples:
         - name: Add client certificate by thumbprint
           text: >
-            az sf cluster client certificate add -g group-name -n cluster1 --thumbprint '5F3660C715EBBDA31DB1FFDCF508302348DE8E7A'
+            az sf cluster client-certificate add -g group-name -n cluster1 --thumbprint '5F3660C715EBBDA31DB1FFDCF508302348DE8E7A'
 
 """
 
 helps["sf cluster client-certificate remove"] = """
     type: command
-    short-summary: Remove a client certificate(s) or certificate subject(s) name(s) from being used for client authentication to the cluster.
+    short-summary: Remove client certificates or subject names used for authentication.
     examples:
-        - name: Remove client certificate
+        - name: Remove a client certificate by thumbprint.
           text: >
-            az sf cluster client certificate remove -g group-name -n cluster1 --thumbprint '5F3660C715EBBDA31DB1FFDCF508302348DE8E7A'
+            az sf cluster client-certificate remove -g group-name -n cluster1 --thumbprint '5F3660C715EBBDA31DB1FFDCF508302348DE8E7A'
 
 """
 
 helps["sf cluster setting set"] = """
     type: command
-    short-summary: Add or update one or multiple Service Fabric settings to the cluster.
+    short-summary: Update the settings of a cluster.
     examples:
-        - name: Set cluster setting
+        - name: Set the `MaxFileOperationTimeout` setting for a cluster to 5 seconds.
           text: >
             az sf cluster setting set -g group-name -n cluster1 --section 'NamingService' --parameter 'MaxFileOperationTimeout' --value 5000
 
@@ -133,9 +127,9 @@ helps["sf cluster setting set"] = """
 
 helps["sf cluster setting remove"] = """
     type: command
-    short-summary: Remove one or multiple Service Fabric setting from the cluster.
+    short-summary: Remove settings from a cluster. 
     examples:
-        - name: Remove cluster setting
+        - name: Remove the `MaxFileOperationTimeout` setting from a cluster.
           text: >
             az sf cluster setting remove -g group-name -n cluster1 --section 'NamingService' --parameter 'MaxFileOperationTimeout'
 
@@ -143,9 +137,9 @@ helps["sf cluster setting remove"] = """
 
 helps["sf cluster reliability update"] = """
     type: command
-    short-summary: Update the reliability tier of the primary node type in a cluster.
+    short-summary: Update the reliability tier for the primary node in a cluster.
     examples:
-        - name: Change cluster reliability
+        - name: Change the cluster reliability level to 'Silver'.
           text: >
             az sf cluster reliability update -g group-name -n cluster1 --reliability-level Silver
 
@@ -153,9 +147,9 @@ helps["sf cluster reliability update"] = """
 
 helps["sf cluster durability update"] = """
     type: command
-    short-summary: Update the durability tier or VmSku of a node type in the cluster.
+    short-summary: Update the durability tier or VM SKU of a node type in the cluster.
     examples:
-        - name: Update cluster durability
+        - name: Change the cluster durability level to 'Silver'.
           text: >
             az sf cluster durability update -g group-name -n cluster1 --durability-level Silver
 
@@ -163,9 +157,9 @@ helps["sf cluster durability update"] = """
 
 helps["sf cluster node-type add"] = """
     type: command
-    short-summary: Add a new node type to the existing cluster.
+    short-summary: Add a new node type to a cluster.
     examples:
-        - name: Add a new node type for the cluster
+        - name: Add a new node type to a cluster.
           text: >
             az sf cluster node-type add -g group-name -n cluster1 --node-type 'n2' --capacity 5 --vm-user-name 'adminName' --vm-password User@1234567890
 
@@ -173,9 +167,9 @@ helps["sf cluster node-type add"] = """
 
 helps["sf cluster node add"] = """
     type: command
-    short-summary: Add nodes to the specific node type in the cluster.
+    short-summary: Add nodes to a node type in a cluster.
     examples:
-        - name: Add nodes to the cluster
+        - name: Add 2 'nt1' nodes to a cluster.
           text: >
             az sf cluster node add -g group-name -n cluster1 --number-of-nodes-to-add 2 --node-type 'nt1'
 
@@ -183,9 +177,9 @@ helps["sf cluster node add"] = """
 
 helps["sf cluster node remove"] = """
     type: command
-    short-summary: Remove nodes from the specific node type from a cluster.
+    short-summary: Remove nodes from a node type in a cluster.
     examples:
-        - name: Example1
+        - name: Remove 2 'nt1' nodes from a cluster.
           text: >
             az sf cluster node remove -g group-name -n cluster1 --node-type 'nt1' --number-of-nodes-to-remove 2
 
@@ -193,9 +187,9 @@ helps["sf cluster node remove"] = """
 
 helps["sf cluster upgrade-type set"] = """
     type: command
-    short-summary: Change the Service Fabric upgrade type of the cluster.
+    short-summary: Change the  upgrade type for a cluster.
     examples:
-        - name: Example1
+        - name: Set a cluster to use the 'Automatic' upgrade mode.
           text: >
             az sf cluster upgrade-type set -g group-name -n cluster1 --upgrade-mode Automatic
 
@@ -203,10 +197,10 @@ helps["sf cluster upgrade-type set"] = """
 
 helps["sf application certificate add"] = """
     type: command
-    short-summary: Add a new certificate to the Virtual Machine Scale Set(s) that make up the cluster. The certificate is intended to be used as an application certificate.
+    short-summary: Add a new certificate to the Virtual Machine Scale Sets that make up the cluster to be used by hosted applications.
     examples:
-        - name: Add application certificate
+        - name: Add an application certificate.
           text: >
-            az sf cluster application certificate add -g group-name -n cluster1  --secret-identifier 'https://contoso03vault.vault.azure.net/secrets/contoso03vaultrg/7f7de9131c034172b9df37ccc549524f'
+            az sf cluster application certificate add -g group-name -n cluster1  --secret-identifier 'https://{KeyVault}.vault.azure.net/secrets/{MySecret}'
 
 """

--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_help.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/_help.py
@@ -54,20 +54,20 @@ helps["sf application certificate"] = """
 
 helps["sf cluster list"] = """
     type: command
-    short-summary: List cluster resources. 
+    short-summary: List cluster resources.
 """
 
 helps["sf cluster create"] = """
     type: command
     short-summary: Create a new Azure Service Fabric cluster.
     examples:
-        - name: Create a cluster with a given size and self-signed certificate that is downloaded locally. 
+        - name: Create a cluster with a given size and self-signed certificate that is downloaded locally.
           text: >
             az sf cluster create -g group-name -n cluster1 -l westus -size 4 --vm-password Password#1234 --certificate-output-folder MyCertificates
         - name: Use a keyvault certificate and custom template to deploy a cluster.
           text: >
-            az sf cluster create -g group-name -n cluster1 -l westus --template-file template.json --parameter-file parameter.json
-            --secret-identifier https://{MyKeyVault}.vault.azure.net:443/secrets/{MyCertificate}
+            az sf cluster create -g group-name -n cluster1 -l westus --template-file template.json \\
+                --parameter-file parameter.json --secret-identifier https://{MyKeyVault}.vault.azure.net:443/secrets/{MyCertificate}
 
 """
 
@@ -127,7 +127,7 @@ helps["sf cluster setting set"] = """
 
 helps["sf cluster setting remove"] = """
     type: command
-    short-summary: Remove settings from a cluster. 
+    short-summary: Remove settings from a cluster.
     examples:
         - name: Remove the `MaxFileOperationTimeout` setting from a cluster.
           text: >

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/_help.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/_help.py
@@ -7,38 +7,37 @@ from azure.cli.core.help_files import helps
 
 helps["sf"] = """
      type: group
-     short-summary: Manage and administer a Service Fabric cluster
+     short-summary: Manage and administer a Service Fabric cluster.
 """
 helps["sf application"] = """
     type: group
-    short-summary: Manage the applications running on a Service Fabric cluster
+    short-summary: Manage applications running on a Service Fabric cluster.
 """
 helps["sf chaos"] = """
     type: group
-    short-summary: Manage the Service Fabric Chaos service, designed to
-                   simulate real failures
+    short-summary: Manage a Service Fabric Chaos service.
 """
 helps["sf cluster"] = """
     type: group
-    short-summary: Select and manage a Service Fabric cluster
+    short-summary: Select and manage a Service Fabric cluster.
 """
 helps["sf compose"] = """
     type: group
-    short-summary: Manage and deploy applications created from Docker Compose
+    short-summary: Manage and deploy applications created from Docker Compose.
 """
 helps["sf node"] = """
     type: group
-    short-summary: Manage the nodes that create a Service Fabric cluster
+    short-summary: Manage the nodes that create a Service Fabric cluster.
 """
 helps["sf partition"] = """
     type: group
-    short-summary: Manage the partitions of a Service Fabric service
+    short-summary: Manage the partitions of a Service Fabric service.
 """
 helps["sf replica"] = """
     type: group
-    short-summary: Manage the replicas of a Service Fabric service partition
+    short-summary: Manage replicas of a Service Fabric service partition.
 """
 helps["sf service"] = """
     type: group
-    short-summary: Manage the services of a Service Fabric application
+    short-summary: Manage services of a Service Fabric application.
 """

--- a/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/_help.py
+++ b/src/command_modules/azure-cli-sf/azure/cli/command_modules/sf/_help.py
@@ -7,19 +7,19 @@ from azure.cli.core.help_files import helps
 
 helps["sf"] = """
      type: group
-     short-summary: Manage and administer a Service Fabric cluster.
+     short-summary: Manage and administer an Azure Service Fabric cluster.
 """
 helps["sf application"] = """
     type: group
-    short-summary: Manage applications running on a Service Fabric cluster.
+    short-summary: Manage applications running on an Azure Service Fabric cluster.
 """
 helps["sf chaos"] = """
     type: group
-    short-summary: Manage a Service Fabric Chaos service.
+    short-summary: Manage an Azure Service Fabric Chaos service.
 """
 helps["sf cluster"] = """
     type: group
-    short-summary: Select and manage a Service Fabric cluster.
+    short-summary: Select and manage an Azure Service Fabric cluster.
 """
 helps["sf compose"] = """
     type: group
@@ -27,17 +27,17 @@ helps["sf compose"] = """
 """
 helps["sf node"] = """
     type: group
-    short-summary: Manage the nodes that create a Service Fabric cluster.
+    short-summary: Manage the nodes of an Azure Service Fabric cluster.
 """
 helps["sf partition"] = """
     type: group
-    short-summary: Manage the partitions of a Service Fabric service.
+    short-summary: Manage the partitions of an Azure Service Fabric service.
 """
 helps["sf replica"] = """
     type: group
-    short-summary: Manage replicas of a Service Fabric service partition.
+    short-summary: Manage replicas of an Azure Service Fabric service partition.
 """
 helps["sf service"] = """
     type: group
-    short-summary: Manage services of a Service Fabric application.
+    short-summary: Manage services of an Azure Service Fabric application.
 """

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
@@ -135,15 +135,20 @@ helps['sql db import'] = """
     short-summary: Imports a bacpac into an existing database.
     examples:
         - name: Get an SAS key for use in import operation.
-          text: az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac \\
-                  --permissions r --expiry 2018-01-01T00:00:00Z
+          text: |
+            az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac \\
+                --permissions r --expiry 2018-01-01T00:00:00Z
         - name: Import bacpac into an existing database using an SAS key.
-          text: az sql db import -s myserver -n mydatabase -g mygroup -p password -u login \\
-                  --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" \\
-                  --storage-key-type SharedAccessKey \\
-                  --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
+          text: |
+            az sql db import -s myserver -n mydatabase -g mygroup -p password -u login \\
+                --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" \\
+                --storage-key-type SharedAccessKey \\
+                --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
         - name: Import bacpac into an existing database using a storage account key.
-          text: az sql db import -s myserver -n mydatabase -g mygroup -p password -u login --storage-key MYKEY== --storage-key-type StorageAccessKey --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
+          text: |
+            az sql db import -s myserver -n mydatabase -g mygroup -p password -u login --storage-key MYKEY== \\
+                --storage-key-type StorageAccessKey \\
+                --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
     """
 helps['sql db restore'] = """
     type: command
@@ -206,7 +211,7 @@ helps['sql dw update'] = """
     """
 helps['sql elastic-pool'] = """
     type: group
-    short-summary: Manage elastic pools. 
+    short-summary: Manage elastic pools.
     """
 helps['sql elastic-pool create'] = """
     type: command

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
@@ -16,7 +16,7 @@ helps['sql db'] = """
     """
 helps['sql db copy'] = """
     type: command
-    short-summary: Create a copy of an existing database.
+    short-summary: Create a copy of a database.
     """
 helps['sql db create'] = """
     type: command
@@ -24,17 +24,16 @@ helps['sql db create'] = """
     """
 helps['sql db delete'] = """
     type: command
-    short-summary: Delete a database or data warehouse.
+    short-summary: Delete a database.
     """
 helps['sql db list'] = """
     type: command
-    short-summary: List all databases and data warehouses in a server, or all databases in an elastic pool.
+    short-summary: List databases a server or elastic pool.
     """
 helps['sql db list-editions'] = """
     type: command
-    short-summary: Show database editions that are available for your subscription.
-    long-summary: Includes available service objectives and storage limits. In order to reduce
-                  verbosity, settings to intentionally reduce storage limits are hidden by default.
+    short-summary: Show database editions available for the currently active subscription.
+    long-summary: Includes available service objectives and storage limits. In order to reduce verbosity, settings to intentionally reduce storage limits are hidden by default.
     examples:
         - name: Show all database editions in a location.
           text: az sql db list-editions -l westus
@@ -45,7 +44,7 @@ helps['sql db list-editions'] = """
     """
 helps['sql db show'] = """
     type: command
-    short-summary: Show a database or data warehouse.
+    short-summary: Get the details for a database.
     """
 helps['sql db update'] = """
     type: command
@@ -70,8 +69,7 @@ helps['sql server ad-admin update'] = """
 helps['sql db audit-policy update'] = """
     type: command
     short-summary: Update a database's auditing policy.
-    long-summary: If the policy is being enabled, storage_account or both storage_endpoint and
-                  storage_account_access_key must be specified.
+    long-summary: If the policy is being enabled, `--storage-account` or both `--storage-endpoint` and `--storage-key` must be specified.
     examples:
         - name: Enable by storage account name.
           text: az sql db audit-policy update -g mygroup -s myserver -n mydb --state Enabled --storage-account mystorage
@@ -102,15 +100,15 @@ helps['sql db replica create'] = """
     """
 helps['sql db replica set-primary'] = """
     type: command
-    short-summary: Sets which replica database is primary by failing over from the current primary replica database.
+    short-summary: Set the primary replica database by failing over from the current primary replica database.
     """
 helps['sql db replica list-links'] = """
     type: command
-    short-summary: List the replicas of a database and corresponding replication status.
+    short-summary: List the replicas of a database and their replication status.
     """
 helps['sql db replica delete-link'] = """
     type: command
-    short-summary: Permanently stops data replication between two database replicas.
+    short-summary: Permanently stop data replication between two database replicas.
     """
 helps['sql db export'] = """
     type: command
@@ -149,11 +147,11 @@ helps['sql db import'] = """
     """
 helps['sql db restore'] = """
     type: command
-    short-summary: Creates a new database by restoring from a database backup.
+    short-summary: Create a new database by restoring from a backup.
     """
 helps['sql db threat-policy'] = """
     type: group
-    short-summary: Manage a database's threat detection policy.
+    short-summary: Manage a database's threat detection policies.
     """
 helps['sql db threat-policy update'] = """
     type: command
@@ -192,15 +190,15 @@ helps['sql dw create'] = """
     """
 helps['sql dw delete'] = """
     type: command
-    short-summary: Delete a database or data warehouse.
+    short-summary: Delete a data warehouse.
     """
 helps['sql dw list'] = """
     type: command
-    short-summary: List all data warehouses in a server.
+    short-summary: List data warehouses for a server.
     """
 helps['sql dw show'] = """
     type: command
-    short-summary: Show information for a database or data warehouse.
+    short-summary: Get the details for a data warehouse.
     """
 helps['sql dw update'] = """
     type: command
@@ -208,7 +206,7 @@ helps['sql dw update'] = """
     """
 helps['sql elastic-pool'] = """
     type: group
-    short-summary: Manage elastic pools. An elastic pool is an allocation of CPU, IO, and memory resources. Databases inside the pool share these resources.
+    short-summary: Manage elastic pools. 
     """
 helps['sql elastic-pool create'] = """
     type: command
@@ -237,7 +235,7 @@ helps['sql elastic-pool update'] = """
     """
 helps['sql server'] = """
     type: group
-    short-summary: Manage SQL servers. Servers contain databases, data warehouses, and elastic pools.
+    short-summary: Manage SQL servers.
     """
 helps['sql server create'] = """
     type: command

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/_help.py
@@ -16,24 +16,24 @@ helps['sql db'] = """
     """
 helps['sql db copy'] = """
     type: command
-    short-summary: Creates a copy of an existing database.
+    short-summary: Create a copy of an existing database.
     """
 helps['sql db create'] = """
     type: command
-    short-summary: Creates a database.
+    short-summary: Create a database.
     """
 helps['sql db delete'] = """
     type: command
-    short-summary: Deletes a database or data warehouse.
+    short-summary: Delete a database or data warehouse.
     """
 helps['sql db list'] = """
     type: command
-    short-summary: Lists all databases and data warehouses in a server, or all databases in an elastic pool.
+    short-summary: List all databases and data warehouses in a server, or all databases in an elastic pool.
     """
 helps['sql db list-editions'] = """
     type: command
-    short-summary: Shows database editions that are available for your subscription.
-    long-summary: Also includes available service objectives and storage limits. In order to reduce
+    short-summary: Show database editions that are available for your subscription.
+    long-summary: Includes available service objectives and storage limits. In order to reduce
                   verbosity, settings to intentionally reduce storage limits are hidden by default.
     examples:
         - name: Show all database editions in a location.
@@ -45,11 +45,11 @@ helps['sql db list-editions'] = """
     """
 helps['sql db show'] = """
     type: command
-    short-summary: Gets a database or data warehouse.
+    short-summary: Show a database or data warehouse.
     """
 helps['sql db update'] = """
     type: command
-    short-summary: Updates a database.
+    short-summary: Update a database.
     """
 helps['sql db audit-policy'] = """
     type: group
@@ -61,37 +61,36 @@ helps['sql server ad-admin'] = """
     """
 helps['sql server ad-admin create'] = """
     type: command
-    short-summary: Creates a new server Active Directory administrator.
+    short-summary: Create a new server Active Directory administrator.
     """
 helps['sql server ad-admin update'] = """
     type: command
-    short-summary: Updates an existing server Active Directory administrator.
+    short-summary: Update an existing server Active Directory administrator.
     """
 helps['sql db audit-policy update'] = """
     type: command
-    short-summary: Updates a database's auditing policy.
+    short-summary: Update a database's auditing policy.
     long-summary: If the policy is being enabled, storage_account or both storage_endpoint and
                   storage_account_access_key must be specified.
     examples:
-        - name: Enable by specifying storage account name
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
-                --state Enabled --storage-account mystorage
-        - name: Enable by specifying storage endpoint and key
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
-                --state Enabled --storage-endpoint https://mystorage.blob.core.windows.net
-                --storage-key MYKEY==
-        - name: Set the list of audit actions
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
+        - name: Enable by storage account name.
+          text: az sql db audit-policy update -g mygroup -s myserver -n mydb --state Enabled --storage-account mystorage
+        - name: Enable by storage endpoint and key.
+          text: |
+            az sql db audit-policy update -g mygroup -s myserver -n mydb --state Enabled \\
+                --storage-endpoint https://mystorage.blob.core.windows.net --storage-key MYKEY==
+        - name: Set the list of audit actions.
+          text: |
+            az sql db audit-policy update -g mygroup -s myserver -n mydb \\
                 --actions FAILED_DATABASE_AUTHENTICATION_GROUP 'UPDATE on database::mydb by public'
-        - name: Add an audit action
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
+        - name: Add an audit action.
+          text: |
+            az sql db audit-policy update -g mygroup -s myserver -n mydb \\
                 --add auditActionsAndGroups FAILED_DATABASE_AUTHENTICATION_GROUP
-        - name: Remove an audit action by list index
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
-                --remove auditActionsAndGroups 0
-        - name: Disable an auditing policy
-          text: az sql db audit-policy update -g mygroup -s myserver -n mydb
-                --state Disabled
+        - name: Remove an audit action by list index.
+          text: az sql db audit-policy update -g mygroup -s myserver -n mydb --remove auditActionsAndGroups 0
+        - name: Disable an auditing policy.
+          text: az sql db audit-policy update -g mygroup -s myserver -n mydb --state Disabled
     """
 helps['sql db replica'] = """
     type: group
@@ -99,7 +98,7 @@ helps['sql db replica'] = """
     """
 helps['sql db replica create'] = """
     type: command
-    short-summary: Creates a database as a readable secondary replica of an existing database.
+    short-summary: Create a database as a readable secondary replica of an existing database.
     """
 helps['sql db replica set-primary'] = """
     type: command
@@ -107,7 +106,7 @@ helps['sql db replica set-primary'] = """
     """
 helps['sql db replica list-links'] = """
     type: command
-    short-summary: Lists the replicas of a database and corresponding replication status.
+    short-summary: List the replicas of a database and corresponding replication status.
     """
 helps['sql db replica delete-link'] = """
     type: command
@@ -115,24 +114,37 @@ helps['sql db replica delete-link'] = """
     """
 helps['sql db export'] = """
     type: command
-    short-summary: Exports a database to a bacpac.
+    short-summary: Export a database to a bacpac.
     examples:
-        - name: Get SAS key for use in export operation
-          text: az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac --permissions w --expiry 2018-01-01T00:00:00Z
-        - name: Export bacpac using SAS key
-          text: az sql db export -s myserver -n mydatabase -g mygroup -p password -u login --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" --storage-key-type SharedAccessKey --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
-        - name: Export bacpac using storage account Key
-          text: az sql db export -s myserver -n mydatabase -g mygroup -p password -u login --storage-key MYKEY== --storage-key-type StorageAccessKey --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
+        - name: Get an SAS key for use in export operation.
+          text: |
+            az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac \\
+                --permissions w --expiry 2018-01-01T00:00:00Z
+        - name: Export bacpac using an SAS key.
+          text: |
+            az sql db export -s myserver -n mydatabase -g mygroup -p password -u login \\
+                --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" \\
+                --storage-key-type SharedAccessKey \\
+                --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
+        - name: Export bacpac using a storage account key.
+          text: |
+            az sql db export -s myserver -n mydatabase -g mygroup -p password -u login \\
+                --storage-key MYKEY== --storage-key-type StorageAccessKey \\
+                --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
     """
 helps['sql db import'] = """
     type: command
     short-summary: Imports a bacpac into an existing database.
     examples:
-        - name: Get SAS key for use in import operation
-          text: az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac --permissions r --expiry 2018-01-01T00:00:00Z
-        - name: Import bacpac into an existing database using SAS key
-          text: az sql db import -s myserver -n mydatabase -g mygroup -p password -u login --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" --storage-key-type SharedAccessKey --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
-        - name: Import bacpac into an existing database using storage account key
+        - name: Get an SAS key for use in import operation.
+          text: az storage blob generate-sas --account-name myAccountName -c myContainer -n myBacpac.bacpac \\
+                  --permissions r --expiry 2018-01-01T00:00:00Z
+        - name: Import bacpac into an existing database using an SAS key.
+          text: az sql db import -s myserver -n mydatabase -g mygroup -p password -u login \\
+                  --storage-key "?sr=b&sp=rw&se=2018-01-01T00%3A00%3A00Z&sig=mysignature&sv=2015-07-08" \\
+                  --storage-key-type SharedAccessKey \\
+                  --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
+        - name: Import bacpac into an existing database using a storage account key.
           text: az sql db import -s myserver -n mydatabase -g mygroup -p password -u login --storage-key MYKEY== --storage-key-type StorageAccessKey --storage-uri https://mystorageaccount.blob.core.windows.net/bacpacs/mybacpac.bacpac
     """
 helps['sql db restore'] = """
@@ -145,63 +157,54 @@ helps['sql db threat-policy'] = """
     """
 helps['sql db threat-policy update'] = """
     type: command
-    short-summary: Updates a database's threat detection policy.
+    short-summary: Update a database's threat detection policy.
     long-summary: If the policy is being enabled, storage_account or both storage_endpoint and
                   storage_account_access_key must be specified.
     examples:
-        - name: Enable by specifying storage account name
-          text: az sql db threat-policy update -g mygroup -s myserver -n mydb
+        - name: Enable by storage account name.
+          text: |
+            az sql db threat-policy update -g mygroup -s myserver -n mydb \\
                 --state Enabled --storage-account mystorage
-        - name: Enable by specifying storage endpoint and key
-          text: az sql db threat-policy update -g mygroup -s myserver -n mydb
-                --state Enabled --storage-endpoint https://mystorage.blob.core.windows.net
+        - name: Enable by storage endpoint and key.
+          text: |
+            az sql db threat-policy update -g mygroup -s myserver -n mydb \\
+                --state Enabled --storage-endpoint https://mystorage.blob.core.windows.net \\
                 --storage-key MYKEY==
-        - name: Disable a subset of alert types
-          text: az sql db threat-policy update -g mygroup -s myserver -n mydb
+        - name: Disable a subset of alert types.
+          text: |
+            az sql db threat-policy update -g mygroup -s myserver -n mydb \\
                 --disabled-alerts Sql_Injection_Vulnerability Access_Anomaly
-        - name: Configure email recipients
-          text: az sql db threat-policy update -g mygroup -s myserver -n mydb
-                --email-addresses me@examlee.com you@example.com --email-account-admins
-                Enabled
-        - name: Disable
-          text: az sql db threat-policy update -g mygroup -s myserver -n mydb
-                --state Disabled
+        - name: Configure email recipients for a policy.
+          text: |
+            az sql db threat-policy update -g mygroup -s myserver -n mydb \\
+                --email-addresses me@examlee.com you@example.com \\
+                --email-account-admins Enabled
+        - name: Disable a threat policy.
+          text: az sql db threat-policy update -g mygroup -s myserver -n mydb --state Disabled
     """
-# helps['sql db restore-point'] = """
-#             type: group
-#             short-summary: Manage database restore points.
-#             """
-# helps['sql db transparent-data-encryption'] = """
-#             type: group
-#             short-summary: Manage database transparent data encryption.
-#             """
-# helps['sql db service-tier-advisor'] = """
-#             type: group
-#             short-summary: Manage database service tier advisors.
-#             """
 helps['sql dw'] = """
     type: group
     short-summary: Manage data warehouses.
     """
 helps['sql dw create'] = """
     type: command
-    short-summary: Creates a data warehouse.
+    short-summary: Create a data warehouse.
     """
 helps['sql dw delete'] = """
     type: command
-    short-summary: Deletes a database or data warehouse.
+    short-summary: Delete a database or data warehouse.
     """
 helps['sql dw list'] = """
     type: command
-    short-summary: Lists all data warehouses in a server.
+    short-summary: List all data warehouses in a server.
     """
 helps['sql dw show'] = """
     type: command
-    short-summary: Gets a database or data warehouse.
+    short-summary: Show information for a database or data warehouse.
     """
 helps['sql dw update'] = """
     type: command
-    short-summary: Updates a data warehouse.
+    short-summary: Update a data warehouse.
     """
 helps['sql elastic-pool'] = """
     type: group
@@ -209,81 +212,69 @@ helps['sql elastic-pool'] = """
     """
 helps['sql elastic-pool create'] = """
     type: command
-    short-summary: Creates an elastic pool.
+    short-summary: Create an elastic pool.
     """
 helps['sql elastic-pool list-editions'] = """
     type: command
-    short-summary: Shows elastic pool editions that are available for your subscription.
+    short-summary: List elastic pool editions available for the active subscription.
     long-summary: Also includes available pool DTU settings, storage limits, and per database
                   settings. In order to reduce verbosity, additional storage limits and per
                   database settings are hidden by default.
     examples:
-        - name: Show all elastic pool editions and pool DTU limits in a location.
+        - name: Show all elastic pool editions and pool DTU limits in the West US region.
           text: az sql elastic-pool list-editions -l westus
-        - name: Show all pool DTU limits for Standard edition.
+        - name: Show all pool DTU limits for Standard edition in the West US region.
           text: az sql elastic-pool list-editions -l westus --edition Standard
-        - name: Show available max sizes for elastic pools with 100 DTUs
+        - name: Show available max sizes for elastic pools with at least 100 DTUs in the West US region.
           text: az sql elastic-pool list-editions -l westus --dtu 100 --show-details max-size
-        - name: Show available per database settings for Standard 100 DTU elastic pools
+        - name: Show available per database settings for Standard 100 DTU elastic pools in the West US region.
           text: az sql elastic-pool list-editions -l westus --edition Standard --dtu 100
                 --show-details db-min-dtu db-max-dtu db-max-size
     """
 helps['sql elastic-pool update'] = """
     type: command
-    short-summary: Updates an elastic pool.
+    short-summary: Update an elastic pool.
     """
-# helps['sql elastic-pool recommended'] = """
-#             type: group
-#             short-summary: Manages recommended elastic pools.
-#             """
-# helps['sql elastic-pool recommended db'] = """
-#             type: group
-#             short-summary: Manage recommended elastic pool databases.
-#             """
 helps['sql server'] = """
     type: group
-    short-summary: Manage servers. Servers contain databases, data warehouses, and elastic pools.
+    short-summary: Manage SQL servers. Servers contain databases, data warehouses, and elastic pools.
     """
 helps['sql server create'] = """
     type: command
-    short-summary: Creates a server.
+    short-summary: Create a server.
     """
 helps['sql server list'] = """
     type: command
-    short-summary: Lists servers.
+    short-summary: List available servers.
     examples:
-        - name: List all servers in the current subscription
+        - name: List all servers in the current subscription.
           text: az sql server list
-        - name: List all servers in a resource group
+        - name: List all servers in a resource group.
           text: az sql server list -g mygroup
     """
 helps['sql server update'] = """
     type: command
-    short-summary: Updates a server.
+    short-summary: Update a server.
     """
 helps['sql server firewall-rule'] = """
     type: group
     short-summary: Manage a server's firewall rules.
     """
-# helps['sql server firewall-rule allow-all-azure-ips'] = """
-#             type: command
-#             short-summary: Create a firewall rule that allows all Azure IP addresses to access the server.
-#             """
 helps['sql server firewall-rule create'] = """
     type: command
-    short-summary: Creates a firewall rule.
+    short-summary: Create a firewall rule.
     """
 helps['sql server firewall-rule update'] = """
     type: command
-    short-summary: Updates a firewall rule.
+    short-summary: Update a firewall rule.
     """
 helps['sql server firewall-rule show'] = """
     type: command
-    short-summary: Shows the detail of a firewall rule.
+    short-summary: Shows the details for a firewall rule.
     """
 helps['sql server firewall-rule list'] = """
     type: command
-    short-summary: Lists the firewall rules.
+    short-summary: List a server's firewall rules.
     """
 helps['sql server vnet-rule'] = """
     type: group
@@ -291,15 +282,15 @@ helps['sql server vnet-rule'] = """
     """
 helps['sql server vnet-rule update'] = """
     type: command
-    short-summary: Updates a virtual network rule.
+    short-summary: Update a virtual network rule.
     """
 helps['sql server vnet-rule create'] = """
     type: command
-    short-summary: Creates a virtual network rule which allows access to an Azure Sql server.
+    short-summary: Create a virtual network rule to allows access to an Azure SQL server.
 
     examples:
-        - name: Create a vnet rule by providing the subnet id. Vnet name is not required.
+        - name: Create a vnet rule by providing the subnet id.
           text: az sql server vnet-rule create --subnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName/providers/Microsoft.Network/virtualNetworks/vnetName/subnets/subnetName
-        - name: Create a vnet rule by providing the vnet and subnet name. The subnet id is created by taking the resource group name and subscription id of the sql server.
+        - name: Create a vnet rule by providing the vnet and subnet name. The subnet id is created by taking the resource group name and subscription id of the SQL server.
           text: az sql server vnet-rule create --subnet subnetName --vnet-name vnetName
     """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -22,7 +22,7 @@ helps['storage entity insert'] = """
                         For example, convert the integer value 1 to the string value "0000001" to ensure proper sorting.
         - name: --if-exists
           type: string
-          short-summary: Specify what should happen if an entity already exists for the specified PartitionKey and RowKey.
+          short-summary: Behavior when an entity already exists for the specified PartitionKey and RowKey.
         - name: --timeout
           short-summary: The server timeout, expressed in seconds.
 """
@@ -47,8 +47,7 @@ helps['storage file upload'] = """
 
 helps['storage blob show'] = """
     type: command
-    short-summary: Show properties for a blob in a container.
-    long-summary: To show the contents of a blob, use 'az storage blob list'.
+    short-summary: Get the details of a blob.
     examples:
         - name: Show all properties of a blob.
           text: az storage blob show -c MyContainer -n MyBlob
@@ -57,8 +56,9 @@ helps['storage blob show'] = """
 helps['storage blob delete'] = """
     type: command
     short-summary: Mark a blob or snapshot for deletion.
-    long-summary: The blob is marked for later deletion during garbage collection.  In order to delete a blob, all of its snapshots must also be deleted.
-                  Both can be removed at the same time at the same time.
+    long-summary: >
+        The blob is marked for later deletion during garbage collection.  In order to delete a blob, all of its snapshots must also be deleted.
+        Both can be removed at the same time.
     examples:
         - name: Delete a blob.
           text: az storage blob delete -c MyContainer -n MyBlob
@@ -92,7 +92,7 @@ helps['storage account list'] = """
     examples:
         - name: List all storage accounts in a subscription.
           text: az storage account list
-        - name: List all storage accounts in a region.
+        - name: List all storage accounts in a resource group.
           text: az storage account list -g MyResourceGroup
 """
 
@@ -100,8 +100,8 @@ helps['storage account show'] = """
     type: command
     short-summary: Show storage account properties.
     examples:
-        - name: Show properties for a storage account using one or more resource ID.
-          text: az storage account show --ids $(storage_account_resource_id)
+        - name: Show properties for a storage account by resource ID.
+          text: az storage account show --ids /subscriptions/{SubID}/resourceGroups/{MyResourceGroup}/providers/Microsoft.Storage/storageAccounts/{MyStorageAccount} 
         - name: Show properties for a storage account using an account name and resource group.
           text: az storage account show -g MyResourceGroup -n MyStorageAccount
 """
@@ -119,7 +119,7 @@ helps['storage account delete'] = """
     short-summary: Delete a storage account.
     examples:
         - name: Delete a storage account using a resource ID.
-          text: az storage account delete --ids ${storage_account_resource_id}
+          text: az storage account delete --ids /subscriptions/{SubID}/resourceGroups/{MyResourceGroup}/providers/Microsoft.Storage/storageAccounts/{MyStorageAccount}
         - name: Delete a storage account using an account name and resource group.
           text: az storage account delete -n MyStorageAccount -g MyResourceGroup
 """
@@ -163,12 +163,12 @@ helps['storage account keys list'] = """
 
 helps['storage blob'] = """
     type: group
-    short-summary: Object storage for unstructured data.
+    short-summary: Manage object storage for unstructured data (blobs).
 """
 
 helps['storage blob exists'] = """
     type: command
-    short-summary: Check for the existance of a blob in a container.
+    short-summary: Check for the existence of a blob in a container.
 """
 
 helps['storage blob list'] = """
@@ -202,9 +202,10 @@ helps['storage blob service-properties'] = """
 """
 helps['storage blob set-tier'] = """
     type: command
-    short-summary: Sets the block or page blob tiers on the blob.
-    long-summary:  For block blob this command only supports block blob on standard storage accounts.
-                   For page blob, this command only supports for page blobs on premium accounts.
+    short-summary: Set the block or page tiers on the blob.
+    long-summary:  >
+        For block blob this command only supports block blob on standard storage accounts.
+        For page blob, this command only supports for page blobs on premium accounts.
 """
 helps['storage blob copy start-batch'] = """
     type: command
@@ -218,7 +219,7 @@ helps['storage blob copy start-batch'] = """
           short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq', and '[!seq]'.
         - name: --dryrun
           type: bool
-          short-summary: List of files or blobs to be uploaded. No actual data transfer will occur.
+          short-summary: List the files or blobs to be uploaded. No actual data transfer will occur.
         - name: --source-account-name
           type: string
           short-summary: The source storage account from which the files or blobs are copied to the destination. If omitted, the source account is used.
@@ -234,7 +235,7 @@ helps['storage blob copy start-batch'] = """
         - name: --source-uri
           type: string
           short-summary: A URI specifying a file share or blob container from which the files or blobs are copied.
-          long-summary: If the source is in another account, the source must either be public or must be authenticated by using a shared access signature.
+          long-summary: If the source is in another account, the source must either be public or be authenticated by using a shared access signature.
         - name: --source-sas
           type: string
           short-summary: The shared access signature for the source storage account.
@@ -246,7 +247,7 @@ helps['storage container'] = """
 
 helps['storage container exists'] = """
     type: command
-    short-summary: Inspect whether or not a container exists.
+    short-summary: Check for the existence of a storage container.
 """
 
 helps['storage container list'] = """
@@ -321,7 +322,7 @@ helps['storage directory'] = """
 
 helps['storage directory exists'] = """
     type: command
-    short-summary: Determines if a directory exists.
+    short-summary: Check for the existence of a storage directory.
 """
 
 helps['storage directory metadata'] = """
@@ -331,7 +332,7 @@ helps['storage directory metadata'] = """
 
 helps['storage directory list'] = """
     type: command
-    short-summary: List directories in the specified share.
+    short-summary: List directories in a share.
 """
 
 helps['storage entity'] = """
@@ -341,7 +342,7 @@ helps['storage entity'] = """
 
 helps['storage entity query'] = """
     type: command
-    short-summary: List entities which satisfy a given query.
+    short-summary: List entities which satisfy a query.
 """
 
 helps['storage file'] = """
@@ -351,7 +352,7 @@ helps['storage file'] = """
 
 helps['storage file exists'] = """
     type: command
-    short-summary: Determine if a file exists.
+    short-summary: Check for the existence of a file.
 """
 
 helps['storage file list'] = """
@@ -375,7 +376,7 @@ helps['storage file metadata'] = """
 
 helps['storage file upload-batch'] = """
     type: command
-    short-summary: Upload files from a local directory to an Azure Storage File Share in batch.
+    short-summary: Upload files from a local directory to an Azure Storage File Share in a batch operation.
     parameters:
         - name: --source -s
           type: string
@@ -389,37 +390,43 @@ helps['storage file upload-batch'] = """
           short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq', and '[!seq]'.
         - name: --dryrun
           type: bool
-          short-summary: The list of files to upload. No actual data transfer occurs.
+          short-summary: List the files and blobs to be uploaded. No actual data transfer will occur.
         - name: --max-connections
           type: integer
           short-summary: The maximum number of parallel connections to use. Default value is 1.
         - name: --validate-content
           type: bool
-          short-summary: If set, calculates an MD5 hash for each range of the file. The Storage service checks the hash of the content that has arrived with the hash that was sent. This is primarily valuable for detecting bitflips on the wire if using http instead of https as https (the default) will already validate. Note that this MD5 hash is not stored with the file.
+          short-summary: If set, calculates an MD5 hash for each range of the file for validation.
+          long-summary: >
+            The storage service checks the hash of the content that has arrived is identical to the hash that was sent.
+            This is mostly valuable for detecting bitflips during transfer if using HTTP instead of HTTPS. This hash is not stored.
 """
 
 helps['storage file download-batch'] = """
     type: command
-    short-summary: Download files from an Azure Storage File Share to a local directory in batch.
+    short-summary: Download files from an Azure Storage File Share to a local directory in a batch operation.
     parameters:
         - name: --source -s
           type: string
-          short-summary: The source of the file download operation. The source can be the file share URL or the share name. When the source is the share URL, the storage account name is parsed from the URL.
+          short-summary: The source of the file download operation. The source can be the file share URL or the share name.
         - name: --destination -d
           type: string
-          short-summary: The directory where the files are downloaded. The directory must exist.
+          short-summary: The local directory where the files are downloaded to. This directory must already exist.
         - name: --pattern
           type: string
           short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq', and '[!seq]'.
         - name: --dryrun
           type: bool
-          short-summary: The list of files to be downloaded. No actual data transfer occurs.
+          short-summary: List the files and blobs to be downloaded. No actual data transfer will occur.
         - name: --max-connections
           type: integer
           short-summary: The maximum number of parallel connections to use. Default value is 1.
         - name: --validate-content
           type: bool
-          short-summary: If set, calculates an MD5 hash for each range of the file. The Storage service checks the hash of the content that has arrived with the hash that was sent. This is primarily valuable for detecting bitflips on the wire if using http instead of https as https (the default) will already validate. Note that this MD5 hash is not stored with the file.
+          short-summary: If set, calculates an MD5 hash for each range of the file for validation.
+          long-summary: >
+            The storage service checks the hash of the content that has arrived is identical to the hash that was sent.
+            This is mostly valuable for detecting bitflips during transfer if using HTTP instead of HTTPS. This hash is not stored.
 """
 
 helps['storage file copy start-batch'] = """
@@ -437,7 +444,7 @@ helps['storage file copy start-batch'] = """
           short-summary: The pattern used for globbing files and blobs. The supported patterns are '*', '?', '[seq', and '[!seq]'.
         - name: --dryrun
           type: bool
-          short-summary: Perform a dry run, listing the data which would be uploaded. No data transfer occurs.
+          short-summary: List the files and blobs to be copied. No actual data transfer will occur.
         - name: --source-account-name
           type: string
           short-summary: The source storage account to copy the data from. If omitted, the destination account is used.
@@ -461,7 +468,7 @@ helps['storage file copy start-batch'] = """
 
 helps['storage logging'] = """
     type: group
-    short-summary: Manage Storage service logging information.
+    short-summary: Manage storage service logging information.
 """
 
 helps['storage logging show'] = """
@@ -496,7 +503,7 @@ helps['storage metrics update'] = """
 
 helps['storage queue'] = """
     type: group
-    short-summary: Manage scaling and traffic routing for storage queues.
+    short-summary: Manage storage queues.
 """
 
 helps['storage queue list'] = """
@@ -521,12 +528,12 @@ helps['storage share'] = """
 
 helps['storage share exists'] = """
     type: command
-    short-summary: Determine if a share exists.
+    short-summary: Check for the existence of a file share.
 """
 
 helps['storage share list'] = """
     type: command
-    short-summary: List file shares.
+    short-summary: List the file shares in a storage account.
 """
 
 helps['storage share metadata'] = """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -101,7 +101,7 @@ helps['storage account show'] = """
     short-summary: Show storage account properties.
     examples:
         - name: Show properties for a storage account by resource ID.
-          text: az storage account show --ids /subscriptions/{SubID}/resourceGroups/{MyResourceGroup}/providers/Microsoft.Storage/storageAccounts/{MyStorageAccount} 
+          text: az storage account show --ids /subscriptions/{SubID}/resourceGroups/{MyResourceGroup}/providers/Microsoft.Storage/storageAccounts/{MyStorageAccount}
         - name: Show properties for a storage account using an account name and resource group.
           text: az storage account show -g MyResourceGroup -n MyStorageAccount
 """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -9,73 +9,76 @@ from azure.cli.core.help_files import helps
 
 helps['storage entity insert'] = """
     type: command
-    short-summary: Insert an entity into the table.
-    long-summary: Inserts an entity into the table. When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties. Together, these properties form the primary key and must be unique within the table. Both the PartitionKey and RowKey values may be up to 64 KB in size. If you are using an integer value as a key, you should convert the integer to a fixed-width string, because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+    short-summary: Insert an entity into a table.
     parameters:
         - name: --table-name -t
           type: string
-          short-summary: 'The name of the table to insert the entity into.'
+          short-summary: The name of the table to insert the entity into.
         - name: --entity -e
           type: list
-          short-summary: 'A space-separated list of key=value pairs. Must contain a PartitionKey and a RowKey.'
+          short-summary: A space-separated list of key=value pairs. Must contain a PartitionKey and a RowKey.
+          long-summary: The PartitionKey and RowKey must be unique within the table, and may be up to 64Kb in size. If using an integer value as a key,
+                        convert it to a fixed-width string which can be canonically sorted.
+                        For example, convert the integer value 1 to the string value "0000001" to ensure proper sorting.
         - name: --if-exists
           type: string
-          short-summary: 'Specify what should happen if an entity already exists for the specified PartitionKey and RowKey.'
+          short-summary: Specify what should happen if an entity already exists for the specified PartitionKey and RowKey.
         - name: --timeout
           short-summary: The server timeout, expressed in seconds.
 """
 
 helps['storage blob upload'] = """
     type: command
-    short-summary: Upload a specified file to a storage blob.
-    long-summary: Creates a new blob from a file path, or updates the content of an existing blob, with automatic chunking and progress notifications.
+    short-summary: Upload a file to a storage blob.
+    long-summary: Creates a new blob from a file path, or updates the content of an existing blob with automatic chunking and progress notifications.
     examples:
-        - name: Upload to a blob with all required fields.
+        - name: Upload to a blob.
           text: az storage blob upload -f /path/to/file -c MyContainer -n MyBlob
 """
 
 helps['storage file upload'] = """
     type: command
-    short-summary: Upload a specified file to a file share that uses the standard SMB 3.0 protocol
-    long-summary: Creates or updates an azure file from a source path with automatic chunking and progress notifications.
+    short-summary: Upload a file to a share that uses the SMB 3.0 protocol.
+    long-summary: Creates or updates an Azure file from a source path with automatic chunking and progress notifications.
     examples:
-        - name: Upload to a file share with all required fields.
+        - name: Upload to a local file to a share.
           text: az storage file upload -s MyShare -source /path/to/file
 """
 
 helps['storage blob show'] = """
     type: command
-    short-summary: Returns properties for a named blob in a container in a storage account.
-    long-summary: Blob properties only.  To show contents of a blob, use az storage blob list
+    short-summary: Show properties for a blob in a container.
+    long-summary: To show the contents of a blob, use 'az storage blob list'.
     examples:
-        - name: Show properties of a blob with all required fields.
+        - name: Show all properties of a blob.
           text: az storage blob show -c MyContainer -n MyBlob
 """
 
 helps['storage blob delete'] = """
     type: command
-    short-summary: Marks the specified blob or snapshot for deletion.
-    long-summary: The blob is marked for later deletion during garbage collection.  Note that in order to delete a blob, you must delete all of its snapshots. You can delete both at the same time with the Delete Blob operation.
+    short-summary: Mark a blob or snapshot for deletion.
+    long-summary: The blob is marked for later deletion during garbage collection.  In order to delete a blob, all of its snapshots must also be deleted.
+                  Both can be removed at the same time at the same time.
     examples:
-        - name: Delete a blob with all required fields.
+        - name: Delete a blob.
           text: az storage blob delete -c MyContainer -n MyBlob
 """
 
 helps['storage account create'] = """
     type: command
-    short-summary: Creates a storage account.
+    short-summary: Create a storage account.
     examples:
-        - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
+        - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --sku Standard_LRS
           min_profile: latest
-        - name: Create a storage account MyStorageAccount in resource group MyResourceGroup in the West US region with locally redundant storage.
+        - name: Create a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
           text: az storage account create -n MyStorageAccount -g MyResourceGroup -l westus --account-type Standard_LRS
           max_profile: 2017-03-09-profile
 """
 
 helps['storage container create'] = """
     type: command
-    short-summary: Creates a container in a storage account.
+    short-summary: Create a container in a storage account.
     examples:
         - name: Create a storage container in a storage account.
           text: az storage container create -n MyStorageContainer
@@ -85,7 +88,7 @@ helps['storage container create'] = """
 
 helps['storage account list'] = """
     type: command
-    short-summary: Lists storage accounts
+    short-summary: List storage accounts.
     examples:
         - name: List all storage accounts in a subscription.
           text: az storage account list
@@ -95,7 +98,7 @@ helps['storage account list'] = """
 
 helps['storage account show'] = """
     type: command
-    short-summary: Returns storage account properties
+    short-summary: Show storage account properties.
     examples:
         - name: Show properties for a storage account using one or more resource ID.
           text: az storage account show --ids $(storage_account_resource_id)
@@ -105,7 +108,7 @@ helps['storage account show'] = """
 
 helps['storage blob list'] = """
     type: command
-    short-summary: Lists storage blobs in a container.
+    short-summary: List storage blobs in a container.
     examples:
         - name: List all storage blobs in a container.
           text: az storage blob list -c MyContainer
@@ -113,10 +116,10 @@ helps['storage blob list'] = """
 
 helps['storage account delete'] = """
     type: command
-    short-summary: Deletes a storage account.
+    short-summary: Delete a storage account.
     examples:
-        - name: Delete a storage account using one or more resource ID.
-          text: az storage account delete --ids $(storage_account_resource_id)
+        - name: Delete a storage account using a resource ID.
+          text: az storage account delete --ids ${storage_account_resource_id}
         - name: Delete a storage account using an account name and resource group.
           text: az storage account delete -n MyStorageAccount -g MyResourceGroup
 """
@@ -124,7 +127,7 @@ helps['storage account delete'] = """
 
 helps['storage account show-connection-string'] = """
     type: command
-    short-summary: Returns the properties for the specified storage account.
+    short-summary: Get the connection string for a storage account.
     examples:
         - name: Get a connection string for a storage account.
           text: az storage account show-connection-string -g MyResourceGroup -n MyStorageAccount
@@ -132,7 +135,7 @@ helps['storage account show-connection-string'] = """
 
 helps['storage'] = """
     type: group
-    short-summary: Durable, highly available, and massively scalable cloud storage.
+    short-summary: Manage Azure Cloud Storage resources.
 """
 
 helps['storage account'] = """
@@ -152,7 +155,7 @@ helps['storage account keys'] = """
 
 helps['storage account keys list'] = """
     type: command
-    short-summary: Lists the primary and secondary keys for a storage account.
+    short-summary: List the primary and secondary keys for a storage account.
     examples:
         - name: List the primary and secondary keys for a storage account.
           text: az storage account keys list -g MyResourceGroup -n MyStorageAccount
@@ -165,7 +168,7 @@ helps['storage blob'] = """
 
 helps['storage blob exists'] = """
     type: command
-    short-summary: Indicates whether the blob exists.
+    short-summary: Check for the existance of a blob in a container.
 """
 
 helps['storage blob list'] = """
@@ -209,7 +212,7 @@ helps['storage blob copy start-batch'] = """
     parameters:
         - name: --destination-container
           type: string
-          short-summary: The blob container where the selected source files or blobs to be copied to.
+          short-summary: The blob container where the selected source files or blobs will be copied to.
         - name: --pattern
           type: string
           short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq', and '[!seq]'.
@@ -218,19 +221,20 @@ helps['storage blob copy start-batch'] = """
           short-summary: List of files or blobs to be uploaded. No actual data transfer will occur.
         - name: --source-account-name
           type: string
-          short-summary: The source storage account from which the files or blobs are copied to the destination. If omitted, it is assumed that source is in the same storage account as destination.
+          short-summary: The source storage account from which the files or blobs are copied to the destination. If omitted, the source account is used.
         - name: --source-account-key
           type: string
           short-summary: The account key for the source storage account.
         - name: --source-container
           type: string
-          short-summary: The source container from which the blobs are copied to the destination.
+          short-summary: The source container from which blobs are copied.
         - name: --source-share
           type: string
-          short-summary: The source share from which the files are copied to the destination.
+          short-summary: The source share from which files are copied.
         - name: --source-uri
           type: string
-          short-summary: A URI specifies an file share or blob container from which the files or blobs are copied to the destination. If the source is in another account, the source must either be public or must be authenticated by using a shared access signature. If the source is public, no authentication is required.
+          short-summary: A URI specifying a file share or blob container from which the files or blobs are copied.
+          long-summary: If the source is in another account, the source must either be public or must be authenticated by using a shared access signature.
         - name: --source-sas
           type: string
           short-summary: The shared access signature for the source storage account.
@@ -242,7 +246,7 @@ helps['storage container'] = """
 
 helps['storage container exists'] = """
     type: command
-    short-summary: Indicates whether the container exists.
+    short-summary: Inspect whether or not a container exists.
 """
 
 helps['storage container list'] = """
@@ -267,7 +271,7 @@ helps['storage container policy'] = """
 
 helps['storage cors'] = """
     type: group
-    short-summary: Manage Storage service Cross-Origin Resource Sharing (CORS).
+    short-summary: Manage storage service Cross-Origin Resource Sharing (CORS).
 """
 
 helps['storage cors add'] = """
@@ -275,10 +279,11 @@ helps['storage cors add'] = """
     short-summary: Add a CORS rule to a storage account.
     parameters:
         - name: --services
-          short-summary: The storage service(s) for which to add the CORS rules. Allowed options are (b)lob (f)ile
-                         (q)ueue (t)able. Can be combined.
+          short-summary: >
+            The storage service(s) to add rules to. Allowed options are: (b)lob, (f)ile,
+            (q)ueue, (t)able. Can be combined.
         - name: --max-age
-          short-summary: The number of seconds the client/browser should cache a preflight response.
+          short-summary: The maximum number of seconds the client/browser should cache a preflight response.
         - name: --origins
           short-summary: List of origin domains that will be allowed via CORS, or "*" to allow all domains.
         - name: --methods
@@ -294,8 +299,9 @@ helps['storage cors clear'] = """
     short-summary: Remove all CORS rules from a storage account.
     parameters:
         - name: --services
-          short-summary: The storage service(s) for which to add the CORS rules. Allowed options are (b)lob (f)ile
-                         (q)ueue (t)able. Can be combined.
+          short-summary: >
+            The storage service(s) to remove rules from. Allowed options are: (b)lob, (f)ile,
+            (q)ueue, (t)able. Can be combined.
 """
 
 helps['storage cors list'] = """
@@ -303,8 +309,9 @@ helps['storage cors list'] = """
     short-summary: List all CORS rules for a storage account.
     parameters:
         - name: --services
-          short-summary: The storage service(s) for which to add the CORS rules. Allowed options are (b)lob (f)ile
-                         (q)ueue (t)able. Can be combined.
+          short-summary: >
+            The storage service(s) to list rules for. Allowed options are: (b)lob, (f)ile,
+            (q)ueue, (t)able. Can be combined.
 """
 
 helps['storage directory'] = """
@@ -314,7 +321,7 @@ helps['storage directory'] = """
 
 helps['storage directory exists'] = """
     type: command
-    short-summary: Indicates whether the directory exists.
+    short-summary: Determines if a directory exists.
 """
 
 helps['storage directory metadata'] = """
@@ -337,24 +344,23 @@ helps['storage entity query'] = """
     short-summary: List entities which satisfy a given query.
 """
 
-
 helps['storage file'] = """
     type: group
-    short-summary: File shares that use the standard SMB 3.0 protocol.
+    short-summary: Manage file shares that use the SMB 3.0 protocol.
 """
 
 helps['storage file exists'] = """
     type: command
-    short-summary: Indicates whether the file exists.
+    short-summary: Determine if a file exists.
 """
 
 helps['storage file list'] = """
     type: command
-    short-summary: List files and directories in the specified share.
+    short-summary: List files and directories in a share.
     parameters:
         - name: --exclude-dir
           type: bool
-          short-summary: List only files in the specified share.
+          short-summary: List only files in the given share.
 """
 
 helps['storage file copy'] = """
@@ -373,10 +379,11 @@ helps['storage file upload-batch'] = """
     parameters:
         - name: --source -s
           type: string
-          short-summary: The directory from which the files should be uploaded.
+          short-summary: The directory to upload files from.
         - name: --destination -d
           type: string
-          short-summary: The destination of the upload operation. The destination can be the file share URL or the share name. When the destination is the share URL, the storage account name is parsed from the URL.
+          short-summary: The destination of the upload operation.
+          long-summary: The destination can be the file share URL or the share name. When the destination is the share URL, the storage account name is parsed from the URL.
         - name: --pattern
           type: string
           short-summary: The pattern used for file globbing. The supported patterns are '*', '?', '[seq', and '[!seq]'.
@@ -421,32 +428,32 @@ helps['storage file copy start-batch'] = """
     parameters:
         - name: --destination-share
           type: string
-          short-summary: The file share where the specified source files or blobs are to be copied to.
+          short-summary: The file share where the source data is copied to.
         - name: --destination-path
           type: string
-          short-summary: The directory where the specified source files or blobs are to be copied to. If omitted, the files or blobs are copied to the root directory.
+          short-summary: The directory where the source data is copied to. If omitted, data is copied to the root directory.
         - name: --pattern
           type: string
-          short-summary: The pattern used for globbing files or blobs in the source. The supported patterns are '*', '?', '[seq', and '[!seq]'.
+          short-summary: The pattern used for globbing files and blobs. The supported patterns are '*', '?', '[seq', and '[!seq]'.
         - name: --dryrun
           type: bool
-
-          short-summary: The list of files or blobs to be uploaded. No actual data transfer occurs.
+          short-summary: Perform a dry run, listing the data which would be uploaded. No data transfer occurs.
         - name: --source-account-name
           type: string
-          short-summary: The source storage account from which the files or blobs are copied to the destination. If omitted, it is assumed that source is in the same storage account as destination.
+          short-summary: The source storage account to copy the data from. If omitted, the destination account is used.
         - name: --source-account-key
           type: string
-          short-summary: The account key for the source storage account. If it is omitted, the command will try to query the key using the current log in.
+          short-summary: The account key for the source storage account. If omitted, the active login is used to determine the account key.
         - name: --source-container
           type: string
-          short-summary: The source container from which the blobs are copied to the destination.
+          short-summary: The source container blobs are copied from.
         - name: --source-share
           type: string
-          short-summary: The source share from which the files are copied to the destination.
+          short-summary: The source share files are copied from.
         - name: --source-uri
           type: string
-          short-summary: A URI that specifies a file share or blob container from which files or blobs are copied to the destination. If the source is in another account, the source must either be public or must be authenticated via a shared access signature. If the source is public, no authentication is required.
+          short-summary: A URI that specifies a the source file share or blob container.
+          long-summary: If the source is in another account, the source must either be public or authenticated via a shared access signature.
         - name: --source-sas
           type: string
           short-summary: The shared access signature for the source storage account.
@@ -474,7 +481,7 @@ helps['storage message'] = """
 
 helps['storage metrics'] = """
     type: group
-    short-summary: Manage Storage service metrics.
+    short-summary: Manage storage service metrics.
 """
 
 helps['storage metrics show'] = """
@@ -489,7 +496,7 @@ helps['storage metrics update'] = """
 
 helps['storage queue'] = """
     type: group
-    short-summary: Use queues to effectively scale applications according to traffic.
+    short-summary: Manage scaling and traffic routing for storage queues.
 """
 
 helps['storage queue list'] = """
@@ -514,12 +521,12 @@ helps['storage share'] = """
 
 helps['storage share exists'] = """
     type: command
-    short-summary: Returns a boolean indicating whether the share exists.
+    short-summary: Determine if a share exists.
 """
 
 helps['storage share list'] = """
     type: command
-    short-summary: List file shares in a storage account.
+    short-summary: List file shares.
 """
 
 helps['storage share metadata'] = """
@@ -534,7 +541,7 @@ helps['storage share policy'] = """
 
 helps['storage table'] = """
     type: group
-    short-summary: NoSQL key-value storage using semi-structured datasets.
+    short-summary: Manage NoSQL key-value storage.
 """
 
 helps['storage table list'] = """

--- a/src/command_modules/azure-cli-taskhelp/azure/cli/command_modules/taskhelp/_help.py
+++ b/src/command_modules/azure-cli-taskhelp/azure/cli/command_modules/taskhelp/_help.py
@@ -9,5 +9,4 @@ from azure.cli.core.help_files import helps
 helps['taskhelp'] = """
     type: group
     short-summary: Provides long-form help content by topic.
-    long-summary: If you don't have the taskhelp component installed, add it with `az component update --add taskhelp`.
 """

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -33,7 +33,7 @@ helps['vm format-secret'] = """
 helps['vm create'] = """
     type: command
     short-summary: Create an Azure Virtual Machine.
-    long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-quick-create-cli.
+    long-summary: 'For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-quick-create-cli.'
     parameters:
         - name: --image
           type: string
@@ -58,7 +58,7 @@ helps['vm create'] = """
         - name: Create a VM by attaching to a managed operating system disk.
           text: >
             az vm create -g MyResourceGroup -n MyVm --attach-os-disk MyOsDisk --os-type linux
-        - name: Create an Ubuntu Linux VM using a cloud-init script for configuration. See: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init.
+        - name: 'Create an Ubuntu Linux VM using a cloud-init script for configuration. See: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init.'
           text: >
             az vm create -g MyResourceGroup -n MyVm --image debian --custom_data MyCloudInitScript.yml
         - name: Create a Debian VM with SSH key authentication and a public DNS entry, located on an existing virtual network and availability set.
@@ -91,7 +91,7 @@ helps['vm create'] = """
 helps['vmss create'] = """
     type: command
     short-summary: Create an Azure Virtual Machine Scale Set.
-    long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-linux-create-cli.
+    long-summary: 'For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-linux-create-cli.'
     parameters:
         - name: --image
           type: string
@@ -112,7 +112,7 @@ helps['vmss create'] = """
           text: >
             az vmss create -n MyVmss -g MyResourceGroup --image centos \\
                 --public-ip-per-vm --vm-domain-name myvmss --dns-servers 10.0.0.6 10.0.0.5
-        - name: Create a Linux VM scale set using a cloud-init script for configuration (https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init).
+        - name: 'Create a Linux VM scale set using a cloud-init script for configuration. See: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init'
           text: >
             az vmss create -g MyResourceGroup -n MyVmss --image debian --custom_data MyCloudInitScript.yml
         - name: Create a Debian VM scaleset using Key Vault secrets.
@@ -135,7 +135,7 @@ helps['vmss create'] = """
 helps['vm availability-set create'] = """
     type: command
     short-summary: Create an Azure Availability Set.
-    long-summary: For more information, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-manage-availability.
+    long-summary: 'For more information, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-manage-availability.'
     examples:
         - name: Create an availability set.
           text: az vm availability-set create -n MyAvSet -g MyResourceGroup --platform-fault-domain-count 2 --platform-update-domain-count 2
@@ -229,7 +229,7 @@ helps['vmss get-instance-view'] = """
     short-summary: View an instance of a VMSS.
     parameters:
         - name: --ids
-          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, do not also use `--instance-id`. 
+          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, do not also use `--instance-id`.
 """
 
 helps['vmss reimage'] = """
@@ -247,7 +247,7 @@ helps['vmss disk'] = """
 
 helps['vmss nic'] = """
     type: group
-    short-summary: Manage network interfaces of a VMSS. 
+    short-summary: Manage network interfaces of a VMSS.
 """
 
 helps['vmss show'] = """
@@ -339,7 +339,7 @@ helps[vm_boot_diagnostics_disable] = """
     short-summary: Disable the boot diagnostics on a VM.
     examples:
 {0}
-""".format( vm_ids_example.format('Disable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_disable))
+""".format(vm_ids_example.format('Disable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_disable))
 
 vm_boot_diagnostics_enable = 'vm boot-diagnostics enable'
 vm_boot_diagnostics_enable_cmd = "{0} --storage https://mystor.blob.core.windows.net/".format(vm_boot_diagnostics_enable)
@@ -441,9 +441,9 @@ helps['vm diagnostics set'] = """
 """
 
 disk_long_summary = """
-        Just like any other computer, virtual machines in Azure use disks as a place to store an operating system, applications, and data. 
-        All Azure virtual machines have at least two disks: An operating system disk, and a temporary disk. 
-        The operating system disk is created from an image, and both the operating system disk and the image are actually virtual hard disks (VHDs) 
+        Just like any other computer, virtual machines in Azure use disks as a place to store an operating system, applications, and data.
+        All Azure virtual machines have at least two disks: An operating system disk, and a temporary disk.
+        The operating system disk is created from an image, and both the operating system disk and the image are actually virtual hard disks (VHDs)
         stored in an Azure storage account. Virtual machines also can have one or more data disks, that are also stored as VHDs.
 
         Operating System Disk
@@ -788,7 +788,7 @@ deallocate_generalize_capture = """        - name: Deallocate, generalize, and c
 helps['vm capture'] = """
     type: command
     short-summary: Capture information for a stopped VM.
-    long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image.
+    long-summary: 'For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image'
     examples:
 {0}
 """.format(deallocate_generalize_capture)
@@ -806,7 +806,7 @@ helps['vm delete'] = """
 helps['vm deallocate'] = """
     type: command
     short-summary: Deallocate a VM.
-    long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image.
+    long-summary: 'For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image'
     examples:
 {0}
 """.format(deallocate_generalize_capture)
@@ -814,7 +814,7 @@ helps['vm deallocate'] = """
 helps['vm generalize'] = """
     type: command
     short-summary: Mark a VM as generalized, allowing it to be imaged for multiple deployments.
-    long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image.
+    long-summary: 'For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image'
     examples:
 {0}
 """.format(deallocate_generalize_capture)
@@ -831,7 +831,7 @@ helps['vm get-instance-view'] = """
 helps['vm list'] = """
     type: command
     short-summary: List details of Virtual Machines.
-    long-summary: For more information on querying information about Virtual Machines, see https://docs.microsoft.com/en-us/cli/azure/query-az-cli2.
+    long-summary: 'For more information on querying information about Virtual Machines, see https://docs.microsoft.com/en-us/cli/azure/query-az-cli2'
     examples:
         - name: List all VMs.
           text: az vm list
@@ -996,11 +996,14 @@ helps['disk create'] = """
     short-summary: Create a managed disk.
     examples:
         - name: Create a managed disk by importing from a blob uri.
-          text: az disk create -g MyResourceGroup -n MyDisk --source https://vhd1234.blob.core.windows.net/vhds/osdisk1234.vhd
+          text: >
+            az disk create -g MyResourceGroup -n MyDisk --source https://vhd1234.blob.core.windows.net/vhds/osdisk1234.vhd
         - name: Create an empty managed disk.
-          text: az disk create -g MyResourceGroup -n MyDisk --size-gb 10
+          text: >
+            az disk create -g MyResourceGroup -n MyDisk --size-gb 10
         - name: Create a managed disk by copying an existing disk or snapshot.
-          text: az disk create -g MyResourceGroup -n MyDisk2 --source MyDisk
+          text: >
+            az disk create -g MyResourceGroup -n MyDisk2 --source MyDisk
 """
 
 helps['disk list'] = """
@@ -1039,7 +1042,8 @@ helps['snapshot create'] = """
     short-summary: Create a snapshot.
     examples:
         - name: Create a snapshot by importing from a blob uri.
-          text: az snapshot create -g MyResourceGroup -n MySnapshot --source https://vhd1234.blob.core.windows.net/vhds/osdisk1234.vhd
+          text: >
+            az snapshot create -g MyResourceGroup -n MySnapshot --source https://vhd1234.blob.core.windows.net/vhds/osdisk1234.vhd
         - name: Create an empty snapshot.
           text: az snapshot create -g MyResourceGroup -n MySnapshot --size-gb 10
         - name: Create a snapshot by copying an existing disk in the same resource group.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -7,25 +7,14 @@
 
 from azure.cli.core.help_files import helps
 
-image_long_summary = """                      URN aliases: CentOS, CoreOS, Debian, openSUSE, RHEL, SLES, UbuntuLTS, Win2008R2SP1, Win2012Datacenter, Win2012R2Datacenter.
-                      Example URN: MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest
-                      Example Custom Image Resource ID or Name: /subscriptions/subscription-id/resourceGroups/MyResourceGroup/providers/Microsoft.Compute/images/MyImage
-                      Example URI: http://<storageAccount>.blob.core.windows.net/vhds/osdiskimage.vhd
-"""
-
 vm_ids_example = """        - name: {0}
           text: >
             az {1} --ids $(az vm list -g MyResourceGroup --query "[].id" -o tsv)
 """
 
-name_group_example = """        - name: {0} by name and group.
-          text: az {1} -n name -g MyResourceGroup
-"""
-
 helps['vm format-secret'] = """
     type: command
-    short-summary: >
-        Transform secrets into a form that can be used by VMs and VMMSSes.
+    short-summary: Transform secrets into a form that can be used by VMs and VMSSes.
     examples:
         - name: Create a self-signed certificate with the default policy, and add it to a virtual machine.
           text: >
@@ -48,10 +37,9 @@ helps['vm create'] = """
     parameters:
         - name: --image
           type: string
-          short-summary: The name of the operating system image as a URN alias, URN, custom image name or ID, or VHD blob URI.
-                         This parameter is required unless using --attach-os-disk.
-          long-summary: |
-{0}
+          short-summary: >
+            The name of the operating system image as a URN alias, URN, custom image name or ID, or VHD blob URI.
+            This parameter is required unless using `--attach-os-disk.`
           populator-commands:
           - az vm image list
           - az vm image show
@@ -70,7 +58,7 @@ helps['vm create'] = """
         - name: Create a VM by attaching to a managed operating system disk.
           text: >
             az vm create -g MyResourceGroup -n MyVm --attach-os-disk MyOsDisk --os-type linux
-        - name: Create an Ubuntu Linux VM using a cloud-init script for configuration. (https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init).
+        - name: Create an Ubuntu Linux VM using a cloud-init script for configuration. See: https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init.
           text: >
             az vm create -g MyResourceGroup -n MyVm --image debian --custom_data MyCloudInitScript.yml
         - name: Create a Debian VM with SSH key authentication and a public DNS entry, located on an existing virtual network and availability set.
@@ -98,7 +86,7 @@ helps['vm create'] = """
         - name: Create a CentOS VM with Managed Service Identity. The VM will have a 'Contributor' role with access to a storage account.
           text: >
              az vm create -n MyVm -g MyResourceGroup --image centos --assign-identity --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1
-""".format(image_long_summary)
+"""
 
 helps['vmss create'] = """
     type: command
@@ -108,8 +96,6 @@ helps['vmss create'] = """
         - name: --image
           type: string
           short-summary: The name of the operating system image as a URN alias, URN, or URI.
-          long-summary: |
-{0}
     examples:
         - name: Create a Windows VM scale set with 5 instances, a load balancer, a public IP address, and a 2GB data disk.
           text: >
@@ -141,11 +127,10 @@ helps['vmss create'] = """
 
             az vmss create -g group-name -n vm-name --admin-username deploy  \\
               --image debian --secrets "$vm_secrets"
-        - name: Create a VM scaleset with Managed Service Identity. The VM will have a 'Contributor' Role with access to a storage account
+        - name: Create a VM scaleset with Managed Service Identity. The VM will have a 'Contributor' Role with access to a storage account.
           text: >
              az vm create -n MyVm -g MyResourceGroup --image centos --assign-identity --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1
-
-""".format(image_long_summary)
+"""
 
 helps['vm availability-set create'] = """
     type: command
@@ -176,8 +161,7 @@ helps['vm availability-set convert'] = """
           text: vm availability-set convert -g MyResourceGroup -n MyAvSet
         - name: Convert an availability set to use managed disks by ID.
           text: >
-            az vm availability-set convert --ids $(az vm availability-set \\
-                list -g MyResourceGroup --query "[].id" -o tsv)
+            az vm availability-set convert --ids $(az vm availability-set list -g MyResourceGroup --query "[].id" -o tsv)
 """
 
 helps['vm extension set'] = """
@@ -242,36 +226,36 @@ helps['vm update'] = """
 
 helps['vmss get-instance-view'] = """
     type: command
-    short-summary: View an instance of a VMMS.
+    short-summary: View an instance of a VMSS.
     parameters:
         - name: --ids
-          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified.
+          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, do not also use `--instance-id`. 
 """
 
 helps['vmss reimage'] = """
     type: command
-    short-summary: Reimage VMs within a VMMS.
+    short-summary: Reimage VMs within a VMSS.
     parameters:
         - name: --ids
-          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified.
+          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, do not also use `--instance-id`.
 """
 
 helps['vmss disk'] = """
     type: group
-    short-summary: Manage data disks of a virtual machine scale set.
+    short-summary: Manage data disks of a VMSS.
 """
 
 helps['vmss nic'] = """
     type: group
-    short-summary: Manage network interfaces of a virtual machine scale set.
+    short-summary: Manage network interfaces of a VMSS. 
 """
 
 helps['vmss show'] = """
     type: command
-    short-summary: Show information for VMs within a VMMS.
+    short-summary: Get details on VMs within a VMSS.
     parameters:
         - name: --ids
-          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified.
+          short-summary: One or more VM scale sets or specific VM instance IDs. If provided, do not also use `--instance-id`.
 """
 
 helps['vmss update'] = """
@@ -281,7 +265,7 @@ helps['vmss update'] = """
 
 helps['vmss wait'] = """
     type: command
-    short-summary: Place the CLI in a waiting state until a condition of the scale set is met.
+    short-summary: Place the CLI in a waiting state until a condition of a scale set is met.
 """
 
 helps['vm convert'] = """
@@ -295,11 +279,11 @@ helps['vm convert'] = """
 
 helps['vm'] = """
     type: group
-    short-summary: Provision Linux or Windows virtual machines in seconds.
+    short-summary: Provision Linux or Windows virtual machines.
 """
 helps['vm user'] = """
     type: group
-    short-summary: Manage a user account on a VM.
+    short-summary: Manage user accounts for a VM.
 """
 
 helps['vm user delete'] = """
@@ -346,8 +330,7 @@ helps['vm availability-set'] = """
 helps['vm boot-diagnostics'] = """
     type: group
     short-summary: Troubleshoot the startup of an Azure Virtual Machine.
-    long-summary: >
-        Use this feature to troubleshoot boot failures for custom or platform images.
+    long-summary: Use this feature to troubleshoot boot failures for custom or platform images.
 """
 
 vm_boot_diagnostics_disable = 'vm boot-diagnostics disable'
@@ -356,9 +339,7 @@ helps[vm_boot_diagnostics_disable] = """
     short-summary: Disable the boot diagnostics on a VM.
     examples:
 {0}
-{1}
-""".format(name_group_example.format('Disable boot diagnostics.', vm_boot_diagnostics_disable),
-           vm_ids_example.format('Disable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_disable))
+""".format( vm_ids_example.format('Disable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_disable))
 
 vm_boot_diagnostics_enable = 'vm boot-diagnostics enable'
 vm_boot_diagnostics_enable_cmd = "{0} --storage https://mystor.blob.core.windows.net/".format(vm_boot_diagnostics_enable)
@@ -367,9 +348,7 @@ helps[vm_boot_diagnostics_enable] = """
     short-summary: Enable the boot diagnostics on a VM.
     examples:
 {0}
-{1}
-""".format(name_group_example.format('Enable boot diagnostics.', vm_boot_diagnostics_enable_cmd),
-           vm_ids_example.format('Enable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_enable_cmd))
+""".format(vm_ids_example.format('Enable boot diagnostics on all VMs in a resource group.', vm_boot_diagnostics_enable_cmd))
 
 boot_diagnostics_log = 'vm boot-diagnostics get-boot-log'
 helps[boot_diagnostics_log] = """
@@ -377,9 +356,7 @@ helps[boot_diagnostics_log] = """
     short-summary: Get the boot diagnostics log from a VM.
     examples:
 {0}
-{1}
-""".format(name_group_example.format('Get boot diagnostics log.', boot_diagnostics_log),
-           vm_ids_example.format('Get diagnostics logs for all VMs in a resource group.', boot_diagnostics_log))
+""".format(vm_ids_example.format('Get diagnostics logs for all VMs in a resource group.', boot_diagnostics_log))
 
 helps['acs'] = """
     type: group
@@ -402,12 +379,12 @@ helps['acs delete'] = """
 
 helps['acs list'] = """
     type: command
-    short-summary: List the container services.
+    short-summary: List container services.
 """
 
 helps['acs show'] = """
     type: command
-    short-summary: Show a container service.
+    short-summary: Get the details for a container service.
 """
 
 helps['acs scale'] = """
@@ -425,7 +402,7 @@ helps['vm diagnostics get-default-config'] = """
     short-summary: Get the default configuration settings for a VM.
     examples:
         - name: Get the default diagnostics for a Linux VM and override the storage account name and the VM resource ID.
-          text: >
+          text: |
             az vm diagnostics get-default-config \\
                 | sed "s#__DIAGNOSTIC_STORAGE_ACCOUNT__#MyStorageAccount#g" \\
                 | sed "s#__VM_OR_VMSS_RESOURCE_ID__#MyVmResourceId#g"
@@ -464,16 +441,23 @@ helps['vm diagnostics set'] = """
 """
 
 disk_long_summary = """
-        Just like any other computer, virtual machines in Azure use disks as a place to store an operating system, applications, and data. All Azure virtual machines have at least two disks: An operating system disk, and a temporary disk. The operating system disk is created from an image, and both the operating system disk and the image are actually virtual hard disks (VHDs) stored in an Azure storage account. Virtual machines also can have one or more data disks, that are also stored as VHDs.
+        Just like any other computer, virtual machines in Azure use disks as a place to store an operating system, applications, and data. 
+        All Azure virtual machines have at least two disks: An operating system disk, and a temporary disk. 
+        The operating system disk is created from an image, and both the operating system disk and the image are actually virtual hard disks (VHDs) 
+        stored in an Azure storage account. Virtual machines also can have one or more data disks, that are also stored as VHDs.
 
         Operating System Disk
-        Every virtual machine has one attached operating system disk. It's registered as a SATA drive and is labeled /dev/sda by default. This disk has a maximum capacity of 1023 gigabytes (GB).
+        Every virtual machine has one attached operating system disk. It's registered as a SATA drive and is labeled /dev/sda by default.
+        This disk has a maximum capacity of 1023 gigabytes (GB).
 
         Temporary disk
-        The temporary disk is automatically created for you. On Linux virtual machines, the disk is typically /dev/sdb and is formatted and mounted to /mnt/resource by the Azure Linux Agent. The size of the temporary disk varies, based on the size of the virtual machine.
+        The temporary disk is automatically created for you. On Linux virtual machines, the disk is typically /dev/sdb and is formatted and
+        mounted to /mnt/resource by the Azure Linux Agent. The size of the temporary disk varies, based on the size of the virtual machine.
 
         Data disk
-        A data disk is a VHD that's attached to a virtual machine to store application data, or other data you need to keep. Data disks are registered as SCSI drives and are labeled by the creator. Each data disk has a maximum capacity of 1023 GB. The size of the virtual machine determines how many data disks can be attached and the type of storage that can be used to host the disks.
+        A data disk is a VHD that's attached to a virtual machine to store application data, or other data you need to keep. Data disks are
+        registered as SCSI drives and are labeled by the creator. Each data disk has a maximum capacity of 1023 GB. The size of the virtual
+        machine determines how many data disks can be attached and the type of storage that can be used to host the disks.
 """
 
 helps['vm disk'] = """
@@ -495,7 +479,7 @@ helps['vm unmanaged-disk attach'] = """
     short-summary: Attach an unmanaged persistent disk to a VM.
     long-summary: This allows for the preservation of data, even if the VM is reprovisioned due to maintenance or resizing.
     examples:
-        - name: Attach a new default sized (1023 GiB) unmanaged data disk to a VM.
+        - name: Attach a new default sized (1023 GB) unmanaged data disk to a VM.
           text: az vm unmanaged-disk attach -g MyResourceGroup --vm-name MyVm
         - name: Attach an existing data disk to a VM as unmanaged.
           text: >
@@ -538,7 +522,7 @@ helps['vm disk attach'] = """
     short-summary: Attach a managed persistent disk to a VM.
     long-summary: This allows for the preservation of data, even if the VM is reprovisioned due to maintenance or resizing.
     examples:
-        - name: Attach a new default sized (1023 GiB) managed data disk to a VM.
+        - name: Attach a new default sized (1023 GB) managed data disk to a VM.
           text: az vm disk attach -g MyResourceGroup --vm-name MyVm --disk disk_name --new
 """
 
@@ -551,7 +535,9 @@ helps['vm extension'] = """
     type: group
     short-summary: Manage extensions on VMs.
     long-summary: >
-        Extensions are small applications that provide post-deployment configuration and automation tasks on Azure virtual machines. For example, if a virtual machine requires software installation, anti-virus protection, or Docker configuration, a VM extension can be used to complete these tasks. Extensions can be bundled with a new virtual machine deployment or run against any existing system.
+        Extensions are small applications that provide post-deployment configuration and automation tasks on Azure virtual machines.
+        For example, if a virtual machine requires software installation, anti-virus protection, or Docker configuration, a VM extension
+        can be used to complete these tasks. Extensions can be bundled with a new virtual machine deployment or run against any existing system.
 """
 
 helps['vm extension list'] = """
@@ -570,7 +556,7 @@ helps['vm extension delete'] = """
     type: command
     short-summary: Remove an extension attached to a VM.
     examples:
-        - name: Use VM name and extension to delete an extension from a VM.
+        - name: Use a VM name and extension to delete an extension from a VM.
           text: az vm extension delete -g MyResourceGroup --vm-name MyVm -n extension_name
         - name: Delete extensions with IDs containing the string "MyExtension" from a VM.
           text: >
@@ -600,7 +586,7 @@ helps['vm extension image list'] = """
         - name: Find extensions with "Docker" in the name.
           text: az vm extension image list --query "[].name" -o tsv | sort -u | grep Docker
         - name: List extension names where the publisher name starts with "Microsoft.Azure.App".
-          text: >
+          text: |
             az vm extension image list --query \\
                 "[?starts_with(publisher, 'Microsoft.Azure.App')].publisher" \\
                 -o tsv | sort -u | xargs -I{} az vm extension image list-names --publisher {} -l westus
@@ -673,9 +659,9 @@ helps['vm image list-offers'] = """
     type: command
     short-summary: List the VM image offers available in the Azure Marketplace.
     examples:
-        - name: List all offers from Microsoft in westus.
+        - name: List all offers from Microsoft in the West US region.
           text: az vm image list-offers -l westus -p Microsoft
-        - name: List all offers from OpenLocic in westus.
+        - name: List all offers from OpenLocic in the West US region.
           text: az vm image list-offers -l westus -p OpenLogic
 """
 
@@ -683,7 +669,7 @@ helps['vm image list-publishers'] = """
     type: command
     short-summary: List the VM image publishers available in the Azure Marketplace.
     examples:
-        - name: List all publishers in westus.
+        - name: List all publishers in the West US region.
           text: az vm image list-publishers -l westus
         - name: List all publishers with names starting with "Open" in westus.
           text: az vm image list-publishers -l westus --query "[?starts_with(name, 'Open')]"
@@ -693,13 +679,13 @@ helps['vm image list-skus'] = """
     type: command
     short-summary: List the VM image SKUs available in the Azure Marketplace.
     examples:
-        - name: List all skus available for CentOS published by OpenLogic in westus.
+        - name: List all skus available for CentOS published by OpenLogic in the West US region.
           text: az vm image list-skus -l westus -f CentOS -p OpenLogic
 """
 
 helps['vm image show'] = """
     type: command
-    short-summary: Show a VM image available in the Azure Marketplace.
+    short-summary: Get the details for a VM image available in the Azure Marketplace.
     examples:
         - name: Show information for the latest available CentOS image from OpenLogic.
           text: >
@@ -710,7 +696,7 @@ helps['vm image show'] = """
 
 helps['vm nic'] = """
     type: group
-    short-summary: Manage network interfaces. See also 'az network nic'.
+    short-summary: Manage network interfaces. See also `az network nic`.
     long-summary: >
         A network interface (NIC) is the interconnection between a VM and the underlying software
         network. For more information, see https://docs.microsoft.com/azure/virtual-network/virtual-network-network-interface-overview.
@@ -752,7 +738,7 @@ helps['vm nic set'] = """
     type: command
     short-summary: Configure settings of a NIC attached to a VM.
     examples:
-        - name: Set a NIC on a VM to be primary.
+        - name: Set a NIC on a VM to be the primary interface.
           text: az vm nic set -g MyResourceGroup --vm-name MyVm --nic nic_name1 nic_name2 --primary-nic nic_name2
 """
 
@@ -787,16 +773,16 @@ helps['vmss extension image'] = """
 """
 
 deallocate_generalize_capture = """        - name: Deallocate, generalize, and capture a stopped virtual machine.
-          text: >
-            az vm deallocate -g MyResourceGroup -n MyVm\n
-            az vm generalize -g MyResourceGroup -n MyVm\n
-            az vm capture -g MyResourceGroup -n MyVm --vhd-name-prefix MyPrefix\n
+          text: |
+            az vm deallocate -g MyResourceGroup -n MyVm
+            az vm generalize -g MyResourceGroup -n MyVm
+            az vm capture -g MyResourceGroup -n MyVm --vhd-name-prefix MyPrefix
         - name: Deallocate, generalize, and capture multiple stopped virtual machines.
-          text: >
-            vms_ids=$(az vm list -g MyResourceGroup --query "[].id" -o tsv)\n
-            az vm deallocate --ids ${vms_ids}\n
-            az vm generalize --ids ${vms_ids}\n
-            az vm capture --ids ${vms_ids} --vhd-name-prefix MyPrefix\n
+          text: |
+            vms_ids=$(az vm list -g MyResourceGroup --query "[].id" -o tsv)
+            az vm deallocate --ids ${vms_ids}
+            az vm generalize --ids ${vms_ids}
+            az vm capture --ids ${vms_ids} --vhd-name-prefix MyPrefix
 """
 
 helps['vm capture'] = """
@@ -827,7 +813,7 @@ helps['vm deallocate'] = """
 
 helps['vm generalize'] = """
     type: command
-    short-summary: Mark a VM as gerneralized, allowing it to be imaged for multiple deployments.
+    short-summary: Mark a VM as generalized, allowing it to be imaged for multiple deployments.
     long-summary: For an end-to-end tutorial, see https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-capture-image.
     examples:
 {0}
@@ -835,16 +821,16 @@ helps['vm generalize'] = """
 
 helps['vm get-instance-view'] = """
     type: command
-    short-summary: Get information about a VM including instance information.
+    short-summary: Get instance information about a VM.
     examples:
-        - name: Use resource group and name to get instance view information of a VM.
+        - name: Use a resource group and name to get instance view information of a VM.
           text: az vm get-instance-view -g MyResourceGroup -n MyVm
 {0}
 """.format(vm_ids_example.format('Get instance views for all VMs in a resource group.', 'vm get-instance-view'))
 
 helps['vm list'] = """
     type: command
-    short-summary: List information about Virtual Machines.
+    short-summary: List details of Virtual Machines.
     long-summary: For more information on querying information about Virtual Machines, see https://docs.microsoft.com/en-us/cli/azure/query-az-cli2.
     examples:
         - name: List all VMs.
@@ -868,7 +854,7 @@ helps['vm list-sizes'] = """
     type: command
     short-summary: List available sizes for VMs.
     examples:
-        - name: List the available VM sizes in West US.
+        - name: List the available VM sizes in the West US region.
           text: az vm list-sizes -l westus
 """
 
@@ -876,7 +862,7 @@ helps['vm list-usage'] = """
     type: command
     short-summary: List available usage resources for VMs.
     examples:
-        - name: Get the compute resource usage for West US.
+        - name: Get the compute resource usage for the West US region.
           text: az vm list-usage -l westus
 """
 
@@ -891,7 +877,7 @@ helps['vm list-vm-resize-options'] = """
 
 helps['vm list-skus'] = """
     type: command
-    short-summary: Get compute related resource SKUs.
+    short-summary: Get details for compute-related resource SKUs.
     long-summary: This command incorporates subscription level restriction, offering the most accurate information.
     examples:
         - name: List all SKUs in the West US region.
@@ -938,12 +924,12 @@ helps['vm restart'] = """
 
 helps['vm show'] = """
     type: command
-    short-summary: Show details of a VM.
+    short-summary: Get the details of a VM.
     examples:
         - name: Show information about a VM.
           text: az vm show -g MyResourceGroup -n MyVm -d
 {0}
-""".format(vm_ids_example.format('Show details for all VMs in a resource group.', 'vm show -d'))
+""".format(vm_ids_example.format('Get the details for all VMs in a resource group.', 'vm show -d'))
 
 helps['vm start'] = """
     type: command
@@ -967,7 +953,7 @@ helps['vm wait'] = """
     type: command
     short-summary: Place the CLI in a waiting state until a condition of the VM is met.
     examples:
-        - name: Wait until the VM is created.
+        - name: Wait until a VM is created.
           text: az vm wait -g MyResourceGroup -n MyVm --created
 {0}
 """.format(vm_ids_example.format('Wait until all VMs in a resource group are deleted.', 'vm wait --deleted'))
@@ -977,7 +963,7 @@ helps['vm assign-identity'] = """
     short-summary: Enable managed service identity on a VM.
     long-summary: This is required to authenticate and interact with other Azure services using bearer tokens.
     examples:
-        - name: Enable identity on a VM. It will have a role of 'Reader' in the VM's resource group.
+        - name: Enable identity on a VM with the 'Reader' role.
           text: az vm assign-identity -g MyResourceGroup -n MyVm --role Reader
 """
 
@@ -986,7 +972,7 @@ helps['vmss assign-identity'] = """
     short-summary: Enable managed service identity on a VMSS.
     long-summary: This is required to authenticate and interact with other Azure services using bearer tokens.
     examples:
-        - name: Enable identity on a VMSS. It will have a role of 'Owner' in the VMSS's resource group.
+        - name: Enable identity on a VMSS with the 'Owner' role.
           text: az vmss assign-identity -g MyResourceGroup -n MyVmss --role Owner
 """
 
@@ -1040,12 +1026,12 @@ helps['disk wait'] = """
 
 helps['disk grant-access'] = """
     type: command
-    short-summary: Grant read access to a managed disk.
+    short-summary: Grant a resource read access to a managed disk.
 """
 
 helps['disk revoke-access'] = """
     type: command
-    short-summary: Revoke read access to a managed disk.
+    short-summary: Revoke a resource's read access to a managed disk.
 """
 
 helps['snapshot create'] = """
@@ -1085,7 +1071,10 @@ helps['image create'] = """
     short-summary: Create a custom Virtual Machine Image from managed disks or snapshots.
     examples:
         - name: Create an image from an existing disk.
-          text: az image create -g MyResourceGroup -n image1 --os-type Linux --source /subscriptions/db5eb68e-73e2-4fa8-b18a-0123456789999/resourceGroups/rg1/providers/Microsoft.Compute/snapshots/s1 --data-snapshot /subscriptions/db5eb68e-73e2-4fa8-b18a-0123456789999/resourceGroups/rg/providers/Microsoft.Compute/snapshots/s2
+          text: |
+            az image create -g MyResourceGroup -n image1 --os-type Linux \\
+                --source /subscriptions/db5eb68e-73e2-4fa8-b18a-0123456789999/resourceGroups/rg1/providers/Microsoft.Compute/snapshots/s1 \\
+                --data-snapshot /subscriptions/db5eb68e-73e2-4fa8-b18a-0123456789999/resourceGroups/rg/providers/Microsoft.Compute/snapshots/s2
         - name: Create an image by capturing an existing generalized virtual machine in the same resource group.
           text: az image create -g MyResourceGroup -n image1 --source MyVm1
 """


### PR DESCRIPTION
This PR is for a complete copyedit of the `_help.py` inline help, and many examples. This does __not__ include any information from outside these files (such as most command arguments.) This work is a preliminary copyedit done to provide a degree of consistency and clean up some ambiguous or unnecessary language contained within the help.

In the future, there will be linter rules run as part of any PR which touches the `_help.py` files to check for editing errors (including regular nightly or per-release runs to catch all style errors.)