### PR TITLE
az.bat: fix exit code

### DIFF
--- a/src/azure-cli/az.bat
+++ b/src/azure-cli/az.bat
@@ -3,5 +3,3 @@ setlocal
 
 SET PYTHONPATH=%~dp0/src;%PYTHONPATH%
 python -m azure.cli %*
-
-endlocal


### PR DESCRIPTION
endlocal is implicit at the end of a batch file, cf. https://technet.microsoft.com/en-us/library/bb490898.aspx.
Right now, it masks the exit code of the python process; the batch file always returns exit code 0.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
