### PR TITLE
Improve CI script that runs --help on all commands

### DIFF
--- a/scripts/automation/tests/verify_packages.py
+++ b/scripts/automation/tests/verify_packages.py
@@ -147,9 +147,13 @@ def verify_packages():
     chunk_size = 10
     command_results = []
     p = multiprocessing.Pool(pool_size)
+    prev_percent = 0
     for i, res in enumerate(p.imap_unordered(run_help_on_command_without_err, all_commands, chunk_size), 1):
         command_results.append(res)
-        print('{0:%} complete'.format(i/len(all_commands)), file=sys.stderr)
+        cur_percent = int((i/len(all_commands))*100)
+        if cur_percent - prev_percent >= 10:
+            print('{}% complete'.format(cur_percent), file=sys.stderr)
+        prev_percent = cur_percent
     p.close()
     p.join()
     if not all(command_results):

--- a/scripts/automation/tests/verify_packages.py
+++ b/scripts/automation/tests/verify_packages.py
@@ -151,7 +151,7 @@ def verify_packages():
     for i, res in enumerate(p.imap_unordered(run_help_on_command_without_err, all_commands, chunk_size), 1):
         command_results.append(res)
         cur_percent = int((i/len(all_commands))*100)
-        if cur_percent - prev_percent >= 10:
+        if cur_percent != prev_percent:
             print('{}% complete'.format(cur_percent), file=sys.stderr)
         prev_percent = cur_percent
     p.close()

--- a/scripts/automation/tests/verify_packages.py
+++ b/scripts/automation/tests/verify_packages.py
@@ -143,7 +143,7 @@ def verify_packages():
     config = Configuration()
 
     all_commands = list(config.get_command_table())
-    pool_size = 10
+    pool_size = 5
     chunk_size = 10
     command_results = []
     p = multiprocessing.Pool(pool_size)


### PR DESCRIPTION
- Reduce pool size to help concurrency issue.
- Show percentage for each individual percentage to reduce the log output. (Doing every 10% was too infrequent and would case the build to error out)