### PR TITLE
MSI: use the same extension naming as portal does

### DIFF
--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -4,6 +4,8 @@ Release History
 ===============
 (unreleased)
 +++++++++++++++++++
+* msi: use the same extension naming as portal does
+* msi: remove the useless `subscription` from the `vm/vmss create` commands output
 * `vm/vmss create`: fix a bug that the storage sku is not applied on data disks coming with an image
 
 2.0.13 (2017-08-28)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -245,7 +245,7 @@ for scope in ['vm create', 'vmss create']:
 for scope in ['vm create', 'vmss create', 'vm assign-identity', 'vmss assign-identity']:
     arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
     register_cli_argument(scope, 'identity_scope', options_list='--scope', arg_group=arg_group,
-                          help="The scope the managed identity has access to, or specify "" for None. Default: VM/VMSS's resource group.")
+                          help='The scope the managed identity has access to, or specify "" for None. Default: VM/VMSS\'s resource group.')
     register_cli_argument(scope, 'identity_role', options_list='--role', arg_group=arg_group,
                           help="Role name or id the managed identity will be assigned")
     register_cli_argument(scope, 'identity_role_id', ignore_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_template_builder.py
@@ -282,15 +282,16 @@ def build_msi_role_assignment(vm_vmss_name, vm_vmss_resource_id, role_definition
 
 
 def build_vm_msi_extension(vm_name, location, role_assignment_guid, port, is_linux, extension_version):
+    ext_type_name = 'ManagedIdentityExtensionFor' + ('Linux' if is_linux else 'Windows')
     return {
         'type': 'Microsoft.Compute/virtualMachines/extensions',
-        'name': vm_name + '/MSIExtension',
+        'name': vm_name + '/' + ext_type_name,
         'apiVersion': get_api_version(ResourceType.MGMT_COMPUTE),
         'location': location,
         'dependsOn': [role_assignment_guid or 'Microsoft.Compute/virtualMachines/' + vm_name],
         'properties': {
             'publisher': "Microsoft.ManagedIdentity",
-            'type': 'ManagedIdentityExtensionFor' + ('Linux' if is_linux else 'Windows'),
+            'type': ext_type_name,
             'typeHandlerVersion': extension_version,
             'autoUpgradeMinorVersion': True,
             'settings': {'port': port}

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vm_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vm_msi.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:44 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -34,9 +34,9 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -46,7 +46,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:44 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -104,9 +104,9 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:45 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:34 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Fri, 25 Aug 2017 20:46:45 GMT']
+      expires: ['Sat, 02 Sep 2017 16:15:34 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
@@ -114,12 +114,12 @@ interactions:
       x-cache: [MISS]
       x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [b444b1a3f98e42ce5e3c17bb33ca8d6543884ebc]
+      x-fastly-request-id: [bd347defb8f6ea6c2718cd8cac8108fab7e317b7]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['E708:100CC:4F4D8C:54D21C:59A08B89']
-      x-served-by: [cache-dfw1828-DFW]
-      x-timer: ['S1503693705.409889,VS0,VE235']
+      x-github-request-id: ['76EC:2814D:81DE8F:8B3C66:59AAD7FA']
+      x-served-by: [cache-sjc3150-SJC]
+      x-timer: ['S1504368635.954394,VS0,VE40']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -130,8 +130,8 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
@@ -141,7 +141,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:45 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -155,12 +155,12 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27Contributor%27
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
         you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
@@ -168,7 +168,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['696']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:46 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -180,69 +180,70 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"outputs": {}, "variables": {}, "contentVersion":
-      "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"location": "westus", "type": "Microsoft.Network/virtualNetworks",
-      "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets":
-      [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vm1Subnet"}]}, "apiVersion":
-      "2015-06-15", "tags": {}, "name": "vm1VNET", "dependsOn": []}, {"type": "Microsoft.Network/networkSecurityGroups",
-      "properties": {"securityRules": [{"properties": {"destinationPortRange": "22",
-      "sourceAddressPrefix": "*", "protocol": "Tcp", "sourcePortRange": "*", "access":
-      "Allow", "priority": 1000, "direction": "Inbound", "destinationAddressPrefix":
-      "*"}, "name": "default-allow-ssh"}]}, "apiVersion": "2015-06-15", "dependsOn":
-      [], "tags": {}, "name": "vm1NSG", "location": "westus"}, {"type": "Microsoft.Network/publicIPAddresses",
-      "properties": {"publicIPAllocationMethod": "dynamic"}, "apiVersion": "2017-08-01",
-      "dependsOn": [], "tags": {}, "name": "vm1PublicIP", "location": "westus"}, {"type":
-      "Microsoft.Network/networkInterfaces", "properties": {"networkSecurityGroup":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
-      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
-      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}},
-      "name": "ipconfigvm1"}]}, "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
+      {"contentVersion": "1.0.0.0", "parameters": {}, "outputs": {}, "resources":
+      [{"tags": {}, "dependsOn": [], "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2015-06-15", "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
+      "name": "vm1Subnet"}]}, "name": "vm1VNET", "location": "westus"}, {"tags": {},
+      "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups", "apiVersion":
+      "2015-06-15", "properties": {"securityRules": [{"properties": {"sourceAddressPrefix":
+      "*", "access": "Allow", "priority": 1000, "protocol": "Tcp", "destinationAddressPrefix":
+      "*", "direction": "Inbound", "destinationPortRange": "22", "sourcePortRange":
+      "*"}, "name": "default-allow-ssh"}]}, "name": "vm1NSG", "location": "westus"},
+      {"tags": {}, "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2017-08-01", "properties": {"publicIPAllocationMethod": "dynamic"},
+      "name": "vm1PublicIP", "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
       "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
-      "tags": {}, "name": "vm1VMNic", "location": "westus"}, {"apiVersion": "2015-07-01",
-      "type": "Microsoft.Authorization/roleAssignments", "properties": {"scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001",
-      "principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"},
-      "name": "cd58500a-f421-4815-b5cf-a36a1e16c1a0", "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"]},
-      {"type": "Microsoft.Compute/virtualMachines/extensions", "properties": {"autoUpgradeMinorVersion":
-      true, "type": "ManagedIdentityExtensionForLinux", "typeHandlerVersion": "1.0",
-      "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"}, "apiVersion":
-      "2017-03-30", "location": "westus", "name": "vm1/MSIExtension", "dependsOn":
-      ["cd58500a-f421-4815-b5cf-a36a1e16c1a0"]}, {"type": "Microsoft.Compute/virtualMachines",
-      "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
-      "osProfile": {"adminPassword": "PasswordPassword1!", "adminUsername": "admin123",
-      "computerName": "vm1"}, "storageProfile": {"imageReference": {"version": "latest",
-      "offer": "Debian", "sku": "8", "publisher": "credativ"}, "osDisk": {"createOption":
-      "fromImage", "managedDisk": {"storageAccountType": null}, "name": null, "caching":
-      null}}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "apiVersion": "2017-03-30",
-      "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"], "identity": {"type":
-      "systemAssigned"}, "tags": {}, "name": "vm1", "location": "westus"}], "parameters":
-      {}}, "mode": "Incremental", "parameters": {}}}'''
+      "type": "Microsoft.Network/networkInterfaces", "apiVersion": "2015-06-15", "properties":
+      {"networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},
+      "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm1"}]}, "name": "vm1VMNic",
+      "location": "westus"}, {"properties": {"principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default\'',
+      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001"},
+      "dependsOn": ["Microsoft.Compute/virtualMachines/vm1"], "type": "Microsoft.Authorization/roleAssignments",
+      "name": "cd58500a-f421-4815-b5cf-a36a1e16c1a0", "apiVersion": "2015-07-01"},
+      {"dependsOn": ["cd58500a-f421-4815-b5cf-a36a1e16c1a0"], "type": "Microsoft.Compute/virtualMachines/extensions",
+      "apiVersion": "2017-03-30", "properties": {"type": "ManagedIdentityExtensionForLinux",
+      "autoUpgradeMinorVersion": true, "typeHandlerVersion": "1.0", "settings": {"port":
+      50342}, "publisher": "Microsoft.ManagedIdentity"}, "name": "vm1/ManagedIdentityExtensionForLinux",
+      "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-03-30", "identity":
+      {"type": "systemAssigned"}, "properties": {"osProfile": {"adminPassword": "PasswordPassword1!",
+      "computerName": "vm1", "adminUsername": "admin123"}, "hardwareProfile": {"vmSize":
+      "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "storageProfile": {"osDisk": {"managedDisk": {"storageAccountType": null}, "caching":
+      null, "name": null, "createOption": "fromImage"}, "imageReference": {"version":
+      "latest", "offer": "Debian", "sku": "8", "publisher": "credativ"}}}, "name":
+      "vm1", "location": "westus"}], "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm create]
       Connection: [keep-alive]
-      Content-Length: ['4402']
+      Content-Length: ['4422']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2cjRv58ZNSEhL5MB3PXV5Z2Ui9eRVqVm","name":"vm_deploy_2cjRv58ZNSEhL5MB3PXV5Z2Ui9eRVqVm","properties":{"templateHash":"17479457720237319177","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-25T20:41:47.825636Z","duration":"PT0.6433657S","correlationId":"7806d606-f82a-4535-8128-e841dcb20e0b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MSIExtension","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/MSIExtension"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Aj2tlI5pG8MhOuSUGgDmfEbSC24Awd","name":"vm_deploy_n8Aj2tlI5pG8MhOuSUGgDmfEbSC24Awd","properties":{"templateHash":"15400844077362389512","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:10:37.8283787Z","duration":"PT1.0746908S","correlationId":"ec31f8be-a125-4951-aff8-40bd6ff1bdd7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2cjRv58ZNSEhL5MB3PXV5Z2Ui9eRVqVm/operationStatuses/08586979131782953736?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Aj2tlI5pG8MhOuSUGgDmfEbSC24Awd/operationStatuses/08586972382487239536?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['4618']
+      content-length: ['4659']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:41:47 GMT']
+      date: ['Sat, 02 Sep 2017 16:10:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -252,19 +253,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:42:18 GMT']
+      date: ['Sat, 02 Sep 2017 16:11:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -278,19 +279,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:42:48 GMT']
+      date: ['Sat, 02 Sep 2017 16:11:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -304,19 +305,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:43:17 GMT']
+      date: ['Sat, 02 Sep 2017 16:12:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -330,19 +331,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:43:48 GMT']
+      date: ['Sat, 02 Sep 2017 16:12:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -356,19 +357,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:18 GMT']
+      date: ['Sat, 02 Sep 2017 16:13:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -382,19 +383,45 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979131782953736?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 02 Sep 2017 16:13:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972382487239536?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:48 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -408,19 +435,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_2cjRv58ZNSEhL5MB3PXV5Z2Ui9eRVqVm","name":"vm_deploy_2cjRv58ZNSEhL5MB3PXV5Z2Ui9eRVqVm","properties":{"templateHash":"17479457720237319177","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-25T20:44:43.3794116Z","duration":"PT2M56.1971413S","correlationId":"7806d606-f82a-4535-8128-e841dcb20e0b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MSIExtension","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/MSIExtension"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MSIExtension"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Aj2tlI5pG8MhOuSUGgDmfEbSC24Awd","name":"vm_deploy_n8Aj2tlI5pG8MhOuSUGgDmfEbSC24Awd","properties":{"templateHash":"15400844077362389512","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:13:56.3304828Z","duration":"PT3M19.5767949S","correlationId":"ec31f8be-a125-4951-aff8-40bd6ff1bdd7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm1/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c1a0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm1/ManagedIdentityExtensionForLinux"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c1a0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['6149']
+      content-length: ['6209']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:49 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -434,22 +461,22 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d41bb969-4c1d-4280-b4ba-416856dff546\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"43389e2e-5848-427d-93f8-3daa845d2c01\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_b043f10484a14deb897e818b9584903e\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_6f961b17af444aa2b60405d3e2289604\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_b043f10484a14deb897e818b9584903e\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_6f961b17af444aa2b60405d3e2289604\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -457,34 +484,35 @@ interactions:
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.14\",\r\n\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.15\",\r\n\
         \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
-        \       \"time\": \"2017-08-25T20:44:48+00:00\"\r\n          }\r\n       \
+        \       \"time\": \"2017-09-02T16:14:08+00:00\"\r\n          }\r\n       \
         \ ],\r\n        \"extensionHandlers\": [\r\n          {\r\n            \"\
         type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\",\r\n\
-        \            \"typeHandlerVersion\": \"1.0.0.1\",\r\n            \"status\"\
+        \            \"typeHandlerVersion\": \"1.0.0.3\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         ,\r\n              \"message\": \"Plugin enabled\"\r\n            }\r\n  \
         \        }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n\
-        \          \"name\": \"vm1_OsDisk_1_b043f10484a14deb897e818b9584903e\",\r\n\
+        \          \"name\": \"vm1_OsDisk_1_6f961b17af444aa2b60405d3e2289604\",\r\n\
         \          \"statuses\": [\r\n            {\r\n              \"code\": \"\
         ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\n \
         \             \"displayStatus\": \"Provisioning succeeded\",\r\n         \
-        \     \"time\": \"2017-08-25T20:42:13.5199395+00:00\"\r\n            }\r\n\
+        \     \"time\": \"2017-09-02T16:11:00.769631+00:00\"\r\n            }\r\n\
         \          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n     \
-        \   {\r\n          \"name\": \"MSIExtension\",\r\n          \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
-        ,\r\n          \"typeHandlerVersion\": \"1.0.0.1\",\r\n          \"statuses\"\
+        \   {\r\n          \"name\": \"ManagedIdentityExtensionForLinux\",\r\n   \
+        \       \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux\"\
+        ,\r\n          \"typeHandlerVersion\": \"1.0.0.3\",\r\n          \"statuses\"\
         : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n              \"message\": \"Successfully\
-        \ started managed identity extension service. 2017-08-25 20:44:33.5517674\
+        \ started managed identity extension service. 2017-09-02 16:13:34.5113501\
         \ +0000 UTC.\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n\
         \      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-08-25T20:44:36.9115034+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2017-09-02T16:13:39.1434416+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -493,18 +521,19 @@ interactions:
         typeHandlerVersion\": \"1.0\",\r\n        \"autoUpgradeMinorVersion\": true,\r\
         \n        \"settings\": {\"port\":50342},\r\n        \"provisioningState\"\
         : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MSIExtension\"\
-        ,\r\n      \"name\": \"MSIExtension\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"18025d77-8840-46cd-816a-7356e95996df\"\
-        ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux\"\
+        ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
+        \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
+        westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
+        ,\r\n    \"principalId\": \"5ff92f4e-fd12-4956-abdc-86cb56a9cb47\",\r\n  \
+        \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['4665']
+      content-length: ['4724']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:50 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -520,19 +549,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"197a0318-1b15-42b2-a659-66fab4048879\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4993ae61-d6fc-4f80-8edc-f30fe1c7b046\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"3c3b4d6e-a1f2-4935-bef0-9f054f9c76f1\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e36d7502-9ddb-4e79-9527-a375c246eeda\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
-        ,\r\n        \"etag\": \"W/\\\"197a0318-1b15-42b2-a659-66fab4048879\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"4993ae61-d6fc-4f80-8edc-f30fe1c7b046\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -541,8 +570,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"vnpzcziec1qujbt5ab45h0apqb.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-32-19-CF\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"zw5jfsp4teberh1n3pjgynn3ub.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-7C-D2\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -553,8 +582,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2495']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:50 GMT']
-      etag: [W/"197a0318-1b15-42b2-a659-66fab4048879"]
+      date: ['Sat, 02 Sep 2017 16:14:12 GMT']
+      etag: [W/"4993ae61-d6fc-4f80-8edc-f30fe1c7b046"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -570,17 +599,17 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"71ff5cad-ab43-494c-ae61-d88f81d191d1\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"7fd14e00-2a90-4341-8408-4c262430200d\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"bbe51f80-a0b3-4147-a877-33b19d0fa552\"\
-        ,\r\n    \"ipAddress\": \"52.160.106.51\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f12507a0-fb18-4301-98b7-93da25ef8de4\"\
+        ,\r\n    \"ipAddress\": \"40.85.153.169\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
         \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\
@@ -589,8 +618,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['978']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:50 GMT']
-      etag: [W/"71ff5cad-ab43-494c-ae61-d88f81d191d1"]
+      date: ['Sat, 02 Sep 2017 16:14:12 GMT']
+      etag: [W/"7fd14e00-2a90-4341-8408-4c262430200d"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -606,22 +635,22 @@ interactions:
       CommandName: [vm extension list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d41bb969-4c1d-4280-b4ba-416856dff546\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"43389e2e-5848-427d-93f8-3daa845d2c01\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm1_OsDisk_1_b043f10484a14deb897e818b9584903e\",\r\n        \"createOption\"\
+        : \"vm1_OsDisk_1_6f961b17af444aa2b60405d3e2289604\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_b043f10484a14deb897e818b9584903e\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_6f961b17af444aa2b60405d3e2289604\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -634,18 +663,19 @@ interactions:
         typeHandlerVersion\": \"1.0\",\r\n        \"autoUpgradeMinorVersion\": true,\r\
         \n        \"settings\": {\"port\":50342},\r\n        \"provisioningState\"\
         : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/MSIExtension\"\
-        ,\r\n      \"name\": \"MSIExtension\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"18025d77-8840-46cd-816a-7356e95996df\"\
-        ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/extensions/ManagedIdentityExtensionForLinux\"\
+        ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
+        \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
+        westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
+        ,\r\n    \"principalId\": \"5ff92f4e-fd12-4956-abdc-86cb56a9cb47\",\r\n  \
+        \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\
         ,\r\n  \"name\": \"vm1\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2566']
+      content-length: ['2606']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:50 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -661,9 +691,9 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -673,7 +703,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:51 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -731,22 +761,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:51 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:14 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Fri, 25 Aug 2017 20:49:51 GMT']
-      source-age: ['15']
+      expires: ['Sat, 02 Sep 2017 16:19:14 GMT']
+      source-age: ['219']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
       x-cache: [HIT]
       x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [23ee194154745dbc5263c0734ef2764b1b5eb548]
+      x-fastly-request-id: [2d661a274f44b4d1e02558cd9a7921e4eeacaa3b]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['879E:1E3AD:608762:6808D2:59A08C32']
-      x-served-by: [cache-sea1048-SEA]
-      x-timer: ['S1503693892.584095,VS0,VE1']
+      x-github-request-id: ['76EC:2814D:81DE8F:8B3C66:59AAD7FA']
+      x-served-by: [cache-sjc3635-SJC]
+      x-timer: ['S1504368854.145131,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -757,35 +787,36 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"89b1fd05-da8f-437a-b770-db67b5128dbb\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"e3a3356e-d2e3-46f7-bf52-9331af357e24\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"65915fab-1604-44e1-867f-007df3e80f81\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"c992becd-99fe-4802-9f6d-ebd26c35bda1\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"89b1fd05-da8f-437a-b770-db67b5128dbb\\\"\
+        ,\r\n            \"etag\": \"W/\\\"e3a3356e-d2e3-46f7-bf52-9331af357e24\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
         \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
-        \n        ],\r\n        \"virtualNetworkPeerings\": []\r\n      }\r\n    }\r\
-        \n  ]\r\n}"}
+        \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
+        : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
+        \  ]\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1606']
+      content-length: ['1684']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:50 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -801,12 +832,12 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27reader%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27reader%27
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
         you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
@@ -814,7 +845,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:51 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -826,65 +857,66 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"outputs": {}, "variables": {}, "contentVersion":
-      "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"type": "Microsoft.Network/networkSecurityGroups", "properties":
-      {"securityRules": [{"properties": {"destinationPortRange": "3389", "sourceAddressPrefix":
-      "*", "protocol": "Tcp", "sourcePortRange": "*", "access": "Allow", "priority":
-      1000, "direction": "Inbound", "destinationAddressPrefix": "*"}, "name": "rdp"}]},
-      "apiVersion": "2015-06-15", "dependsOn": [], "tags": {}, "name": "vm2NSG", "location":
-      "westus"}, {"type": "Microsoft.Network/publicIPAddresses", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "apiVersion": "2017-08-01", "dependsOn": [], "tags": {}, "name":
-      "vm2PublicIP", "location": "westus"}, {"type": "Microsoft.Network/networkInterfaces",
-      "properties": {"networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
+    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
+      {"contentVersion": "1.0.0.0", "parameters": {}, "outputs": {}, "resources":
+      [{"tags": {}, "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2015-06-15", "properties": {"securityRules": [{"properties":
+      {"sourceAddressPrefix": "*", "access": "Allow", "priority": 1000, "protocol":
+      "Tcp", "destinationAddressPrefix": "*", "direction": "Inbound", "destinationPortRange":
+      "3389", "sourcePortRange": "*"}, "name": "rdp"}]}, "name": "vm2NSG", "location":
+      "westus"}, {"tags": {}, "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2017-08-01", "properties": {"publicIPAllocationMethod": "dynamic"},
+      "name": "vm2PublicIP", "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
+      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2015-06-15", "properties": {"networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},
       "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"},
-      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}},
-      "name": "ipconfigvm2"}]}, "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
-      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "tags": {}, "name": "vm2VMNic",
-      "location": "westus"}, {"apiVersion": "2015-07-01", "type": "Microsoft.Compute/virtualMachines/providers/roleAssignments",
-      "properties": {"scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1",
-      "principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"},
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm2"}]}, "name": "vm2VMNic",
+      "location": "westus"}, {"properties": {"principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default\'',
+      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+      "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},
+      "dependsOn": ["Microsoft.Compute/virtualMachines/vm2"], "type": "Microsoft.Compute/virtualMachines/providers/roleAssignments",
       "name": "vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81",
-      "dependsOn": ["Microsoft.Compute/virtualMachines/vm2"]}, {"type": "Microsoft.Compute/virtualMachines/extensions",
-      "properties": {"autoUpgradeMinorVersion": true, "type": "ManagedIdentityExtensionForWindows",
-      "typeHandlerVersion": "1.0", "settings": {"port": 50342}, "publisher": "Microsoft.ManagedIdentity"},
-      "apiVersion": "2017-03-30", "location": "westus", "name": "vm2/MSIExtension",
-      "dependsOn": ["c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"]}, {"type": "Microsoft.Compute/virtualMachines",
-      "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
-      "osProfile": {"adminPassword": "PasswordPassword1!", "adminUsername": "admin123",
-      "computerName": "vm2"}, "storageProfile": {"imageReference": {"version": "latest",
-      "offer": "WindowsServer", "sku": "2016-Datacenter", "publisher": "MicrosoftWindowsServer"},
-      "osDisk": {"createOption": "fromImage", "managedDisk": {"storageAccountType":
-      null}, "name": null, "caching": null}}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}},
-      "apiVersion": "2017-03-30", "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
-      "identity": {"type": "systemAssigned"}, "tags": {}, "name": "vm2", "location":
-      "westus"}], "parameters": {}}, "mode": "Incremental", "parameters": {}}}'''
+      "apiVersion": "2015-07-01"}, {"dependsOn": ["c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"],
+      "type": "Microsoft.Compute/virtualMachines/extensions", "apiVersion": "2017-03-30",
+      "properties": {"type": "ManagedIdentityExtensionForWindows", "autoUpgradeMinorVersion":
+      true, "typeHandlerVersion": "1.0", "settings": {"port": 50342}, "publisher":
+      "Microsoft.ManagedIdentity"}, "name": "vm2/ManagedIdentityExtensionForWindows",
+      "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-03-30", "identity":
+      {"type": "systemAssigned"}, "properties": {"osProfile": {"adminPassword": "PasswordPassword1!",
+      "computerName": "vm2", "adminUsername": "admin123"}, "hardwareProfile": {"vmSize":
+      "Standard_DS1_v2"}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
+      "storageProfile": {"osDisk": {"managedDisk": {"storageAccountType": null}, "caching":
+      null, "name": null, "createOption": "fromImage"}, "imageReference": {"version":
+      "latest", "offer": "WindowsServer", "sku": "2016-Datacenter", "publisher": "MicrosoftWindowsServer"}}},
+      "name": "vm2", "location": "westus"}], "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vm create]
       Connection: [keep-alive]
-      Content-Length: ['4179']
+      Content-Length: ['4201']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_6ER2EWmDNIdgI4olYU7PuN6U9HDQvip1","name":"vm_deploy_6ER2EWmDNIdgI4olYU7PuN6U9HDQvip1","properties":{"templateHash":"13939314849154409211","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-25T20:44:53.5938258Z","duration":"PT0.5771991S","correlationId":"82c6dc6c-df18-43f0-a2c1-365fcb46b423","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/MSIExtension","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/MSIExtension"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_VpR4T2jWEzKRhwiqGyJK18d0ljMiCIDl","name":"vm_deploy_VpR4T2jWEzKRhwiqGyJK18d0ljMiCIDl","properties":{"templateHash":"3680693601348310379","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:14:17.0512327Z","duration":"PT0.9343116S","correlationId":"85ebe2b5-3656-48b0-b678-8760efa9cd09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForWindows","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForWindows"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_6ER2EWmDNIdgI4olYU7PuN6U9HDQvip1/operationStatuses/08586979129924610322?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_VpR4T2jWEzKRhwiqGyJK18d0ljMiCIDl/operationStatuses/08586972380293607165?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['4441']
+      content-length: ['4484']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:44:53 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1133']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -894,19 +926,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:45:23 GMT']
+      date: ['Sat, 02 Sep 2017 16:14:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -920,19 +952,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:45:53 GMT']
+      date: ['Sat, 02 Sep 2017 16:15:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -946,19 +978,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:46:24 GMT']
+      date: ['Sat, 02 Sep 2017 16:15:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -972,19 +1004,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:46:53 GMT']
+      date: ['Sat, 02 Sep 2017 16:16:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -998,19 +1030,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:47:24 GMT']
+      date: ['Sat, 02 Sep 2017 16:16:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1024,19 +1056,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:47:54 GMT']
+      date: ['Sat, 02 Sep 2017 16:17:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1050,19 +1082,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:48:24 GMT']
+      date: ['Sat, 02 Sep 2017 16:17:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1076,19 +1108,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:48:55 GMT']
+      date: ['Sat, 02 Sep 2017 16:18:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1102,19 +1134,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:25 GMT']
+      date: ['Sat, 02 Sep 2017 16:18:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1128,19 +1160,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979129924610322?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972380293607165?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:55 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1154,19 +1186,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_6ER2EWmDNIdgI4olYU7PuN6U9HDQvip1","name":"vm_deploy_6ER2EWmDNIdgI4olYU7PuN6U9HDQvip1","properties":{"templateHash":"13939314849154409211","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-25T20:49:48.9074986Z","duration":"PT4M55.8908719S","correlationId":"82c6dc6c-df18-43f0-a2c1-365fcb46b423","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/MSIExtension","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/MSIExtension"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/MSIExtension"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_VpR4T2jWEzKRhwiqGyJK18d0ljMiCIDl","name":"vm_deploy_VpR4T2jWEzKRhwiqGyJK18d0ljMiCIDl","properties":{"templateHash":"3680693601348310379","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:18:58.63364Z","duration":"PT4M42.5167189S","correlationId":"85ebe2b5-3656-48b0-b678-8760efa9cd09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachines/extensions","locations":["westus"]},{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachines/providers/Identities","resourceName":"vm2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81","resourceType":"Microsoft.Compute/virtualMachines/providers/roleAssignments","resourceName":"vm1/Microsoft.Authorization/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForWindows","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"vm2/ManagedIdentityExtensionForWindows"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/c1e7fc22-cb48-407e-be6a-19f0f1ed9c81"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForWindows"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['5815']
+      content-length: ['5878']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:56 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1180,22 +1212,22 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?$expand=instanceView&api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3a42ecb4-8f16-4dc6-b820-8fc735863d79\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"ac378f43-86ad-4412-abe7-f54dcf9e9056\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
         WindowsServer\",\r\n        \"sku\": \"2016-Datacenter\",\r\n        \"version\"\
         : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
-        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_9fbe6b22f0fc42cf9b3cf3db1ceb2b2e\"\
+        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_66c0252ee70f4926860e73dfa3546a95\"\
         ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_9fbe6b22f0fc42cf9b3cf3db1ceb2b2e\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_66c0252ee70f4926860e73dfa3546a95\"\
         \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"windowsConfiguration\"\
@@ -1207,30 +1239,30 @@ interactions:
         ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
         Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
-        \ new configurations.\",\r\n            \"time\": \"2017-08-25T20:49:44+00:00\"\
+        \ new configurations.\",\r\n            \"time\": \"2017-09-02T16:19:14+00:00\"\
         \r\n          }\r\n        ],\r\n        \"extensionHandlers\": [\r\n    \
         \      {\r\n            \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForWindows\"\
-        ,\r\n            \"typeHandlerVersion\": \"1.0.0.1\",\r\n            \"status\"\
+        ,\r\n            \"typeHandlerVersion\": \"1.0.0.3\",\r\n            \"status\"\
         : {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n      \
         \        \"level\": \"Info\",\r\n              \"displayStatus\": \"Ready\"\
         \r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"disks\"\
-        : [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_9fbe6b22f0fc42cf9b3cf3db1ceb2b2e\"\
+        : [\r\n        {\r\n          \"name\": \"vm2_OsDisk_1_66c0252ee70f4926860e73dfa3546a95\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-08-25T20:45:20.0055184+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-09-02T16:14:41.2363825+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"extensions\": [\r\n    \
-        \    {\r\n          \"name\": \"MSIExtension\",\r\n          \"type\": \"\
-        Microsoft.ManagedIdentity.ManagedIdentityExtensionForWindows\",\r\n      \
-        \    \"typeHandlerVersion\": \"1.0.0.1\",\r\n          \"statuses\": [\r\n\
-        \            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
+        \    {\r\n          \"name\": \"ManagedIdentityExtensionForWindows\",\r\n\
+        \          \"type\": \"Microsoft.ManagedIdentity.ManagedIdentityExtensionForWindows\"\
+        ,\r\n          \"typeHandlerVersion\": \"1.0.0.3\",\r\n          \"statuses\"\
+        : [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n              \"level\": \"Info\",\r\n              \"displayStatus\"\
         : \"Provisioning succeeded\",\r\n              \"message\": \"Successfully\
-        \ started managed identity extension service. 2017-08-25 20:49:20.2593419\
+        \ started managed identity extension service. 2017-09-02 16:18:32.5485647\
         \ +0000 GMT.\"\r\n            }\r\n          ]\r\n        }\r\n      ],\r\n\
         \      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
-        \ succeeded\",\r\n          \"time\": \"2017-08-25T20:49:35.1905562+00:00\"\
+        \ succeeded\",\r\n          \"time\": \"2017-09-02T16:18:42.6919203+00:00\"\
         \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
         ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
         \r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"resources\": [\r\n    {\r\
@@ -1239,18 +1271,19 @@ interactions:
         \ \"typeHandlerVersion\": \"1.0\",\r\n        \"autoUpgradeMinorVersion\"\
         : true,\r\n        \"settings\": {\"port\":50342},\r\n        \"provisioningState\"\
         : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/MSIExtension\"\
-        ,\r\n      \"name\": \"MSIExtension\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"7f5ef2f5-f47f-4955-9a71-5f4b440f257e\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForWindows\"\
+        ,\r\n      \"name\": \"ManagedIdentityExtensionForWindows\"\r\n    }\r\n \
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"\
+        SystemAssigned\",\r\n    \"principalId\": \"f3572288-40a6-46c8-8e13-1ecc9342bb4c\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\
         ,\r\n  \"name\": \"vm2\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['4733']
+      content-length: ['4799']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:56 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1266,19 +1299,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"a97b0d3f-5001-4167-bc6d-fd805fc124f5\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"ed5a047d-b4a1-4755-95a0-35838b59cae6\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"dbef3562-3e21-477e-9ada-d5cd93bc366f\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"b4fe7cff-d51e-4873-90f5-647a49c9b5e2\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
-        ,\r\n        \"etag\": \"W/\\\"a97b0d3f-5001-4167-bc6d-fd805fc124f5\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"ed5a047d-b4a1-4755-95a0-35838b59cae6\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1287,8 +1320,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"vnpzcziec1qujbt5ab45h0apqb.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-32-14-E8\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"zw5jfsp4teberh1n3pjgynn3ub.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-36-73-BC\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1299,8 +1332,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2495']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:56 GMT']
-      etag: [W/"a97b0d3f-5001-4167-bc6d-fd805fc124f5"]
+      date: ['Sat, 02 Sep 2017 16:19:22 GMT']
+      etag: [W/"ed5a047d-b4a1-4755-95a0-35838b59cae6"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1316,27 +1349,27 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"0f07c106-f28c-4e52-8898-ea75366d67ab\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4284a22c-5bca-4f6c-ae23-dbd83c445981\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"3112f416-0e32-4c37-a9d6-ba9dfa871b3a\"\
-        ,\r\n    \"ipAddress\": \"13.93.167.0\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"19fe67e3-d666-4148-a8c4-70cc978511ff\"\
+        ,\r\n    \"ipAddress\": \"40.85.156.55\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
         \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\
         \n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['976']
+      content-length: ['977']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:57 GMT']
-      etag: [W/"0f07c106-f28c-4e52-8898-ea75366d67ab"]
+      date: ['Sat, 02 Sep 2017 16:19:23 GMT']
+      etag: [W/"4284a22c-5bca-4f6c-ae23-dbd83c445981"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1352,22 +1385,22 @@ interactions:
       CommandName: [vm extension list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"3a42ecb4-8f16-4dc6-b820-8fc735863d79\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"ac378f43-86ad-4412-abe7-f54dcf9e9056\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"\
         WindowsServer\",\r\n        \"sku\": \"2016-Datacenter\",\r\n        \"version\"\
         : \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"\
-        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_9fbe6b22f0fc42cf9b3cf3db1ceb2b2e\"\
+        Windows\",\r\n        \"name\": \"vm2_OsDisk_1_66c0252ee70f4926860e73dfa3546a95\"\
         ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
         ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
-        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_9fbe6b22f0fc42cf9b3cf3db1ceb2b2e\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm2_OsDisk_1_66c0252ee70f4926860e73dfa3546a95\"\
         \r\n        },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"windowsConfiguration\"\
@@ -1380,18 +1413,19 @@ interactions:
         \ \"typeHandlerVersion\": \"1.0\",\r\n        \"autoUpgradeMinorVersion\"\
         : true,\r\n        \"settings\": {\"port\":50342},\r\n        \"provisioningState\"\
         : \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\"\
-        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/MSIExtension\"\
-        ,\r\n      \"name\": \"MSIExtension\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
-        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"7f5ef2f5-f47f-4955-9a71-5f4b440f257e\"\
+        ,\r\n      \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2/extensions/ManagedIdentityExtensionForWindows\"\
+        ,\r\n      \"name\": \"ManagedIdentityExtensionForWindows\"\r\n    }\r\n \
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"\
+        SystemAssigned\",\r\n    \"principalId\": \"f3572288-40a6-46c8-8e13-1ecc9342bb4c\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\
         ,\r\n  \"name\": \"vm2\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2635']
+      content-length: ['2679']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1407,9 +1441,9 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -1419,7 +1453,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:57 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:23 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1477,22 +1511,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:24 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Fri, 25 Aug 2017 20:54:58 GMT']
-      source-age: ['0']
+      expires: ['Sat, 02 Sep 2017 16:24:24 GMT']
+      source-age: ['215']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [4f8c8cc7dbb770c77c094996c6466a202eee5119]
+      x-fastly-request-id: [31b9b2aad96fdd4ba99b9928f4dda723b2581729]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['2660:1E3AE:61D532:694590:59A08D76']
-      x-served-by: [cache-sea1048-SEA]
-      x-timer: ['S1503694199.725194,VS0,VE26']
+      x-github-request-id: ['C7A8:13A14:1FA44C:22C0A1:59AAD933']
+      x-served-by: [cache-sjc3121-SJC]
+      x-timer: ['S1504369164.298340,VS0,VE0']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1503,23 +1537,23 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\
         \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"a868af50-2262-4ba9-ac5e-6724b60a5ea1\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"101dc286-ffb6-446f-8aa8-4e3a3ce6df89\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"65915fab-1604-44e1-867f-007df3e80f81\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"c992becd-99fe-4802-9f6d-ebd26c35bda1\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vm1Subnet\",\r\n           \
         \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"a868af50-2262-4ba9-ac5e-6724b60a5ea1\\\"\
+        ,\r\n            \"etag\": \"W/\\\"101dc286-ffb6-446f-8aa8-4e3a3ce6df89\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
@@ -1527,13 +1561,14 @@ interactions:
         \r\n                },\r\n                {\r\n                  \"id\": \"\
         /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
-        \n        ],\r\n        \"virtualNetworkPeerings\": []\r\n      }\r\n    }\r\
-        \n  ]\r\n}"}
+        \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
+        : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
+        \  ]\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['1899']
+      content-length: ['1977']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1542,31 +1577,31 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"template": {"outputs": {}, "variables": {}, "contentVersion":
-      "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "resources": [{"type": "Microsoft.Network/networkSecurityGroups", "properties":
-      {"securityRules": [{"properties": {"destinationPortRange": "22", "sourceAddressPrefix":
-      "*", "protocol": "Tcp", "sourcePortRange": "*", "access": "Allow", "priority":
-      1000, "direction": "Inbound", "destinationAddressPrefix": "*"}, "name": "default-allow-ssh"}]},
-      "apiVersion": "2015-06-15", "dependsOn": [], "tags": {}, "name": "vm3NSG", "location":
-      "westus"}, {"type": "Microsoft.Network/publicIPAddresses", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "apiVersion": "2017-08-01", "dependsOn": [], "tags": {}, "name":
-      "vm3PublicIP", "location": "westus"}, {"type": "Microsoft.Network/networkInterfaces",
-      "properties": {"networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},
+    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
+      {"contentVersion": "1.0.0.0", "parameters": {}, "outputs": {}, "resources":
+      [{"tags": {}, "dependsOn": [], "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2015-06-15", "properties": {"securityRules": [{"properties":
+      {"sourceAddressPrefix": "*", "access": "Allow", "priority": 1000, "protocol":
+      "Tcp", "destinationAddressPrefix": "*", "direction": "Inbound", "destinationPortRange":
+      "22", "sourcePortRange": "*"}, "name": "default-allow-ssh"}]}, "name": "vm3NSG",
+      "location": "westus"}, {"tags": {}, "dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2017-08-01", "properties": {"publicIPAllocationMethod": "dynamic"},
+      "name": "vm3PublicIP", "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm3NSG",
+      "Microsoft.Network/publicIpAddresses/vm3PublicIP"], "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2015-06-15", "properties": {"networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},
       "ipConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"},
-      "privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"}},
-      "name": "ipconfigvm3"}]}, "apiVersion": "2015-06-15", "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm3NSG",
-      "Microsoft.Network/publicIpAddresses/vm3PublicIP"], "tags": {}, "name": "vm3VMNic",
-      "location": "westus"}, {"type": "Microsoft.Compute/virtualMachines", "properties":
-      {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
-      "osProfile": {"adminPassword": "PasswordPassword1!", "adminUsername": "admin123",
-      "computerName": "vm3"}, "storageProfile": {"imageReference": {"version": "latest",
-      "offer": "Debian", "sku": "8", "publisher": "credativ"}, "osDisk": {"createOption":
-      "fromImage", "managedDisk": {"storageAccountType": null}, "name": null, "caching":
-      null}}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "apiVersion": "2017-03-30",
-      "dependsOn": ["Microsoft.Network/networkInterfaces/vm3VMNic"], "tags": {}, "name":
-      "vm3", "location": "westus"}], "parameters": {}}, "mode": "Incremental", "parameters":
-      {}}}'''
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}, "name": "ipconfigvm3"}]}, "name": "vm3VMNic",
+      "location": "westus"}, {"tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm3VMNic"],
+      "type": "Microsoft.Compute/virtualMachines", "apiVersion": "2017-03-30", "properties":
+      {"osProfile": {"adminPassword": "PasswordPassword1!", "computerName": "vm3",
+      "adminUsername": "admin123"}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"},
+      "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
+      "storageProfile": {"osDisk": {"managedDisk": {"storageAccountType": null}, "caching":
+      null, "name": null, "createOption": "fromImage"}, "imageReference": {"version":
+      "latest", "offer": "Debian", "sku": "8", "publisher": "credativ"}}}, "name":
+      "vm3", "location": "westus"}], "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "variables": {}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1574,20 +1609,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['2803']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zI5bM6xjMDSldXgFCxAlXscfBuJ1KfwU","name":"vm_deploy_zI5bM6xjMDSldXgFCxAlXscfBuJ1KfwU","properties":{"templateHash":"3936124977023368307","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-25T20:50:00.1269614Z","duration":"PT0.2768056S","correlationId":"a2425137-b48a-40a7-adda-f90afe2b0236","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zxonxyeC08OmJY77858oJsiu1zrTsEgq","name":"vm_deploy_zxonxyeC08OmJY77858oJsiu1zrTsEgq","properties":{"templateHash":"3784393240420337736","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:19:26.1113872Z","duration":"PT0.5727308S","correlationId":"b2dc4e08-b923-4ad5-8ea3-4d0d2d2139fc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zI5bM6xjMDSldXgFCxAlXscfBuJ1KfwU/operationStatuses/08586979126856274724?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zxonxyeC08OmJY77858oJsiu1zrTsEgq/operationStatuses/08586972377199389669?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2363']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:49:59 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1601,19 +1636,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979126856274724?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972377199389669?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:50:29 GMT']
+      date: ['Sat, 02 Sep 2017 16:19:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1627,19 +1662,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979126856274724?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972377199389669?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:51:00 GMT']
+      date: ['Sat, 02 Sep 2017 16:20:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1653,19 +1688,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979126856274724?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972377199389669?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:51:30 GMT']
+      date: ['Sat, 02 Sep 2017 16:20:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1679,19 +1714,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586979126856274724?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972377199389669?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:00 GMT']
+      date: ['Sat, 02 Sep 2017 16:21:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1705,19 +1740,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zI5bM6xjMDSldXgFCxAlXscfBuJ1KfwU","name":"vm_deploy_zI5bM6xjMDSldXgFCxAlXscfBuJ1KfwU","properties":{"templateHash":"3936124977023368307","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-25T20:51:48.4112461Z","duration":"PT1M48.5610903S","correlationId":"a2425137-b48a-40a7-adda-f90afe2b0236","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_zxonxyeC08OmJY77858oJsiu1zrTsEgq","name":"vm_deploy_zxonxyeC08OmJY77858oJsiu1zrTsEgq","properties":{"templateHash":"3784393240420337736","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:20:59.7038216Z","duration":"PT1M34.1651652S","correlationId":"b2dc4e08-b923-4ad5-8ea3-4d0d2d2139fc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['3226']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:01 GMT']
+      date: ['Sat, 02 Sep 2017 16:21:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1731,22 +1766,22 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?$expand=instanceView&api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1758,17 +1793,17 @@ interactions:
         \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\"\
         ,\r\n            \"level\": \"Warning\",\r\n            \"displayStatus\"\
         : \"Not Ready\",\r\n            \"message\": \"VM status blob is found but\
-        \ not yet populated.\",\r\n            \"time\": \"2017-08-25T20:52:02+00:00\"\
+        \ not yet populated.\",\r\n            \"time\": \"2017-09-02T16:21:27+00:00\"\
         \r\n          }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n       \
-        \ {\r\n          \"name\": \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        \ {\r\n          \"name\": \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-08-25T20:50:27.9721727+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-09-02T16:19:51.6447824+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-08-25T20:51:34.3007209+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-09-02T16:20:52.2735582+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
@@ -1778,7 +1813,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2882']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:01 GMT']
+      date: ['Sat, 02 Sep 2017 16:21:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1794,19 +1829,19 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm3VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\"\
-        ,\r\n  \"etag\": \"W/\\\"b614691f-dcd9-4027-97f6-e23b42900d81\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"455d5ac3-e832-4786-bcbe-4392252aaf2d\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"b7358a39-5c70-410d-b85d-562101f56ea7\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"45c1644c-2d9c-41cc-8c77-88c4f5a9af26\"\
         ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm3\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\
-        ,\r\n        \"etag\": \"W/\\\"b614691f-dcd9-4027-97f6-e23b42900d81\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"455d5ac3-e832-4786-bcbe-4392252aaf2d\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.6\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
@@ -1815,8 +1850,8 @@ interactions:
         \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
         : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
         \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
-        internalDomainNameSuffix\": \"vnpzcziec1qujbt5ab45h0apqb.dx.internal.cloudapp.net\"\
-        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-32-3A-34\",\r\n    \"enableAcceleratedNetworking\"\
+        internalDomainNameSuffix\": \"zw5jfsp4teberh1n3pjgynn3ub.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-30-66-4B\",\r\n    \"enableAcceleratedNetworking\"\
         : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
         : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG\"\
         \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
@@ -1827,8 +1862,8 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2495']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:02 GMT']
-      etag: [W/"b614691f-dcd9-4027-97f6-e23b42900d81"]
+      date: ['Sat, 02 Sep 2017 16:21:28 GMT']
+      etag: [W/"455d5ac3-e832-4786-bcbe-4392252aaf2d"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1844,27 +1879,27 @@ interactions:
       CommandName: [vm create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vm3PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP\"\
-        ,\r\n  \"etag\": \"W/\\\"65ef2824-1e9a-4f90-97cf-a0ca87198f51\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"ec1726c5-6f23-47ce-94be-0edbcc87f35a\\\"\",\r\n \
         \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
-        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8686e67c-58c5-4473-8dcb-d5d6c8dff1d8\"\
-        ,\r\n    \"ipAddress\": \"40.83.140.161\",\r\n    \"publicIPAddressVersion\"\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e637fbab-744e-4f3f-9c91-18291a2013b9\"\
+        ,\r\n    \"ipAddress\": \"13.91.47.94\",\r\n    \"publicIPAddressVersion\"\
         : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
         : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\
         \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\
         \n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['978']
+      content-length: ['976']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:02 GMT']
-      etag: [W/"65ef2824-1e9a-4f90-97cf-a0ca87198f51"]
+      date: ['Sat, 02 Sep 2017 16:21:29 GMT']
+      etag: [W/"ec1726c5-6f23-47ce-94be-0edbcc87f35a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1880,12 +1915,12 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27reader%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27reader%27
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
         you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
@@ -1893,7 +1928,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:03 GMT']
+      date: ['Sat, 02 Sep 2017 16:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1912,22 +1947,22 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1942,7 +1977,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1709']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:02 GMT']
+      date: ['Sat, 02 Sep 2017 16:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1951,16 +1986,15 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"identity": {"type": "SystemAssigned"}, "properties": {"networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
-      "osProfile": {"adminUsername": "admin123", "linuxConfiguration": {"disablePasswordAuthentication":
-      false}, "computerName": "vm3", "secrets": []}, "storageProfile": {"dataDisks":
-      [], "imageReference": {"version": "latest", "publisher": "credativ", "sku":
-      "8", "offer": "Debian"}, "osDisk": {"createOption": "fromImage", "managedDisk":
-      {"storageAccountType": "Premium_LRS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203"},
-      "caching": "ReadWrite", "diskSizeGB": 30, "name": "vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203",
-      "osType": "Linux"}}, "hardwareProfile": {"vmSize": "Standard_DS1_v2"}}, "tags":
-      {}, "location": "westus"}'''
+    body: 'b''{"identity": {"type": "SystemAssigned"}, "tags": {}, "location": "westus",
+      "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"computerName":
+      "vm3", "linuxConfiguration": {"disablePasswordAuthentication": false}, "secrets":
+      [], "adminUsername": "admin123"}, "storageProfile": {"dataDisks": [], "osDisk":
+      {"managedDisk": {"storageAccountType": "Premium_LRS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d"},
+      "createOption": "fromImage", "diskSizeGB": 30, "caching": "ReadWrite", "name":
+      "vm3_OsDisk_1_76b430c07399464599a735748b29006d", "osType": "Linux"}, "imageReference":
+      {"offer": "Debian", "version": "latest", "sku": "8", "publisher": "credativ"}}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1968,22 +2002,61 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['1117']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: '{"error":{"code":"InternalResourceIdentityError","message":"There
+        was a problem communicating with the identity service. Diagnostic information:
+        timestamp ''20170902T162201Z'', subscription id ''0b1f6471-1bf0-4dda-aec3-cb9272f09590'',
+        tracking id ''e92687cf-0cce-4c37-b87d-f0d2ca18c7eb'', request correlation
+        id ''e92687cf-0cce-4c37-b87d-f0d2ca18c7eb''."}}'}
+    headers:
+      cache-control: [no-cache]
+      connection: [close]
+      content-length: ['348']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 02 Sep 2017 16:22:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-failure-cause: [gateway]
+    status: {code: 500, message: Internal Server Error}
+- request:
+    body: 'b''{"identity": {"type": "SystemAssigned"}, "tags": {}, "location": "westus",
+      "properties": {"networkProfile": {"networkInterfaces": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
+      "hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "osProfile": {"computerName":
+      "vm3", "linuxConfiguration": {"disablePasswordAuthentication": false}, "secrets":
+      [], "adminUsername": "admin123"}, "storageProfile": {"dataDisks": [], "osDisk":
+      {"managedDisk": {"storageAccountType": "Premium_LRS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d"},
+      "createOption": "fromImage", "diskSizeGB": 30, "caching": "ReadWrite", "name":
+      "vm3_OsDisk_1_76b430c07399464599a735748b29006d", "osType": "Linux"}, "imageReference":
+      {"offer": "Debian", "version": "latest", "sku": "8", "publisher": "credativ"}}}}'''
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm assign-identity]
+      Connection: [keep-alive]
+      Content-Length: ['1117']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -1993,23 +2066,23 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44\",\r\n    \"\
+        \    \"principalId\": \"1c4da89b-108b-4513-81dd-5a05e29e0253\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/43fe0302-d0ad-4696-aa21-276b5f97cb72?api-version=2017-03-30']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/aa3876e7-6df0-4f77-beb7-c766c7e7e663?api-version=2017-03-30']
       cache-control: [no-cache]
       content-length: ['1878']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:05 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2019,20 +2092,20 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/43fe0302-d0ad-4696-aa21-276b5f97cb72?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/aa3876e7-6df0-4f77-beb7-c766c7e7e663?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-08-25T20:52:05.8165016+00:00\",\r\
-        \n  \"endTime\": \"2017-08-25T20:52:12.0386524+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"43fe0302-d0ad-4696-aa21-276b5f97cb72\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-02T16:22:02.3389709+00:00\",\r\
+        \n  \"endTime\": \"2017-09-02T16:22:17.2919347+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"aa3876e7-6df0-4f77-beb7-c766c7e7e663\"\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['184']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:35 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2048,22 +2121,22 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2073,7 +2146,7 @@ interactions:
         }]},\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"\
         Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n  \"\
         tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\",\r\n\
-        \    \"principalId\": \"e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44\",\r\n    \"\
+        \    \"principalId\": \"1c4da89b-108b-4513-81dd-5a05e29e0253\",\r\n    \"\
         tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"id\":\
         \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
@@ -2081,7 +2154,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['1879']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:35 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2090,7 +2163,7 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"principalId": "e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44",
+    body: '{"properties": {"principalId": "1c4da89b-108b-4513-81dd-5a05e29e0253",
       "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"}}'
     headers:
       Accept: [application/json]
@@ -2099,26 +2172,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['233']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d41732?api-version=2015-07-01
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","createdOn":"2017-08-25T20:52:37.6136900Z","updatedOn":"2017-08-25T20:52:37.6136900Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d41732","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d41732"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"1c4da89b-108b-4513-81dd-5a05e29e0253","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","createdOn":"2017-09-02T16:22:35.8988441Z","updatedOn":"2017-09-02T16:22:35.8988441Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1/providers/Microsoft.Authorization/roleAssignments/88daaf5a-ea86-4a68-9d45-477538d41732","type":"Microsoft.Authorization/roleAssignments","name":"88daaf5a-ea86-4a68-9d45-477538d41732"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['964']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:40 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
       set-cookie: [x-ms-gateway-slice=productionb; path=/; secure; HttpOnly]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1120']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
@@ -2129,22 +2202,22 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?$expand=instanceView&api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2152,26 +2225,26 @@ interactions:
         \    \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\"\
         }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
-        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n\
-        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\"\
-        ,\r\n            \"level\": \"Warning\",\r\n            \"displayStatus\"\
-        : \"Not Ready\",\r\n            \"message\": \"VM status blob is found but\
-        \ not yet populated.\",\r\n            \"time\": \"2017-08-25T20:52:40+00:00\"\
-        \r\n          }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n       \
-        \ {\r\n          \"name\": \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.15\",\r\n\
+        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n     \
+        \       \"time\": \"2017-09-02T16:22:38+00:00\"\r\n          }\r\n       \
+        \ ],\r\n        \"extensionHandlers\": []\r\n      },\r\n      \"disks\":\
+        \ [\r\n        {\r\n          \"name\": \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
         : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
         \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
-        \       \"time\": \"2017-08-25T20:52:06.3790362+00:00\"\r\n            }\r\
+        \       \"time\": \"2017-09-02T16:22:03.0108497+00:00\"\r\n            }\r\
         \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
         \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
         \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
-        ,\r\n          \"time\": \"2017-08-25T20:52:12.0230016+00:00\"\r\n       \
+        ,\r\n          \"time\": \"2017-09-02T16:22:17.2763026+00:00\"\r\n       \
         \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
         \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
         \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
         ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\
-        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44\"\
+        \n    \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"1c4da89b-108b-4513-81dd-5a05e29e0253\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
@@ -2179,7 +2252,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['3052']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:39 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2188,9 +2261,9 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"settings": {"port": 50343}, "autoUpgradeMinorVersion":
-      true, "typeHandlerVersion": "1.0", "type": "ManagedIdentityExtensionForLinux",
-      "publisher": "Microsoft.ManagedIdentity"}, "location": "westus"}'
+    body: '{"properties": {"type": "ManagedIdentityExtensionForLinux", "autoUpgradeMinorVersion":
+      true, "typeHandlerVersion": "1.0", "publisher": "Microsoft.ManagedIdentity",
+      "settings": {"port": 50343}}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2198,8 +2271,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['215']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3/extensions/ManagedIdentityExtensionForLinux?api-version=2017-03-30
@@ -2212,16 +2285,16 @@ interactions:
         : \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3/extensions/ManagedIdentityExtensionForLinux\"\
         ,\r\n  \"name\": \"ManagedIdentityExtensionForLinux\"\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c7b4046a-95f9-4f59-bf22-dae68e4d7d65?api-version=2017-03-30']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/95b60f9e-2573-481f-8810-7dfc772f3c1b?api-version=2017-03-30']
       cache-control: [no-cache]
       content-length: ['644']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:52:40 GMT']
+      date: ['Sat, 02 Sep 2017 16:22:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -2231,20 +2304,20 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c7b4046a-95f9-4f59-bf22-dae68e4d7d65?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/95b60f9e-2573-481f-8810-7dfc772f3c1b?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"startTime\": \"2017-08-25T20:52:41.166625+00:00\",\r\n\
-        \  \"endTime\": \"2017-08-25T20:53:05.4949097+00:00\",\r\n  \"status\": \"\
-        Succeeded\",\r\n  \"name\": \"c7b4046a-95f9-4f59-bf22-dae68e4d7d65\"\r\n}"}
+    body: {string: "{\r\n  \"startTime\": \"2017-09-02T16:22:38.7760325+00:00\",\r\
+        \n  \"status\": \"InProgress\",\r\n  \"name\": \"95b60f9e-2573-481f-8810-7dfc772f3c1b\"\
+        \r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['183']
+      content-length: ['134']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:53:11 GMT']
+      date: ['Sat, 02 Sep 2017 16:23:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2260,8 +2333,37 @@ interactions:
       CommandName: [vm assign-identity]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/95b60f9e-2573-481f-8810-7dfc772f3c1b?api-version=2017-03-30
+  response:
+    body: {string: "{\r\n  \"startTime\": \"2017-09-02T16:22:38.7760325+00:00\",\r\
+        \n  \"endTime\": \"2017-09-02T16:23:15.338046+00:00\",\r\n  \"status\": \"\
+        Succeeded\",\r\n  \"name\": \"95b60f9e-2573-481f-8810-7dfc772f3c1b\"\r\n}"}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['183']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 02 Sep 2017 16:23:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vm assign-identity]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3/extensions/ManagedIdentityExtensionForLinux?api-version=2017-03-30
@@ -2277,7 +2379,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['645']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:53:11 GMT']
+      date: ['Sat, 02 Sep 2017 16:23:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2293,22 +2395,22 @@ interactions:
       CommandName: [vm extension list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?api-version=2017-03-30
   response:
-    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"5233f662-e451-463e-ac2d-a776889ee9e5\"\
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"da571ea0-02cd-46af-9249-7e2f8b8fa39f\"\
         ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\
         \n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n \
         \       \"publisher\": \"credativ\",\r\n        \"offer\": \"Debian\",\r\n\
         \        \"sku\": \"8\",\r\n        \"version\": \"latest\"\r\n      },\r\n\
         \      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\"\
-        : \"vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\",\r\n        \"createOption\"\
+        : \"vm3_OsDisk_1_76b430c07399464599a735748b29006d\",\r\n        \"createOption\"\
         : \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\"\
         : {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_8b24833fd86747b9ba0f88cda49e4203\"\
+        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/vm3_OsDisk_1_76b430c07399464599a735748b29006d\"\
         \r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\"\
         : []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\"\
         ,\r\n      \"adminUsername\": \"admin123\",\r\n      \"linuxConfiguration\"\
@@ -2325,7 +2427,7 @@ interactions:
         ,\r\n      \"name\": \"ManagedIdentityExtensionForLinux\"\r\n    }\r\n  ],\r\
         \n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"\
         westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"type\": \"SystemAssigned\"\
-        ,\r\n    \"principalId\": \"e4fb3d82-b63e-4f7b-a8c1-d8e73bc1cd44\",\r\n  \
+        ,\r\n    \"principalId\": \"1c4da89b-108b-4513-81dd-5a05e29e0253\",\r\n  \
         \  \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n  \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\
         ,\r\n  \"name\": \"vm3\"\r\n}"}
@@ -2333,7 +2435,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2606']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 25 Aug 2017 20:53:12 GMT']
+      date: ['Sat, 02 Sep 2017 16:23:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2350,9 +2452,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -2361,11 +2463,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 25 Aug 2017 20:53:12 GMT']
+      date: ['Sat, 02 Sep 2017 16:23:41 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdUWFlOVVNYTktVUEpYSFZYRTZJRjNQQjIzV0VGREJYWTRNWHw3NzkzRDM0QTRCMDIzN0VFLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdMRVRQNkxLTFJBNEpWWDI3RkdENkY0Tk1URFFKSklMVzZJWHw4OTNCNjk5RDdEODk2RTkzLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_msi.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_msi.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:22 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -34,9 +34,9 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -46,7 +46,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:22 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -104,22 +104,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:23 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:05 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Wed, 23 Aug 2017 21:39:23 GMT']
-      source-age: ['229']
+      expires: ['Sat, 02 Sep 2017 16:33:05 GMT']
+      source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
+      x-cache: [MISS]
+      x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [1ac333d36d10cd087600de293c475508561dfcde]
+      x-fastly-request-id: [821952c79ce2a8d54f144862989348770e955ad6]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['70BA:1E3AD:5FD5A:678CE:599DF3F9']
-      x-served-by: [cache-sea1037-SEA]
-      x-timer: ['S1503524064.549405,VS0,VE0']
+      x-github-request-id: ['D30C:28148:402953:44EB57:59AADC15']
+      x-served-by: [cache-sjc3126-SJC]
+      x-timer: ['S1504369686.616029,VS0,VE44']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -130,8 +130,8 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
@@ -141,7 +141,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:23 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -155,12 +155,12 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27Contributor%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
         you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-12-14T02:04:45.1393855Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}]}'}
@@ -168,7 +168,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['696']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:23 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -180,73 +180,75 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
-      {"parameters": {}, "resources": [{"location": "westus", "properties": {"subnets":
-      [{"properties": {"addressPrefix": "10.0.0.0/24"}, "name": "vmss11Subnet"}],
-      "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}}, "dependsOn": [], "apiVersion":
-      "2015-06-15", "name": "vmss11VNET", "tags": {}, "type": "Microsoft.Network/virtualNetworks"},
-      {"location": "westus", "properties": {"publicIPAllocationMethod": "dynamic"},
-      "dependsOn": [], "apiVersion": "2015-06-15", "name": "vmss11LBPublicIP", "tags":
-      {}, "type": "Microsoft.Network/publicIPAddresses"}, {"location": "westus", "properties":
-      {"frontendIPConfigurations": [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}], "backendAddressPools": [{"name": "vmss11LBBEPool"}],
-      "inboundNatPools": [{"properties": {"frontendPortRangeEnd": "50119", "frontendIPConfiguration":
-      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss11LB\''),
-      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "frontendPortRangeStart":
-      "50000", "backendPort": 22, "protocol": "tcp"}, "name": "vmss11LBNatPool"}]},
-      "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss11LBPublicIP"], "apiVersion":
-      "2015-06-15", "name": "vmss11LB", "tags": {}, "type": "Microsoft.Network/loadBalancers"},
-      {"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"contentVersion":
+      "1.0.0.0", "variables": {}, "resources": [{"dependsOn": [], "type": "Microsoft.Network/virtualNetworks",
+      "properties": {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
+      "name": "vmss11Subnet"}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}},
+      "name": "vmss11VNET", "tags": {}, "apiVersion": "2015-06-15", "location": "westus"},
+      {"dependsOn": [], "type": "Microsoft.Network/publicIPAddresses", "properties":
+      {"publicIPAllocationMethod": "Dynamic"}, "name": "vmss11LBPublicIP", "sku":
+      {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01", "location": "westus"},
+      {"dependsOn": ["Microsoft.Network/publicIpAddresses/vmss11LBPublicIP"], "type":
+      "Microsoft.Network/loadBalancers", "properties": {"frontendIPConfigurations":
+      [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendPortRangeEnd":
+      "50119", "protocol": "tcp", "backendPort": 22, "frontendPortRangeStart": "50000",
+      "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss11LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}},
+      "name": "vmss11LBNatPool"}], "backendAddressPools": [{"name": "vmss11LBBEPool"}]},
+      "name": "vmss11LB", "sku": {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01",
+      "location": "westus"}, {"apiVersion": "2015-07-01", "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss11"],
+      "type": "Microsoft.Authorization/roleAssignments", "properties": {"scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001",
       "principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001"},
-      "name": "cd58500a-f421-4815-b5cf-a36a1e16c121", "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss11"],
-      "apiVersion": "2015-07-01", "type": "Microsoft.Authorization/roleAssignments"},
-      {"location": "westus", "properties": {"upgradePolicy": {"mode": "Manual"}, "virtualMachineProfile":
-      {"extensionProfile": {"extensions": [{"properties": {"autoUpgradeMinorVersion":
-      true, "typeHandlerVersion": "1.0", "settings": {"port": 50342}, "type": "ManagedIdentityExtensionForLinux",
-      "publisher": "Microsoft.ManagedIdentity"}, "name": "MSIExtension"}]}, "osProfile":
-      {"adminUsername": "admin123", "adminPassword": "PasswordPassword1!", "computerNamePrefix":
-      "vmss15347"}, "storageProfile": {"imageReference": {"version": "latest", "offer":
-      "Debian", "sku": "8", "publisher": "credativ"}, "osDisk": {"managedDisk": {"storageAccountType":
-      null}, "createOption": "FromImage", "caching": "ReadWrite"}}, "networkProfile":
-      {"networkInterfaceConfigurations": [{"properties": {"primary": "true", "ipConfigurations":
-      [{"properties": {"loadBalancerBackendAddressPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/backendAddressPools/vmss11LBBEPool"}],
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/inboundNatPools/vmss11LBNatPool"}],
-      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"}},
-      "name": "vmss15347IPConfig"}]}, "name": "vmss15347Nic"}]}}, "singlePlacementGroup":
-      true, "overprovision": true}, "dependsOn": ["Microsoft.Network/virtualNetworks/vmss11VNET",
-      "Microsoft.Network/loadBalancers/vmss11LB"], "identity": {"type": "systemAssigned"},
-      "apiVersion": "2017-03-30", "sku": {"capacity": 1, "name": "Standard_D1_v2",
-      "tier": "Standard"}, "name": "vmss11", "tags": {}, "type": "Microsoft.Compute/virtualMachineScaleSets"}],
-      "contentVersion": "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"},
+      "name": "cd58500a-f421-4815-b5cf-a36a1e16c121"}, {"dependsOn": ["Microsoft.Network/virtualNetworks/vmss11VNET",
+      "Microsoft.Network/loadBalancers/vmss11LB"], "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "properties": {"overprovision": true, "upgradePolicy": {"mode": "Manual"}, "singlePlacementGroup":
+      true, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
+      [{"properties": {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/backendAddressPools/vmss11LBBEPool"}],
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/inboundNatPools/vmss11LBNatPool"}]},
+      "name": "vmss15d93IPConfig"}]}, "name": "vmss15d93Nic"}]}, "storageProfile":
+      {"imageReference": {"publisher": "credativ", "offer": "Debian", "version": "latest",
+      "sku": "8"}, "osDisk": {"caching": "ReadWrite", "createOption": "FromImage",
+      "managedDisk": {"storageAccountType": null}}}, "extensionProfile": {"extensions":
+      [{"properties": {"publisher": "Microsoft.ManagedIdentity", "typeHandlerVersion":
+      "1.0", "settings": {"port": 50342}, "type": "ManagedIdentityExtensionForLinux",
+      "autoUpgradeMinorVersion": true}, "name": "ManagedIdentityExtensionForLinux"}]},
+      "osProfile": {"adminPassword": "PasswordPassword1!", "adminUsername": "admin123",
+      "computerNamePrefix": "vmss15d93"}}}, "name": "vmss11", "sku": {"tier": "Standard",
+      "name": "Standard_D1_v2", "capacity": 1}, "tags": {}, "apiVersion": "2017-03-30",
+      "identity": {"type": "systemAssigned"}, "location": "westus"}], "outputs": {"VMSS":
+      {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
       \''vmss11\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}}}}'''
+      "type": "object"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['4793']
+      Content-Length: ['4865']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_n59ZB3o6wFpRhJPy0iIA0euyWJjyJZIU","name":"vmss_deploy_n59ZB3o6wFpRhJPy0iIA0euyWJjyJZIU","properties":{"templateHash":"18248750515147547487","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-23T21:34:25.5710496Z","duration":"PT0.6944115S","correlationId":"999d8eb4-f16f-4921-a09c-1e39fcefb213","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss11LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss11/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c121"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss11VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_KGDtWQHE41IcS70o4fjWvRD49kEWqL8a","name":"vmss_deploy_KGDtWQHE41IcS70o4fjWvRD49kEWqL8a","properties":{"templateHash":"6346625774394686626","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:28:07.9575261Z","duration":"PT0.538135S","correlationId":"0ece7584-990c-4f2e-b0c9-83930af80bc5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss11LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss11/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c121"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss11VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_n59ZB3o6wFpRhJPy0iIA0euyWJjyJZIU/operationStatuses/08586980828206009935?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_KGDtWQHE41IcS70o4fjWvRD49kEWqL8a/operationStatuses/08586972371980582438?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3586']
+      content-length: ['3584']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:25 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1184']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -256,19 +258,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:34:55 GMT']
+      date: ['Sat, 02 Sep 2017 16:28:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -282,19 +284,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:35:26 GMT']
+      date: ['Sat, 02 Sep 2017 16:29:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -308,19 +310,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:35:56 GMT']
+      date: ['Sat, 02 Sep 2017 16:29:39 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -334,19 +336,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:36:26 GMT']
+      date: ['Sat, 02 Sep 2017 16:30:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -360,19 +362,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:36:57 GMT']
+      date: ['Sat, 02 Sep 2017 16:30:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -386,19 +388,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:27 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -412,19 +414,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980828206009935?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972371980582438?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:57 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -438,19 +440,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_n59ZB3o6wFpRhJPy0iIA0euyWJjyJZIU","name":"vmss_deploy_n59ZB3o6wFpRhJPy0iIA0euyWJjyJZIU","properties":{"templateHash":"18248750515147547487","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-23T21:37:46.6459828Z","duration":"PT3M21.7693447S","correlationId":"999d8eb4-f16f-4921-a09c-1e39fcefb213","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss11LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss11/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c121"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss11VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss15347","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss15347Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss15347IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/backendAddressPools/vmss11LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/inboundNatPools/vmss11LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForLinux","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"MSIExtension"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"dade5ae2-1bb2-4396-b344-297fc3e1ff5b"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_KGDtWQHE41IcS70o4fjWvRD49kEWqL8a","name":"vmss_deploy_KGDtWQHE41IcS70o4fjWvRD49kEWqL8a","properties":{"templateHash":"6346625774394686626","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:31:30.0629117Z","duration":"PT3M22.6435206S","correlationId":"0ece7584-990c-4f2e-b0c9-83930af80bc5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss11LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss11/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121","resourceType":"Microsoft.Authorization/roleAssignments","resourceName":"cd58500a-f421-4815-b5cf-a36a1e16c121"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss11VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss11LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss11"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss15d93","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss15d93Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss15d93IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/backendAddressPools/vmss11LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/inboundNatPools/vmss11LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForLinux","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"ManagedIdentityExtensionForLinux"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"90eae0b8-ff28-40e3-8f90-6de3660ce354"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c121"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss11LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['6583']
+      content-length: ['6602']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:40 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -464,8 +466,8 @@ interactions:
       CommandName: [vmss extension list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11?api-version=2017-03-30
@@ -474,7 +476,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 1\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss15347\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss15d93\"\
         ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -484,9 +486,9 @@ interactions:
         \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"credativ\"\
         ,\r\n          \"offer\": \"Debian\",\r\n          \"sku\": \"8\",\r\n   \
         \       \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\"\
-        : {\"networkInterfaceConfigurations\":[{\"name\":\"vmss15347Nic\",\"properties\"\
+        : {\"networkInterfaceConfigurations\":[{\"name\":\"vmss15d93Nic\",\"properties\"\
         :{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"\
-        dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"vmss15347IPConfig\",\"\
+        dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"vmss15d93IPConfig\",\"\
         properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss11LB/backendAddressPools/vmss11LBBEPool\"\
@@ -496,20 +498,20 @@ interactions:
         : \"Microsoft.ManagedIdentity\",\r\n              \"type\": \"ManagedIdentityExtensionForLinux\"\
         ,\r\n              \"typeHandlerVersion\": \"1.0\",\r\n              \"autoUpgradeMinorVersion\"\
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
-        \n            \"name\": \"MSIExtension\"\r\n          }\r\n        ]\r\n \
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\"\
-        : true,\r\n    \"uniqueId\": \"dade5ae2-1bb2-4396-b344-297fc3e1ff5b\"\r\n\
-        \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
-        location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"\
-        type\": \"SystemAssigned\",\r\n    \"principalId\": \"5f815bb4-897a-4692-b349-0d9465caacc3\"\
+        \n            \"name\": \"ManagedIdentityExtensionForLinux\"\r\n         \
+        \ }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"90eae0b8-ff28-40e3-8f90-6de3660ce354\"\
+        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"fa3a724f-9088-461d-8acb-365b2b3c3746\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11\"\
         ,\r\n  \"name\": \"vmss11\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2996']
+      content-length: ['3016']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -525,9 +527,9 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -537,7 +539,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:58 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -595,22 +597,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:37:59 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:42 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Wed, 23 Aug 2017 21:42:59 GMT']
-      source-age: ['0']
+      expires: ['Sat, 02 Sep 2017 16:36:42 GMT']
+      source-age: ['217']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [9206cbb0ede9df776cb5333148d75009a7af955c]
+      x-fastly-request-id: [41cb98bd53abe3d504906503c30a859d342d5970]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['FB06:100D1:D4807:E0231:599DF5B7']
-      x-served-by: [cache-dfw1842-DFW]
-      x-timer: ['S1503524280.731251,VS0,VE57']
+      x-github-request-id: ['D30C:28148:402953:44EB57:59AADC15']
+      x-served-by: [cache-sjc3635-SJC]
+      x-timer: ['S1504369903.994048,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -621,37 +623,38 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss11VNET\"\
         ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"a900d2e5-580c-4e86-8002-dead52a4291a\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"dafa1f8b-ca06-4485-8385-d0b2cca982b2\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"2407540f-97c4-472d-baf7-2efb926676d5\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"5c059219-0f83-4154-8e98-f498f67fd4db\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vmss11Subnet\",\r\n        \
         \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"a900d2e5-580c-4e86-8002-dead52a4291a\\\"\
+        ,\r\n            \"etag\": \"W/\\\"dafa1f8b-ca06-4485-8385-d0b2cca982b2\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
-        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/0/networkInterfaces/vmss15347Nic/ipConfigurations/vmss15347IPConfig\"\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/0/networkInterfaces/vmss15d93Nic/ipConfigurations/vmss15d93IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/1/networkInterfaces/vmss15347Nic/ipConfigurations/vmss15347IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/1/networkInterfaces/vmss15d93Nic/ipConfigurations/vmss15d93IPConfig\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
-        \n        ],\r\n        \"virtualNetworkPeerings\": []\r\n      }\r\n    }\r\
-        \n  ]\r\n}"}
+        \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
+        : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
+        \  ]\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2032']
+      content-length: ['2110']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:38:00 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -667,12 +670,12 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 authorizationmanagementclient/0.30.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27reader%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27reader%27&api-version=2015-07-01
   response:
     body: {string: '{"value":[{"properties":{"roleName":"Reader","type":"BuiltInRole","description":"Lets
         you view everything, but not make any changes.","assignableScopes":["/"],"permissions":[{"actions":["*/read"],"notActions":[]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-08-19T00:03:56.0652623Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","type":"Microsoft.Authorization/roleDefinitions","name":"acdd72a7-3385-48ef-bd42-f606fba81ae7"}]}'}
@@ -680,7 +683,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['578']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:38:00 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -692,72 +695,72 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
-      {"parameters": {}, "resources": [{"location": "westus", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "dependsOn": [], "apiVersion": "2015-06-15", "name": "vmss2LBPublicIP",
-      "tags": {}, "type": "Microsoft.Network/publicIPAddresses"}, {"location": "westus",
-      "properties": {"frontendIPConfigurations": [{"properties": {"publicIPAddress":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}], "backendAddressPools": [{"name": "vmss2LBBEPool"}],
-      "inboundNatPools": [{"properties": {"frontendPortRangeEnd": "50119", "frontendIPConfiguration":
-      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss2LB\''),
-      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "frontendPortRangeStart":
-      "50000", "backendPort": 3389, "protocol": "tcp"}, "name": "vmss2LBNatPool"}]},
-      "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"], "apiVersion":
-      "2015-06-15", "name": "vmss2LB", "tags": {}, "type": "Microsoft.Network/loadBalancers"},
-      {"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"contentVersion":
+      "1.0.0.0", "variables": {}, "resources": [{"dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "properties": {"publicIPAllocationMethod": "Dynamic"}, "name": "vmss2LBPublicIP",
+      "sku": {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01", "location":
+      "westus"}, {"dependsOn": ["Microsoft.Network/publicIpAddresses/vmss2LBPublicIP"],
+      "type": "Microsoft.Network/loadBalancers", "properties": {"frontendIPConfigurations":
+      [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendPortRangeEnd":
+      "50119", "protocol": "tcp", "backendPort": 3389, "frontendPortRangeStart": "50000",
+      "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss2LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}},
+      "name": "vmss2LBNatPool"}], "backendAddressPools": [{"name": "vmss2LBBEPool"}]},
+      "name": "vmss2LB", "sku": {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01",
+      "location": "westus"}, {"apiVersion": "2015-07-01", "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss2"],
+      "type": "Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments",
+      "properties": {"scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11",
       "principalId": "[reference(\''/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default\'',
-      \''2015-08-31-PREVIEW\'').principalId]", "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11"},
-      "name": "vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122",
-      "dependsOn": ["Microsoft.Compute/virtualMachineScaleSets/vmss2"], "apiVersion":
-      "2015-07-01", "type": "Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments"},
-      {"location": "westus", "properties": {"upgradePolicy": {"mode": "Manual"}, "virtualMachineProfile":
-      {"extensionProfile": {"extensions": [{"properties": {"autoUpgradeMinorVersion":
-      true, "typeHandlerVersion": "1.0", "settings": {"port": 50342}, "type": "ManagedIdentityExtensionForWindows",
-      "publisher": "Microsoft.ManagedIdentity"}, "name": "MSIExtension"}]}, "osProfile":
-      {"adminUsername": "admin123", "adminPassword": "PasswordPassword1!", "computerNamePrefix":
-      "vmss26c16"}, "storageProfile": {"imageReference": {"version": "latest", "offer":
-      "WindowsServer", "sku": "2016-Datacenter", "publisher": "MicrosoftWindowsServer"},
-      "osDisk": {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage",
-      "caching": "ReadWrite"}}, "networkProfile": {"networkInterfaceConfigurations":
+      \''2015-08-31-PREVIEW\'').principalId]", "roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"},
+      "name": "vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122"},
+      {"dependsOn": ["Microsoft.Network/loadBalancers/vmss2LB"], "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "properties": {"overprovision": true, "upgradePolicy": {"mode": "Manual"}, "singlePlacementGroup":
+      true, "virtualMachineProfile": {"networkProfile": {"networkInterfaceConfigurations":
       [{"properties": {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
       [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}],
-      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"}},
-      "name": "vmss26c16IPConfig"}]}, "name": "vmss26c16Nic"}]}}, "singlePlacementGroup":
-      true, "overprovision": true}, "dependsOn": ["Microsoft.Network/loadBalancers/vmss2LB"],
-      "identity": {"type": "systemAssigned"}, "apiVersion": "2017-03-30", "sku": {"capacity":
-      1, "name": "Standard_D1_v2", "tier": "Standard"}, "name": "vmss2", "tags": {},
-      "type": "Microsoft.Compute/virtualMachineScaleSets"}], "contentVersion": "1.0.0.0",
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]},
+      "name": "vmss240c6IPConfig"}]}, "name": "vmss240c6Nic"}]}, "storageProfile":
+      {"imageReference": {"publisher": "MicrosoftWindowsServer", "offer": "WindowsServer",
+      "version": "latest", "sku": "2016-Datacenter"}, "osDisk": {"caching": "ReadWrite",
+      "createOption": "FromImage", "managedDisk": {"storageAccountType": null}}},
+      "extensionProfile": {"extensions": [{"properties": {"publisher": "Microsoft.ManagedIdentity",
+      "typeHandlerVersion": "1.0", "settings": {"port": 50342}, "type": "ManagedIdentityExtensionForWindows",
+      "autoUpgradeMinorVersion": true}, "name": "ManagedIdentityExtensionForWindows"}]},
+      "osProfile": {"adminPassword": "PasswordPassword1!", "adminUsername": "admin123",
+      "computerNamePrefix": "vmss240c6"}}}, "name": "vmss2", "sku": {"tier": "Standard",
+      "name": "Standard_D1_v2", "capacity": 1}, "tags": {}, "apiVersion": "2017-03-30",
+      "identity": {"type": "systemAssigned"}, "location": "westus"}], "outputs": {"VMSS":
+      {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
       \''vmss2\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}}}}'''
+      "type": "object"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['4581']
+      Content-Length: ['4655']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_AWuL7Pl59FpRK7CMzA6JakISXwt8ZUFQ","name":"vmss_deploy_AWuL7Pl59FpRK7CMzA6JakISXwt8ZUFQ","properties":{"templateHash":"10239601876627738574","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-23T21:38:01.9301139Z","duration":"PT0.6538768S","correlationId":"9ecd015d-b2df-43de-86c5-0043e3783982","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_5e3Itv9M5ak6aaunTxwUzLcFxUxW48K6","name":"vmss_deploy_5e3Itv9M5ak6aaunTxwUzLcFxUxW48K6","properties":{"templateHash":"3765298443504471026","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:31:46.7009094Z","duration":"PT1.89706S","correlationId":"6b3d323a-861e-4df0-a096-34851e24b011","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_AWuL7Pl59FpRK7CMzA6JakISXwt8ZUFQ/operationStatuses/08586980826042013873?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_5e3Itv9M5ak6aaunTxwUzLcFxUxW48K6/operationStatuses/08586972369806737770?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['3324']
+      content-length: ['3321']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:38:01 GMT']
+      date: ['Sat, 02 Sep 2017 16:31:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -767,19 +770,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:38:32 GMT']
+      date: ['Sat, 02 Sep 2017 16:32:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -793,19 +796,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:39:02 GMT']
+      date: ['Sat, 02 Sep 2017 16:32:50 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -819,19 +822,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:39:32 GMT']
+      date: ['Sat, 02 Sep 2017 16:33:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -845,19 +848,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:40:03 GMT']
+      date: ['Sat, 02 Sep 2017 16:33:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -871,19 +874,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:40:32 GMT']
+      date: ['Sat, 02 Sep 2017 16:34:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -897,19 +900,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:41:03 GMT']
+      date: ['Sat, 02 Sep 2017 16:34:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -923,19 +926,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:41:33 GMT']
+      date: ['Sat, 02 Sep 2017 16:35:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -949,19 +952,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:42:04 GMT']
+      date: ['Sat, 02 Sep 2017 16:35:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -975,19 +978,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:42:34 GMT']
+      date: ['Sat, 02 Sep 2017 16:36:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1001,19 +1004,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:43:05 GMT']
+      date: ['Sat, 02 Sep 2017 16:36:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1027,19 +1030,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:43:34 GMT']
+      date: ['Sat, 02 Sep 2017 16:37:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1053,19 +1056,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:44:05 GMT']
+      date: ['Sat, 02 Sep 2017 16:37:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1079,123 +1082,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:44:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:45:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:45:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      CommandName: [vmss create]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980826042013873?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972369806737770?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:36 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1209,19 +1108,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_AWuL7Pl59FpRK7CMzA6JakISXwt8ZUFQ","name":"vmss_deploy_AWuL7Pl59FpRK7CMzA6JakISXwt8ZUFQ","properties":{"templateHash":"10239601876627738574","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-23T21:46:26.417841Z","duration":"PT8M25.1416039S","correlationId":"9ecd015d-b2df-43de-86c5-0043e3783982","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss26c16","adminUsername":"admin123","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss26c16Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss26c16IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForWindows","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"MSIExtension"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"af669b29-80d2-43f3-851e-884c0d6fb97a"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_5e3Itv9M5ak6aaunTxwUzLcFxUxW48K6","name":"vmss_deploy_5e3Itv9M5ak6aaunTxwUzLcFxUxW48K6","properties":{"templateHash":"3765298443504471026","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:37:59.8989144Z","duration":"PT6M15.095065S","correlationId":"6b3d323a-861e-4df0-a096-34851e24b011","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets/providers/roleAssignments","locations":[null]},{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss2LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/providers/Microsoft.ManagedIdentity/Identities/default","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/Identities","resourceName":"vmss2/Microsoft.ManagedIdentity/default","apiVersion":"2015-08-31-PREVIEW"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122","resourceType":"Microsoft.Compute/virtualMachineScaleSets/providers/roleAssignments","resourceName":"vmss11/Microsoft.Authorization/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss2LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss2"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss240c6","adminUsername":"admin123","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2016-Datacenter","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss240c6Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss240c6IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"properties":{"publisher":"Microsoft.ManagedIdentity","type":"ManagedIdentityExtensionForWindows","typeHandlerVersion":"1.0","autoUpgradeMinorVersion":true,"settings":{"port":50342}},"name":"ManagedIdentityExtensionForWindows"}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"79692a92-4ef7-4ad0-94af-b40afbf2892b"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/providers/Microsoft.Authorization/roleAssignments/cd58500a-f421-4815-b5cf-a36a1e16c122"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss2LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['6220']
+      content-length: ['6241']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:37 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1235,8 +1134,8 @@ interactions:
       CommandName: [vmss extension list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2?api-version=2017-03-30
@@ -1245,7 +1144,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 1\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss26c16\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss240c6\"\
         ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"windowsConfiguration\"\
         : {\r\n          \"provisionVMAgent\": true,\r\n          \"enableAutomaticUpdates\"\
         : true\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\"\
@@ -1256,9 +1155,9 @@ interactions:
         MicrosoftWindowsServer\",\r\n          \"offer\": \"WindowsServer\",\r\n \
         \         \"sku\": \"2016-Datacenter\",\r\n          \"version\": \"latest\"\
         \r\n        }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\"\
-        :[{\"name\":\"vmss26c16Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
+        :[{\"name\":\"vmss240c6Nic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\"\
         :false,\"dnsSettings\":{\"dnsServers\":[]},\"ipConfigurations\":[{\"name\"\
-        :\"vmss26c16IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet\"\
+        :\"vmss240c6IPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/backendAddressPools/vmss2LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss2LB/inboundNatPools/vmss2LBNatPool\"\
@@ -1267,20 +1166,20 @@ interactions:
         : \"Microsoft.ManagedIdentity\",\r\n              \"type\": \"ManagedIdentityExtensionForWindows\"\
         ,\r\n              \"typeHandlerVersion\": \"1.0\",\r\n              \"autoUpgradeMinorVersion\"\
         : true,\r\n              \"settings\": {\"port\":50342}\r\n            },\r\
-        \n            \"name\": \"MSIExtension\"\r\n          }\r\n        ]\r\n \
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\"\
-        : true,\r\n    \"uniqueId\": \"af669b29-80d2-43f3-851e-884c0d6fb97a\"\r\n\
-        \  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"\
-        location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n    \"\
-        type\": \"SystemAssigned\",\r\n    \"principalId\": \"17aec090-fd7a-4242-afe5-f6925e14e095\"\
+        \n            \"name\": \"ManagedIdentityExtensionForWindows\"\r\n       \
+        \   }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\
+        ,\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"79692a92-4ef7-4ad0-94af-b40afbf2892b\"\
+        \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
+        \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"identity\": {\r\n \
+        \   \"type\": \"SystemAssigned\",\r\n    \"principalId\": \"46e996a2-25c3-4205-a633-f2172cfa8b1a\"\
         ,\r\n    \"tenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\"\r\n  },\r\n\
         \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2\"\
         ,\r\n  \"name\": \"vmss2\"\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['3058']
+      content-length: ['3080']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:38 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1296,9 +1195,9 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -1308,7 +1207,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:38 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1366,22 +1265,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:39 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:28 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Wed, 23 Aug 2017 21:51:39 GMT']
-      source-age: ['236']
+      expires: ['Sat, 02 Sep 2017 16:43:28 GMT']
+      source-age: ['209']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
       x-cache: [HIT]
       x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [f8e22279fee4adb4612ba13ecf1c7127e291bd5e]
+      x-fastly-request-id: [7b6699d0a01dc72ccda0808c7b94b575337e674e]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['63FA:1E3AD:6593C:6DC5A:599DF6D3']
-      x-served-by: [cache-sea1048-SEA]
-      x-timer: ['S1503524799.253861,VS0,VE1']
+      x-github-request-id: ['4CA8:13A1B:5A7D5E:631D44:59AADDB1']
+      x-served-by: [cache-sjc3128-SJC]
+      x-timer: ['S1504370308.247522,VS0,VE1']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -1392,39 +1291,40 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vmss11VNET\"\
         ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET\"\
-        ,\r\n      \"etag\": \"W/\\\"57387cc4-d28b-4820-88dd-48dff80e8995\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"c8f8ae1d-7966-4297-ba78-f5fdbd027b28\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/virtualNetworks\",\r\n      \"location\"\
         : \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"2407540f-97c4-472d-baf7-2efb926676d5\"\
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"5c059219-0f83-4154-8e98-f498f67fd4db\"\
         ,\r\n        \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n \
         \           \"10.0.0.0/16\"\r\n          ]\r\n        },\r\n        \"subnets\"\
         : [\r\n          {\r\n            \"name\": \"vmss11Subnet\",\r\n        \
         \    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet\"\
-        ,\r\n            \"etag\": \"W/\\\"57387cc4-d28b-4820-88dd-48dff80e8995\\\"\
+        ,\r\n            \"etag\": \"W/\\\"c8f8ae1d-7966-4297-ba78-f5fdbd027b28\\\"\
         \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
         : \"Succeeded\",\r\n              \"addressPrefix\": \"10.0.0.0/24\",\r\n\
         \              \"ipConfigurations\": [\r\n                {\r\n          \
-        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/1/networkInterfaces/vmss15347Nic/ipConfigurations/vmss15347IPConfig\"\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/0/networkInterfaces/vmss15d93Nic/ipConfigurations/vmss15d93IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/0/networkInterfaces/vmss26c16Nic/ipConfigurations/vmss26c16IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/0/networkInterfaces/vmss240c6Nic/ipConfigurations/vmss240c6IPConfig\"\
         \r\n                },\r\n                {\r\n                  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/1/networkInterfaces/vmss26c16Nic/ipConfigurations/vmss26c16IPConfig\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss2/virtualMachines/1/networkInterfaces/vmss240c6Nic/ipConfigurations/vmss240c6IPConfig\"\
         \r\n                }\r\n              ]\r\n            }\r\n          }\r\
-        \n        ],\r\n        \"virtualNetworkPeerings\": []\r\n      }\r\n    }\r\
-        \n  ]\r\n}"}
+        \n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\"\
+        : false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n\
+        \  ]\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['2382']
+      content-length: ['2460']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:38 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1433,62 +1333,63 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
-      {"parameters": {}, "resources": [{"location": "westus", "properties": {"publicIPAllocationMethod":
-      "dynamic"}, "dependsOn": [], "apiVersion": "2015-06-15", "name": "vmss3LBPublicIP",
-      "tags": {}, "type": "Microsoft.Network/publicIPAddresses"}, {"location": "westus",
-      "properties": {"frontendIPConfigurations": [{"properties": {"publicIPAddress":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}},
-      "name": "loadBalancerFrontEnd"}], "backendAddressPools": [{"name": "vmss3LBBEPool"}],
-      "inboundNatPools": [{"properties": {"frontendPortRangeEnd": "50119", "frontendIPConfiguration":
-      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss3LB\''),
-      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "frontendPortRangeStart":
-      "50000", "backendPort": 22, "protocol": "tcp"}, "name": "vmss3LBNatPool"}]},
-      "dependsOn": ["Microsoft.Network/publicIpAddresses/vmss3LBPublicIP"], "apiVersion":
-      "2015-06-15", "name": "vmss3LB", "tags": {}, "type": "Microsoft.Network/loadBalancers"},
-      {"location": "westus", "properties": {"upgradePolicy": {"mode": "Manual"}, "virtualMachineProfile":
-      {"osProfile": {"adminUsername": "admin123", "adminPassword": "PasswordPassword1!",
-      "computerNamePrefix": "vmss327f6"}, "storageProfile": {"imageReference": {"version":
-      "latest", "offer": "Debian", "sku": "8", "publisher": "credativ"}, "osDisk":
-      {"managedDisk": {"storageAccountType": null}, "createOption": "FromImage", "caching":
-      "ReadWrite"}}, "networkProfile": {"networkInterfaceConfigurations": [{"properties":
-      {"primary": "true", "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"contentVersion":
+      "1.0.0.0", "variables": {}, "resources": [{"dependsOn": [], "type": "Microsoft.Network/publicIPAddresses",
+      "properties": {"publicIPAllocationMethod": "Dynamic"}, "name": "vmss3LBPublicIP",
+      "sku": {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01", "location":
+      "westus"}, {"dependsOn": ["Microsoft.Network/publicIpAddresses/vmss3LBPublicIP"],
+      "type": "Microsoft.Network/loadBalancers", "properties": {"frontendIPConfigurations":
+      [{"properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}},
+      "name": "loadBalancerFrontEnd"}], "inboundNatPools": [{"properties": {"frontendPortRangeEnd":
+      "50119", "protocol": "tcp", "backendPort": 22, "frontendPortRangeStart": "50000",
+      "frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
+      \''vmss3LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}},
+      "name": "vmss3LBNatPool"}], "backendAddressPools": [{"name": "vmss3LBBEPool"}]},
+      "name": "vmss3LB", "sku": {"name": "Basic"}, "tags": {}, "apiVersion": "2017-08-01",
+      "location": "westus"}, {"dependsOn": ["Microsoft.Network/loadBalancers/vmss3LB"],
+      "type": "Microsoft.Compute/virtualMachineScaleSets", "properties": {"overprovision":
+      true, "upgradePolicy": {"mode": "Manual"}, "singlePlacementGroup": true, "virtualMachineProfile":
+      {"networkProfile": {"networkInterfaceConfigurations": [{"properties": {"primary":
+      "true", "ipConfigurations": [{"properties": {"loadBalancerBackendAddressPools":
       [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],
-      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}],
-      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"}},
-      "name": "vmss327f6IPConfig"}]}, "name": "vmss327f6Nic"}]}}, "singlePlacementGroup":
-      true, "overprovision": true}, "dependsOn": ["Microsoft.Network/loadBalancers/vmss3LB"],
-      "apiVersion": "2017-03-30", "sku": {"capacity": 1, "name": "Standard_D1_v2",
-      "tier": "Standard"}, "name": "vmss3", "tags": {}, "type": "Microsoft.Compute/virtualMachineScaleSets"}],
-      "contentVersion": "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "variables": {}, "outputs": {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]},
+      "name": "vmss3062bIPConfig"}]}, "name": "vmss3062bNic"}]}, "storageProfile":
+      {"imageReference": {"publisher": "credativ", "offer": "Debian", "version": "latest",
+      "sku": "8"}, "osDisk": {"caching": "ReadWrite", "createOption": "FromImage",
+      "managedDisk": {"storageAccountType": null}}}, "osProfile": {"adminPassword":
+      "PasswordPassword1!", "adminUsername": "admin123", "computerNamePrefix": "vmss3062b"}}},
+      "name": "vmss3", "sku": {"tier": "Standard", "name": "Standard_D1_v2", "capacity":
+      1}, "tags": {}, "apiVersion": "2017-03-30", "location": "westus"}], "outputs":
+      {"VMSS": {"value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
       \''vmss3\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]",
-      "type": "object"}}}}}'''
+      "type": "object"}}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "parameters": {}}, "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['3276']
+      Content-Length: ['3328']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_lFR3zw2Ni5cN4C6TdR0pZFSNjzFdxzLL","name":"vmss_deploy_lFR3zw2Ni5cN4C6TdR0pZFSNjzFdxzLL","properties":{"templateHash":"9048127037669982292","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-23T21:46:47.7681469Z","duration":"PT0.4759063S","correlationId":"852e1680-ed64-4741-9b2b-1a3733556f0a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZXgxPmsVvjKJY3asxww40tbZIGoMm3Kd","name":"vmss_deploy_ZXgxPmsVvjKJY3asxww40tbZIGoMm3Kd","properties":{"templateHash":"2074726559376603107","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-02T16:38:30.3238217Z","duration":"PT0.5660598S","correlationId":"cf9179a2-8b4f-4c19-b5eb-41fefabb64d0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_lFR3zw2Ni5cN4C6TdR0pZFSNjzFdxzLL/operationStatuses/08586980820781853826?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZXgxPmsVvjKJY3asxww40tbZIGoMm3Kd/operationStatuses/08586972365757198600?api-version=2017-05-10']
       cache-control: [no-cache]
       content-length: ['2025']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:46:46 GMT']
+      date: ['Sat, 02 Sep 2017 16:38:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1498,19 +1399,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980820781853826?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:47:17 GMT']
+      date: ['Sat, 02 Sep 2017 16:39:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1524,19 +1425,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980820781853826?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:47:47 GMT']
+      date: ['Sat, 02 Sep 2017 16:39:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1550,19 +1451,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980820781853826?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:48:18 GMT']
+      date: ['Sat, 02 Sep 2017 16:40:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1576,19 +1477,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980820781853826?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:48:48 GMT']
+      date: ['Sat, 02 Sep 2017 16:40:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1602,19 +1503,45 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980820781853826?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 02 Sep 2017 16:41:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586972365757198600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:49:18 GMT']
+      date: ['Sat, 02 Sep 2017 16:41:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1628,19 +1555,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_lFR3zw2Ni5cN4C6TdR0pZFSNjzFdxzLL","name":"vmss_deploy_lFR3zw2Ni5cN4C6TdR0pZFSNjzFdxzLL","properties":{"templateHash":"9048127037669982292","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-23T21:49:01.4463442Z","duration":"PT2M14.1541036S","correlationId":"852e1680-ed64-4741-9b2b-1a3733556f0a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss327f6","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss327f6Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss327f6IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"61771b98-776e-4b59-ae64-31962f4b1eb8"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_ZXgxPmsVvjKJY3asxww40tbZIGoMm3Kd","name":"vmss_deploy_ZXgxPmsVvjKJY3asxww40tbZIGoMm3Kd","properties":{"templateHash":"2074726559376603107","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-02T16:41:15.5983643Z","duration":"PT2M45.8406024S","correlationId":"cf9179a2-8b4f-4c19-b5eb-41fefabb64d0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmss3LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss3LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss3"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss3062b","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"credativ","offer":"Debian","sku":"8","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss3062bNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss3062bIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss11VNET/subnets/vmss11Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/backendAddressPools/vmss3LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB/inboundNatPools/vmss3LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"ca31edb0-93fd-4014-b609-c4ce53345997"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss3LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vmss3LBPublicIP"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['4328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:49:18 GMT']
+      date: ['Sat, 02 Sep 2017 16:41:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1655,9 +1582,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -1666,11 +1593,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 23 Aug 2017 21:49:19 GMT']
+      date: ['Sat, 02 Sep 2017 16:41:34 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkc1U0xCS0ZXQjUzU05GUEtaTlNMTVBQNzRWNFRWWlJMU0tCRHw0MUREMUZCQTc2QzlFQjBGLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkc0RDZUTUM1S001UVpRNTVJQVFFVDRTQ0w1NlVMTE9aNFBMSnxEODEzNkZBM0U0NjFERDdDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1977,7 +1977,6 @@ class MSIScenarioTest(ScenarioTest):
             self.cmd('vm create -g {} -n {} --image debian --assign-identity --admin-username admin123 --admin-password PasswordPassword1!'.format(resource_group, vm1), checks=[
                 JMESPathCheckV2('identity.role', 'Contributor'),
                 JMESPathCheckV2('identity.scope', '/subscriptions/{}/resourceGroups/{}'.format(subscription_id, resource_group)),
-                JMESPathCheckV2('identity.subscription', subscription_id),
                 JMESPathCheckV2('identity.port', 50342)
             ])
 
@@ -1990,7 +1989,6 @@ class MSIScenarioTest(ScenarioTest):
             self.cmd('vm create -g {} -n {} --image Win2016Datacenter --assign-identity --scope {} --role reader --admin-username admin123 --admin-password PasswordPassword1!'.format(resource_group, vm2, vm1_id), checks=[
                 JMESPathCheckV2('identity.role', 'reader'),
                 JMESPathCheckV2('identity.scope', vm1_id),
-                JMESPathCheckV2('identity.subscription', subscription_id),
                 JMESPathCheckV2('identity.port', 50342)
             ])
 
@@ -2006,7 +2004,6 @@ class MSIScenarioTest(ScenarioTest):
             self.cmd('vm assign-identity -g {} -n {} --scope {} --role reader --port 50343'.format(resource_group, vm3, vm1_id), checks=[
                 JMESPathCheckV2('role', 'reader'),
                 JMESPathCheckV2('scope', vm1_id),
-                JMESPathCheckV2('subscription', subscription_id),
                 JMESPathCheckV2('port', 50343)
             ])
 
@@ -2035,7 +2032,6 @@ class MSIScenarioTest(ScenarioTest):
             self.cmd('vmss create -g {} -n {} --image debian --instance-count 1 --assign-identity --admin-username admin123 --admin-password PasswordPassword1!'.format(resource_group, vmss1), checks=[
                 JMESPathCheckV2('vmss.identity.role', 'Contributor'),
                 JMESPathCheckV2('vmss.identity.scope', '/subscriptions/{}/resourceGroups/{}'.format(subscription_id, resource_group)),
-                JMESPathCheckV2('vmss.identity.subscription', subscription_id),
                 JMESPathCheckV2('vmss.identity.port', 50342)
             ])
 
@@ -2049,7 +2045,6 @@ class MSIScenarioTest(ScenarioTest):
             self.cmd('vmss create -g {} -n {} --image Win2016Datacenter --instance-count 1 --assign-identity --scope {} --role reader --admin-username admin123 --admin-password PasswordPassword1!'.format(resource_group, vmss2, vmss1_id), checks=[
                 JMESPathCheckV2('vmss.identity.role', 'reader'),
                 JMESPathCheckV2('vmss.identity.scope', vmss1_id),
-                JMESPathCheckV2('vmss.identity.subscription', subscription_id),
                 JMESPathCheckV2('vmss.identity.port', 50342)
             ])
             self.cmd('vmss extension list -g {} --vmss-name {}'.format(resource_group, vmss2), checks=[
@@ -2067,7 +2062,6 @@ class MSIScenarioTest(ScenarioTest):
                 self.cmd('vmss assign-identity -g {} -n {} --scope "{}" --role reader --port 50343'.format(resource_group, vmss3, vmss1_id), checks=[
                     JMESPathCheckV2('role', 'reader'),
                     JMESPathCheckV2('scope', vmss1_id),
-                    JMESPathCheckV2('subscription', subscription_id),
                     JMESPathCheckV2('port', 50343)
                 ])
 
@@ -2078,8 +2072,6 @@ class MSIScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer()
     def test_msi_no_scope(self, resource_group):
-        subscription_id = self.get_subscription_id()
-
         vm1 = 'vm1'
         vmss1 = 'vmss1'
         vm2 = 'vm2'
@@ -2087,7 +2079,6 @@ class MSIScenarioTest(ScenarioTest):
 
         # create a linux vm with identity but w/o a role assignment (--scope "")
         self.cmd('vm create -g {} -n {} --image debian --assign-identity --admin-username admin123 --admin-password PasswordPassword1! --scope ""'.format(resource_group, vm1), checks=[
-            JMESPathCheckV2('identity.subscription', subscription_id),
             JMESPathCheckV2('identity.scope', ''),
             JMESPathCheckV2('identity.port', 50342)
         ])
@@ -2099,7 +2090,6 @@ class MSIScenarioTest(ScenarioTest):
 
         # create a vmss with identity but w/o a role assignment (--scope "")
         self.cmd('vmss create -g {} -n {} --image debian --assign-identity --admin-username admin123 --admin-password PasswordPassword1! --scope ""'.format(resource_group, vmss1), checks=[
-            JMESPathCheckV2('vmss.identity.subscription', subscription_id),
             JMESPathCheckV2('vmss.identity.scope', ''),
             JMESPathCheckV2('vmss.identity.port', 50342)
         ])
@@ -2115,7 +2105,6 @@ class MSIScenarioTest(ScenarioTest):
         # assign identity but w/o a role assignment
         self.cmd('vm assign-identity -g {} -n {} --scope ""'.format(resource_group, vm2), checks=[
             JMESPathCheckV2('scope', ''),
-            JMESPathCheckV2('subscription', subscription_id),
             JMESPathCheckV2('port', 50342)
         ])
         # the extension should still get provisioned
@@ -2129,7 +2118,6 @@ class MSIScenarioTest(ScenarioTest):
         if self.is_live:
             self.cmd('vmss assign-identity -g {} -n {} --scope ""'.format(resource_group, vmss2), checks=[
                 JMESPathCheckV2('scope', ''),
-                JMESPathCheckV2('subscription', subscription_id),
                 JMESPathCheckV2('port', 50342)
             ])
 


### PR DESCRIPTION
1. This change is according to a recent discussion with Portal folks so to have consistency between CLI and Portal
2. MSI is not a public feature yet, so removing the `subscription` from the output is not deemed as a breaking change. For context, `subscription` was added for users to login through `az login -u <subscription>@50342`; however, such usages have been simplified as `az login --msi`

### General Guidelines

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
