### PR TITLE
Enable module to register its own correlation ID

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+unreleased
+++++++++++
+* Enable command module to set its own correlation ID in telemetry
+
 2.0.15 (2017-08-31)
 +++++++++++++++++++
 * minor fixes

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -47,6 +47,7 @@ class TelemetrySession(object):  # pylint: disable=too-many-instance-attributes
     result_summary = None
     payload_properties = None
     exceptions = []
+    module_correlation = None
 
     def add_exception(self, exception, fault_type, description=None, message=''):
         details = {
@@ -152,6 +153,7 @@ class TelemetrySession(object):  # pylint: disable=too-many-instance-attributes
         self.set_custom_properties(result, 'OutputType', self.output_type)
         self.set_custom_properties(result, 'Parameters', ','.join(self.parameters or []))
         self.set_custom_properties(result, 'PythonVersion', platform.python_version())
+        self.set_custom_properties(result, 'ModuleCorrelation', self.module_correlation)
 
         return result
 
@@ -257,6 +259,11 @@ def set_command_details(command, output_type=None, parameters=None):
     _session.command = command
     _session.output_type = output_type
     _session.parameters = parameters
+
+
+@decorators.suppress_all_exceptions(raise_in_diagnostics=True)
+def set_module_correlation_data(correlation_data):
+    _session.module_correlation = correlation_data[:512]
 
 
 # definitions


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/4363

To register a correlation ID, call method `azure.cli.core.telemetry.set_module_correlation_data` in custom data or invoke it in a common path which all intended commands will go through (example: https://gist.github.com/troydai/cd2511d16ec242d7180bdc3d38169cd4)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
