### PR TITLE
cloud shell: output hostname when runs into credential issues

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -15,7 +15,7 @@ from enum import Enum
 import azure.cli.core.azlogging as azlogging
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core._session import ACCOUNT
-from azure.cli.core.util import CLIError, get_file_json
+from azure.cli.core.util import CLIError, get_file_json, in_cloud_console
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription, init_known_clouds
 
 logger = azlogging.get_az_logger(__name__)
@@ -714,7 +714,8 @@ class CredsCache(object):
         context = self._auth_ctx_factory(tenant, cache=self.adal_token_cache)
         token_entry = context.acquire_token(resource, username, _CLIENT_ID)
         if not token_entry:
-            raise CLIError("Could not retrieve token from local cache, please run 'az login'.")
+            raise CLIError("Could not retrieve token from local cache.{}".format(
+                " Please run 'az login'." if not in_cloud_console() else ''))
 
         if self.adal_token_cache.has_state_changed:
             self.persist_cached_creds()

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -234,3 +234,8 @@ def hash_string(value, length=16, force_lower=False):
     while len(digest) < length:
         digest = digest + digest
     return digest[:length]
+
+
+def in_cloud_console():
+    import os
+    return os.environ.get('ACC_CLOUD', None)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 from azure.cli.core.prompting import prompt_pass, NoTTYException
 from azure.cli.core import get_az_logger
 from azure.cli.core._profile import Profile
-from azure.cli.core.util import CLIError
+from azure.cli.core.util import CLIError, in_cloud_console
 from azure.cli.core.cloud import get_active_cloud
 from azure.cli.core.commands.validators import DefaultStr
 
@@ -102,7 +102,7 @@ def login(username=None, password=None, service_principal=None, tenant=None,
 
     profile = Profile()
 
-    if _in_cloud_console():
+    if in_cloud_console():
         console_tokens = os.environ.get('AZURE_CONSOLE_TOKENS', None)
         if console_tokens:
             return profile.find_subscriptions_in_cloud_console(re.split(';|,', console_tokens))
@@ -149,7 +149,7 @@ def login(username=None, password=None, service_principal=None, tenant=None,
 
 def logout(username=None):
     """Log out to remove access to Azure subscriptions"""
-    if _in_cloud_console():
+    if in_cloud_console():
         raise CLIError(_CLOUD_CONSOLE_ERR_TEMPLATE.format('logout'))
 
     profile = Profile()
@@ -161,8 +161,3 @@ def logout(username=None):
 def list_locations():
     from azure.cli.core.commands.parameters import get_subscription_locations
     return get_subscription_locations()
-
-
-def _in_cloud_console():
-    import os
-    return os.environ.get('ACC_CLOUD', None)


### PR DESCRIPTION
Per discussion, output this field for cross checking kusto system so to nail down the root cause. Also I remove mentionings of `az login` when in a cloud shell

- [na ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [na] Each command and parameter has a meaningful description.
- [na] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
