### PR TITLE
[KeyVault] Fix permission case sensitivity and VM format-secret command

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -93,7 +93,7 @@ class LiveScenarioTest(IntegrationTestBase):
 class ExecutionResult(object):
     def __init__(self, command, expect_failure=False, in_process=True):
         if in_process:
-            self._in_process_execute(command)
+            self._in_process_execute(command, expect_failure=expect_failure)
         else:
             self._out_of_process_execute(command)
 
@@ -135,7 +135,7 @@ class ExecutionResult(object):
 
         return self.json_value
 
-    def _in_process_execute(self, command):
+    def _in_process_execute(self, command, expect_failure=False):
         from azure.cli.main import main as cli_main
         from six import StringIO
         from vcr.errors import CannotOverwriteExistingCassetteException
@@ -155,7 +155,11 @@ class ExecutionResult(object):
         except CannotOverwriteExistingCassetteException as ex:
             raise AssertionError(ex)
         except CliExecutionError as ex:
-            if ex.exception:
+            if expect_failure:
+                self.exit_code = 1
+                self.output = stdout_buf.getvalue()
+                self.applog = logging_buf.getvalue()
+            elif ex.exception:
                 raise ex.exception
             else:
                 raise ex

--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -3,10 +3,13 @@
 Release History
 ===============
 
+unreleased
+++++++++++++++++++
+* `keyvault set-policy`: Fix issue where permissions were case sensitive.
+
 2.0.9 (2017-08-31)
 ++++++++++++++++++
 * `keyvault secret download`: Fix bug when trying to automatically resolve secret encoding.
-
 
 2.0.8 (2017-07-07)
 ++++++++++++++++++

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -24,7 +24,7 @@ from azure.cli.command_modules.keyvault._validators import \
     (datetime_type, certificate_type,
      get_attribute_validator,
      vault_base_url_type, validate_key_import_source,
-     validate_key_type, validate_key_ops, validate_policy_permissions,
+     validate_key_type, validate_policy_permissions,
      validate_principal, validate_resource_group_name,
      validate_x509_certificate_chain,
      process_certificate_cancel_namespace,
@@ -71,10 +71,6 @@ def get_keyvault_version_completion_list(resource_name):
 
 # CUSTOM CHOICE LISTS
 
-key_permission_values = ', '.join([x.value for x in KeyPermissions])
-secret_permission_values = ', '.join([x.value for x in SecretPermissions])
-certificate_permission_values = ', '.join([x.value for x in CertificatePermissions])
-json_web_key_op_values = ', '.join([x.value for x in JsonWebKeyOperation])
 secret_encoding_values = secret_text_encoding_values + secret_binary_encoding_values
 certificate_format_values = ['PEM', 'DER']
 
@@ -157,15 +153,14 @@ register_cli_argument('keyvault list', 'resource_group_name', resource_group_nam
 
 register_cli_argument('keyvault delete-policy', 'object_id', validator=validate_principal)
 register_cli_argument('keyvault set-policy', 'key_permissions', metavar='PERM', nargs='*',
-                      help='Space separated list. Possible values: {}'.format(
-                          key_permission_values), arg_group='Permission',
-                      validator=validate_policy_permissions)
+                      help='Space separated list of key permissions to assign.', arg_group='Permission',
+                      validator=validate_policy_permissions, **enum_choice_list(KeyPermissions))
 register_cli_argument('keyvault set-policy', 'secret_permissions', metavar='PERM', nargs='*',
-                      help='Space separated list. Possible values: {}'.format(
-                          secret_permission_values), arg_group='Permission')
+                      help='Space separated list of secret permissions to assign.', arg_group='Permission',
+                      **enum_choice_list(SecretPermissions))
 register_cli_argument('keyvault set-policy', 'certificate_permissions', metavar='PERM', nargs='*',
-                      help='Space separated list. Possible values: {}'.format(
-                          certificate_permission_values), arg_group='Permission')
+                      help='Space separated list of certificate permissions to assign.', arg_group='Permission',
+                      **enum_choice_list(CertificatePermissions))
 
 
 for item in ['key', 'secret', 'certificate']:
@@ -180,9 +175,8 @@ register_cli_argument('keyvault certificate pending', 'certificate_name',
                       id_part='child_name', completer=None)
 
 register_cli_argument('keyvault key', 'key_ops', options_list=('--ops'), nargs='*',
-                      help='Space separated list of permitted JSON web key operations. Possible '
-                           'values: {}'.format(json_web_key_op_values),
-                      validator=validate_key_ops, type=str.lower)
+                      help='Space separated list of permitted JSON web key operations.',
+                      **enum_choice_list(JsonWebKeyOperation))
 register_cli_argument('keyvault key', 'key_version', options_list=('--version', '-v'),
                       help='The key version. If omitted, uses the latest version.', default='',
                       required=False, completer=get_keyvault_version_completion_list('key'))
@@ -241,7 +235,7 @@ register_extra_cli_argument('keyvault secret set', 'file_path', options_list=('-
                             completer=FilesCompleter(), arg_group='Content Source')
 register_extra_cli_argument('keyvault secret set', 'encoding', options_list=('--encoding', '-e'),
                             help='Source file encoding. The value is saved as a tag '
-                                 '(`file-encoding=<val>`) and used during download to automtically '
+                                 '(`file-encoding=<val>`) and used during download to automatically '
                                  'encode the resulting file.',
                             default='utf-8', validator=process_secret_set_namespace,
                             arg_group='Content Source', **enum_choice_list(secret_encoding_values))

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
@@ -10,15 +10,11 @@ from datetime import datetime
 import re
 
 from azure.mgmt.keyvault import KeyVaultManagementClient
-from azure.mgmt.keyvault.models.key_vault_management_client_enums import \
-    (KeyPermissions, SecretPermissions, CertificatePermissions)
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.arm import parse_resource_id
 from azure.cli.core.commands.validators import validate_tags
 from azure.cli.core.util import CLIError
-
-from azure.keyvault.models import JsonWebKeyOperation
 
 secret_text_encoding_values = ['utf-8', 'utf-16le', 'utf-16be', 'ascii']
 secret_binary_encoding_values = ['base64', 'hex']
@@ -129,13 +125,6 @@ def validate_key_import_source(ns):
         raise ValueError('--pem-password must be used with --pem-file')
 
 
-def validate_key_ops(ns):
-    allowed = [x.value.lower() for x in JsonWebKeyOperation]
-    for p in ns.key_ops or []:
-        if p not in allowed:
-            raise ValueError("unrecognized key operation '{}'".format(p))
-
-
 def validate_key_type(ns):
     if ns.destination:
         dest_to_type_map = {
@@ -157,22 +146,6 @@ def validate_policy_permissions(ns):
             None,
             'specify at least one: --key-permissions, --secret-permissions, '
             '--certificate-permissions')
-
-    key_allowed = [x.value for x in KeyPermissions]
-    secret_allowed = [x.value for x in SecretPermissions]
-    cert_allowed = [x.value for x in CertificatePermissions]
-
-    for p in key_perms or []:
-        if p not in key_allowed:
-            raise ValueError("unrecognized key permission '{}'".format(p))
-
-    for p in secret_perms or []:
-        if p not in secret_allowed:
-            raise ValueError("unrecognized secret permission '{}'".format(p))
-
-    for p in cert_perms or []:
-        if p not in cert_allowed:
-            raise ValueError("unrecognized cert permission '{}'".format(p))
 
 
 def validate_principal(ns):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_certificate.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_certificate.yaml
@@ -1,32 +1,58 @@
 interactions:
 - request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_cert000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_cert000001","name":"cli_test_keyvault_cert000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 16:25:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d22ca480-9413-11e7-b087-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:30:51 GMT']
-      duration: ['650860']
+      date: ['Fri, 08 Sep 2017 16:25:47 GMT']
+      duration: ['787278']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U=]
-      ocp-aad-session-key: [8ZLafW_mnMm2Yf1_-QM5sBZ3HxjtQ0u2UJEXC1v2Tp-HfKTzt8tbatcmmmKnh4TbP77ggK8t9fQYHNm2OAcxdBslr2yFPixZT8kvwcFljgcnjmNBxQS5W-NfFeFcE-ey.DzzpflYtRSDwWMY_dUDTtNMRFyUPNYt1vHklbVi0KEU]
+      ocp-aad-diagnostics-server-name: [kLgfBDBbbmdI5i6h/TZLDCS0c4hDk+160Sy1hFyeaqo=]
+      ocp-aad-session-key: [nepWk_0kwC_G4Omy0UIHwcutyxnDWOGWepyh692HQpNjYhzISz5_IiorfONe4KU33Qj1oyyvpmvRzpM8b-krzhBVj-JnHLJ2KACVN0CHAkoYkFUos8ZLFEPAYPLRlZI7.VAIz6YxJV6EmzAI_q6pTwEr9NyjhWl9O5EPpfF-v2QA]
       pragma: [no-cache]
-      request-id: [66f49bfb-bb87-4abf-92a2-f98656a0f5fd]
+      request-id: [a741346b-4430-4915-8c0d-943ca9d6d785]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -35,36 +61,35 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
-      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
-      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
-      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
-      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
-      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
-      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"location": "westus", "properties": {"accessPolicies": [{"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
+      "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
+      "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"],
+      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"]},
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}], "sku": {"family": "A",
+      "name": "premium"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d281f06e-9413-11e7-ac6a-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_cert000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_cert000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"secrets":["get","list","set","delete","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-000002.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1018']
+      content-length: ['1068']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:30:59 GMT']
+      date: ['Fri, 08 Sep 2017 16:25:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -74,7 +99,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -84,18 +109,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9d158b0-9413-11e7-ac4a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:31:30 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -115,19 +139,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9d158b0-9413-11e7-ac4a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
+    body: {string: '{"value":null,"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:31 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -139,31 +162,30 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
-      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
-      "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "attributes": {"exp": 1509130436, "enabled": true, "nbf":
+      1477593836}, "policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}, "key_props": {"exportable": true, "key_size": 2048,
+      "kty": "RSA", "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3170']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ea1a2180-9413-11e7-8a0f-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504888101,"updated":1504888101,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888101,"updated":1504888101}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2195']
+      content-length: ['2199']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:30 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -181,19 +203,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eac2485e-9413-11e7-8e58-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504888101,"updated":1504888101,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888101,"updated":1504888101}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2195']
+      content-length: ['2199']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:33 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -211,19 +232,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eaf12091-9413-11e7-b395-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504888101,"updated":1504888101,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888101,"updated":1504888101}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2195']
+      content-length: ['2199']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:32 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -242,19 +262,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb6cb930-9413-11e7-ba11-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert1/c886f7b85e4d49f1a018756a6ef64ca3","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504888101,"updated":1504888101,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888101,"updated":1504888101}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2195']
+      content-length: ['2199']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:32 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -266,39 +285,37 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmon,
-      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
-      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
-      60}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
-      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
-      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
-      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
-      {"enabled": true}}'
+    body: '{"policy": {"secret_props": {"contentType": "application/x-pkcs12"}, "lifetime_actions":
+      [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}],
+      "x509_props": {"subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
+      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
+      "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months": 60}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "issuer":
+      {"name": "Self"}, "attributes": {"enabled": true}}, "attributes": {"enabled":
+      true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ebf4d4f0-9413-11e7-9e21-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANrGkIPAWh0oSiYppyzjUhg4nfjNlsDCOr8oC+sjQcMP7ILCAfJITDERriO3htN3kVtvBDfBP0spheZA53FUg2xMIInFApUUWPFSi4oYh4aayDQM4b4YdkHcXvzpfiyde3b96Jngzdjxe9ImoYI5fOYd528p4SSFYw0PkuWr3aFk8bbxE9XGaMozDggfKM8DjzNZAjTAZ7p+TbqqxNGxyXAqA/gIJcZ5o0QfW6j4yAVBARgoQo2hxvHtAQfh6p36pHd2OTnjT0eK4/QaNmuQ/7VbuN8lq13UWJHdVlBRyEM7+r7xSMIXnV52yQmc6me1b1C8Ywg32EBqJwuH+gvJEe0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBoc5X35pz8vftLLZ6fGW8K5gy0FfQa0+U7Y3SFTTZv1/8vQoulwHgE+oSBAnHo5o7exp23fnLB5Kfq41uUy0RuWUfwDs5zMpZILU4yPwq0u2ruCphfiXWcIGkiyF1Gek3ngUVa7FRwTi6kJyHYNKP0P2ehDsgk9/SWV2Am1xqaMU3QIO1afjiRuGRSphuR5tpDCE9ZaARYBxqwgN3Stb91o+T8a8qLCN4pfMHEhzPD9eLSGEtwqiOtVXiErNq7nUC58b296R1fkeBiwi4+GsnYrJwGkcP9z1NsN1vrnQ7pPhdIcvBF4rW3XgqUksWFPjx1MfVD21ZL2QlDpXkMzFtY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
+        time based on the issuer provider. Please check again later.","request_id":"ea62e8495fb64629a6131da4ada687b3"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1418']
+      content-length: ['1419']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:34 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:24 GMT']
       expires: ['-1']
-      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=39e4adc32e9a4064b1bf7afb598546f9']
+      location: ['https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=ea62e8495fb64629a6131da4ada687b3']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -314,24 +331,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecccbe5e-9413-11e7-9b57-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANrGkIPAWh0oSiYppyzjUhg4nfjNlsDCOr8oC+sjQcMP7ILCAfJITDERriO3htN3kVtvBDfBP0spheZA53FUg2xMIInFApUUWPFSi4oYh4aayDQM4b4YdkHcXvzpfiyde3b96Jngzdjxe9ImoYI5fOYd528p4SSFYw0PkuWr3aFk8bbxE9XGaMozDggfKM8DjzNZAjTAZ7p+TbqqxNGxyXAqA/gIJcZ5o0QfW6j4yAVBARgoQo2hxvHtAQfh6p36pHd2OTnjT0eK4/QaNmuQ/7VbuN8lq13UWJHdVlBRyEM7+r7xSMIXnV52yQmc6me1b1C8Ywg32EBqJwuH+gvJEe0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBoc5X35pz8vftLLZ6fGW8K5gy0FfQa0+U7Y3SFTTZv1/8vQoulwHgE+oSBAnHo5o7exp23fnLB5Kfq41uUy0RuWUfwDs5zMpZILU4yPwq0u2ruCphfiXWcIGkiyF1Gek3ngUVa7FRwTi6kJyHYNKP0P2ehDsgk9/SWV2Am1xqaMU3QIO1afjiRuGRSphuR5tpDCE9ZaARYBxqwgN3Stb91o+T8a8qLCN4pfMHEhzPD9eLSGEtwqiOtVXiErNq7nUC58b296R1fkeBiwi4+GsnYrJwGkcP9z1NsN1vrnQ7pPhdIcvBF4rW3XgqUksWFPjx1MfVD21ZL2QlDpXkMzFtY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
+        time based on the issuer provider. Please check again later.","request_id":"ea62e8495fb64629a6131da4ada687b3"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1418']
+      content-length: ['1419']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:35 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -347,85 +362,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f2e590b0-9413-11e7-aaa6-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANrGkIPAWh0oSiYppyzjUhg4nfjNlsDCOr8oC+sjQcMP7ILCAfJITDERriO3htN3kVtvBDfBP0spheZA53FUg2xMIInFApUUWPFSi4oYh4aayDQM4b4YdkHcXvzpfiyde3b96Jngzdjxe9ImoYI5fOYd528p4SSFYw0PkuWr3aFk8bbxE9XGaMozDggfKM8DjzNZAjTAZ7p+TbqqxNGxyXAqA/gIJcZ5o0QfW6j4yAVBARgoQo2hxvHtAQfh6p36pHd2OTnjT0eK4/QaNmuQ/7VbuN8lq13UWJHdVlBRyEM7+r7xSMIXnV52yQmc6me1b1C8Ywg32EBqJwuH+gvJEe0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBoc5X35pz8vftLLZ6fGW8K5gy0FfQa0+U7Y3SFTTZv1/8vQoulwHgE+oSBAnHo5o7exp23fnLB5Kfq41uUy0RuWUfwDs5zMpZILU4yPwq0u2ruCphfiXWcIGkiyF1Gek3ngUVa7FRwTi6kJyHYNKP0P2ehDsgk9/SWV2Am1xqaMU3QIO1afjiRuGRSphuR5tpDCE9ZaARYBxqwgN3Stb91o+T8a8qLCN4pfMHEhzPD9eLSGEtwqiOtVXiErNq7nUC58b296R1fkeBiwi4+GsnYrJwGkcP9z1NsN1vrnQ7pPhdIcvBF4rW3XgqUksWFPjx1MfVD21ZL2QlDpXkMzFtY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
+        time based on the issuer provider. Please check again later.","request_id":"ea62e8495fb64629a6131da4ada687b3"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1418']
+      content-length: ['1419']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f8fa1d40-9413-11e7-a4ce-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1418']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:31:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff1c3e61-9413-11e7-9636-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1331']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:06 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -443,19 +393,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff4f0e30-9413-11e7-84ee-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918}}],"nextLink":null}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANrGkIPAWh0oSiYppyzjUhg4nfjNlsDCOr8oC+sjQcMP7ILCAfJITDERriO3htN3kVtvBDfBP0spheZA53FUg2xMIInFApUUWPFSi4oYh4aayDQM4b4YdkHcXvzpfiyde3b96Jngzdjxe9ImoYI5fOYd528p4SSFYw0PkuWr3aFk8bbxE9XGaMozDggfKM8DjzNZAjTAZ7p+TbqqxNGxyXAqA/gIJcZ5o0QfW6j4yAVBARgoQo2hxvHtAQfh6p36pHd2OTnjT0eK4/QaNmuQ/7VbuN8lq13UWJHdVlBRyEM7+r7xSMIXnV52yQmc6me1b1C8Ywg32EBqJwuH+gvJEe0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBoc5X35pz8vftLLZ6fGW8K5gy0FfQa0+U7Y3SFTTZv1/8vQoulwHgE+oSBAnHo5o7exp23fnLB5Kfq41uUy0RuWUfwDs5zMpZILU4yPwq0u2ruCphfiXWcIGkiyF1Gek3ngUVa7FRwTi6kJyHYNKP0P2ehDsgk9/SWV2Am1xqaMU3QIO1afjiRuGRSphuR5tpDCE9ZaARYBxqwgN3Stb91o+T8a8qLCN4pfMHEhzPD9eLSGEtwqiOtVXiErNq7nUC58b296R1fkeBiwi4+GsnYrJwGkcP9z1NsN1vrnQ7pPhdIcvBF4rW3XgqUksWFPjx1MfVD21ZL2QlDpXkMzFtY","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1","request_id":"ea62e8495fb64629a6131da4ada687b3"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['245']
+      content-length: ['1333']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:06 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -467,39 +416,65 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmond,
-      O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
-      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
-      50}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
-      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
-      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
-      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
-      {"enabled": true}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates?api-version=2016-10-01
+  response:
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1","x5t":"4uTpWwm7M3ap67u18dNke4DJ_ZI","attributes":{"enabled":true,"nbf":1504887521,"exp":1662654521,"created":1504888121,"updated":1504888121}}],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['246']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 16:28:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"policy": {"secret_props": {"contentType": "application/x-pkcs12"}, "lifetime_actions":
+      [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}],
+      "x509_props": {"subject": "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com",
+      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
+      "keyCertSign"], "validity_months": 50}, "key_props": {"exportable": true, "key_size":
+      2048, "kty": "RSA", "reuse_key": false}, "issuer": {"name": "Self"}, "attributes":
+      {"enabled": true}}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['578']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff8adeae-9413-11e7-a0e7-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBsPBO6a2FWUKl77nPqUQcsAE+B7cnBk09QfprdvcHJikCA0vuzQ9mzPHCYkmCXismD7DSlv/MSR+fMVzFs+dnQ/ZgaJ+YdGmS2Gu8b62ia+QBSBZ4fvvm7RVLK0UlMMFmpnE9lzbvhH+TQOAw7KoqAhXZ/a5PQBrvZn7FKb+t3w+gGha8lLfOYJBDjfd3e92CkypXdrAOjnEIxSV5Yz4ZE9XwGgTxcfZrM7QLO3oR/b0ckxGhXxivCRk54HVIeq9yxF2Azlckw7WY4LyXc87tyJjbEy8G6b9RX/SbL6473i3vXsqnJ78Z71hLlP9yK67cmZmHXAzFlev7b4Ut+zDXy","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
+        time based on the issuer provider. Please check again later.","request_id":"c91f7dba349346b8ac3cdd1a13aaaff4"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1406']
+      content-length: ['1407']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:08 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:46 GMT']
       expires: ['-1']
-      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=90b1571a12034ceeb97c665a54570dd6']
+      location: ['https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=c91f7dba349346b8ac3cdd1a13aaaff4']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -515,85 +490,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [00564500-9414-11e7-82f2-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBsPBO6a2FWUKl77nPqUQcsAE+B7cnBk09QfprdvcHJikCA0vuzQ9mzPHCYkmCXismD7DSlv/MSR+fMVzFs+dnQ/ZgaJ+YdGmS2Gu8b62ia+QBSBZ4fvvm7RVLK0UlMMFmpnE9lzbvhH+TQOAw7KoqAhXZ/a5PQBrvZn7FKb+t3w+gGha8lLfOYJBDjfd3e92CkypXdrAOjnEIxSV5Yz4ZE9XwGgTxcfZrM7QLO3oR/b0ckxGhXxivCRk54HVIeq9yxF2Azlckw7WY4LyXc87tyJjbEy8G6b9RX/SbL6473i3vXsqnJ78Z71hLlP9yK67cmZmHXAzFlev7b4Ut+zDXy","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
+        time based on the issuer provider. Please check again later.","request_id":"c91f7dba349346b8ac3cdd1a13aaaff4"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1406']
+      content-length: ['1407']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [066fb38f-9414-11e7-a743-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1406']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0c8e0421-9414-11e7-8716-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1319']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:29 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -611,19 +521,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0cc567cf-9414-11e7-8332-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","attributes":{"enabled":true,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819948}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918}}],"nextLink":null}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBsPBO6a2FWUKl77nPqUQcsAE+B7cnBk09QfprdvcHJikCA0vuzQ9mzPHCYkmCXismD7DSlv/MSR+fMVzFs+dnQ/ZgaJ+YdGmS2Gu8b62ia+QBSBZ4fvvm7RVLK0UlMMFmpnE9lzbvhH+TQOAw7KoqAhXZ/a5PQBrvZn7FKb+t3w+gGha8lLfOYJBDjfd3e92CkypXdrAOjnEIxSV5Yz4ZE9XwGgTxcfZrM7QLO3oR/b0ckxGhXxivCRk54HVIeq9yxF2Azlckw7WY4LyXc87tyJjbEy8G6b9RX/SbL6473i3vXsqnJ78Z71hLlP9yK67cmZmHXAzFlev7b4Ut+zDXy","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1","request_id":"c91f7dba349346b8ac3cdd1a13aaaff4"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['529']
+      content-length: ['1321']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:29 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -641,20 +550,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0cff8a9e-9414-11e7-8e85-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":true,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819948,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819927}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/21817d869e7d47c7860d9c410ac837c8","x5t":"JWKpNUtxcWmAEwDQQnQO5bsnVgM","attributes":{"enabled":true,"nbf":1504887536,"exp":1636388936,"created":1504888136,"updated":1504888136}},{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/4591a30c57c74b3b9ff514ccd5740737","x5t":"4uTpWwm7M3ap67u18dNke4DJ_ZI","attributes":{"enabled":true,"nbf":1504887521,"exp":1662654521,"created":1504888121,"updated":1504888121}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2625']
+      content-length: ['531']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:27 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -672,19 +579,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d31be30-9414-11e7-b010-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b2e10431dcb0416bba778e9428eb3da5","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b2e10431dcb0416bba778e9428eb3da5","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","cer":"MIID8DCCAtigAwIBAgIQaCtCSavSSYCESCjr6EMv0zANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjE1N1oXDTIyMDkwNzIxMzE1N1owdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFM+OhfirgosTtW3kEv0d/Iq5q2A3MB0GA1UdDgQWBBTPjoX4q4KLE7Vt5BL9HfyKuatgNzANBgkqhkiG9w0BAQsFAAOCAQEACMUqXws0vEdZYjpeg1zUqxasF6x5j7FRuMABscmO4uZpnVQ/paPX28z5ZcnNwEpVxzbTMgA+6drOEKziEi1QKv/kBB1T6wcH/RErvyeYwb/TdjKOT1+XU+LzEvjVbpOGy4MuRlS2cx9Byw7uTwYsZwnKJS1Bvl4npK4gbetEto+y2oXEoZxU0EHfC62zSSAljM0n3AAJnOxWQhhCfaelES2YsdS+sDFoArqvSHch8VkeI9BuvlSqXNOHXUf8QP6wqFmnwZiYw/DTGgsXNwQkGsmlKdlVKqwZy4wMvl+xx12LH6NvXkMoAL2ULPLABrm0T7pCmUZ77IQ/31NQz09/oQ==","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918,"recoveryLevel":"Purgeable"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/21817d869e7d47c7860d9c410ac837c8","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/21817d869e7d47c7860d9c410ac837c8","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/21817d869e7d47c7860d9c410ac837c8","x5t":"JWKpNUtxcWmAEwDQQnQO5bsnVgM","cer":"MIID3jCCAsagAwIBAgIQZkG7CY61SdOEhnprjpUsFDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwODE2MTg1NloXDTIxMTEwODE2Mjg1NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFF/VU6gwy55kkuygza5nYC+qbroBMB0GA1UdDgQWBBRf1VOoMMueZJLsoM2uZ2Avqm66ATANBgkqhkiG9w0BAQsFAAOCAQEAeIhReiTHXICuTMam7EcjhwO93gQmo2dSaCXQVt9ZtBarSUL6UM2LX8h3kiDabSo9Gm+7s93k7m3WkS3ms5QZ0cwNmvzJaMQwxX7kuBLb27R4m+BnLwfZaWRUCzF9D663rmGRe4s7EMyJenZdEmDtCGjncsHV15/lSC1jKnybeIufhk1jTxdiULrWs8soPrZsx6H/ywW/w6O0K2y7AbZVGGI9W7KdEJoY1G/vQHy2ddkoH8waM0ytn06iqwNmd1An+gRKFy7q7qg6AiLn+Y+eKw4p/+LpFOywz9ZkT33QDRriBRMWB1kfpVZpcP//SNxd6+mZjE314KRds0p5AEXZPA==","attributes":{"enabled":true,"nbf":1504887536,"exp":1636388936,"created":1504888136,"updated":1504888136,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888104,"updated":1504888126}},"pending":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1842']
+      content-length: ['2630']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:28 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -696,34 +603,62 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmon,
-      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
-      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
-      60}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
-      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
-      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
-      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
-      {"enabled": false}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/4591a30c57c74b3b9ff514ccd5740737?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/4591a30c57c74b3b9ff514ccd5740737","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/4591a30c57c74b3b9ff514ccd5740737","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/4591a30c57c74b3b9ff514ccd5740737","x5t":"4uTpWwm7M3ap67u18dNke4DJ_ZI","cer":"MIID8DCCAtigAwIBAgIQTlmnBBZfRPu/1kqJ1NSKJTANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwODE2MTg0MVoXDTIyMDkwODE2Mjg0MVowdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANrGkIPAWh0oSiYppyzjUhg4nfjNlsDCOr8oC+sjQcMP7ILCAfJITDERriO3htN3kVtvBDfBP0spheZA53FUg2xMIInFApUUWPFSi4oYh4aayDQM4b4YdkHcXvzpfiyde3b96Jngzdjxe9ImoYI5fOYd528p4SSFYw0PkuWr3aFk8bbxE9XGaMozDggfKM8DjzNZAjTAZ7p+TbqqxNGxyXAqA/gIJcZ5o0QfW6j4yAVBARgoQo2hxvHtAQfh6p36pHd2OTnjT0eK4/QaNmuQ/7VbuN8lq13UWJHdVlBRyEM7+r7xSMIXnV52yQmc6me1b1C8Ywg32EBqJwuH+gvJEe0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFGrwvRqnPQYvX8O9F7zvopqVThUeMB0GA1UdDgQWBBRq8L0apz0GL1/DvRe876KalU4VHjANBgkqhkiG9w0BAQsFAAOCAQEAfioZzSv0XJ+kOM9KpwwDXC6jLm/Sqz14VBOgdnqJ8s8KZ4KJ6DY3tFyXz7yLRfSZw/Ssja3/KY+t56DSaxL+x6S5v9eh6L4fRNODxdNGMPxf7mjOcDBGXicSJXeRlKJWdPH8gjrYUAY5oRzXagUMP/Kdli+BMqqfCfVHNs1t+emsvxkzHBZn0FKquQT3QVWDoARtGHg8u5gP/QIoduhen48KpSmrEOcMASoXnE1FjXKMnyO/bxZ+A3PG7rq9iOeaVRkwhVwFixC5WTgtJVyhDXxAlNoQaLPLPe+IVc3BXjN46i+5iPIToQjL72jgT+oSQWhSFqC5BlfHF1kOo14yBw==","attributes":{"enabled":true,"nbf":1504887521,"exp":1662654521,"created":1504888121,"updated":1504888121,"recoveryLevel":"Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1845']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 16:28:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"policy": {"secret_props": {"contentType": "application/x-pkcs12"}, "lifetime_actions":
+      [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type": "AutoRenew"}}],
+      "x509_props": {"subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget,
+      CN=www.mytestdomain.com", "key_usage": ["digitalSignature", "nonRepudiation",
+      "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months": 60}, "key_props":
+      {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key": false}, "issuer":
+      {"name": "Self"}, "attributes": {"enabled": true}}, "attributes": {"enabled":
+      false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['588']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d63075e-9414-11e7-aa69-a0b3ccf7272a]
     method: PATCH
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":false,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819951,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819951}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/21817d869e7d47c7860d9c410ac837c8","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/21817d869e7d47c7860d9c410ac837c8","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/21817d869e7d47c7860d9c410ac837c8","x5t":"JWKpNUtxcWmAEwDQQnQO5bsnVgM","cer":"MIID3jCCAsagAwIBAgIQZkG7CY61SdOEhnprjpUsFDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwODE2MTg1NloXDTIxMTEwODE2Mjg1NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFF/VU6gwy55kkuygza5nYC+qbroBMB0GA1UdDgQWBBRf1VOoMMueZJLsoM2uZ2Avqm66ATANBgkqhkiG9w0BAQsFAAOCAQEAeIhReiTHXICuTMam7EcjhwO93gQmo2dSaCXQVt9ZtBarSUL6UM2LX8h3kiDabSo9Gm+7s93k7m3WkS3ms5QZ0cwNmvzJaMQwxX7kuBLb27R4m+BnLwfZaWRUCzF9D663rmGRe4s7EMyJenZdEmDtCGjncsHV15/lSC1jKnybeIufhk1jTxdiULrWs8soPrZsx6H/ywW/w6O0K2y7AbZVGGI9W7KdEJoY1G/vQHy2ddkoH8waM0ytn06iqwNmd1An+gRKFy7q7qg6AiLn+Y+eKw4p/+LpFOywz9ZkT33QDRriBRMWB1kfpVZpcP//SNxd6+mZjE314KRds0p5AEXZPA==","attributes":{"enabled":false,"nbf":1504887536,"exp":1636388936,"created":1504888136,"updated":1504888137,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888104,"updated":1504888137}},"pending":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2635']
+      content-length: ['2640']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -741,20 +676,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e069a5e-9414-11e7-b781-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"error":{"code":"ContactsNotFound","message":"Contacts
-        not found"}}'}
+    body: {string: '{"error":{"code":"ContactsNotFound","message":"Contacts not found"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['68']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -766,28 +699,27 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: !!python/unicode '{"contacts": [{"phone": "123-456-7890", "email": "admin@contoso.com",
-      "name": "John Doe"}]}'
+    body: '{"contacts": [{"email": "admin@contoso.com", "name": "John Doe", "phone":
+      "123-456-7890"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['91']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e2b6070-9414-11e7-9546-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['162']
+      content-length: ['163']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:31 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -805,20 +737,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e5e3040-9414-11e7-8bbb-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['162']
+      content-length: ['163']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -830,28 +761,27 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"contacts": [{"phone": "123-456-7890", "email": "admin@contoso.com",
-      "name": "John Doe"}, {"email": "other@contoso.com"}]}'
+    body: '{"contacts": [{"email": "admin@contoso.com", "name": "John Doe", "phone":
+      "123-456-7890"}, {"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e8407c0-9414-11e7-a7e9-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['192']
+      content-length: ['193']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -869,20 +799,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0eb59f0f-9414-11e7-ad76-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['192']
+      content-length: ['193']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -900,20 +829,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ee365cf-9414-11e7-9f1a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['192']
+      content-length: ['193']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      date: ['Fri, 08 Sep 2017 16:28:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -925,26 +853,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"contacts": [{"email": "other@contoso.com"}]}'
+    body: '{"contacts": [{"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['46']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f106940-9414-11e7-b746-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['121']
+      content-length: ['122']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -962,19 +889,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f4d4b30-9414-11e7-bf26-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['121']
+      content-length: ['122']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -986,27 +912,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {}, "org_details": {"admin_details": []},
-      "provider": "Test", "attributes": {"enabled": true}}'
+    body: '{"provider": "Test", "org_details": {"admin_details": []}, "attributes":
+      {"enabled": true}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f82da21-9414-11e7-802a-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888141}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['235']
+      content-length: ['236']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1024,19 +949,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0fb5d100-9414-11e7-b079-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888141}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['235']
+      content-length: ['236']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1054,19 +978,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0fe98b2e-9414-11e7-acc3-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888141}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['235']
+      content-length: ['236']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1078,28 +1001,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {"account_id": "test_account"}, "org_details":
-      {"id": "TestOrg", "admin_details": []}, "provider": "Test", "attributes": {"enabled":
-      true}}'
+    body: '{"provider": "Test", "org_details": {"id": "TestOrg", "admin_details":
+      []}, "attributes": {"enabled": true}, "credentials": {"account_id": "test_account"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [10130c30-9414-11e7-844e-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819955}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888141}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['277']
+      content-length: ['278']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1117,20 +1038,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1048c230-9414-11e7-bc5b-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
+    body: {string: '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
         not found"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['75']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1148,19 +1068,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [107613c0-9414-11e7-b7f4-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819955}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888141}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['277']
+      content-length: ['278']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1172,27 +1091,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
-      []}, "provider": "Test", "attributes": {"enabled": true}}'
+    body: '{"provider": "Test", "org_details": {"id": "TestOrg", "admin_details":
+      []}, "attributes": {"enabled": true}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [10a51300-9414-11e7-bd9d-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819956}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888143}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['250']
+      content-length: ['251']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:35 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1210,19 +1128,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [10e83680-9414-11e7-a7f4-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['131']
+      content-length: ['132']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1240,19 +1157,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [111b2d5e-9414-11e7-8f35-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819956}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888143}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['250']
+      content-length: ['251']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1264,28 +1180,27 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
-      [{"phone": "123-456-7890", "first_name": "Test", "last_name": "Admin", "email":
-      "test@test.com"}]}, "provider": "Test", "attributes": {"enabled": true}}'
+    body: '{"provider": "Test", "org_details": {"id": "TestOrg", "admin_details":
+      [{"first_name": "Test", "email": "test@test.com", "phone": "123-456-7890", "last_name":
+      "Admin"}]}, "attributes": {"enabled": true}, "credentials": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1148f421-9414-11e7-8342-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['338']
+      content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1303,19 +1218,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [11816940-9414-11e7-b984-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['338']
+      content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:35 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1333,19 +1247,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [11b4390f-9414-11e7-952a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['338']
+      content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1357,29 +1270,28 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
-      [{"phone": "123-456-7890", "first_name": "Test", "last_name": "Admin", "email":
-      "test@test.com"}, {"email": "test2@test.com"}]}, "provider": "Test", "attributes":
-      {"enabled": true}}'
+    body: '{"provider": "Test", "org_details": {"id": "TestOrg", "admin_details":
+      [{"first_name": "Test", "email": "test@test.com", "phone": "123-456-7890", "last_name":
+      "Admin"}, {"email": "test2@test.com"}]}, "attributes": {"enabled": true}, "credentials":
+      {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [11df8ed1-9414-11e7-aca0-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['365']
+      content-length: ['366']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1397,19 +1309,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [121285b0-9414-11e7-8c48-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['365']
+      content-length: ['366']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:37 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1427,19 +1338,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [12430b8f-9414-11e7-8b53-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888144}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['365']
+      content-length: ['366']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1451,28 +1361,27 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
-      [{"email": "test2@test.com"}]}, "provider": "Test", "attributes": {"enabled":
-      true}}'
+    body: '{"provider": "Test", "org_details": {"id": "TestOrg", "admin_details":
+      [{"email": "test2@test.com"}]}, "attributes": {"enabled": true}, "credentials":
+      {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [126bc940-9414-11e7-8d60-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888145}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['276']
+      content-length: ['277']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1490,19 +1399,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [12a85d11-9414-11e7-8d0c-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888145}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['276']
+      content-length: ['277']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1521,19 +1429,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [12e2a6f0-9414-11e7-8011-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504888141,"updated":1504888145}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['276']
+      content-length: ['277']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1551,19 +1458,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [13166121-9414-11e7-b6ed-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    body: {string: '{"value":[],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['28']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1575,36 +1481,34 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "attributes": {"enabled": true}, "secret_props":
-      {"contentType": "application/x-pkcs12"}, "x509_props": {"subject": "C=US, ST=WA,
-      L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
-      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
-      50}, "issuer": {"name": "Unknown"}}, "attributes": {"enabled": true}}'
+    body: '{"policy": {"secret_props": {"contentType": "application/x-pkcs12"}, "issuer":
+      {"name": "Unknown"}, "attributes": {"enabled": true}, "x509_props": {"subject":
+      "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage":
+      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
+      "validity_months": 50}, "key_props": {"exportable": true, "key_size": 2048,
+      "kty": "RSA", "reuse_key": false}}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [134f998f-9414-11e7-b9cf-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKY/Cy67wUGIafyH+oGFb198WgWwSSAvKGCJXF7WEKW+Job/kqj8Mp0jJqPrfwhlQ1cGxbx2fA8yMXbB6w0X1P84QwinutxfluwsGafUX141GUU8w/vL0O6UBxMR3F2SutA33Ks6zE2C+1wqW+AJV5EJqeCUMMwEvfRUcs4nnycICSeuoPlSoGAFcQ3v+9rU1x5yVSFYNBBKXHr0tbRvV+6ew9JfxM5K5LhyPEi1oJOWPxidmsfDuJ2HxAuwaNFYYt+FuhvwdVUZXIwaL/h7n1HVME51nAJ+JhV35fOzJn7HROMrhRLoMDcw5iRjHBKxEYr4vcJVVc03qWzrKh4t0XUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCcnXahBlyiOsZ4eTLYP0JbaytcxZwc9W8Z2cp5nr5a77MefezyqTmCeQPPTpwXXFgbcwF04WysLE/raRUadXtJdoa3ZJsiJbPLNxRI3j22yD6JtiNok8yZ/n6uGzFYC4T1O3+Ldg+05bB9nBZ+5MSIsEARkJbZqAvXcqL8sUcOkw5JC6b3prJDTOGMLxsLolCX4nwj7X8fcNQDvxLV6UC92fzPSBx5ofDFhM3ZyK5tIg9pLenkIDvRU+Medxe9E264eTPSRG4OZ/P6io9TjEjMJT6hYST1vd50jvOUQe+T1wP268jYW93cQdF6AdiDW4MaZN108Kmy6RwbWM3Pc/hx","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"b616dd632869460ea3388ce71d577b72"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1346']
+      content-length: ['1347']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:07 GMT']
       expires: ['-1']
-      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=84fc1b189fbb47a59b642d45369ed240']
+      location: ['https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=b616dd632869460ea3388ce71d577b72']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -1620,23 +1524,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [14300e80-9414-11e7-888b-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKY/Cy67wUGIafyH+oGFb198WgWwSSAvKGCJXF7WEKW+Job/kqj8Mp0jJqPrfwhlQ1cGxbx2fA8yMXbB6w0X1P84QwinutxfluwsGafUX141GUU8w/vL0O6UBxMR3F2SutA33Ks6zE2C+1wqW+AJV5EJqeCUMMwEvfRUcs4nnycICSeuoPlSoGAFcQ3v+9rU1x5yVSFYNBBKXHr0tbRvV+6ew9JfxM5K5LhyPEi1oJOWPxidmsfDuJ2HxAuwaNFYYt+FuhvwdVUZXIwaL/h7n1HVME51nAJ+JhV35fOzJn7HROMrhRLoMDcw5iRjHBKxEYr4vcJVVc03qWzrKh4t0XUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCcnXahBlyiOsZ4eTLYP0JbaytcxZwc9W8Z2cp5nr5a77MefezyqTmCeQPPTpwXXFgbcwF04WysLE/raRUadXtJdoa3ZJsiJbPLNxRI3j22yD6JtiNok8yZ/n6uGzFYC4T1O3+Ldg+05bB9nBZ+5MSIsEARkJbZqAvXcqL8sUcOkw5JC6b3prJDTOGMLxsLolCX4nwj7X8fcNQDvxLV6UC92fzPSBx5ofDFhM3ZyK5tIg9pLenkIDvRU+Medxe9E264eTPSRG4OZ/P6io9TjEjMJT6hYST1vd50jvOUQe+T1wP268jYW93cQdF6AdiDW4MaZN108Kmy6RwbWM3Pc/hx","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"b616dd632869460ea3388ce71d577b72"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1346']
+      content-length: ['1347']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -1652,23 +1554,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1462691e-9414-11e7-a585-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKY/Cy67wUGIafyH+oGFb198WgWwSSAvKGCJXF7WEKW+Job/kqj8Mp0jJqPrfwhlQ1cGxbx2fA8yMXbB6w0X1P84QwinutxfluwsGafUX141GUU8w/vL0O6UBxMR3F2SutA33Ks6zE2C+1wqW+AJV5EJqeCUMMwEvfRUcs4nnycICSeuoPlSoGAFcQ3v+9rU1x5yVSFYNBBKXHr0tbRvV+6ew9JfxM5K5LhyPEi1oJOWPxidmsfDuJ2HxAuwaNFYYt+FuhvwdVUZXIwaL/h7n1HVME51nAJ+JhV35fOzJn7HROMrhRLoMDcw5iRjHBKxEYr4vcJVVc03qWzrKh4t0XUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCcnXahBlyiOsZ4eTLYP0JbaytcxZwc9W8Z2cp5nr5a77MefezyqTmCeQPPTpwXXFgbcwF04WysLE/raRUadXtJdoa3ZJsiJbPLNxRI3j22yD6JtiNok8yZ/n6uGzFYC4T1O3+Ldg+05bB9nBZ+5MSIsEARkJbZqAvXcqL8sUcOkw5JC6b3prJDTOGMLxsLolCX4nwj7X8fcNQDvxLV6UC92fzPSBx5ofDFhM3ZyK5tIg9pLenkIDvRU+Medxe9E264eTPSRG4OZ/P6io9TjEjMJT6hYST1vd50jvOUQe+T1wP268jYW93cQdF6AdiDW4MaZN108Kmy6RwbWM3Pc/hx","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"b616dd632869460ea3388ce71d577b72"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1346']
+      content-length: ['1347']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
-      retry-after: ['10']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000;includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -1678,27 +1578,27 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="]}'
+    body: '{"x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="],
+      "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [149538f0-9414-11e7-a610-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"error":{"code":"BadParameter","message":"Public
-        key from x509 certificate and key of this instance doesn''t match"}}'}
+    body: {string: '{"error":{"code":"BadParameter","message":"Public key from x509
+        certificate and key of this instance doesn''t match"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['117']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1717,20 +1617,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [14cd38de-9414-11e7-9a55-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKY/Cy67wUGIafyH+oGFb198WgWwSSAvKGCJXF7WEKW+Job/kqj8Mp0jJqPrfwhlQ1cGxbx2fA8yMXbB6w0X1P84QwinutxfluwsGafUX141GUU8w/vL0O6UBxMR3F2SutA33Ks6zE2C+1wqW+AJV5EJqeCUMMwEvfRUcs4nnycICSeuoPlSoGAFcQ3v+9rU1x5yVSFYNBBKXHr0tbRvV+6ew9JfxM5K5LhyPEi1oJOWPxidmsfDuJ2HxAuwaNFYYt+FuhvwdVUZXIwaL/h7n1HVME51nAJ+JhV35fOzJn7HROMrhRLoMDcw5iRjHBKxEYr4vcJVVc03qWzrKh4t0XUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCcnXahBlyiOsZ4eTLYP0JbaytcxZwc9W8Z2cp5nr5a77MefezyqTmCeQPPTpwXXFgbcwF04WysLE/raRUadXtJdoa3ZJsiJbPLNxRI3j22yD6JtiNok8yZ/n6uGzFYC4T1O3+Ldg+05bB9nBZ+5MSIsEARkJbZqAvXcqL8sUcOkw5JC6b3prJDTOGMLxsLolCX4nwj7X8fcNQDvxLV6UC92fzPSBx5ofDFhM3ZyK5tIg9pLenkIDvRU+Medxe9E264eTPSRG4OZ/P6io9TjEjMJT6hYST1vd50jvOUQe+T1wP268jYW93cQdF6AdiDW4MaZN108Kmy6RwbWM3Pc/hx","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"b616dd632869460ea3388ce71d577b72"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1346']
+      content-length: ['1347']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1748,20 +1647,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [151abca1-9414-11e7-af3f-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"error":{"code":"PendingCertificateNotFound","message":"Pending
+    body: {string: '{"error":{"code":"PendingCertificateNotFound","message":"Pending
         certificate not found: pending-cert"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['103']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1780,20 +1678,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1547c00f-9414-11e7-8496-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":false,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819951,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819951}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/21817d869e7d47c7860d9c410ac837c8","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/21817d869e7d47c7860d9c410ac837c8","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/21817d869e7d47c7860d9c410ac837c8","x5t":"JWKpNUtxcWmAEwDQQnQO5bsnVgM","cer":"MIID3jCCAsagAwIBAgIQZkG7CY61SdOEhnprjpUsFDANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwODE2MTg1NloXDTIxMTEwODE2Mjg1NlowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKZDHwf4LAYhlh6Yq8KxqW/0IZm74ix20wmIajJ/DDIAb/nInUZdIOcstHh4UuFincJgU3fbD1oztxw+luUONHC2e9uJejvOafZgQiwXLvKMQvMiaE+IFNCL8Jxs8crIh29Nsktfs39wYzGg+mGrn0MY9X46t67OHEhiKFSoB9mFFiv6Gc1WShI1aeBQlWijWZTs4A5zCv0Sb32VfkN1CQi7S1ffmFm8icYoQ5uOvh3qHUdJJM3Revn/e7OSyyvtPfidF6DDNOU0DTGv1Rnkiun7OepXXnoB428wunOtNQf8zt1zo6Y/3jPwLJ2Z/MUEVSGhBKvsPMc32+tRKYTmtn0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFF/VU6gwy55kkuygza5nYC+qbroBMB0GA1UdDgQWBBRf1VOoMMueZJLsoM2uZ2Avqm66ATANBgkqhkiG9w0BAQsFAAOCAQEAeIhReiTHXICuTMam7EcjhwO93gQmo2dSaCXQVt9ZtBarSUL6UM2LX8h3kiDabSo9Gm+7s93k7m3WkS3ms5QZ0cwNmvzJaMQwxX7kuBLb27R4m+BnLwfZaWRUCzF9D663rmGRe4s7EMyJenZdEmDtCGjncsHV15/lSC1jKnybeIufhk1jTxdiULrWs8soPrZsx6H/ywW/w6O0K2y7AbZVGGI9W7KdEJoY1G/vQHy2ddkoH8waM0ytn06iqwNmd1An+gRKFy7q7qg6AiLn+Y+eKw4p/+LpFOywz9ZkT33QDRriBRMWB1kfpVZpcP//SNxd6+mZjE314KRds0p5AEXZPA==","attributes":{"enabled":false,"nbf":1504887536,"exp":1636388936,"created":1504888136,"updated":1504888137,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888104,"updated":1504888137}},"pending":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2635']
+      content-length: ['2640']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:42 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1811,19 +1708,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [15a1039e-9414-11e7-bbb9-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    body: {string: '{"value":[],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['28']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1835,31 +1731,30 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
-      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
-      "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
+      CERTIFICATE-----", "attributes": {"exp": 1509130436, "enabled": true, "nbf":
+      1477593836}, "policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}, "key_props": {"exportable": true, "key_size": 2048,
+      "kty": "RSA", "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3170']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [15cfdbcf-9414-11e7-a964-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/5ef300623ece44baaf6defeefa45cb11","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/5ef300623ece44baaf6defeefa45cb11","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/5ef300623ece44baaf6defeefa45cb11","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819965,"updated":1504819965,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819965,"updated":1504819965}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/4cb2fe88b00544ccb432f786a9efa9c3","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert1/4cb2fe88b00544ccb432f786a9efa9c3","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert1/4cb2fe88b00544ccb432f786a9efa9c3","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504888151,"updated":1504888151,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888151,"updated":1504888151}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2195']
+      content-length: ['2199']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:45 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1871,32 +1766,31 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
-      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1469603703,
-      "exp": 1556003703}, "pwd": "1234", "value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
+    body: '{"pwd": "1234", "value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
       CERTIFICATE-----\n-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE6jAcBgoqhkiG9w0BDAEDMA4ECJiLClPM6t5JAgIIAASCBMigL+KlEA9fagX0\nPFhQBeFjDiebJbMuTfa9HcOVZEDyrqmGng2Lfz+TUa3ys/V86okbUp2N9MoGK7gx\ncPqdq7rnu563LT9wGhtn8mUn8Wul0FfV2K56wsBGehJ+MPmlEjs6OZR0nVdXkwAh\ndVIzH9eFdz8mhJZOZI61TQNKCKbCqsR7lslkL2VWrSFgnHCUj5bR/BLIA2oRpQZv\nnw0SeYFQWMRyXgKH4VWMqOlObXm/ELnVOr9dJVzvTG42DRaK5N8BA9NTMsK1+8m+\nenCg4iNI/s81MD8iIy/d7MmsJFh8WQoqzUZmOVxfqNHw0TPgDpbCpCWRNigkRoGS\nRosc7MIlCPPangjPMFZg5QeMuUBrE01fSvJtZ52jSMkyloSfQzQJJb9Aam6q6Dzo\nuPCH32zz1GV/56yJoO8IefOMIujvXFZku/QNzKWiXnuSA+xjFZhGEGQToU5wLtHX\neEhz1cF519c8CkM4Ll/UUHPWtb90vqO2+O2DLug9qUUnoQl7P0O3W2NpAoBCLxUO\nqrfSyLUosms7Eg1DIVo5pwxawPK8qk7gwLntATZc+aTSUR9Y1dn4vJ9j9GZWIu9J\nVKO616gDO7q8R1C3mT72k2oUuUG25TtZOxsl+Y3iJgEyp9N7jo/Rdx5KkcvvB8zt\ngPCh5diKDjbo3LxmYRt62heOLEPs2YDjKByn0Nikco3LqTnedJeXEH2mBc7x1VWE\n0qTV4xqOXL9F7000Mv1cJcE2E88fN6tDge1IpuJbs03Ij0OgpaFRfS57NciBthgm\nBp3lREHYNVa4sqWHlUqakoNtc2H62t9nmpzFV7zXJkqKPPpanKV5Q9zOD0VKgcoF\nyAuMkhuPV4IfOEbG8iiZozayk2nfRrm4+nz7b31/5Him2MEce3wbUtmWR6OPdswr\nB6K58j8TGGzOAEDTdWc9yOf/auSIBVDw+23/TbrVD3xRWdesKa4sj7rMW+3VZ1mh\n3/ghyhVPtvFcUKrAjjBjkdeMl84m+P+KcV9Ov57bojKVQdKc7kHrkpi4F66s4Z/J\nZvWHw4LyK4PRlRFzm8eKtXkYLFssxtTRYRydT4wh6VJaOQD2Ww1cPOc/D74Qr/ap\nwQu/fx1Guqk1artbE+BalJakMNKd5Cu2/MfWt8kEjNctGrAHeDmznk/TbvX2rEpv\n/P16WFcjB4bb1Nee96xfuGPUcHul3fG5TRmKJnaxWeg5FM4H4cP5jmeXyGNqdbDS\nrgqpXChenTBwS5JvAVgv8ZvxJxp4h8fLFlUOKuKUR95gB09nBGnwAtEM4zgjKkcC\nPcvDZ7YpzU40gx6QiCVb2UPtggiEp2WyIrpe8VfzK4C7pQGInLn3Rm4G7mEFacv5\nHlbGJO+2XIk3ibFJYTQvMFYc/ESeRSOw6TDoy1sg3+Yl5BXYC+90lCGR9JK/sBYs\n12eVEqxi8kmoNXJ4on0snfDuRDv/6bIIDpfPAKqZzbTq7h6wzIreoz3wx4Oa8A9V\nrtG8TOkCYaoJRYD5uV1lc6Ok3CpZrI7kTGAfvQNi+H0Obz+sSXGksNtfdwNUzUd6\np4CXrZmc/r6o3j4biteWTURnRQqkh67QM5qHJhmXuWD82sjSKU16MM0KqPze/Tl+\n+Figx8pgk29H6LM+N9Y=\n-----END
-      ENCRYPTED PRIVATE KEY-----"}'
+      ENCRYPTED PRIVATE KEY-----", "attributes": {"exp": 1556003703, "enabled": true,
+      "nbf": 1469603703}, "policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}, "key_props": {"exportable": true, "key_size": 2048,
+      "kty": "RSA", "reuse_key": false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3395']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1668c070-9414-11e7-94e9-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/f3160729ecf7401390b07ee91b9215dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/f3160729ecf7401390b07ee91b9215dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/f3160729ecf7401390b07ee91b9215dd","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1504819966,"updated":1504819966,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
-        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819966,"updated":1504819966}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert2/f3c0796709324608baa157c1d0b19d68","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pem-cert2/f3c0796709324608baa157c1d0b19d68","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pem-cert2/f3c0796709324608baa157c1d0b19d68","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1504888151,"updated":1504888151,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
+        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888151,"updated":1504888151}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2295']
+      content-length: ['2299']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:46 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1908,30 +1802,30 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pkcs12"},
-      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477521404,
-      "exp": 1509057404}, "value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n"}'
+    body: '{"value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n",
+      "attributes": {"exp": 1509057404, "enabled": true, "nbf": 1477521404}, "policy":
+      {"secret_props": {"contentType": "application/x-pkcs12"}, "issuer": {"name":
+      "Self"}, "key_props": {"exportable": true, "key_size": 2048, "kty": "RSA", "reuse_key":
+      false}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3874']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1706870f-9414-11e7-8d12-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/a3005f389ed549028fdce6082dbd379e","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/a3005f389ed549028fdce6082dbd379e","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/a3005f389ed549028fdce6082dbd379e","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1504819966,"updated":1504819966,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
-        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819966,"updated":1504819966}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pfx-cert/32c4a1aacb864ebfa9ca32af6dcf6f6f","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/pfx-cert/32c4a1aacb864ebfa9ca32af6dcf6f6f","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/pfx-cert/32c4a1aacb864ebfa9ca32af6dcf6f6f","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1504888151,"updated":1504888151,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
+        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504888151,"updated":1504888151}}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2551']
+      content-length: ['2555']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:32:46 GMT']
+      date: ['Fri, 08 Sep 2017 16:29:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1942,4 +1836,31 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.821]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_cert000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 08 Sep 2017 16:29:12 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGS0VZVkFVTFQ6NUZDRVJUTkhHNVJGTlFJWEY0TFhRT08zT3wyRTcyQjg1NUIwMEFFOUEyLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_certificate.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_certificate.yaml
@@ -6,75 +6,76 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d1ea1d34-4fc9-11e7-928f-5065f34efe31]
+      x-ms-client-request-id: [d22ca480-9413-11e7-b087-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:49:49 GMT']
-      Duration: ['792999']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [p2NaZ5ydjavneyu4zRMy1gXJEs25Bc55kPa1lYyjYz8=]
-      ocp-aad-session-key: [2yNoA1cjO5pMj8umZVqJ1WeTm5pnjcB-V4EfFStcpg5yfohOYKTF9E5GGUYMWCJb1TDJspWTjGzSqNKdnadxehXp2-yCFXpVD3OogQKbt3XyuDmkC4sytjzvrF_h8x9p.W-aoGww0LFJzPjk38iEJq_nEQwo54cDOSMl2wZPp_kA]
-      request-id: [6a524ce3-af2f-4902-ab22-dd17e95ba121]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:30:51 GMT']
+      duration: ['650860']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U=]
+      ocp-aad-session-key: [8ZLafW_mnMm2Yf1_-QM5sBZ3HxjtQ0u2UJEXC1v2Tp-HfKTzt8tbatcmmmKnh4TbP77ggK8t9fQYHNm2OAcxdBslr2yFPixZT8kvwcFljgcnjmNBxQS5W-NfFeFcE-ey.DzzpflYtRSDwWMY_dUDTtNMRFyUPNYt1vHklbVi0KEU]
+      pragma: [no-cache]
+      request-id: [66f49bfb-bb87-4abf-92a2-f98656a0f5fd]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"sku": {"name": "premium", "family": "A"}, "accessPolicies":
-      [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "permissions": {"keys":
-      ["get", "create", "delete", "list", "update", "import", "backup", "restore",
-      "recover"], "secrets": ["get", "list", "set", "delete", "backup", "restore",
-      "recover"], "certificates": ["get", "list", "delete", "create", "import", "update",
-      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
-      "manageissuers", "recover"], "storage": ["get", "list", "delete", "set", "update",
-      "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "7541419d-883d-452f-a823-56aa8bf0749f"}],
-      "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}, "location": "westus"}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
+      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
+      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
+      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d20e3fec-4fc9-11e7-8967-5065f34efe31]
+      x-ms-client-request-id: [d281f06e-9413-11e7-ac6a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-cert1.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:49:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1018']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:30:59 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -83,29 +84,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2cfde34a-4fca-11e7-aa67-5065f34efe31]
+      x-ms-client-request-id: [e9d158b0-9413-11e7-ac4a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:52:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:31:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      www-authenticate: ['Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
           resource="https://vault.azure.net"']
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 401, message: Unauthorized}
 - request:
     body: null
@@ -114,64 +115,64 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2cfde34a-4fca-11e7-aa67-5065f34efe31]
+      x-ms-client-request-id: [e9d158b0-9413-11e7-ac4a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":null,"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['30']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
+      "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----", "policy": {"issuer": {"name": "Self"}, "secret_props": {"contentType":
-      "application/x-pem-file"}, "key_props": {"exportable": true, "key_size": 2048,
-      "reuse_key": false, "kty": "RSA"}}, "attributes": {"exp": 1509130436, "enabled":
-      true, "nbf": 1477593836}}'
+      CERTIFICATE-----"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3170']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2d8022d8-4fca-11e7-bb86-5065f34efe31]
+      x-ms-client-request-id: [ea1a2180-9413-11e7-8a0f-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/ca172093ea8847e792a978bf417775dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/ca172093ea8847e792a978bf417775dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/ca172093ea8847e792a978bf417775dd","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311543,"updated":1497311543,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311543,"updated":1497311543}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2195']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -180,28 +181,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e12485e-4fca-11e7-9529-5065f34efe31]
+      x-ms-client-request-id: [eac2485e-9413-11e7-8e58-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/ca172093ea8847e792a978bf417775dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/ca172093ea8847e792a978bf417775dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/ca172093ea8847e792a978bf417775dd","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311543,"updated":1497311543,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311543,"updated":1497311543}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2195']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -210,28 +211,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e3bd030-4fca-11e7-8612-5065f34efe31]
+      x-ms-client-request-id: [eaf12091-9413-11e7-b395-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/ca172093ea8847e792a978bf417775dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/ca172093ea8847e792a978bf417775dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/ca172093ea8847e792a978bf417775dd","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311543,"updated":1497311543,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311543,"updated":1497311543}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2195']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -241,69 +242,70 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e6498f4-4fca-11e7-be6c-5065f34efe31]
+      x-ms-client-request-id: [eb6cb930-9413-11e7-ba11-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/ca172093ea8847e792a978bf417775dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/ca172093ea8847e792a978bf417775dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/ca172093ea8847e792a978bf417775dd","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311543,"updated":1497311543,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311543,"updated":1497311543}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/6aa9367da093407599d015acb259886a","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/6aa9367da093407599d015acb259886a","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/6aa9367da093407599d015acb259886a","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819891,"updated":1504819891,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819891,"updated":1504819891}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2195']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"policy": {"issuer": {"name": "Self"}, "attributes": {"enabled": true},
-      "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type":
-      "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props":
-      {"subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"], "validity_months": 60}, "key_props": {"exportable": true, "key_size":
-      2048, "reuse_key": false, "kty": "RSA"}}, "attributes": {"enabled": true}}'
+    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmon,
+      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
+      60}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
+      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
+      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
+      {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2ea0c512-4fca-11e7-88d7-5065f34efe31]
+      x-ms-client-request-id: [ebf4d4f0-9413-11e7-9e21-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ1OKC9o5YzjCELu9zO2UYBvD42XEsRj9ZZGkHiJY+T4DrflfB91qA6LE/fwuyvQV50vOrsLrFdN6cgUBCwFH/2UyvfgHLRKmQigEVp3d8932iJomjCqii4Syi5qgVhG4CRKnGGb6+T7tPvp5sLZlLMGptP4Wau/dS7hCYxC62VGBSPc6e5OMe9MTe6oPF4Gc36K9LBZ2PX+G5fIEXDw+xaXpoBq5mRY12cLHr+HubLPudktSCLNdPDfQ6u0xWESCNLQpMf8fOZ7fSCx8M0KcjrG+t8i71PxqUU0YpIhm9XDwt7AFOroTPz7pnxN0zAoXSLleotwSjnVwzXWCUzkoz0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBz6ixuBs80PFdsm/Nfj5dVGgov/FDEARLDtWzJcvFPf47tpuciysfywk3jGLx7toBh0TqRjJMqq54Fb0eOnjX3ARG0BLwKBatJLdy15yoUceG3utOX7p8CZT2DpX8654DnoNbA2V5NAVtZ4nIyKRyMmK3TfANXu8RZbrLbVLP/Z4cwnImZjM7EaiQ1dTo1YNeJeHle0G0jo3BzVdV6v7sVxw7MriXED9alqKFkQYs6T3rB1W4JkFCK1GiOdsEgjGxKzvpsBttnKEZTc+spMluSQ4ZmB+Q0OytdmThsJAxDnyr+JJ06Y/lgv9I4uNu+ZJZLoD1NS4z1MzfL4Hh8C3UB","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"c8a63705907149f5a7cb98420f2356cb"}'}
+        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1418']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:24 GMT']
-      Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=c8a63705907149f5a7cb98420f2356cb']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1418']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:34 GMT']
+      expires: ['-1']
+      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=39e4adc32e9a4064b1bf7afb598546f9']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -312,31 +314,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f6cf280-4fca-11e7-ab8e-5065f34efe31]
+      x-ms-client-request-id: [ecccbe5e-9413-11e7-9b57-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ1OKC9o5YzjCELu9zO2UYBvD42XEsRj9ZZGkHiJY+T4DrflfB91qA6LE/fwuyvQV50vOrsLrFdN6cgUBCwFH/2UyvfgHLRKmQigEVp3d8932iJomjCqii4Syi5qgVhG4CRKnGGb6+T7tPvp5sLZlLMGptP4Wau/dS7hCYxC62VGBSPc6e5OMe9MTe6oPF4Gc36K9LBZ2PX+G5fIEXDw+xaXpoBq5mRY12cLHr+HubLPudktSCLNdPDfQ6u0xWESCNLQpMf8fOZ7fSCx8M0KcjrG+t8i71PxqUU0YpIhm9XDwt7AFOroTPz7pnxN0zAoXSLleotwSjnVwzXWCUzkoz0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBz6ixuBs80PFdsm/Nfj5dVGgov/FDEARLDtWzJcvFPf47tpuciysfywk3jGLx7toBh0TqRjJMqq54Fb0eOnjX3ARG0BLwKBatJLdy15yoUceG3utOX7p8CZT2DpX8654DnoNbA2V5NAVtZ4nIyKRyMmK3TfANXu8RZbrLbVLP/Z4cwnImZjM7EaiQ1dTo1YNeJeHle0G0jo3BzVdV6v7sVxw7MriXED9alqKFkQYs6T3rB1W4JkFCK1GiOdsEgjGxKzvpsBttnKEZTc+spMluSQ4ZmB+Q0OytdmThsJAxDnyr+JJ06Y/lgv9I4uNu+ZJZLoD1NS4z1MzfL4Hh8C3UB","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"c8a63705907149f5a7cb98420f2356cb"}'}
+        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1418']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1418']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -345,31 +347,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [35819be6-4fca-11e7-a995-5065f34efe31]
+      x-ms-client-request-id: [f2e590b0-9413-11e7-aaa6-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ1OKC9o5YzjCELu9zO2UYBvD42XEsRj9ZZGkHiJY+T4DrflfB91qA6LE/fwuyvQV50vOrsLrFdN6cgUBCwFH/2UyvfgHLRKmQigEVp3d8932iJomjCqii4Syi5qgVhG4CRKnGGb6+T7tPvp5sLZlLMGptP4Wau/dS7hCYxC62VGBSPc6e5OMe9MTe6oPF4Gc36K9LBZ2PX+G5fIEXDw+xaXpoBq5mRY12cLHr+HubLPudktSCLNdPDfQ6u0xWESCNLQpMf8fOZ7fSCx8M0KcjrG+t8i71PxqUU0YpIhm9XDwt7AFOroTPz7pnxN0zAoXSLleotwSjnVwzXWCUzkoz0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBz6ixuBs80PFdsm/Nfj5dVGgov/FDEARLDtWzJcvFPf47tpuciysfywk3jGLx7toBh0TqRjJMqq54Fb0eOnjX3ARG0BLwKBatJLdy15yoUceG3utOX7p8CZT2DpX8654DnoNbA2V5NAVtZ4nIyKRyMmK3TfANXu8RZbrLbVLP/Z4cwnImZjM7EaiQ1dTo1YNeJeHle0G0jo3BzVdV6v7sVxw7MriXED9alqKFkQYs6T3rB1W4JkFCK1GiOdsEgjGxKzvpsBttnKEZTc+spMluSQ4ZmB+Q0OytdmThsJAxDnyr+JJ06Y/lgv9I4uNu+ZJZLoD1NS4z1MzfL4Hh8C3UB","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"c8a63705907149f5a7cb98420f2356cb"}'}
+        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1418']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1418']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -378,28 +380,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3ba2052e-4fca-11e7-b792-5065f34efe31]
+      x-ms-client-request-id: [f8fa1d40-9413-11e7-a4ce-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ1OKC9o5YzjCELu9zO2UYBvD42XEsRj9ZZGkHiJY+T4DrflfB91qA6LE/fwuyvQV50vOrsLrFdN6cgUBCwFH/2UyvfgHLRKmQigEVp3d8932iJomjCqii4Syi5qgVhG4CRKnGGb6+T7tPvp5sLZlLMGptP4Wau/dS7hCYxC62VGBSPc6e5OMe9MTe6oPF4Gc36K9LBZ2PX+G5fIEXDw+xaXpoBq5mRY12cLHr+HubLPudktSCLNdPDfQ6u0xWESCNLQpMf8fOZ7fSCx8M0KcjrG+t8i71PxqUU0YpIhm9XDwt7AFOroTPz7pnxN0zAoXSLleotwSjnVwzXWCUzkoz0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBz6ixuBs80PFdsm/Nfj5dVGgov/FDEARLDtWzJcvFPf47tpuciysfywk3jGLx7toBh0TqRjJMqq54Fb0eOnjX3ARG0BLwKBatJLdy15yoUceG3utOX7p8CZT2DpX8654DnoNbA2V5NAVtZ4nIyKRyMmK3TfANXu8RZbrLbVLP/Z4cwnImZjM7EaiQ1dTo1YNeJeHle0G0jo3BzVdV6v7sVxw7MriXED9alqKFkQYs6T3rB1W4JkFCK1GiOdsEgjGxKzvpsBttnKEZTc+spMluSQ4ZmB+Q0OytdmThsJAxDnyr+JJ06Y/lgv9I4uNu+ZJZLoD1NS4z1MzfL4Hh8C3UB","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"c8a63705907149f5a7cb98420f2356cb"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1331']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1418']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:31:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -408,69 +413,100 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3bcc4f80-4fca-11e7-9ba8-5065f34efe31]
+      x-ms-client-request-id: [ff1c3e61-9413-11e7-9636-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAffR5+pkGRP5ubzv7Gg8Jy8FYQ0yjnfA/hRV3gC0OPU2WD+mT1Khx41uhpthQlXe3v9SpvZ1uJet0ERiLo3RAnIV9mHVVpHIAOae78bRLpudDzc+oKu7S7PpfWn4Dg0rrZEBbYghFhHR8UqW7mNN5CKaQtFoonWlbWOXd3K74hcym6cOf3uW9+wYeJd0v2OCC9Pj0oiGL/U6POqNwpKiQ443SIzLa3kyKLjJ9dt0FuFTS2emd885+C78xFviiTxEs6BQFUnHT/Jug5VsNGnUo1UzbJPxAJc5JwYQphSMUs5EOWq/RbnkX+e2aiqHU9mv246DY4bMWXj6ce4yfYcJgR","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"39e4adc32e9a4064b1bf7afb598546f9"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1331']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ff4f0e30-9413-11e7-84ee-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"rxC3YSm2LsNehKGjSNnPYvODqt8","attributes":{"enabled":true,"nbf":1497310959,"exp":1655077959,"created":1497311559,"updated":1497311559}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['245']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:45 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['245']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"policy": {"issuer": {"name": "Self"}, "attributes": {"enabled": true},
-      "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type":
-      "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props":
-      {"subject": "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"], "validity_months": 50}, "key_props": {"exportable": true, "key_size":
-      2048, "reuse_key": false, "kty": "RSA"}}, "attributes": {"enabled": true}}'
+    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmond,
+      O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
+      50}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
+      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
+      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
+      {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['578']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3bf1e324-4fca-11e7-86db-5065f34efe31]
+      x-ms-client-request-id: [ff8adeae-9413-11e7-a0e7-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDvraodsuyF3Q0kmKZnx6/yqNTrppySLXEmWXmI611Ccf/y3k4RTPqp8tvIQl8smuu6V6ahCRSQh/aS8POzK45ABPT7fPNQsxjA+VxwZyfqjWJp4ctkS8/H6wrE5IuMc8fmnpu2Yd8j56FZcTfWXmSneOvNDmY+em7OB/V0C1zk2bEuhqB025mINaYcutn+4RCMG/tfJafGE7Yjd5YhNpwkuUpdxNqXbkVPJZknebilJAmwsidN+nrjQL27rKXXtlzjuonRN2L1445o4o3rC0jVmqH5bUK8xpdyhmpzhJNisaHiZgXyqb1v6w91UnnrJlnmrMmow9oyHfexlK5KSJi","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3dc6c1e6226740078de8d69826d8093f"}'}
+        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1406']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:46 GMT']
-      Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=3dc6c1e6226740078de8d69826d8093f']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1406']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:08 GMT']
+      expires: ['-1']
+      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01&request_id=90b1571a12034ceeb97c665a54570dd6']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -479,31 +515,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [3c9073a6-4fca-11e7-93ee-5065f34efe31]
+      x-ms-client-request-id: [00564500-9414-11e7-82f2-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDvraodsuyF3Q0kmKZnx6/yqNTrppySLXEmWXmI611Ccf/y3k4RTPqp8tvIQl8smuu6V6ahCRSQh/aS8POzK45ABPT7fPNQsxjA+VxwZyfqjWJp4ctkS8/H6wrE5IuMc8fmnpu2Yd8j56FZcTfWXmSneOvNDmY+em7OB/V0C1zk2bEuhqB025mINaYcutn+4RCMG/tfJafGE7Yjd5YhNpwkuUpdxNqXbkVPJZknebilJAmwsidN+nrjQL27rKXXtlzjuonRN2L1445o4o3rC0jVmqH5bUK8xpdyhmpzhJNisaHiZgXyqb1v6w91UnnrJlnmrMmow9oyHfexlK5KSJi","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"3dc6c1e6226740078de8d69826d8093f"}'}
+        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1406']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1406']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -512,28 +548,31 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42a70928-4fca-11e7-859f-5065f34efe31]
+      x-ms-client-request-id: [066fb38f-9414-11e7-a743-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDvraodsuyF3Q0kmKZnx6/yqNTrppySLXEmWXmI611Ccf/y3k4RTPqp8tvIQl8smuu6V6ahCRSQh/aS8POzK45ABPT7fPNQsxjA+VxwZyfqjWJp4ctkS8/H6wrE5IuMc8fmnpu2Yd8j56FZcTfWXmSneOvNDmY+em7OB/V0C1zk2bEuhqB025mINaYcutn+4RCMG/tfJafGE7Yjd5YhNpwkuUpdxNqXbkVPJZknebilJAmwsidN+nrjQL27rKXXtlzjuonRN2L1445o4o3rC0jVmqH5bUK8xpdyhmpzhJNisaHiZgXyqb1v6w91UnnrJlnmrMmow9oyHfexlK5KSJi","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"3dc6c1e6226740078de8d69826d8093f"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1319']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1406']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -542,28 +581,58 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42d772f6-4fca-11e7-83a0-5065f34efe31]
+      x-ms-client-request-id: [0c8e0421-9414-11e7-8716-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBdDZ+ke6QSGcfP8Afsvu3N/AJigAkNtYF4B4Ow/Xd67d69psuvvmv6tvoRL3heVkE6Q0QMFa6UlwGQSPqwqpfI8jBvE+EsPFX6L7m0UIyYvdMm6OgU/xztcr3+N/oq38siTiLagm4YxLMIEtsrfY/bORb3HRJFY9zqnOLPliGFxiFyTImq/pV8JY0skajuuqXSYecetsTgbbFHMHGx6K0Pdy+FK8rFluep80xQHWeimc7zFX8FBwdu1A0q+PR5P1INd7AY23YfrHnEg7runx+nt4gFR+jseWJb07DXIliL2QY1JK3wV9uCWpRudI7vr9xRTKz342q4sqE+PFOhVaPP","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1","request_id":"90b1571a12034ceeb97c665a54570dd6"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1319']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0cc567cf-9414-11e7-8332-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/10f865d95d1743fc94a2118d0eaf9f19","x5t":"QeMGGbCZLQgXYv0DUeY1oWpbCrI","attributes":{"enabled":true,"nbf":1497310977,"exp":1628812377,"created":1497311577,"updated":1497311577}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/2a955e94fdcf4be6bab4c2914309402e","x5t":"rxC3YSm2LsNehKGjSNnPYvODqt8","attributes":{"enabled":true,"nbf":1497310959,"exp":1655077959,"created":1497311559,"updated":1497311559}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","attributes":{"enabled":true,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819948}},{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['529']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:57 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['529']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -572,29 +641,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4300b542-4fca-11e7-b5d6-5065f34efe31]
+      x-ms-client-request-id: [0cff8a9e-9414-11e7-8e85-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/10f865d95d1743fc94a2118d0eaf9f19","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/10f865d95d1743fc94a2118d0eaf9f19","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/10f865d95d1743fc94a2118d0eaf9f19","x5t":"QeMGGbCZLQgXYv0DUeY1oWpbCrI","cer":"MIID3jCCAsagAwIBAgIQUvuHxfaDSYmKXT67IWQBIjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDYxMjIzNDI1N1oXDTIxMDgxMjIzNTI1N1owbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAAMTkMf3BRDG8ISJv33xpoFclhCMB0GA1UdDgQWBBQADE5DH9wUQxvCEib998aaBXJYQjANBgkqhkiG9w0BAQsFAAOCAQEAccYDM7OXXeVoCEOmdyNgEIiJQxUWm3RdKzqLqMkP33TVgq21JCoo298ql7Ecc/nulE/Y7mrM7p5KDGWekNvuxfhxBELnGzEkq2OfgPX7gfU65YxhauJ43EMDjqZBPEN0/gPmaDXOKQqRN4O9F+MtVfkw5hky02N7WYEyI49aDDXygnrt/1hbgElaqy/0wR5WCPQ/qmw6sIj0k+GCnC2iFh5OfLObDrITPoLS1190RJrNTq+WM7QwpTiaOFCZb0HpW4AqHNMyR/LnuBENyS+B9ZWds32ovYeGk+nSpjd7ynBchNwYxqUlH2XpeXW/zvZGnTS8rmmjez0W0PQh4N2hIA==","attributes":{"enabled":true,"nbf":1497310977,"exp":1628812377,"created":1497311577,"updated":1497311577,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311544,"updated":1497311566}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":true,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819948,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819927}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2625']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2625']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -603,66 +672,67 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [432b79ee-4fca-11e7-901b-5065f34efe31]
+      x-ms-client-request-id: [0d31be30-9414-11e7-b010-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/2a955e94fdcf4be6bab4c2914309402e?api-version=2016-10-01
+    uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/2a955e94fdcf4be6bab4c2914309402e","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/2a955e94fdcf4be6bab4c2914309402e","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/2a955e94fdcf4be6bab4c2914309402e","x5t":"rxC3YSm2LsNehKGjSNnPYvODqt8","cer":"MIID8DCCAtigAwIBAgIQV4XXlkHqQ7KWhLG7laafUjANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDYxMjIzNDIzOVoXDTIyMDYxMjIzNTIzOVowdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ1OKC9o5YzjCELu9zO2UYBvD42XEsRj9ZZGkHiJY+T4DrflfB91qA6LE/fwuyvQV50vOrsLrFdN6cgUBCwFH/2UyvfgHLRKmQigEVp3d8932iJomjCqii4Syi5qgVhG4CRKnGGb6+T7tPvp5sLZlLMGptP4Wau/dS7hCYxC62VGBSPc6e5OMe9MTe6oPF4Gc36K9LBZ2PX+G5fIEXDw+xaXpoBq5mRY12cLHr+HubLPudktSCLNdPDfQ6u0xWESCNLQpMf8fOZ7fSCx8M0KcjrG+t8i71PxqUU0YpIhm9XDwt7AFOroTPz7pnxN0zAoXSLleotwSjnVwzXWCUzkoz0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFGMQ/kayI6INL7ALYG9ZREmzV5D6MB0GA1UdDgQWBBRjEP5GsiOiDS+wC2BvWURJs1eQ+jANBgkqhkiG9w0BAQsFAAOCAQEAb6g4+Gg5/GKTamF0UbiYjT8ANw9EM2DINEKkx/ktigPBgVnU7P6XPcMSY5posXJq3bQSW9+eTPjD+iaFoWQpJm9nUS/pDCU3+M2oN+tVJxtnmi31LKW5IpzO73lSzpxH7L5dTefhHVyXx9bvU9Dkt+T7usiF/o3c7oVl2ix5yM9S5Ac0f3DSey+1fq2QXoapXF4h1Z+TLErXyGbcTBTtwjuUSfigXCkP6rdwI4IfkD3O8ELzpJ8WjFBlQhrhR9qhwBSmvziiQt4wAwtv6cOmXxSB+OYzvltOif3ZCC11PKcTcvqETj9E5AcXensB7ggZK/I6JEyuipUSiWTFvYpiNg==","attributes":{"enabled":true,"nbf":1497310959,"exp":1655077959,"created":1497311559,"updated":1497311559,"recoverylevel":"Purgeable"}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/b2e10431dcb0416bba778e9428eb3da5","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/b2e10431dcb0416bba778e9428eb3da5","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/b2e10431dcb0416bba778e9428eb3da5","x5t":"FlP1Rdxl9W9MmyrnkMHXMOl-StM","cer":"MIID8DCCAtigAwIBAgIQaCtCSavSSYCESCjr6EMv0zANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjE1N1oXDTIyMDkwNzIxMzE1N1owdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAP1tBkG2rlMr4zIgezO/Sngb16cVIsvQh1a/trbJhvHkmtE7BJOb8kezPKqIT2nJpVeE/WgMDFg0zM/ijXBOuw7qAApZEuwrzHxYP0Q0bwmtvxQWHrNSxAXeOWhiQ6oOaB3yIi+eGVFsf11916WsdYq+35z8ULf4DfRkDC0KJm0GyzDd6RcYhuLnRSjDoe1Vy9b8x9lQNIHp4piT6Jv0Ahp6r8T7RuzPA+64ZZWFSHdF2PIEMlnLUplc7Ca8BfY1iH0yNbP4hCu4YISvscFPTWc44HOSl/LAZYpEpXia0bSS7IdKBrwNDnz/zfUaAsiv9y7Hb7GxGyq5Na+M2JywK3kCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFM+OhfirgosTtW3kEv0d/Iq5q2A3MB0GA1UdDgQWBBTPjoX4q4KLE7Vt5BL9HfyKuatgNzANBgkqhkiG9w0BAQsFAAOCAQEACMUqXws0vEdZYjpeg1zUqxasF6x5j7FRuMABscmO4uZpnVQ/paPX28z5ZcnNwEpVxzbTMgA+6drOEKziEi1QKv/kBB1T6wcH/RErvyeYwb/TdjKOT1+XU+LzEvjVbpOGy4MuRlS2cx9Byw7uTwYsZwnKJS1Bvl4npK4gbetEto+y2oXEoZxU0EHfC62zSSAljM0n3AAJnOxWQhhCfaelES2YsdS+sDFoArqvSHch8VkeI9BuvlSqXNOHXUf8QP6wqFmnwZiYw/DTGgsXNwQkGsmlKdlVKqwZy4wMvl+xx12LH6NvXkMoAL2ULPLABrm0T7pCmUZ77IQ/31NQz09/oQ==","attributes":{"enabled":true,"nbf":1504819317,"exp":1662586317,"created":1504819918,"updated":1504819918,"recoveryLevel":"Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1842']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1842']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"policy": {"issuer": {"name": "Self"}, "attributes": {"enabled": true},
-      "lifetime_actions": [{"trigger": {"lifetime_percentage": 90}, "action": {"action_type":
-      "AutoRenew"}}], "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props":
-      {"subject": "C=US, ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com",
-      "key_usage": ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement",
-      "keyCertSign"], "validity_months": 60}, "key_props": {"exportable": true, "key_size":
-      2048, "reuse_key": false, "kty": "RSA"}}, "attributes": {"enabled": false}}'
+    body: !!python/unicode '{"policy": {"x509_props": {"subject": "C=US, ST=WA, L=Redmon,
+      O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
+      60}, "key_props": {"key_size": 2048, "exportable": true, "kty": "RSA", "reuse_key":
+      false}, "lifetime_actions": [{"action": {"action_type": "AutoRenew"}, "trigger":
+      {"lifetime_percentage": 90}}], "attributes": {"enabled": true}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "issuer": {"name": "Self"}}, "attributes":
+      {"enabled": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['588']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [435417fe-4fca-11e7-9f74-5065f34efe31]
+      x-ms-client-request-id: [0d63075e-9414-11e7-aa69-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/10f865d95d1743fc94a2118d0eaf9f19","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/10f865d95d1743fc94a2118d0eaf9f19","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/10f865d95d1743fc94a2118d0eaf9f19","x5t":"QeMGGbCZLQgXYv0DUeY1oWpbCrI","cer":"MIID3jCCAsagAwIBAgIQUvuHxfaDSYmKXT67IWQBIjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDYxMjIzNDI1N1oXDTIxMDgxMjIzNTI1N1owbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAAMTkMf3BRDG8ISJv33xpoFclhCMB0GA1UdDgQWBBQADE5DH9wUQxvCEib998aaBXJYQjANBgkqhkiG9w0BAQsFAAOCAQEAccYDM7OXXeVoCEOmdyNgEIiJQxUWm3RdKzqLqMkP33TVgq21JCoo298ql7Ecc/nulE/Y7mrM7p5KDGWekNvuxfhxBELnGzEkq2OfgPX7gfU65YxhauJ43EMDjqZBPEN0/gPmaDXOKQqRN4O9F+MtVfkw5hky02N7WYEyI49aDDXygnrt/1hbgElaqy/0wR5WCPQ/qmw6sIj0k+GCnC2iFh5OfLObDrITPoLS1190RJrNTq+WM7QwpTiaOFCZb0HpW4AqHNMyR/LnuBENyS+B9ZWds32ovYeGk+nSpjd7ynBchNwYxqUlH2XpeXW/zvZGnTS8rmmjez0W0PQh4N2hIA==","attributes":{"enabled":false,"nbf":1497310977,"exp":1628812377,"created":1497311577,"updated":1497311579,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311544,"updated":1497311579}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":false,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819951,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819951}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2635']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2635']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -671,60 +741,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [43e7a8ca-4fca-11e7-8392-5065f34efe31]
+      x-ms-client-request-id: [0e069a5e-9414-11e7-b781-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"error":{"code":"ContactsNotFound","message":"Contacts not found"}}'}
+    body: {string: !!python/unicode '{"error":{"code":"ContactsNotFound","message":"Contacts
+        not found"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['68']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['68']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"contacts": [{"phone": "123-456-7890", "name": "John Doe", "email": "admin@contoso.com"}]}'
+    body: !!python/unicode '{"contacts": [{"phone": "123-456-7890", "email": "admin@contoso.com",
+      "name": "John Doe"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['91']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44060d12-4fca-11e7-bc83-5065f34efe31]
+      x-ms-client-request-id: [0e2b6070-9414-11e7-9546-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['162']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['162']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -733,62 +805,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4439853a-4fca-11e7-a404-5065f34efe31]
+      x-ms-client-request-id: [0e5e3040-9414-11e7-8bbb-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['162']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['162']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"contacts": [{"phone": "123-456-7890", "name": "John Doe", "email": "admin@contoso.com"},
-      {"email": "other@contoso.com"}]}'
+    body: !!python/unicode '{"contacts": [{"phone": "123-456-7890", "email": "admin@contoso.com",
+      "name": "John Doe"}, {"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4459bf2c-4fca-11e7-a77a-5065f34efe31]
+      x-ms-client-request-id: [0e8407c0-9414-11e7-a7e9-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['192']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['192']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -797,29 +869,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44832448-4fca-11e7-bee9-5065f34efe31]
+      x-ms-client-request-id: [0eb59f0f-9414-11e7-ad76-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['192']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['192']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -828,60 +900,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44a842a2-4fca-11e7-b2e7-5065f34efe31]
+      x-ms-client-request-id: [0ee365cf-9414-11e7-9f1a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"admin@contoso.com","name":"John
         Doe","phone":"123-456-7890"},{"email":"other@contoso.com"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['192']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['192']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"contacts": [{"email": "other@contoso.com"}]}'
+    body: !!python/unicode '{"contacts": [{"email": "other@contoso.com"}]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['46']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44c6b968-4fca-11e7-ab47-5065f34efe31]
+      x-ms-client-request-id: [0f106940-9414-11e7-b746-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['121']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -890,60 +962,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44f02a5e-4fca-11e7-90a9-5065f34efe31]
+      x-ms-client-request-id: [0f4d4b30-9414-11e7-bf26-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/contacts","contacts":[{"email":"other@contoso.com"}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['121']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": []}, "credentials": {}, "attributes":
-      {"enabled": true}, "provider": "Test"}'
+    body: !!python/unicode '{"credentials": {}, "org_details": {"admin_details": []},
+      "provider": "Test", "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [452193b4-4fca-11e7-8070-5065f34efe31]
+      x-ms-client-request-id: [0f82da21-9414-11e7-802a-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311584}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['235']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['235']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -952,28 +1024,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4575b7be-4fca-11e7-9205-5065f34efe31]
+      x-ms-client-request-id: [0fb5d100-9414-11e7-b079-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311584}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['235']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['235']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -982,61 +1054,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [459d6f30-4fca-11e7-b61b-5065f34efe31]
+      x-ms-client-request-id: [0fe98b2e-9414-11e7-acc3-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311584}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819954}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['235']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['235']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "credentials":
-      {"account_id": "test_account"}, "attributes": {"enabled": true}, "provider":
-      "Test"}'
+    body: !!python/unicode '{"credentials": {"account_id": "test_account"}, "org_details":
+      {"id": "TestOrg", "admin_details": []}, "provider": "Test", "attributes": {"enabled":
+      true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45bf2ff6-4fca-11e7-b90a-5065f34efe31]
+      x-ms-client-request-id: [10130c30-9414-11e7-844e-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311581}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819955}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['277']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['277']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1045,29 +1117,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45f0aae4-4fca-11e7-84bc-5065f34efe31]
+      x-ms-client-request-id: [1048c230-9414-11e7-bc5b-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/notexist?api-version=2016-10-01
   response:
-    body: {string: '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
+    body: {string: !!python/unicode '{"error":{"code":"CertificateIssuerNotFound","message":"Issuer
         not found"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['75']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['75']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1076,60 +1148,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4614b64c-4fca-11e7-ab44-5065f34efe31]
+      x-ms-client-request-id: [107613c0-9414-11e7-b7f4-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311581}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819955}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['277']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['277']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [], "id": "TestOrg"}, "credentials":
-      {}, "attributes": {"enabled": true}, "provider": "Test"}'
+    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
+      []}, "provider": "Test", "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [46419de8-4fca-11e7-8370-5065f34efe31]
+      x-ms-client-request-id: [10a51300-9414-11e7-bd9d-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819956}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['250']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1138,28 +1210,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [46745346-4fca-11e7-b0df-5065f34efe31]
+      x-ms-client-request-id: [10e83680-9414-11e7-a7f4-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test"}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['131']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['131']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1168,61 +1240,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4699d59c-4fca-11e7-90f9-5065f34efe31]
+      x-ms-client-request-id: [111b2d5e-9414-11e7-8f35-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819956}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['250']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [{"phone": "123-456-7890", "last_name":
-      "Admin", "first_name": "Test", "email": "test@test.com"}], "id": "TestOrg"},
-      "credentials": {}, "attributes": {"enabled": true}, "provider": "Test"}'
+    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
+      [{"phone": "123-456-7890", "first_name": "Test", "last_name": "Admin", "email":
+      "test@test.com"}]}, "provider": "Test", "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [46b9e866-4fca-11e7-92e5-5065f34efe31]
+      x-ms-client-request-id: [1148f421-9414-11e7-8342-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311586}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['338']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['338']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1231,28 +1303,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [46e7e18c-4fca-11e7-814c-5065f34efe31]
+      x-ms-client-request-id: [11816940-9414-11e7-b984-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311586}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['338']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['338']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1261,62 +1333,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4710d1ac-4fca-11e7-a791-5065f34efe31]
+      x-ms-client-request-id: [11b4390f-9414-11e7-952a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311586}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819957}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['338']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['338']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [{"phone": "123-456-7890", "last_name":
-      "Admin", "first_name": "Test", "email": "test@test.com"}, {"email": "test2@test.com"}],
-      "id": "TestOrg"}, "credentials": {}, "attributes": {"enabled": true}, "provider":
-      "Test"}'
+    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
+      [{"phone": "123-456-7890", "first_name": "Test", "last_name": "Admin", "email":
+      "test@test.com"}, {"email": "test2@test.com"}]}, "provider": "Test", "attributes":
+      {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4732a954-4fca-11e7-89b5-5065f34efe31]
+      x-ms-client-request-id: [11df8ed1-9414-11e7-aca0-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['365']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['365']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1325,28 +1397,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [475fcc12-4fca-11e7-9b17-5065f34efe31]
+      x-ms-client-request-id: [121285b0-9414-11e7-8c48-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['365']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['365']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1355,61 +1427,61 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4787d4a6-4fca-11e7-a7a9-5065f34efe31]
+      x-ms-client-request-id: [12430b8f-9414-11e7-8b53-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['365']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['365']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"org_details": {"admin_details": [{"email": "test2@test.com"}], "id":
-      "TestOrg"}, "credentials": {}, "attributes": {"enabled": true}, "provider":
-      "Test"}'
+    body: !!python/unicode '{"credentials": {}, "org_details": {"id": "TestOrg", "admin_details":
+      [{"email": "test2@test.com"}]}, "provider": "Test", "attributes": {"enabled":
+      true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [47a946e8-4fca-11e7-9c46-5065f34efe31]
+      x-ms-client-request-id: [126bc940-9414-11e7-8d60-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['276']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['276']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1418,28 +1490,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [47d608ee-4fca-11e7-9622-5065f34efe31]
+      x-ms-client-request-id: [12a85d11-9414-11e7-8d0c-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['276']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['276']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1449,28 +1521,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [47ffe37a-4fca-11e7-ba04-5065f34efe31]
+      x-ms-client-request-id: [12e2a6f0-9414-11e7-8011-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1497311584,"updated":1497311585}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1504819954,"updated":1504819958}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['276']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['276']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1479,67 +1551,67 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [485f09e4-4fca-11e7-b59f-5065f34efe31]
+      x-ms-client-request-id: [13166121-9414-11e7-b6ed-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/issuers?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"policy": {"attributes": {"enabled": true}, "issuer": {"name": "Unknown"},
-      "secret_props": {"contentType": "application/x-pkcs12"}, "x509_props": {"subject":
-      "C=US, ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage":
-      ["digitalSignature", "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"],
-      "validity_months": 50}, "key_props": {"exportable": true, "key_size": 2048,
-      "reuse_key": false, "kty": "RSA"}}, "attributes": {"enabled": true}}'
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "attributes": {"enabled": true}, "secret_props":
+      {"contentType": "application/x-pkcs12"}, "x509_props": {"subject": "C=US, ST=WA,
+      L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com", "key_usage": ["digitalSignature",
+      "nonRepudiation", "keyEncipherment", "keyAgreement", "keyCertSign"], "validity_months":
+      50}, "issuer": {"name": "Unknown"}}, "attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [48920c58-4fca-11e7-ad3f-5065f34efe31]
+      x-ms-client-request-id: [134f998f-9414-11e7-b9cf-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/create?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI1UvQ/VcS1g9ofz/0SasN9eaZweNJDLLF2H+Yd/dfj/w3O1zWpPeAWA1VQd+9MM3NunXIU3XsbuhhKs+PeIkv6iyvKH/Dnl0I1DgqM0uhw13j8AddelGELzIvb6Wki0uQgOdMDDXeKKYC8JnheTs96Bw+jwIqfVEs31vnNela0rcG0+VAkgxU7VhUtYt2bKINR6vFPL6KMFdt/8d2fBOg994pPU2QFDCsIorXhF+s2GwNXRENo3lyai6beMzviWTgY9Z1JJ9aT2CLEqwRtDIsQ7kQ9EeWT7NgBgW2+OBBRq9NW5OjrMYvL/sbFyCtuKp7unmBQP5NQXhJE/LE25NtECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCC7mVRvqGj6ktEwDAMhQs2lioLREyJDFLZ8XpxPMyzcrbzORt0URttsMc/CpEfXdS7ZPVZ/EkndOxfwn827UEife3BvZAPX9YPNsQGQgON0LqdeKes4HJtVpF1Sligw9YQdt02s7AjR4XicWvl6GqPu2ZjEUVmmmAkXSw36ZfmIM4ZrPuKjwuawJxwAc9KfD7gKtI+hQ/qkeQEvTn45dzXgiHPmUwhgxLSP7+6td/bOSK0Xk5p0kACJ5b3guhDrsCu5PUMxTofRnmmepFAtMAixypcQaoYIGbGD7B5JkXYxsdth8SD2nTptrvOKhMsO0DY5IKCFD4Ig4Af4mql9wUl","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"3296faf603d5484dafba89df441d5f5f"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:08 GMT']
-      Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=3296faf603d5484dafba89df441d5f5f']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      expires: ['-1']
+      location: ['https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01&request_id=84fc1b189fbb47a59b642d45369ed240']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1548,30 +1620,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4947cf88-4fca-11e7-a507-5065f34efe31]
+      x-ms-client-request-id: [14300e80-9414-11e7-888b-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI1UvQ/VcS1g9ofz/0SasN9eaZweNJDLLF2H+Yd/dfj/w3O1zWpPeAWA1VQd+9MM3NunXIU3XsbuhhKs+PeIkv6iyvKH/Dnl0I1DgqM0uhw13j8AddelGELzIvb6Wki0uQgOdMDDXeKKYC8JnheTs96Bw+jwIqfVEs31vnNela0rcG0+VAkgxU7VhUtYt2bKINR6vFPL6KMFdt/8d2fBOg994pPU2QFDCsIorXhF+s2GwNXRENo3lyai6beMzviWTgY9Z1JJ9aT2CLEqwRtDIsQ7kQ9EeWT7NgBgW2+OBBRq9NW5OjrMYvL/sbFyCtuKp7unmBQP5NQXhJE/LE25NtECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCC7mVRvqGj6ktEwDAMhQs2lioLREyJDFLZ8XpxPMyzcrbzORt0URttsMc/CpEfXdS7ZPVZ/EkndOxfwn827UEife3BvZAPX9YPNsQGQgON0LqdeKes4HJtVpF1Sligw9YQdt02s7AjR4XicWvl6GqPu2ZjEUVmmmAkXSw36ZfmIM4ZrPuKjwuawJxwAc9KfD7gKtI+hQ/qkeQEvTn45dzXgiHPmUwhgxLSP7+6td/bOSK0Xk5p0kACJ5b3guhDrsCu5PUMxTofRnmmepFAtMAixypcQaoYIGbGD7B5JkXYxsdth8SD2nTptrvOKhMsO0DY5IKCFD4Ig4Af4mql9wUl","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"3296faf603d5484dafba89df441d5f5f"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1580,63 +1652,62 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [496cc846-4fca-11e7-8e11-5065f34efe31]
+      x-ms-client-request-id: [1462691e-9414-11e7-a585-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI1UvQ/VcS1g9ofz/0SasN9eaZweNJDLLF2H+Yd/dfj/w3O1zWpPeAWA1VQd+9MM3NunXIU3XsbuhhKs+PeIkv6iyvKH/Dnl0I1DgqM0uhw13j8AddelGELzIvb6Wki0uQgOdMDDXeKKYC8JnheTs96Bw+jwIqfVEs31vnNela0rcG0+VAkgxU7VhUtYt2bKINR6vFPL6KMFdt/8d2fBOg994pPU2QFDCsIorXhF+s2GwNXRENo3lyai6beMzviWTgY9Z1JJ9aT2CLEqwRtDIsQ7kQ9EeWT7NgBgW2+OBBRq9NW5OjrMYvL/sbFyCtuKp7unmBQP5NQXhJE/LE25NtECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCC7mVRvqGj6ktEwDAMhQs2lioLREyJDFLZ8XpxPMyzcrbzORt0URttsMc/CpEfXdS7ZPVZ/EkndOxfwn827UEife3BvZAPX9YPNsQGQgON0LqdeKes4HJtVpF1Sligw9YQdt02s7AjR4XicWvl6GqPu2ZjEUVmmmAkXSw36ZfmIM4ZrPuKjwuawJxwAc9KfD7gKtI+hQ/qkeQEvTn45dzXgiHPmUwhgxLSP7+6td/bOSK0Xk5p0kACJ5b3guhDrsCu5PUMxTofRnmmepFAtMAixypcQaoYIGbGD7B5JkXYxsdth8SD2nTptrvOKhMsO0DY5IKCFD4Ig4Af4mql9wUl","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"3296faf603d5484dafba89df441d5f5f"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="],
-      "attributes": {"enabled": true}}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "x5c": ["MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag=="]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1126']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4991e424-4fca-11e7-b427-5065f34efe31]
+      x-ms-client-request-id: [149538f0-9414-11e7-a610-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2016-10-01
   response:
-    body: {string: '{"error":{"code":"BadParameter","message":"Public key from x509
-        certificate and key of this instance doesn''t match"}}'}
+    body: {string: !!python/unicode '{"error":{"code":"BadParameter","message":"Public
+        key from x509 certificate and key of this instance doesn''t match"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['117']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['117']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 400, message: Bad Request}
 - request:
     body: null
@@ -1646,29 +1717,29 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [49c0088a-4fca-11e7-a4ef-5065f34efe31]
+      x-ms-client-request-id: [14cd38de-9414-11e7-9a55-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI1UvQ/VcS1g9ofz/0SasN9eaZweNJDLLF2H+Yd/dfj/w3O1zWpPeAWA1VQd+9MM3NunXIU3XsbuhhKs+PeIkv6iyvKH/Dnl0I1DgqM0uhw13j8AddelGELzIvb6Wki0uQgOdMDDXeKKYC8JnheTs96Bw+jwIqfVEs31vnNela0rcG0+VAkgxU7VhUtYt2bKINR6vFPL6KMFdt/8d2fBOg994pPU2QFDCsIorXhF+s2GwNXRENo3lyai6beMzviWTgY9Z1JJ9aT2CLEqwRtDIsQ7kQ9EeWT7NgBgW2+OBBRq9NW5OjrMYvL/sbFyCtuKp7unmBQP5NQXhJE/LE25NtECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCC7mVRvqGj6ktEwDAMhQs2lioLREyJDFLZ8XpxPMyzcrbzORt0URttsMc/CpEfXdS7ZPVZ/EkndOxfwn827UEife3BvZAPX9YPNsQGQgON0LqdeKes4HJtVpF1Sligw9YQdt02s7AjR4XicWvl6GqPu2ZjEUVmmmAkXSw36ZfmIM4ZrPuKjwuawJxwAc9KfD7gKtI+hQ/qkeQEvTn45dzXgiHPmUwhgxLSP7+6td/bOSK0Xk5p0kACJ5b3guhDrsCu5PUMxTofRnmmepFAtMAixypcQaoYIGbGD7B5JkXYxsdth8SD2nTptrvOKhMsO0DY5IKCFD4Ig4Af4mql9wUl","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"3296faf603d5484dafba89df441d5f5f"}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL7b4C2868IGyDW+b+bMvOu9Ec0zNh/L4N45rDJwqNYJ+qniPIrForgvvM+pVyoesGcuNOfClEQTAQIN/ScryMMdcxoA0Zxv0yxovSsGUvhrUhnwJ8/D4YTO3jlu2BTbGInp4bofYTI3ZeVH1gtcNuqv2Q9/BPDvnYn7VIVWFcTK3DvP26vS2vo0t4uZeG2GbP8KuTTyKNPGi929q1zQrRxyVdDbpP/T6IrD0Mfu2R7A8R+fpTOYOzTzyRTuTAdKmx6M9jRoUKBoj9ITPCsOvtxjSVFUKdRf8ApfJt1cqQ6BmM1m00K5iZXioefOP1BC8Ae4IhOMxEr9TQKayKyQzfsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCDbPLnp/c6bzlQUTII/10Cqu9sb4RZaKFSdV+yWYoa/Bm7BqkVwg8QsbuZV7mlmLNWSjr4TVlkjw/tQm5jVou5CewnavfOM9Wdf1ws9s3YGudRJVCmP3cHwPOadh2mYq88t0Anm8+W9qshrrBwkpOukkrb7hEXxkBAO1V3KNBNzAEsom1fExS9VMrwdi2Yb8zsXNZqgtVzkZW5OEoJ82iapc7Ue+CBe7UCEwX9o7eAfXSp3gD2MeeKekC4XIkQVVCAELmvzAD+V/hBRsLopRHUvGKaQR2ajtQJdt9UgNRxyYwsNizj54Y/+BoEt+zdKiwyByIBLzWUJr01D+16Sxru","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"84fc1b189fbb47a59b642d45369ed240"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['1346']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['1346']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1677,29 +1748,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a10fa42-4fca-11e7-9552-5065f34efe31]
+      x-ms-client-request-id: [151abca1-9414-11e7-af3f-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pending-cert/pending?api-version=2016-10-01
   response:
-    body: {string: '{"error":{"code":"PendingCertificateNotFound","message":"Pending
+    body: {string: !!python/unicode '{"error":{"code":"PendingCertificateNotFound","message":"Pending
         certificate not found: pending-cert"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['103']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['103']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -1709,29 +1780,29 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a35f2c8-4fca-11e7-8acd-5065f34efe31]
+      x-ms-client-request-id: [1547c00f-9414-11e7-8496-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/10f865d95d1743fc94a2118d0eaf9f19","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/10f865d95d1743fc94a2118d0eaf9f19","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/10f865d95d1743fc94a2118d0eaf9f19","x5t":"QeMGGbCZLQgXYv0DUeY1oWpbCrI","cer":"MIID3jCCAsagAwIBAgIQUvuHxfaDSYmKXT67IWQBIjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDYxMjIzNDI1N1oXDTIxMDgxMjIzNTI1N1owbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMXvoh8WDvQbuOYA47C/n7p0qbdUCKNUklOz6/TRg3A2m24taCHvMCJvi31QvfIiNGzOQvRgoO5DzSmk3yqlYP48mMKOd1qc/IUDyEeBXwlIP+N08wXBWKV8msoEjDY0Y7XEjjMOJoMIZxohDXJrsIA4Y2OE/129WrXfcz3SI2yISZKW6aNHMf29OM+1Wx03nEWBNaJwkDKx5PXSVX/y60qN0Ap8Nfs8J+ggIsWd5pF/QsDx0T2c/zfGAk59P8oZ5VrJ3f/T1cDjOqABCSlbXNkN6rakferkDI0hvFdzyvg5zjOSpvoYW+GpH65vMdMdXHWGanm/gnm1v0/GhJl3Vd8CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFAAMTkMf3BRDG8ISJv33xpoFclhCMB0GA1UdDgQWBBQADE5DH9wUQxvCEib998aaBXJYQjANBgkqhkiG9w0BAQsFAAOCAQEAccYDM7OXXeVoCEOmdyNgEIiJQxUWm3RdKzqLqMkP33TVgq21JCoo298ql7Ecc/nulE/Y7mrM7p5KDGWekNvuxfhxBELnGzEkq2OfgPX7gfU65YxhauJ43EMDjqZBPEN0/gPmaDXOKQqRN4O9F+MtVfkw5hky02N7WYEyI49aDDXygnrt/1hbgElaqy/0wR5WCPQ/qmw6sIj0k+GCnC2iFh5OfLObDrITPoLS1190RJrNTq+WM7QwpTiaOFCZb0HpW4AqHNMyR/LnuBENyS+B9ZWds32ovYeGk+nSpjd7ynBchNwYxqUlH2XpeXW/zvZGnTS8rmmjez0W0PQh4N2hIA==","attributes":{"enabled":false,"nbf":1497310977,"exp":1628812377,"created":1497311577,"updated":1497311579,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311544,"updated":1497311579}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/006f86826d5f4158b362ecb4544a7239","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/cert1/006f86826d5f4158b362ecb4544a7239","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/cert1/006f86826d5f4158b362ecb4544a7239","x5t":"nX0sNgIaqNM24DEaA-8reY2Bt6c","cer":"MIID3jCCAsagAwIBAgIQExaYyyxHQqiw30bGGZ2jUzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE3MDkwNzIxMjIyOFoXDTIxMTEwNzIxMzIyOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLfwi0id6hH9AcQATjzDS8+eq+FdUl4wCj+/KM6mjhJaGHHN7cJpXUwL+Hg9E/n+sCXW36zjG1b5UaUwM6lXgUuamaFwxXJ6dU5DFHDKh7UxYIHftjgFG8ozhP9YygVoP3svUSCsjfA7YI1tMJS/XSQEAJ9yETlKvhghNPGG/spoLc+ZS09dCzoLZN9eB26RreAI3HmLrY0WE3gp4rFtzzxrc8WFfS5h1TWT4sD5c2x9iILVe3QO6hZ2TYUmD4nq/LtNnKr7i0ie6jfnCYgt3cSWWKotSiGiKLUz4q3j224b6yvKpZXfCLx4dYqGvJvvoiZ6AKa/K6EGBvtsU0DjFcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBCxupQmPbiiBm2B8Ahu8YkG/frzMB0GA1UdDgQWBBQQsbqUJj24ogZtgfAIbvGJBv368zANBgkqhkiG9w0BAQsFAAOCAQEASS31ax0ebzP1WCbPQLWH7PaPCa+no4gVEUmhs/wou3LLTy8v0MpPFdf9BLAAWFIYJlnOQGc1887sHJwr082CmighpLoYNR5TBezbc38gNLQ8DYtfFrkMwqX8E8HbhJgk/ZRr9SKfnZ5LXpSf+hWiVD4t6KQkzjpLQkjXT/Po9UnichwYvaVG09gVir8kCElJHdgD2gzkAmxc41+o/Nk55IcZoTT4rF8PwHpKs0f6q8/pb5o+IFa2IwicL9xnbgAqXbfHuW259Xy2+E0i1TWkdWiyLqkiz0fLLnE4jDC+sa8JFrVV5HbtrRmMVV7BBqQWEuV3pLOACBMHe1zkmvDE7Q==","attributes":{"enabled":false,"nbf":1504819348,"exp":1636320748,"created":1504819948,"updated":1504819951,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819895,"updated":1504819951}},"pending":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2635']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2635']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1740,135 +1811,135 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a849ad8-4fca-11e7-b301-5065f34efe31]
+      x-ms-client-request-id: [15a1039e-9414-11e7-bbb9-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
+      "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----", "policy": {"issuer": {"name": "Self"}, "secret_props": {"contentType":
-      "application/x-pem-file"}, "key_props": {"exportable": true, "key_size": 2048,
-      "reuse_key": false, "kty": "RSA"}}, "attributes": {"exp": 1509130436, "enabled":
-      true, "nbf": 1477593836}}'
+      CERTIFICATE-----"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3170']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4aad16da-4fca-11e7-aafe-5065f34efe31]
+      x-ms-client-request-id: [15cfdbcf-9414-11e7-a964-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/be12f7b605f948148ec6369b7c3c7d6c","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/be12f7b605f948148ec6369b7c3c7d6c","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/be12f7b605f948148ec6369b7c3c7d6c","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311593,"updated":1497311593,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311593,"updated":1497311593}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/5ef300623ece44baaf6defeefa45cb11","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert1/5ef300623ece44baaf6defeefa45cb11","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert1/5ef300623ece44baaf6defeefa45cb11","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504819965,"updated":1504819965,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819965,"updated":1504819965}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2195']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
+      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1469603703,
+      "exp": 1556003703}, "pwd": "1234", "value": "-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw\nM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt\nU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE\nCwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn\nB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq\nlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+\nlz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG\npgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8\nNKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT\nQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern\n0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ\nKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1\nNf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r\n8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1\nrqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP\nwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT\n-----END
       CERTIFICATE-----\n-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE6jAcBgoqhkiG9w0BDAEDMA4ECJiLClPM6t5JAgIIAASCBMigL+KlEA9fagX0\nPFhQBeFjDiebJbMuTfa9HcOVZEDyrqmGng2Lfz+TUa3ys/V86okbUp2N9MoGK7gx\ncPqdq7rnu563LT9wGhtn8mUn8Wul0FfV2K56wsBGehJ+MPmlEjs6OZR0nVdXkwAh\ndVIzH9eFdz8mhJZOZI61TQNKCKbCqsR7lslkL2VWrSFgnHCUj5bR/BLIA2oRpQZv\nnw0SeYFQWMRyXgKH4VWMqOlObXm/ELnVOr9dJVzvTG42DRaK5N8BA9NTMsK1+8m+\nenCg4iNI/s81MD8iIy/d7MmsJFh8WQoqzUZmOVxfqNHw0TPgDpbCpCWRNigkRoGS\nRosc7MIlCPPangjPMFZg5QeMuUBrE01fSvJtZ52jSMkyloSfQzQJJb9Aam6q6Dzo\nuPCH32zz1GV/56yJoO8IefOMIujvXFZku/QNzKWiXnuSA+xjFZhGEGQToU5wLtHX\neEhz1cF519c8CkM4Ll/UUHPWtb90vqO2+O2DLug9qUUnoQl7P0O3W2NpAoBCLxUO\nqrfSyLUosms7Eg1DIVo5pwxawPK8qk7gwLntATZc+aTSUR9Y1dn4vJ9j9GZWIu9J\nVKO616gDO7q8R1C3mT72k2oUuUG25TtZOxsl+Y3iJgEyp9N7jo/Rdx5KkcvvB8zt\ngPCh5diKDjbo3LxmYRt62heOLEPs2YDjKByn0Nikco3LqTnedJeXEH2mBc7x1VWE\n0qTV4xqOXL9F7000Mv1cJcE2E88fN6tDge1IpuJbs03Ij0OgpaFRfS57NciBthgm\nBp3lREHYNVa4sqWHlUqakoNtc2H62t9nmpzFV7zXJkqKPPpanKV5Q9zOD0VKgcoF\nyAuMkhuPV4IfOEbG8iiZozayk2nfRrm4+nz7b31/5Him2MEce3wbUtmWR6OPdswr\nB6K58j8TGGzOAEDTdWc9yOf/auSIBVDw+23/TbrVD3xRWdesKa4sj7rMW+3VZ1mh\n3/ghyhVPtvFcUKrAjjBjkdeMl84m+P+KcV9Ov57bojKVQdKc7kHrkpi4F66s4Z/J\nZvWHw4LyK4PRlRFzm8eKtXkYLFssxtTRYRydT4wh6VJaOQD2Ww1cPOc/D74Qr/ap\nwQu/fx1Guqk1artbE+BalJakMNKd5Cu2/MfWt8kEjNctGrAHeDmznk/TbvX2rEpv\n/P16WFcjB4bb1Nee96xfuGPUcHul3fG5TRmKJnaxWeg5FM4H4cP5jmeXyGNqdbDS\nrgqpXChenTBwS5JvAVgv8ZvxJxp4h8fLFlUOKuKUR95gB09nBGnwAtEM4zgjKkcC\nPcvDZ7YpzU40gx6QiCVb2UPtggiEp2WyIrpe8VfzK4C7pQGInLn3Rm4G7mEFacv5\nHlbGJO+2XIk3ibFJYTQvMFYc/ESeRSOw6TDoy1sg3+Yl5BXYC+90lCGR9JK/sBYs\n12eVEqxi8kmoNXJ4on0snfDuRDv/6bIIDpfPAKqZzbTq7h6wzIreoz3wx4Oa8A9V\nrtG8TOkCYaoJRYD5uV1lc6Ok3CpZrI7kTGAfvQNi+H0Obz+sSXGksNtfdwNUzUd6\np4CXrZmc/r6o3j4biteWTURnRQqkh67QM5qHJhmXuWD82sjSKU16MM0KqPze/Tl+\n+Figx8pgk29H6LM+N9Y=\n-----END
-      ENCRYPTED PRIVATE KEY-----", "policy": {"issuer": {"name": "Self"}, "secret_props":
-      {"contentType": "application/x-pem-file"}, "key_props": {"exportable": true,
-      "key_size": 2048, "reuse_key": false, "kty": "RSA"}}, "attributes": {"exp":
-      1556003703, "enabled": true, "nbf": 1469603703}, "pwd": "1234"}'
+      ENCRYPTED PRIVATE KEY-----"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3395']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4b279970-4fca-11e7-ac58-5065f34efe31]
+      x-ms-client-request-id: [1668c070-9414-11e7-94e9-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/df4f891e087849978f268a792896ef19","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/df4f891e087849978f268a792896ef19","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/df4f891e087849978f268a792896ef19","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1497311591,"updated":1497311591,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
-        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311591,"updated":1497311591}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/f3160729ecf7401390b07ee91b9215dd","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pem-cert2/f3160729ecf7401390b07ee91b9215dd","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pem-cert2/f3160729ecf7401390b07ee91b9215dd","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1504819966,"updated":1504819966,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
+        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819966,"updated":1504819966}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2295']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2295']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n",
-      "policy": {"issuer": {"name": "Self"}, "secret_props": {"contentType": "application/x-pkcs12"},
-      "key_props": {"exportable": true, "key_size": 2048, "reuse_key": false, "kty":
-      "RSA"}}, "attributes": {"exp": 1509057404, "enabled": true, "nbf": 1477521404}}'
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pkcs12"},
+      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477521404,
+      "exp": 1509057404}, "value": "MIIKiQIBAzCCCk8GCSqGSIb3DQEHAaCCCkAEggo8MIIKODCCBO8GCSqGSIb3DQEHBqCCBOAwggTcAgEAMIIE1QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIbwOBx4/NrhYCAggAgIIEqFt2jRoReOisPRhk+PHevFOIHIeT75hijC68TKAHmEK7bCZ6RFzyCD+gMarF6XyaHiNW6GDdXW4xy8eyf89DeyiHmbckcQKYZW01cqLNwmWy36haXI+RW+YBEGOndBiyeQEiXgFASyDTqfP7dmyEe9J1j8Jokbmju7tBFMRRxAdGQDyPscazA2q0BF9uX3jDZvQra7upxn9chHJqOdO21gQ+Dogv0bb6fOEvio9AqUWfmstHYiXTIkwaq8oxNy509OkHSiNFeEvJKUK4EV7Hye1mqQw41UJu4+R8nI9HncE504pjwDc0f3vwhQT+j+eH1HGugayUzEBihl9Ylp/VfxeSIIEtLegELCHas9E7ygWSFonXdCPMAKE3ozWoXM43ew2CQZe+j2v1eX5t9KSmydcwG0w/DdbIPQQeiR/A7xY8DH4z2V49v10mmwH0uG//1JNWciKbt47C2sBcxPvLDkGXq7xX0f9zZcWO5ipNuaPq7Rhr7JHFnfvlVag3Cg9j70GQ6c1xhgsuNzV0L6Nrajsu5WS+GE05hFos1EalHz58KOAF0Q4sn7cg9nmwGfvXDPRDA8ol2ySXWD/TDj0GNMaLTEoXUQtxwebVh2wuipoEB13KjzW/m6AeKEmXLmkSwQeZq2IBTZxxzrxXUbIT2qTUbjI96fxeXm+VHm9JZSa73r6vkONA1Xcx9Q8tvV2ZCfTVz9dnEcD4CE33fX0XS5rZEiUGqmNdnvQI3B7gsoPt8eh17vSpHNeJThD24kBEXf4c3DaGZAvKOut6pi28qSNe1OcQwzZnpNro8AKmHVsrMICG7ZucmKoYNndRlPrHrfkFi1aoNugJOvPcc4x0u5OYe7XW6/MBU/bnUbow2vRtklI68TCEpCj9YS/dbAB5uxTxxnljatqh7Oyqcd6T8La7Wugz0Ufu6ddjuohfu9IHSAAK0qvrO+AAOIl19p+wOx0RVbtZcppIIQutff0dTop5+auNDinY6Q4L4EoUb2zqZ/ZA8fyecMzuON3hjKI3cB0Wmx7dZUgc4w1mND+AxQp8irIYT8Rfh16aYg/gP9/q8kd5FDApPkOdB5wkIaudArtdtAo8jmJzPyBVqtZYdKA88WINqaBt9c1RMYgTlU6tLllseJNRBtGHaW0kdW8qBxIbW8M443njiqtrNy5QRdYXoK12w5TQES9rtG0nRLNmaB0Wj0sdTMyf5vpWnaAwqYSEB4uRFdFMTbaFNONCyn1cYSPnegjOfvvnS2/KWXK2OynAaJn77fy8eGssMuvVh75vb5W95zGhVtHpG4N+nhJozVToufYPD3V9EcTnOUanTI5uien+D5Doy8L+KxU6Iki2m9dbLOS55TPbTh5LL7UC8AWZcd3ol5kgs5XxUOVMc8RGutmeb4AjGM2bG6Ac2By+LHZAirTdoV9TP8CUhFZ9iowipZhKACVTthjKQa/4PVFALcn9P3/uf0g0Bghk2LgXn/SZFATZp0WqyNHR6MGuthjYebVbmzb3WWEldlLXXnhqxANiAIDzSWpplH/C5wPBCS7m89lk4Hupi34SeFyGBp83K1oV9pdgV2k0bb3ehKzEc4rFWzUwggVBBgkqhkiG9w0BBwGgggUyBIIFLjCCBSowggUmBgsqhkiG9w0BDAoBAqCCBO4wggTqMBwGCiqGSIb3DQEMAQMwDgQI/IAsnGbwllsCAggABIIEyMkD/raO26bnX/+TkW72DueRJK1UrUzJftrmgimEuV5xP7NqKaODiuc636Lp0VJvKeeS3xFk/3QTeNWFR6TM0vhaJ5e2WkFScY+cRWwYBG1E91+FSsrZWLi1yAsrfyddy8ocCca9PP8MgMFKD/zBhxtw66J9kPTZC80f53sIumXwvzzQ0FA5JB7kfddPg2fZokg7DF3ZoBS/P3alaQ+jpx0k5s19l0jYzvI+2FzIasoXs/Mx8OJbnP+QTkmUv7AOwtZfPRg1VVoLtB1eDyEwDGjR9neDgmxIHLFa1I911D6fyR1LL/jqjz2HRMIZBx1x5bI5ippQMneuaeZq9ZpU9el3Jj8UzxkpmP1gzTnfld3BSil0LLjgjTOV0HYtb8ifb/Lli8rJoUpycMdZF19DPnj0CZKaThV9fGlMm9MbfEK+ENIKXXLmC9kV5piyzF4q/ORGysbemoW1G8UvPsxyKOWVeALKEdwMXJyZ4G+Kfgd5zMMrIGg8C8xoX5wQ3kKIVZqhuKmQVM1t7pLOuJNxNFmvzS/08trulzPBNK+UDGghri2VBrRrE8NElNbsDDWnMNtF3uvmyQMa1MhyT/7P4viTdcU1C6WF4y5I6K2ySX/x5Uoukh0zfNzsMt3hzeYyQDAscI6gKUqqAinEUQWYj1ErUsgz7u8qFAe7ZJEKtVOPWOrGEOnMdJ7YeR5dnx9WX+s8Uy2+gFJVOGrWn6UQzz/++DOM2AH6oF6QDwpT51flSzBN5UhLl88uubtgo7JB67RJpBC4eZ6Mjnh88gtEn9LvaUUp8qVsYECrK4PF3kfGbknu2y2K/rPMelKvSGikS2KHMDPpf4HKshuIlB2hn8fImcrLymDCzkqiSV7WdcK6D//wnQELRk+xn7SXJU+StPGfcOnC1Hcnstnh17w9G4XJ9Gsb6kbZP7Gpy3L0vwBR3PU4S8kkOEpBELiTYhrmWHBWy5zS9h2UME6/EaebyokPrzrDrF2tgkKHV4m84pKPfeCxAEGsUm8HgTUBaMS/Z0yR5+B7oac7yZuhRBtecDFsg/AVzsjyWB/0PbwME6bRQbau8vJRVCS8NcpbJYcwzOnOEoO0GjIes1tYddmZXx8Jl/VevqeMw2u3/fItLCyxDw894flF2tbxWC/lD7YGeU7cnAfscrKXBNUuHZTDv2l1k1R4GnvnFep4bcvOWI9MdpV0Omov6dEC8x18RmfxWofhAFTHvz1fiI7myPYRdAxwhxqkslKuRIcX8zluOf1L7P3o6goJfGeTlj+6iB1N82u+zECC/37c6vaz40HI/k+k+KyyKe7FQyrbhepy/8ds1NMpsGPmqsJxrvyr4vwDfkBzBeSPlO8c0r4NBSRF3jOjAO2H2mxnBSGv+4uLtyPCTwVg3HOIe6XTItWCiT0lffuJr5UbS0Z3Xqfko70ZVMznLooSlevbjHKI7ZX5HIjWT9hrKYRW2xrdfhHE8uOsOJgVDPkpaBPBTu7l2vc+CQlW/s0HhuIcnVUoL8f2DPVUHWRM5I9YKrlpmDEyOc+0EHrEmeVD9Hm570Hg4jC1MtQvFjBxua2tmiF7vKh0OLN97Y/tlMeYgWDHuSKCRzS11LuOUYAQPGv4rXWo7SA4dSM39PBwsQ9BUDElMCMGCSqGSIb3DQEJFTEWBBSU2HhO0VVjW3d6L/gL/6Gwhvk8hjAxMCEwCQYFKw4DAhoFAAQUm/7xVQGGqpxCCp1Tc+48jv6GxbkECF8YkC0nzqwrAgIIAA==\n"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['3874']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4bb889cc-4fca-11e7-8fa5-5065f34efe31]
+      x-ms-client-request-id: [1706870f-9414-11e7-8d12-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/2931c9378b8c48448f1bf21ff98bb712","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/2931c9378b8c48448f1bf21ff98bb712","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/2931c9378b8c48448f1bf21ff98bb712","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1497311593,"updated":1497311593,"recoverylevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
-        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311593,"updated":1497311593}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/a3005f389ed549028fdce6082dbd379e","kid":"https://cli-test-keyvault-cert1.vault.azure.net/keys/pfx-cert/a3005f389ed549028fdce6082dbd379e","sid":"https://cli-test-keyvault-cert1.vault.azure.net/secrets/pfx-cert/a3005f389ed549028fdce6082dbd379e","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1504819966,"updated":1504819966,"recoveryLevel":"Purgeable"},"policy":{"id":"https://cli-test-keyvault-cert1.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
+        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504819966,"updated":1504819966}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2551']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:53:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2551']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:32:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_key.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_key.yaml
@@ -6,75 +6,76 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [406d3a82-52df-11e7-8aef-5065f34efe31]
+      x-ms-client-request-id: [8553ae00-9414-11e7-895c-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Fri, 16 Jun 2017 22:00:46 GMT']
-      Duration: ['1155535']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [7lfhhMghj6mXb4ltmows5KMPeH8GaP5FwRwLQN71ZT0=]
-      ocp-aad-session-key: [qtnqeYtqDyLdI2R5lX9TjQQ7pc__h2iqz__bnpq_-xFrSWse_gyjHv12-QGcH4Nn7dCZSDpudxAObeYJcMJ2ZsTkr8vcEiaEbBpT2NhUOhuWCaRB-70fyOU1ajEevtLs.rdwllYdYdbLQ_XiEFJffqav7IZnKEq7FgYGGYa694d0]
-      request-id: [bf0958f6-e125-42b5-a2ec-3a0891e37bcc]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:35:51 GMT']
+      duration: ['544998']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [DRh1E8KpzyDQ2JIEbQFJYUEDvVJ2kaqlg9shn22LEv0=]
+      ocp-aad-session-key: [VOaE6sd63ucCmZk7x2cxWVk1y9GjR6MVFmBMtFz6ynh6AOsyvuQoUuH8GWYKX1H26zazy5cdqOyyh5GP5n7zmDGaffZROX-WV2v_BeF35QrVlg7mg9SKKPg3McSnQPDf.uC8VQ0UcFxHvmXAhAlQKvNE5i5BNYmMY0K_7O84uWcY]
+      pragma: [no-cache]
+      request-id: [f1c6e49b-266b-4284-98f1-d06113f43397]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "premium"},
-      "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "accessPolicies": [{"tenantId":
-      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "7541419d-883d-452f-a823-56aa8bf0749f",
-      "permissions": {"storage": ["get", "list", "delete", "set", "update", "regeneratekey",
-      "setsas", "listsas", "getsas", "deletesas"], "secrets": ["get", "list", "set",
-      "delete", "backup", "restore", "recover"], "certificates": ["get", "list", "delete",
-      "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover"]}}]}}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
+      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
+      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
+      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.9+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40d62c94-52df-11e7-a068-5065f34efe31]
+      x-ms-client-request-id: [8574ca8f-9414-11e7-8ef1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1011']
-      x-ms-keyvault-service-version: [1.0.0.171]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -83,29 +84,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [419227f6-52df-11e7-b74e-5065f34efe31]
+      x-ms-client-request-id: [e040a840-9414-11e7-8c49-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Fri, 16 Jun 2017 22:00:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:38:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      www-authenticate: ['Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
           resource="https://vault.azure.net"']
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 401, message: Unauthorized}
 - request:
     body: null
@@ -114,59 +115,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [419227f6-52df-11e7-b74e-5065f34efe31]
+      x-ms-client-request-id: [e040a840-9414-11e7-8c49-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":null,"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['30']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"kty": "RSA", "attributes": {"enabled": true}}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "kty": "RSA"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42371b9c-52df-11e7-9cd9-5065f34efe31]
+      x-ms-client-request-id: [e0848f0f-9414-11e7-b86d-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/02b0ac2cc0794c1cbe139c9ee83da4f8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"x4jhwRV2gumuWs3hc5hWsSJL_-AFCM4soRXLsbY6DzkMiwJFApsReui3Yl21DeteklQHL4iZ91xFdubVfdBlkVkU6k6wLcokIu14gHDxoziC6Hij9vW3Y8n_5aJ4gT-bp9k7NoWSo1Gxf4eZ9c96mMW85EH3k-o7QYJ3pBWIQAY2vcj_yMDs4EuIweyyi7ZWdOHui9AyaWMbOUdfZpleBI970EjTZsHjuLTD5r8yECwfeoUP73U8KDjyiCpbm44QU1QrZnlOlUxCBvfsZtLLGmWH-3dz4D8irZZMNMcBCvY5At8u65xUtZoICAnV1jaoie5dYoMd-7-0o7vh2w9ltQ","e":"AQAB"},"attributes":{"enabled":true,"created":1497650450,"updated":1497650450,"recoverylevel":"Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ndb-XyULSUqs9aUsAkhjbmFwq8cEq6O8HhKahejHN6_G1R2iQbXXk26tpjghcdDOKyxGwUaTZfy44qPaucKrdlHUev2BBF6W84GI9qAse3b4uVtpb99cMC0NLoda29nrLWBhRNmkjIAt6zQC3o2sYs6Ji_FD6ReTAMNIXY2DQn9xd9S8LqUfITFk7lzn7r7HAPovKknFVVZP4-ZEop8q-gSY7Qu9UnjEuXbDRRJa0NNpAGM4RaHvDBJiBtOBLb57aZNZguiX1Nb6yRujUYprobTBSsxrKHgyiW_rav3v0--w24fCiK6w0YfwuZVSJev9S1HinQgShTytig6UssfL6Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['648']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['648']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -175,60 +176,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42a0d886-52df-11e7-ab60-5065f34efe31]
+      x-ms-client-request-id: [e0d2d621-9414-11e7-814b-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1497650450,"updated":1497650450,"recoverylevel":"Purgeable"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['193']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['193']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:24 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"kty": "RSA", "tags": {"test": "foo"}, "key_ops": ["encrypt", "decrypt"],
-      "attributes": {"enabled": false}}'
+    body: !!python/unicode '{"attributes": {"enabled": false}, "key_ops": ["encrypt",
+      "decrypt"], "kty": "RSA", "tags": {"test": "foo"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [42c551a6-52df-11e7-9834-5065f34efe31]
+      x-ms-client-request-id: [e0f1f6e1-9414-11e7-b931-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"zw0pC_r4l9hurzpN2viSOCcehX16tPF_s5Gs1li7VBh5GbcArYPpiGW8JH2OE-YUkSpEwxvQslAvPtyGJ2f7yCvgoE7CtxvFpI1HjGUURcg11Gs02HLA4IOS0t4aYTP8o-m5LUQTy0TFNgGj9KiEumJxbqWDd96WrHVmYRJUXf_WY4mLwkMsIgKQYzDu2jRCA_0xB28E-UdwLjS5SriILOWJzmx5PnpbaaeJU_ex1vnelgyLR5_6wRE-vH4jAoQwGAgD3PSdSJ9Drek3URt0GN-qmjaffNlWN8GLDBn-4SdwXuZrlFHW8JWXSGJ_D5wRJ_WN9EmSb4Q26L35-VfYIQ","e":"AQAB"},"attributes":{"enabled":false,"created":1497650449,"updated":1497650449,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['633']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['633']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -237,28 +238,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [430999fe-52df-11e7-ab4d-5065f34efe31]
+      x-ms-client-request-id: [e1408c0f-9414-11e7-907d-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/02b0ac2cc0794c1cbe139c9ee83da4f8","attributes":{"enabled":true,"created":1497650450,"updated":1497650450,"recoverylevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","attributes":{"enabled":false,"created":1497650449,"updated":1497650449,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['448']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['448']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -267,28 +268,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [43773ad4-52df-11e7-9473-5065f34efe31]
+      x-ms-client-request-id: [e165ee61-9414-11e7-8775-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"zw0pC_r4l9hurzpN2viSOCcehX16tPF_s5Gs1li7VBh5GbcArYPpiGW8JH2OE-YUkSpEwxvQslAvPtyGJ2f7yCvgoE7CtxvFpI1HjGUURcg11Gs02HLA4IOS0t4aYTP8o-m5LUQTy0TFNgGj9KiEumJxbqWDd96WrHVmYRJUXf_WY4mLwkMsIgKQYzDu2jRCA_0xB28E-UdwLjS5SriILOWJzmx5PnpbaaeJU_ex1vnelgyLR5_6wRE-vH4jAoQwGAgD3PSdSJ9Drek3URt0GN-qmjaffNlWN8GLDBn-4SdwXuZrlFHW8JWXSGJ_D5wRJ_WN9EmSb4Q26L35-VfYIQ","e":"AQAB"},"attributes":{"enabled":false,"created":1497650449,"updated":1497650449,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['633']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['633']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -297,59 +298,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [439f841e-52df-11e7-b12f-5065f34efe31]
+      x-ms-client-request-id: [e1870af0-9414-11e7-a782-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/02b0ac2cc0794c1cbe139c9ee83da4f8?api-version=2016-10-01
+    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/02b0ac2cc0794c1cbe139c9ee83da4f8","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"x4jhwRV2gumuWs3hc5hWsSJL_-AFCM4soRXLsbY6DzkMiwJFApsReui3Yl21DeteklQHL4iZ91xFdubVfdBlkVkU6k6wLcokIu14gHDxoziC6Hij9vW3Y8n_5aJ4gT-bp9k7NoWSo1Gxf4eZ9c96mMW85EH3k-o7QYJ3pBWIQAY2vcj_yMDs4EuIweyyi7ZWdOHui9AyaWMbOUdfZpleBI970EjTZsHjuLTD5r8yECwfeoUP73U8KDjyiCpbm44QU1QrZnlOlUxCBvfsZtLLGmWH-3dz4D8irZZMNMcBCvY5At8u65xUtZoICAnV1jaoie5dYoMd-7-0o7vh2w9ltQ","e":"AQAB"},"attributes":{"enabled":true,"created":1497650450,"updated":1497650450,"recoverylevel":"Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ndb-XyULSUqs9aUsAkhjbmFwq8cEq6O8HhKahejHN6_G1R2iQbXXk26tpjghcdDOKyxGwUaTZfy44qPaucKrdlHUev2BBF6W84GI9qAse3b4uVtpb99cMC0NLoda29nrLWBhRNmkjIAt6zQC3o2sYs6Ji_FD6ReTAMNIXY2DQn9xd9S8LqUfITFk7lzn7r7HAPovKknFVVZP4-ZEop8q-gSY7Qu9UnjEuXbDRRJa0NNpAGM4RaHvDBJiBtOBLb57aZNZguiX1Nb6yRujUYprobTBSsxrKHgyiW_rav3v0--w24fCiK6w0YfwuZVSJev9S1HinQgShTytig6UssfL6Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['648']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['648']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}}'
+    body: !!python/unicode '{"attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['33']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [43d78498-52df-11e7-8e6b-5065f34efe31]
+      x-ms-client-request-id: [e1a9d530-9414-11e7-85b8-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"zw0pC_r4l9hurzpN2viSOCcehX16tPF_s5Gs1li7VBh5GbcArYPpiGW8JH2OE-YUkSpEwxvQslAvPtyGJ2f7yCvgoE7CtxvFpI1HjGUURcg11Gs02HLA4IOS0t4aYTP8o-m5LUQTy0TFNgGj9KiEumJxbqWDd96WrHVmYRJUXf_WY4mLwkMsIgKQYzDu2jRCA_0xB28E-UdwLjS5SriILOWJzmx5PnpbaaeJU_ex1vnelgyLR5_6wRE-vH4jAoQwGAgD3PSdSJ9Drek3URt0GN-qmjaffNlWN8GLDBn-4SdwXuZrlFHW8JWXSGJ_D5wRJ_WN9EmSb4Q26L35-VfYIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1497650449,"updated":1497650454,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['632']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['632']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -359,28 +360,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4417873a-52df-11e7-915e-5065f34efe31]
+      x-ms-client-request-id: [e1e2e68f-9414-11e7-9081-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/backup?api-version=2016-10-01
   response:
-    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnRfTVF4eS15LWN3cW5lRkthem9iWURuMWZSRUpFZVFoT0hPTTlJb2xKR2dYblRRWEp1cktNMEVlQVBHOURGVDdqRXV1SFozaUJTUEJBaGRJRV92NERUOGRESzhDalppZ1Q5dmg1eFVqTWZTMThFbHhyVTBaWGNrMDRtOUcxb21CRmU2VmxUaFdGZDNWM3NZanBuQXlGUXI1bDdUZmVLS1lsVnJjT21tMUF5cTBFNFE0QXNiNGx0aTNhNTNiNFNJMUxOWUlrcFpwTFllOEtwTW9aek9QaWV2UHNEckJqMk01cEdBWUNGYTBGTWItODBkRzJtX1BkMWxKT19rVzVzTTBmUjd2NEtSWmpwOU1lWUtEdFgxLTR5elBmQjljV21QU2k1YnpSRFpoYlF0cHhCZmItc3ZpblFUNW9JMUJTMm9GQUhGcDN6bUd5SHVmNXZWbFgwRmdNUS5haEpjbjZZaXFZMlRPWll1eW5CX2F3Lm1oa3lTNWxQUnRvUmZFVlkzUkZneGFydk5fOEJDOVIweHhCbUZRYUs1N0djZE40TEdyRkpsalRSNnVhMmpHN1ZWdUh6UGRnRGs0Y3N2ZHlDNU9URTBuRlMybWMwdXR5dXA4ejNURVVXZnI4Z05Tb2dWVVR1RlpNSk5ncDZYci1xdEU3SWprX0tnRTFEZzh0M1g3LXQ0ZVdlZi1CeWlIYllvMjNING5OVzJKbG9tNnNYY2ZjbkkwZmVmR25tNk5VekJZWG5qWHc5YkdhdnhqZDhEQU5FZkhuTGFCWUxDV0tERDRhQ3dXOVg5encwV0I2QUJYZVg5andmazU5d2VEMFFGdVNud250Q2FhcTdSR1d2WGhRQTlfVXIyYmZlYi05bU40RVl2UWx2V2FtRXVBUjVWODNmRWhjM1Z5R25KVDdscWVpZzI5YWJEa2ltOHhjUC1VUEF6VlktTlo5Ny1UTERtMjJXcmI3M1lhazZKaFJLcnotT2RNbXNGdWdyWEFvdm45YWhycFloVzlEVFlhNzBDNkFWR1hLM29yTHkzLWlqUmJ0Y3JYRmNUV0pObWJNM2c0SXJRZEVPWTJES0c4WmNldS1hdk5fR2RRVDhCTEdmV0ZENVdhbnJIcWpwWG42OFJPaFN1VFdGS3h3Q01WZ1lsb1k1U3RhRURQd202OE9mVmVIdVJnNlAzeTJmMjViNU5DZm1TdDNwbnVjYzNaczZLY3ZYWlRXRHJsTDRKNGJLTGZBd2swbzFOanRmeU53MmNZSWd3S1Zpc2wxcVZwV2Fpem10OEE1WU5rSFNHNHpMaUFzTWU3TExBa2ZXenJ1ZHlETDFJbURGbXlVeF9GdjdzUi1oVDBaZGpnTVpXOENPSXlVM2VEVG4yOW9UbEtnbzRHTlZ3SGktZWNDOU1kWmtDNGNvODFFcUlXTm95NVdrOVpmM0RsdWNpUG9mWXc5TjZyQkhLcktWekxKSHYzbDc4MnJzWHp3TjVscmpia2RvRkJDR1FURkhQREU4VS1VZmEyc3JHZGd5emdzUHJUMk92ODM0eFpvenA0Q0d3SlpVV2pGZDVobG5ZVTAwajktWDl4a1UxYjN5UTZfUThFMnRuYWVsdnFTUkNXbEI3a2hZMW4xa3dKeER2X3U3aGlGSll4RDEwc19XTjl3cjM4UEtWMlVlMzdrdjYzYy0yS05qRm5zZUE0WUNabFpScWpmSWdHT3NydXNIWFQzRUhlVG5maUVFS3dPaXljZWxmS3JaaGREMDRGaWs3bEtlMDNPZXM4d3dscVV4bkowd0FzM2t4d1VLN1BkcmNYUm1COWtROGIzYVg5Q0dDcmRVUzB1b3FDM2dKdWxZWWI3al9nU0xaYlpLdjJXSUJ6TnM3LVNLZFg3YlRRdXotSUx0eWRublI1LTBuUmZDdlNSSE5hMFY2OUFVaEMxVGxHclcxSzVnTnNJc0s4djZwZU1ZM2lTZWZuMElIVEtFV1JoSjVBLXlMT0xIbUYxVmIwR2x5NlBnZ21NbFFSX0taWU1yM0ZzdFNFS0s5bHE5Q3JkYVJnWXUzekxGeW5WS3VIZ1g5aDE3T2RNcmJ4MTBpQ0FNQmJPaGc1VGhjbVNsZkE4a09hdTk5bmxVdDZhdy1NRmVFLXhKZ1VmS2dDNGVnTy13YTBTSTVlM0s5cU1ubTV4MmVKc2thM1lfcFhBZVdWYVNNOW1CUjJPWjFSUG1OUWVCZzRFVktqM3RXbVBEcmdpVFlIOHpLcHpSRGsxWUlUTVVKcjFjRzZHX2FvODllY1gwTWtZeFVGUV9YY29sbEt2VElUdnlDMDdlZFlzaFhrYzF2aEQ2cnJUbkYzZmRuN0xUWE9xWnl3V2tVamJDejNhVVhIeVdqdjlHM2RFQ3B0d1ZDWTNqT3dpbUY4eFpBVFBjRU81ckg0bElyNWNmOEgzMXlya2lLM2RxdXVvWU5mNVd6S0xSckFxVkpBTy1zTmFaVGZ4eGoxcHNrV1UxTFBWb3RUV3R5MW1zeU5oY1FQT194dUVMQnpEZkpRaHBKZnBSVDBtQzhRN2g1ODNHRFlGcmpxZlAwX0h6VGVFelZBaS1rekRqV1VuX1U3QVQ4cnJsaXpELUpGMDZhR1FLOGR1WGlSRkpoX3g1aUwyQmhKLWZWTDFMb2VFRTNqV2tYTXRJdnBBaXhpNlBxeGdaZWN3NWpjLU1CN0ZIbUE0eXMySG9MVFZWS19tUjl5Qlp6Qjk2RzRZTWR5dWJFWGp3aDVvNG5GLWJmOGtOeF9LeHZfWDFVZElVSzIyS0QzTG4yYS1SWUhlUWtBckNneEFiRndVY0p4RC1TYlEwSW91aWpPZkgzS2g0UGwweW4xWm1HTnJldURuOEgzVDZ2THF4bHNrWFVNSU5ZMnJldmtwVFlZeWIxVW13blB1bTYzeTZsOEJaVDVxbmFYY0RzNU1OaXpjTHJjRkdGQkQySVdqMTFrTE5QRXVRMDlDQ2lEZWQxSzEwTkt1UUUtaTlsT29mMDF2d3hmRTBjVElueXBIdWRFQ1BGdmxuQ3ZuTUNScEQzUnBuQmQ1dlpoUTVjYms0WHNBYUlvRE9kUk1BT3Y4U29veEMzbWZFNFN0R0cyQ21oWUZFYkY3LWQzbk5rYW9zTFVmbTJxLXZyRDZLX1pJdHhxbmt0MGRENWE5ZzlNU2VVSnZsVFhpMmFiMFEzUzlFTXhxeFM2bEVRbmdrbTNnV3hvS0pMd25jQjd0WHF1ZjQxeDljTXJSRHBoSHNWcU1pM3NvcmU1czg1VUVKZ2tFRTFBQWRQcW5kWGM3V3BuSHluaGFsTUtYeEJYMjBkcjdXVzRrYVNINWVVRnJrZXRUeHhFT1RBa194Ukx6SmlSVXE0ZUh4MXVmRVpCTzN1MGxQUGlDUGhxZTJmTkNnUERsTEtQSFNPbklJcEJHa2xjZzZscHNTcG5YSkRiSG9pV3ltbkw5b05rb2dGZGhWb0E3UVJsRHhJWE1ieGFUSmVtekxhcXk4WkU4VkpYamQzSXVwbWFNcHhFbFNLd3ItejBvODlJSU10U0xVVmd1ZjhmT2x5VllkS3RjdEgxSC03djlxeGduWEgtbW0xdUVodVRNY0tGcTk0QWx6Z2RZTHdheTlRaldOOW9VWENQWkV2Yzdxd0gxMC1xZUViUGFDdHFXREIwOUxkU29XVldzd2dJNjByd2U4bWRNQ0owd25uMXdXYk5ZbTdJcHlfcUVOeXFGU3Fta0w1bUpRM0Z5d2d6aGFDM3NpVmFWTmhvTnl4aXRYRkZYYzNYWHRTTGp6ZnZKQTJ6a2NJUUpLT0dtVVl5RjhzUEJGaXVKMlQ5ZGluLUlWcU82V0NJckFJNlU4SGVjUkROTVBURXgwcGFYYzl6a0Zpa0F0SW1saEs2Mm5TY2hqZUJYUlJqWWRocDlMSG1oTmVSd0Z3MThud1ZkVlhoM3ZkYmxXRzI0MDNCUzFRUEJrTGNlRjN1Q21mUTV4bXRvdEgzWGlQb2IzMVptRUtyOS10Y0NoUnZFc3p1dXFpYmR1dGprV3o0M0pvS0tJcTRuQ1ljS3RDdDdicnZ6V0txTEpDcGpPU2NFNWZ5c0NZM2JrSTRHVFJBbndUcXI5OGdVN1VkcEttSk9OX3BPSVZfaFZuS2dNOEhCZ01SNk1NYVlmcjE5MzFsU1FaTjhSZU1RRlluazNpRzVHTllIZXZBWWJfWW14QXc2NnBraWs3dmtsLXFDWGZxb1VoS29BNGdiNm5uU3BleWFnOUdka3J2eVJQbEdwYzRHNWlta20xLWZXZ003M3k3Z19YV0REaTF6QkVaWjc2VVhkMno1VWd3M3hZYTdKZjJWT0l4T1M4SmpFREVXdkxlSF84NTFMQ3FMWm1oNEh5S05xZ0pKa2xpQm80eS15VVFCSTZHeE51WngxbmhkVzhBRmxqWGNIT2tILUZNWFFfMG1KUmRwUXZhdkdnNm1iWjRvR3R3Nk5Va1hLRWxnTGt1SEpvQ0IwOUhOMUp3NTA4cU9pU1BvQWNBMFVMWTk2YVdtRGNZRWlPb3EtcTNPX0tIcVZ5Q1BtUkxzZXhwT1JCTDdsOU5YZTFybnhLbVZyS25UUElwY0JuY1BwRWZ6MWRSdF9aWW9zUE10STZyQWhhdUpjcVZKZnZaamRVNC1PakFreEswMmZoN1dTM3FVWTVWQTFBeXFWbEd6WEFEdHk4SFktY1l0VWRnekR4WTd4Y0dUVFpvdU5qbDlaOEtQaTZzanZkQWF0SHAzRFhTNmxWcUhCMEVHYjVkbXJBYVdVTEFuSWp4QXNHdXdsRmI1R1M0OFZVSDhpU1d1TWZiekoySEFnY29oT2dBWC1OYUF1VXRvY0p4SG80dlMtaWJaMEJfWjQzWXo0V1BkQ2FZdUROVVE4UDU3b0d1RVE5a1BxbDZScXZLaVV3YVBiWTFuU211ZEdRMmRkYVJrcTRRTHJndzBNcnBFUFFaNDZoZjB0Wk9WUmJJOENuOElGVU85Q184aVB1M0hkVW9iazd3a2tmaEplYldMSE8yVzY1ZGhKc2N2My13eVRnSEg0aHFMZTc1cGl2N1RLeHFKQlJ2eXlFbTExa0s5NGdaN2o2SDhBTkt4VmlDU290UThSUkZaWTBiSElEZFRYTGlSRm5ZdjlUcjl3V0NJaEdudGcwZEpyTVlUZFM2bFhoYkdnTlpIVzhhRjVfX0h1Vl9IN0RleExQVXBRMW5rRm5INmdnaVNzNmt2SkFjLXBMOV9hTHJla2I4d0I0UE5Ycm95YWJmcTRGTGlkSWV0ZEQ4Vmo0V2I2SHQweGE3WlJKbUhCVFlWX2tmSGJrUUFDY2FfVExwYzlCejRPOGUyN0FNRkpVbVBpYkNfdGZxQUtPUnI0VmhwLVJnTVFmVGY5emN6NnBFbjhNN1EzMWhyQzNEUkFIWWZBYm12UUl6WWZmc0FIcnZ4MU9fcG1HWUtEaDNvdkF5dEhaVVF0VHBTZVBCS0FiQUJLcmVpeXU4R0Zrb0Z3cUhZVG5YbW9DQklBS1FERHdfYUhEbUlXU3N5em5tLXpnaFNjYzBOYmZmVm8zMlVhWjlPY0FldUF2RGg2eWo4cnlPRWJYaEhLY3ItQW5RaGd6SjN2Vm1QaXE1RVhGUWJWOEFWdTFVX0FITzI4XzJIUWpOb2FtV056SGc3c1VYX1NnN0EzblVoSFBLUWdvaUNUbi0wT2RVR1FZV21jMkdwc2JfQk1kQnB4OHJxMGt5TFJsSVRFYVpwd25QUHpaSFpfNXNHNGdYQ01QTG9RT3VZS3RhTWRqcTBsMGVsbGV5NmszeS16QmY3QVR0cEE1bkdTQzc1YTBoZzdRUEk1TnFlRVRVYnZCbFJPTXpab1pja2lwMU80Z19CWVo0ZkJnT3BhQnRFS192azh1QTVRYnJUWW9FbXViZWZ4T0prVlNmS3UzdzZQWUpObW5Zb2d3SlI5ZkdPQ1oteTdnVkt5RDdBN2VFbjAzalpSR2pyTXI3Vk15c3hCNVp6aWt5NDZCZlR2eV8tMUl2bWtkSHZSZi1fVVdvWjRDZVJBYURKV3drRzM3M0h4OFBlcFM2QURpUi1MTm45cDkxU2lMM0dLRnRqR2FFaE1wN2FGNHpYVkg5bWFXUm9qRzgyMkpGSTUzelVEVzJOREtnZDVVRnRZcEtWeS1MVWpjTkg0VXpkRHRIdGxFNnB6YzgtQUZ5MjlZTk8xLXFoR0Eta2Q4UENtcmViS1hwSEllWFlDUkV2eUM2cUZrR2R4cVlNNFp0bmlPQUhqQnZ2cXBEaUluNENwc0NkOW5yY0pENGlmSmRPR19lcDlOQzhPM3N0R0NIV21jTFpjY1NwdlNDMTFSdFQ0YUliMjlzTEg0cEUyMGprNFRjeXIxY1U1ZW4xMVRlelR6Rno4Smg2Tk0zT29nSzczTldjV3U4RTFEbmxFNGFCcDkwN0Fod1RTUUFKemlTWmdIbWhvcTAyUTNYWjhsU3k4UjdOQ3V5X045bzh1UjhZa2JEUG1qRlFoT25uWkt4MGhIWmFDYzBlRHFYQ20xeWY5ckxrTzhpWmJFLWNCeXBBYmpDelB3MnltVXBlbkhua1U4TEZIMTlhbVFhTUpVQ3Y0QXVLWFBRVkJ2NllId05xY1R2cVBRZDNHcTN3Ym5KYlJNN2V0VkU2dUtuR2UzdERGRVhtVjhhMzhUT1Nvc1RXNTJteGZzb3NMRmktcmptdDlOakozYkgtMU1YWWJ2OXNQd0pKUzMwdUhWUjFnb2pVQnlKS0pMcC1IQ1NmVUJNUnlseHppOXBMV25aOHdpX0VzMXlLUjZRbHNtRXJiS0NkQ2k2WVFqS3JDUXNUbFk4U09Yb3lPVC1odkdKanQtb2VWRDNSaVB0M1VKdUo5N3BCR3h0TEJHTmRlb3l4MTgtcE9EODVjdF9JYzFCNnZrQTFTb2VjMVU4WHNhTnRVVFJVNDVzcVdCMzB1VlZPV2NrUXFMVFp0UXlWbnlKZmtCNmRxdDRNeS1jWFVua0ltalBFNjdGUlJkN0hJSmZsb2JndU5PUTJsM1NkMXRXRTlKbkRGSFZGQmozZHZ5N2lIZlZXd0xDUkhxQml3NkdEcDRUY1F6elBVNVM1Q0hNUEFrcEVRbllmZTVVZF9RUElYTUNmd3JJaEdMbFE4RXZlVUhQaWVQc0FreEg2blJ0dlhJQlBfa0dzX1RWSGlyNlR1cW5WdFFPblNVQXhaUVNZRWVaUXFYTHJjcXpDQlFMc2R2aHpQSkJNanlpYU9SOEVXMjM0NGgwa3V6R1FHMWw0M3Fkb0U0Rl9oek1RUUN3cVBwTjFBQ1pMRXRqRmJZRXJLa3NOVV8tQjNWQ012N0dEb0VMYlV1S0hHUjBpTC1UQUNNOWlNUnVveDRQS25pR1JOT01wWExNZFliSFVCWDNRUUVGS0Y4SHFKQ3ptSV9SZjNEajNZeXA5bGZNRFdIYmk4T2VhRGt5b2szYllpaHozY2NKbXFmMkRHMEdDOU1SMDJ0VVJZTFU0LWpaUDEybkJVWkFjMkFrQ2xpY3F1TV9IeGpYVkJDdFVRb1k0dk1FRkxiWUY5cHpLMkZZMlVWcXhPU0lYRUdwM2dNR2RHWE9saUg4V3QxTEN1dTE5a1dsY1NWY1pQVDh3NU5scmp3ZVhhYV9lNWFBaDJDcXhPNm5ESjRYN3VsZWxlSmIwZGVGME95SDdQdVZNZ0JVcVZwNlZFc0ItbU5leXZGQVRYRG9RNGJxdndza0NmZ3RiOENSWkpjTzB4cjl6b29TYTVONlM3cVliQVdocWF1cEVlTGxJR0dfNklKVHNOUVE2ekRLdUNFeDhxVHk0N1R2MXBYb0ZfRUk1X3lZZzRGcllIRFpSMUIzQUJQR0MwdjhyYV9Xd0xOd1Nwdi1UNHpBUjJZRXUwMDFwazY3SVFXc3BpNDdvQU1Mc3hveTg0c21yakZzNHZ1YVNtbzQ4NFhlaXBLOWh2dUpGbUkyWEF3Zlp5T0c2Z2lRVXVQU2w0V0xqTVFqdVl6R2lTcEV4aE55SWtCSjRTSUhoRzFVV0hqRW53MDNLcndQTlNXTlFCYmVESWttR3hreGl4bHJMS01xNmZCRU54R3RLbWlrRXBPSlM2NTdBa0Q0MzhRbGo3V0VoLUxySXNDMWR2WDdKM2wwdE8xclZSQjhMMi1WeHNleGEzQ1IxU1h0d245RWJ5NnFRSWh2LUtNNmRReldab2ZEalA0Y1VrbWM0ZnFlYUZOZmxIcHJxSFJVQTN0NGZwNDFkdWdRU0FTMWZFc2RTZjNBNTBwYlFoSGVja1N6dzVKeEYxdGRJS1VfZTRqaUI5SWRNYXRPR0R0NDE3NTg5UWFaVVIyeGpQVm82cVAtWEp5akplZFc4RWFsTEQ1QzRsS1FrakI4c0JTcEJjN3pxUEE3elJfZXB2aWpfczh1c0pBbzNQcGY4aUNqN0lhWERWVjJXSzJ5MWJael92NzV1YTdKczNSQVpRaVBET3BOVzRLN0JLWFNmaG5SZEpGREFaZkZiczBrQ0w2LUVaTG1Ya3BIQmw4NEJibG9HbUlVLWVKZ1hIbkxuQ3RBR2NrUUhmVW1SNXpXVmxUTXFlMThLTjF4QlRkZU5MQW1ITHlwNF9HdDl4bFdNekdOM3h1VWM5SmdsT0JXOEdDQUR6N1h4QjVKb0VpZy1ENW1IclpFdGZNSU5oem50cF9BU2dGWE1SLVF1YllOS0hpYzNsRXBNUVZuT2RGWGxaRXYtRzlia1VpSmdOMUM2cnBpZUsxS284S1ozYmE1a3AwQ3RNQzdyWjl5cXI3YUVJdlJFNUp5OUlmUVRDZDl1Nk9FUFAtM3B2X1FQQzlhTEJBdVlQcWVfcmpLcGRvVWJISjhpMkdoNnR5QU01LWFSTzB0YnpTaFlYVUl1ekRTY0J1VjlUXzlZRm1aT1hNVDZjMEY0VFVUX2hOOW40RzUtTEFmbmh4OFh5WjNjYnZzcEMwa29acVAzT280b0Q4OE9UZ2FxNHYtZURReURzU2JRWEQ5Q1EwSG1tek9fb0Q2dGVXZ2JFeTA1RmxZRUdNbUtORk94THFSRldOUVZVUnBpVTNrVmJndmd0aEZsWTdDYW4zMjF3VFVjOFluaDhkZUdYNzJpUVNpU01obFFxWFJPMFpBTUpzU0hyd2ZYMTZWMlVmYjZhdWM1WWt5N2s4MDBtT1N4anFwLUJJYjJIWUtFbEdVNGNnc1lRNExxdGZ1b211TVRtcDd0eHdvSnk3TnNLalVndmZEWTFBYTNHTEFzdUs1MzRrbzg5MWFQeWJQbUtERHd0dDN0cEFzc3BuVU03Mm9OWnlvUllDVFVoOERUMXdIWi15aldBZU9OYllNdFdBX2FfTGNUUjduWVBNQW9OcmhwRVhyTGJ1dFRXSktXRjVlc3BBMDVTQUl0YkJDTE5udUsxSUlnSXNZWmM3T0FsR2VYNHIzSm1oeFNvYkJDUTIyMXJqSjItbFZXeDlSaDROVVNUWFI2Vndpbmh0eFFlb3dhbGh1WTlMaWdqckU2ZUlUUjFnaW9qeW13VXNPWWFBalQ5THo0aXVBUG40RnkyNHdhaWpNcEphN0RnWlhpbW5ZTTNPU045NzUwNnJfNGxyc3hiTXhyQjZrNlZ2N21YbjNSTkMyVkxyN2FxLWFGVXY1YzlWMDdsOFpicnAta3RzN1VzM1FXUmtabzg2MEtPVE1xeDdaX2JJTjdMUlBQSEhfNGdjTUVQN2QyUU9IbXJ5b2xLeS16ZjFpeERfcm1qd1M5NGtkYi1GX1dyQXh2dlpWV2lPOFNlV0Rockktd0VmTFhFS3hRNUlQLTJEZmFSdENrYnJXNzJZbFJlNHdfMlZJWkRSekxlV1lFS2RvTlJBTWwxSU5lQmQxYV9WaVpILXk0ZExPUWZrUzJEMXo4NUEycHkwMkhEbFcyQnhhWUpVZE96dlZYMkNRYmJNc1Z4aXRmRGFuVGRESDNVRFllUzVSQlRmX3BmcE1Wb1RHN2liN0pvZjRYWWNVdFNXRWV6RnNmaWNvanhJQU1FZUlMZWh1WFNrR0RpMTdGdUVzZjBGekkyYmY1STlrMVYxUFlkUFZ3Z1lmTHprOWRucTFmQXBNRDFWZzRzNmQtbkVHcE9ySDdKeHMySVFNanozdENsQVk0SzF4cEM3ckZhT3BXVmpWb3JLdk5KOE05TFAzUVdRRVpzNnNoVXhiU2E1ZFVOSXlCTzdZZ1Z5MWtEcXRKTTBhcjVkOENjM2E2YmVBTC11NDZmNURGbG9KQTIxdHRWckp2cmlPNjY3c2FVX21kUzdkYjhJRllVWU9RNmR4UmpBVzJjNkV6dGNaa2YzZC1pT194eE9FOVBsNmFDSGxjdWdnbzFuY2VYU2k3TWNHQk9VVzBGVzVQOTR3N1AzTkxIbTJjazlrUkoyZUQ2dkxIbWhfcnlranJlVWtxQnNkTkpXblNVSWtkWmVfX0JLWmY4dTBQMzBuTnRDWDdBUzBNMWl3NzRJYTB3OW9PTUJ6bEYtVGJhejFnRFNRU3RMZjVaXzNnYWgySTVTM0p6Um8tQldYTnZoOGtaOTVDaEZTRm9lWDR1VXNEMVhzRERSUkxuSXlNZ3FoV1lHQThHbkEyd3M1T1ZfOTlMWVpsM0ZqbjBfbk1lZ0VFT0tWelMyZW5faHZNYXZUdmVQQ3BmRnNhekYwWEFVblJJcW1NUUhiaVpfRXd3Zk5RT0VFejEzaXF5cndkTms3UDJxVndoaWphYktqN3BWQmFYMUlmRDRPbUFZenhjVThLZ2VvVTlTTGZKUWxrUk1fbGtxR1hZdlJMQjlxYy1yYk5PNDZDUzAzVjhsbzRocTRuUUtjaTV3LXAwRzl6Vm9nQ05VWHQzVkJqRlB4cm5JNmhQbE83Y296SWREWjN1a2JydlJtdmpLbjFnY0p6QWN5VmpXUnYxS3dsMWRlQkppbjg4OVVkWHAtYTJweXdITVZ4TUNUbmR3aldhY0NWOFlVd2U0NlZUR0l0RlNCc0prUGpnWjRBSWh2MEFVNmFpaE5vT1VnalRQbkNZQzN1OEQ1MGFwNGljaHc5Umttd0w0QU56LVdjYkkwbV85U0liY2dPNmJoWENpWFh0eHFpZldrNDJxdU01ZjRHNzByd2ZyckdmUjBtQlFva2pNVGpDTHM1c3ByMF9FZVNLNjNWbWNNcG9tenU4NlJxTWFpNkljbldNWTFBMGFNdXdNbXBycVU5UGdHR1NpV28xM1NyUTdWeE9XcGtiNzdfR1JEN19oblZleGk0MXh1SERSdEk2T1ZycnloZzgtNno3MDM1YzFMT1VzLUdKQ2FhTVJWd1dBbTBfa3g0TnYzT1lRd1h2Rlg3Sl9BNHYtNVExNFpPZjczazhndkttVFdQS1l2TEhmckZTOVFfMVRiWUhKMnZEdkZMX1ZMOFdLVURRakNzdU02ci1vcS01WWZMX1FGUGREeHhJcUIybk5Xcm02MWlobUFRdDNHSzhmVmhvZmdQZnFVellGVmU4VDlFYllGam56dUhtVUxuMjMwNkJScVRZRG5wWFNndXZnMWgtaFRUSFZfMzVpM0tIcWJkUDc1WnhHNW5pX2VDQUFVRTJsUkpUU0EydmYtdmxZVmhucXh1dXVtOWNoRnRWSk1BR055ZnNza05mWWhuNDk1bFd3eHl4U2J6N3lVcEp6SUJEQV9idk80cjhyTmJWNHgyaU95UkFJZ0x3VG9XdnlmYTN5MWdNUXN4dHFXMlBZN2lkOWpJbGJQcjJTaWg1d3B3MVo0RktzTTNseDFsdmt6cmllREdSTGtUZDRnVmFaYzhSVXVBcWZfdXNmQ3pUVUpWWS03OFBKcENhOHU0QXJBTzlTU1h6aUwyb2k4ZUhBWEZCdWZ1aFZ0N0c1VVN5WnRMcjV1M25WandnRDBuZHBuSXltaEtrSFZlb3ZnbVJSWnNQNVlZNm1YRlloZFJvQjRPR3ZmeEhFMVpYeFM1Zk1VQ2VGMnh0VEpicWV3bFBjM1FNMm9LX0lsU3ZnSU9YbTNPTUZ1LTROaHNaaTUzR2NjNEdEMFdhWTIyVnIweUZXLVZyS3BBZUFBS3FITXgxN1dzN3g5Z3NILUVzbC11bEEzamYxaG1OWnVWbHlnWXZKR3owM3ZTMGtOYW9YSGhvM3BPTXJvOTZqQmZWUFY0UWNZMklfclQ4S19ZNVNOT25OQ1pvQmctT290SGpDTEVQZGtqY1JQdXc4VUhYMW9nOXBIM212V3NXeGlCS0xVQk9fWFNyRnZDUkhYd3Jleld4YThnNS5wZ0wzZnNxX00wWlFXSnFLT1hhNXVR"}'}
+    body: {string: !!python/unicode '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkZfenBGemJ2TGRDQVExVW1oOVNMSVVQVWFpMmtQanNRWVNVVHZqdVFObWg2ZDFlUXNEbmN5VHBXS2w2QzVuTHJBMDZRUmZhQm9MQy1yN25Xc2JBZTY5Y1BiOV9GR0pzZGlLd1BZYURpWlNVdWVSbHNEQUF3UDM4bGVYbWtKUXM2RnVjd1ZIZ2JDaThYNEZkYmpCS3hlWW1ZQVlZNUZTMzhZM3JHbHRKTzlUNU5WUWU5cmNjOVFOOGJWTzNvWURUUG8tejBjMUtoMUJiS3p6bHRIZktGYWYyZDFPSnlfX3hHa3RiQ1g3LTAxNmZlTm9lbHM0Vkk2RUNzV19wY2Vlb3l4RHdsR3FCOE1lVkVpQWktY0F0T0dXWXF6N1BxOUQ3TXJCNGJCcExaSS1kQzNyV2g5RkdYLWpqXzBDNU41bmpGTlRBQXlnWnZvY19lSlR6d19qeUZrQS5qcHpNSTVQYjFQRGd0ak4wWllQZnRRLmlYZUduZEs3ZnVnZmZwZ2lmcU1UbFFYQjhvc0tKNlFiU2pIWjFRZnhzQTZMMmpFTWE5NUw0cUxiMFZtbURGbmN3Y3RIazB1bU05Z1JMT1RMbEVlN2YwaDhlbDBTV1M1TUVpS0huTng1SWg2Unp4NUVxWU84MGY3VmRvbWdQdUx2NGNqbUZzWmhhNC11Z1FTU25zZDhJYUhKWGlDZUkySkxMNUNZLUpNTUlaX3R3Q21lcHZUTzBxZmVkcE82aUFmS2I3SU01c3lhRUdOb0s2d21jVEIwdEVBWXFySWx6VFl4WGF2cHR2MHhYUmQ1ekdBTGdnR3Y1aURlSDVjbW13UncySElyR294YVItaEs5OXZfY04xcVhuVEJQYXdNLTJjVTVxM3FTYkZlTkhiMDctZjFUUnNEM21ScHQ4YWRrWm4tcTNBazNQbmw1d1NmQUtZeVBoa0pVZUgwbjlWVHdPT05jRTRHMVhFTUstRGxHVXlCeTktazdXanRuc0hSZ3hPeVVXaTU2Ujc3ZnR0NzkzcVNjODg2a0l6clpfSFprZVRZYVU3aUdZeGRRMklMaVVIVFk2ZGJLN3VHd19nTHkzNWwtbEtVczdyakdqTEJrZjJiLVdJUS1DRjVKRlNYcEU4bnlnYW1WOW5USzZsM1BBY2RVM1F3OEc4WFhQMS1DV3JZc0wwNjB3MmM5cnlxdTNxZ0g5WUpyQS1MbU1keklWYld2dVZ2UkVlMWlMbDhyczViaEFENG9zdk1TckU1cEFoTmcxeFZKYnFWMlJfSTZLYmdSS0RzLUM4WkFmWjJaSzl2RW0tY2ZBOVgtZVdIazFRa04tRkxKalpNcm9KUXlYRXRlSUpYejFGa3hVS28tUHpYTVktV1JiUV9POXNpNGMzb3VnVzkxWm5SNV91bUxkdmY5VENiZ1haMDdCeHF6U3Z3X3hGY3liWTFCa05yZllDa3h2ZF9iZ0VOQ0VtQS1RU2NOcFdOSk5ZOU16djBHSDhxd29HTmowYlVlR3ZJcGZzS3dWWnFnd3FVTFFuVEIzbk1yWDRDaGpCUTRaUGNyNVRaRW11OUxNaGZManZxejIyQWVXclV6S1gtTmd5OUFadWc0SC10M215Z1hJYXIxeU5fdWtzZ2h2aXNHcWFhYXdfLWRMOUNnQlEtYThabDNOYkt3cmpBVFNKLVhFV3BwV01hcnFaZVlaS3B5SDJ4eWlXQ1VTR1B1ZjdzUXlfakk3bzZtSHRlSFozX1pTVDJrWEtLY3QtYWJWU2VaeWpzYTJFZU40NE5SajItVlgwSTNPN0ZBTUZxVzJxVTFEM2doeGpUMEh2N3l2cHBRa1FTRzlLZ2J0czdwS3owZ29oUmFuWFh5QlNHbkdXX2pvZ2d1bDd3X01Ca283X2lnbmZnNVlZX2N4RU5VMzJyakdjckJ1NmtBZVFkSko1dTNzSXlOeFl4Q193V3BaMUJsTVlWaVJvVGhobl9JUktudHdLMmJZU0JSQVBxdFJpZExOakFGSWZuWXFhSEtpbzlTQ3hHMHNUUjdJMWR2SldJeFpjSHc5WHFGc3V0MVpGSE1SbVlOZktoNnZCXzVvNW5jUk85R2FYT2FPd3VWUnBkU29KYUg4YmM4dWdLWUU2OXU0V2lyVmRzVDI0b05USGNrOFhQM21PbnhHNjcyOEVxMFcxamszTEQtSXlrU0sxSnJadDJaXzdQelNDRmMzTzY2MWFST0gxNVJOMUxnal8yT3ZIdkJNUWQzVW1vYS1vX202T092WTR2Tzk0Z2FkaXo0TUh4eDBVRmZVRmxlNmZqUU5NMTBWREdMNFRNQ1VHYTFSZmI2MnVMd01ILUdMSFBSeTc2emFra2I4OXQ3cGpMZWdQNXlhckxtc1czakVuN1ZJLW9jekRLLXBzNFZ2SHBoR2N0M1JwN2gtSTBsWDdUb243YkxXN3MwQThyNGY0R08zc2pXRzhFR1BfMEV1cXA5MzBRV203MHFtb195QVhNRDI2Q2dzcU9KNGxscThNLXNXR3B2X21SQU45RTY2dS1UZUxqdlVUOWFBakZfcGp3bHZKLWVsbFowZDlFYnpBS1FUdUplTjUxSVJZV1RfZ2RzSURNR3J3UGpKcnVFTVUxSkpTbjJXbWpzYmlScURRZnVVQWZlOThGLUtJTnc3SE5fcV9xQk4wOWdoQTJkVzFla0Mzb3pNV3BFT095MHEwNVQzaEFWZHFHWjNUS3NIQVptNzZ5US16eDlrMk1KTlJNRHU0TVNkamhKclFXTTBEbzU1bVBKbVVyM002TElDV2Uza2FoNkJPeXhYdmctd2V2UnBTQ09CU21JNUhhYkNnNjRBLU5fdi1jMndnbnl6WXFDR0JiTVczaWRLeUVzeXliWXlIUHVXR1I2SUNTb3BLY1lWVWV1Undyb0xEQTZxMXZWVUtBTkN3cGxmRDFpckQ3eDFqczI1X2dGQWV4ekpnQUhrLTdsUnBjdFZIVk1HVnB5Vk91TXg1bWgzTk5zS3FzZ2hreE1mb3JodkZhYUNPcjFISlFwd0ViSzZrRmZxXzhjR0dPZ1p3blVoXzBfRkZHRFRiSHh1LXR0TGtuU0ttdWJpQmNRYjJ1MzB2R1VwcWNjcFgtdlUwakl1dmVWbXZLWGM5aV9CeWVaalRYd3U2czVqTDd4UTdnMkdab1VHcFBxUE9qY0FFdHl1amNTR1NXMDRRWjZpbzRiUVY4M2pTb013WmhNOEJDeVQ0ZnpWaGJ6UV9oYlhhcnlTZFhnM1dobzRSSGtsRXRxdDBjX2wwTEhFNkNobzFtMVRlMXNSVDAzWTNheUlyUEtDZjV1YjdGM21LdV81b1loWmRwM09WWkwwM3dwaW1aaEgzVVh3RWRmWk5KUkF0WE04RDdjY0kwM2NRNGFyRGxpa3FEdy1vT3dYODZBSHVST3JzQ1ppU1ZjV2ZzLWdoN3lGcmlKdEoxa1dqMmhlUmFCMHFXekcwZDhULW54NUJkM2Y1eUxGRW1hUkJ5bEVVMTlWN184UENpTmdQSnB6a056VFpGTUlaM2w5NEpseG5GVHp3ck5aa0hjMnlCaWE2ZDNqWFc4S0RSclUzVEUxNGE4MXRJX213SmxuWllZTnlENlU3YXp0eXVNVU1nWHhOeThMRGhoaGg0bk5jRGlFc213VTVJR3pvZWNfcGdVMmZBWUxzczFNcGswUnFCVUJfbEVlZkdUMmtUQmttVU9rZ1dhdEVzdWpTc0tTemNvUXVuWDQ0SFJ1VTFqdVl6eE15MFFMVVNoTnBlVkFXUGk5VVFvMTc2YThka0JId2E5UEg4QzZNZ2t6enptMGZNWU5aNVlYcXdEemRMSlZFV2RMcVlnanFQUmpCeWJnWGFaQUtyNDdOX1pkaXc1cUVEbldmNFNqZk9HN2p6TVVZRk5Icl9hLW9aaVgyT2tLT3RJTlE0TGRlb3lnVzBHV2JnLUJIa1NISUh6SUlab25VSkt3V2Z1T0tPY0MxUUp3bjJqdURNMGp3NkZJOTU3YkpLYTdaWVlEdjAzMThpelAzd1BHZEtEcGM1TWY3alBjOFA0QmhaTTNrOGNIb0hycjZLaWV2c2lFYksyQ2JwRGRPOVZCTEdIQ1pyTlc5Mlk5d3dKQU1BUFBVcXpZMndlcVFCT1lPMldfQXNjWGFqSHhVZkNCOHhIQnhEWEZYdXpRZHgxNXZXNDJkRVdEWl9CQzZiTGpaOFdPczA2dW55X3loU2VSS0FaVDhhNmZiNDN4RjU3ZGpqNFBVOGl1OEFVZ2cxUXlmeTBjcGZMVHB1RUVBQno3QUg4RjV1VE9VUTYyZ3NIMWxyNmxaOEI1Q2ZhVUFxeTZmSy1XRVRSeEQzcFBybVNfVEs1TS1sYkR4elVkN3ZNNUw0eWJPSDU3STIwenQ1Z3pSRjc4eldyRzN3NWN2LWRWNmNiNTJOVGdxWTBGaHZNdXE2ejFZLUd0cmRXRXoyZ01jMHlvak1BS3pfSnl4d3JERnZUeGRIOEZNbnU4Rk4yUjVfWEt5eEpuYlViMTNDamhPaEtHNUdJQUNFUXVRc2RWaWNyYXFUOXVkMGs4czVqN2dvRTc4dTJSZEVrMTVET2JDb05OZFJISG9fS2V5ekNJSlMxWV9NeTVNamFmWlg3UVJfc3dwQjQzbDVBZWFTRFZndjRWTV9sT2RydnV3RGxDdEM4anNCMzJrNldxSFBySWtNWG1RNnVIQjhWNlM3ZW1rSjNweEYwT3ByNnBxOXV0NVpGajRkSEhOMGI1V01jbnlmZjM1ejlSSjVwR2FDRlgzdG0yZW1lOTBBXzdFZWlod3Zaa1lQczVBWnhrbksxRTlhYk5nWjFSUTBiWHYtU21vM3M4U2FsQ0VrcE8wMXg0VEZmVGdJRjBRaHdiUFZIQVZrdTdLM1hnYWQ3VV9RdjBQTG1ISXJhMVQxY1pYajBfQnlMMWFxOE5kWVpPaE5mX0hQX2d6Ylh4TXFFazRRckJLSzE3NXh6V3ZlXzAzeVluWXM5c0pBb0hma2J6RFJUS2tEMWZvVkRIYl9QWTBBUGdoc1czS1VMVHJCbkJPYkNRZzFiSmRFZm5XUGlzTHlaM2xQSktORWUyMHFCSXgxX2VfVmRNbXpXNE84Ylc2UHIwZ1lHTWdUZDRqeUlXRVMtZlVkeFZTUnUxUVhONE5iUVBZTVM5aE4zcUpxLTFsamR4dUlyd2xEU1lVdWM0UTVZd21XUVZrb0p2dDNHY1F3VWJ1WU9DM2lxZTVlMlRJSE1ZcXRaTlpPMGRZc3NwaTJTLWNTYmpXTFg2b3diMG43eHNOdjRHekI0WXJKVlNDRkxQZm10UXR5ZjE5N0t5RTdVQnNYT1lQM2dDV0NGOTA5Ym92WmY4OUhrNFlfV3FJcV9vdWhVbXZDYzl5MVVvNlVRTlBNVjJkelBDUGozRG5zLUQ3Tk1NN2d3RVhmX3NOU2JtbFBBX0J2M3ZVcWFYOGJRa3ZIMUNoT19mak1ZcmRDYjZTeEROYjlGQUZHb041Tnp5OWQ1VTlXSlhOa1M5S1J1R3lmaXBJR2NtVFkwUm9lUE5jS0JUb05TR3o0Z2RLUFN4U29aZVZmX3g3SUZFX002WGVFSXo3ZzFLb1R3Q2dOSXViZlhRQ3QtaDllazA2X0F1SDBsbGpSLXU4b3lTdzUtZmtFYm9ORFMxeWFFU0hYOGZjRTBXVkR0QU5xLWRwbHBFTnlmVS1NeHZuNmxSWnlXY0d4aVQzZm9pQWtsR0NrLWc0Y1B6cS1fUHhMZkF1cDBkSE5xdXNBMmRYQU8xaXJmZ0J2OTJqSXVRVXVrdVEtRzJUeFNObjRyM05vWDM3SkREMnJfTGVNa3ZCTFRsSThBME1CSGdzZHdOWFV5Vld0bEdVcW5NTjM2aHREcy1ka1hWNkVVRUxleUV1dkNoUTUxU3FaZFBjeGk0eGtoVGxfaHg4cXhsUFdPUVNmZnZOc2tMS3BIY3VnN0ctYUdXSGI3alREaEtLLXVvOFZoYkM4NG01dlJaLTBaekJpT2hlQk1HczRyYkcyVmtZTkVka1hXQWNqQXFwNURFYlZBX0d5Q1UtcTQ1dEc2cHdtanpxUVdZdk5SaUlQejZUdnFMTElXbzd2M015b2VYeHBybDBveEZWSkxoT0Y1ZE1GVE5VYURVRVZHWXlqYUIzSFBhSDNKQkxxVGhKVjNNS2VuQklSLXdZZncwZlRWQnZCUVFzV3VuSWRmN3FJTmY0TTM2NThSMTJHemljSXI1ZEY4UWt1azdlWmlMLXFmc2VUN2xkVjJwSW9YVUJlOFllM0RCRFlWZElMSGpfcGxEOTJBa1V4c0YzQ2ZNRkNYTDBJYXJuTUNvcnJ1dnFSMEtsSWE0MkNVVDF6bjN4bU5SODNxN2RSUXp0NGZGN1M0ZllVdEY3eHlaMzdwcVZ4VDNoUnFMY19MU2lMTFNhcXJNcmFZcElHXzBMSU1KY3d5RUo1NVlNaHI5cGdXQVFRUjF0djJua295UV91OTdRQXl4Z08zUHFQNzdMMG1ySGVCMlVOY1FaRlhud09oNXZyMEwzRmZra09IUXN5RXUyRTBvRGZ3b3pyZXpxTXVTakkxSDE0WUpmbE12TnlRemJqbjNjcDRCaUo1NWV1WjgwV0lNaElHcWF2OWNwMjFPRDZHRUhiaGk3N0FyWkEtX05sQV9iR1gzM2l1ZVBaS05ucW1mbU9HVkdKTXphaXNGR0hVRzB5TGFqR0VQeHBPM094WkYyNU5xMWhHcUhXNzFqcWw3YkVXV3V6UExsbWFOMC1IRlZNbi1qUkd3U0VSS0tTbk1ZUVdyUEdZS1F5dEh3eDdxT05hRUwtdE5sdHlPTkdEbDhkTy1rTlc2bmVUZXZObGFqeTh1WFJwYXdmeXJUS0F4R19CYzFRUzBYcVgxWW5iNXk3WEM2dTBMcDB6bE51LUQxZGxOZS1naXBkbFBUbUN1bmwxU2lFbExudzRRenJVSmN1Wm1BclhBT29EbEhabzM4dWlnS1hmdUZYN3BRWExwMENsQXk4RWVoUm5xSEhHLTRERDVUdlYyYUh1TFRNYmR1M29VcVlSd01aMnRsaWFKLXN6aktoV3M1QzFhckVTTHMxTFFIeW85QUhaSmUtaTZ3TzVveHZIdmMwV05vVG5WTlpFVHdoYlg2aGt3aUdhWVY4aWxkSUktS20wTWUtNlJmMlRzR1VJd1hkZS1VNTVMdzl5WnpJS01JQWdkN2x5c2ZDQTM5N2ZNME5XSTFiNVlOYW83ejIwWGFwY0tFOVhPZGtSNEI3MmZNcHdCVzFxY21yS2VQcExfWG5XZ29md3QtQ2dGU2RYbEw2S3pVNlhKRGQ3b0FMQ3V5dldWYVdKYnRFUkpweksxbDdQTy1wckpMa2VqZTEyOG1sZTFZTnUyMkdsV1BfUTAtQmVTaTV0SHAwX0dBZ3hvdUxGVWxvbW5RRXJuN3laSWlORHo5NTRGTjdoZVh4UFdIbm01V2F4ekF5MG52Q016Y2k1cE13Ym9pMjcxZVNtZ0NHbmNjT3BOUXlmcllxM1Q2UHZxYUZqaVhpY3JQTHI1OGNJOUM0VEY4cUdsOFRsbmh2U2x4MFVzZHl1dzI0MnJDYzVVc1ZMM203QXk1b3c2ZDkwd05zdWVxWDhqY25FNW9WS2ZnYVB2djZHVkpxNEtrcmg5Ukc0Mi02UnllNEdkRGdIand5bjdhcDhVNkZOdTEyUERoSVlScDJuWXBPRDhzTzZHVDM0djFsdUNhNVJxbWJISnpkaVZ5U2x3bzhPLWcwMHhDZzJnOUpGeEMxWEtoZFJaMklBUi11Q2tiQTl4S1Rxb1ZFQVVIeFQ5TWQ2T0ZPalF6cHdWRndWN0dzVGpGblFkYXk5cjRDTWtIWlU1OVpRaHFYeWJPaU4wdDRXY1hTYzBaeUxHOG5SbTYwMjdEOTVLczZ6Rzl4bjlwM21Hb2tCQUQxY2YteDYxdG85b2lwWUZzTTV5cjdIZWtHMmJsWmhFZ1pfWHE1MUt0N3dhSkRzV0tHQzZiWVVIelZTbXljWWNER2EzNnJUOUFUWjNCTmI4OTNtcXNxQ3ZkVU1Ua3lPT2JmY3A1Z3l2R1VTZjRYSHlNT2tZR2hzNC04Z3Q1cjhZSDhDY1RCNXJKaHVoYlJlS05YbWoyTXpiZFhNU1EySk5PdVNBeFk1bEVSU2UycUtldUowUHhjWHBTRHg1Z3ljeTVPekZ5RmU3SnV6Unp6RWZxVm5OUUhacG5pNDAtX2xLSm1UdEVZTnNud3JaVDZHNk9MbUdESE54WXJCVWVaZVctcEIyaXpycDVMWVhwejlWV2Uxa1c2UFBNQzdNYjRyU3hscl9UVmtkUUxaa3N4YktnbXBVNXRxUVQyOEdCcm9NdG5HRk5kbDNVRlM3M3JpV3JHUWxWbVNMVUM3MjR1dGYwWFZEQi1BOTdWazhlTEFmbFh2NEx0eEdLUUhKaEI1OEJHaDhzZDFXVnl6TzdhWm9KNktodEp2ekl6SGxYSmxDLWZiYmVHaTBhYkxuR0lRX0drNVNSM0JfMjUyWTN6Z1NmeVd6ZHl5U0xPN1lDbktuRHgzYl9YUDFVd2M3QXBoM1ZFbmp4ZUNxbUJmWlhWSDNwdDdxd1k4RS1Bcy02TGFicHNzTHZMcmF5RUd3Y1BDOUZVVEJkRjRBdFZHRUJLa0hGcVZST2VfQlJlVmJMZVpxTTBlOG1mNFVnYUQ2TXFZa21GelJjQkRvamh3MVRFVC1aV096T0E5NGhOY1NQOHZ6T2luenk1NHp6TER4Vkg5ejJaTG9LWjQzQVJKTDdwUUR1U2Q1enFONlJOcmRFZTNJdTRGcFRWVWZQbGFzWl9sTDBueTIwMXZiU2E2RXQ2RHFXb05wV1FLUGlnME5ubEtSa0llNy0zb1dRczRpWjJpdklEeUVUWVhCUUVOcDR4OHBuRGhXQUFuNWhfVWJQdXZ4NUs0cWJTOTktM2x4X29NcVdmc0EtaVp5eVV3OXc0R3ZnWVA3TU50RThFNVVBT1pWVElUX3BBWElxaDdLaVlNMWxad01uLUJQeFdaaVJDNGp5SHN2cUUtSXJsNm1BN1dRanNiUW0zaDBMX2RTS3g0UEhTRTBYQnF5OU9GX2xjcjJTYkg0WHlRNlA0SUFrcUMwYjRlX251UUZ1Y3Q3c2Y0M2hObXJRZTk1RC1BQ0dVamFFZ3dkYmFqMGhEUV9pRy1vU3JEeDEzVTFLNVE2R21RTnpsUDM4QmlwVFN2b09NRVVIdngySUd2cmtoeHRyX2t4d0o4ZG5JV19Ed1pkZWptT05zUjljLUV3Sjhhc3NzMmYwSkt1ckdPZUxZZFNidnBHeUJ1YTVST1Y0MUtWanFtb0NsTXlJZllSVk1zVWMwSmJ3SHpoUGpTZGJONUVCVlVYUzlibE5oeHVXUnF2SnhVQkNEN0ktUmdDbVlSZm16RTVUcjlXODBGSDRVTzN4UU1TdFBQTjAtc0xXanBtcFZfWHd4aHhzQjZIbTNxTkxUaVdOZVU3TlRUZG5ZeEVZMWh5ajd0M0MxNy1KR0NtY2l1OFJYRVBIWGt3MFJ5d085VV91X1BjWTRLejRyRllfR1IxYWhaMFdWZU10R3BLS1k5Y0swRG1HTEpoOGNKQ0FBMXUyZW5wUUZCMzhPeHVTRWVzX181RklnZ2dWU2RvaVc1M0ZMT0tLZXc3b1FhLTRnaC05OWFYZEJFbHpmbk5vSnNuX0hOQ2NVZ3dTYmNuWFgzYWlRSnJxZVhoLUN0UnhRVzZHZm42X25pejJvc0Mxc0E5elBKanpubF9WVHU0dGNOUm0wa2lIQWpOazRXNjFPVkNGLXNmcXNmQWw3UkFEU0NtUWZ1TjdndWlnVWJWWXpSRFVHbHhRM2dKSDRoZ1Z4WU0xVHZuWC02M21pRUU2VUNlLVFDN3hOTjV6WEx4d2JQOFdJVmxNaVpLdjdyNlNLQTJtWWFLNmhESGQ4WnZpVWdKQUZZUjhJb3YxbkZObS1qU2dvdlpjdkVsUjlMVXBWZ1dOMU1OSU90TnZfbkhMUG00TklVNEJ0ekdWdmhiNHdaVVJ5dVhnU0pDN08yZzV6YkdUdHBVdEcxS291bHNJMjRTMUxST3VFYVdvUDZlX2l2Qm8wYWc1aEFOM0dodFBuc1J2RzFNZ2VxcUZqTkpFaFM4NEVyWG9mUHdWbUVRdUdYMGxZRkJYd2d1OWVndHlCdVN0Wl9sdnlPTDhHOFZXQjgtMHZtOG1pS2dCVk81bnVMbnFNbS02QmRodHNqTmNkMTFrRm5kWjI5Wk55VkFDVl84UGJVN2w0SFNyUzlCMm5aOUo5c1FPUmFqSDFSMVdNNWduR3JUX2Fwd1NaY2xyMFR1TFNOS1NQUzlIMm9XbXAtX0RCSXAyYXhhNzFjZ3lzWjVRNjdSdGd6a3RaMnZQRXdxQ0tmd05GS2l2TWxMTTJjZE5iQ3FVVUFVNjFUS0lrN0xUVDFPLXRrZlk5cUg4QjZSeVVZNUhhRmZ3cElWX3ZKampNZW02OUc1TXpJRExNajRJZjQwckZnWmY4LUFXcGM0UGtoeHYxcDFVYk9OZ1ZQUDB3WkFwMmhMRS04WDhuQThhbWMzRS1OVTdJVk00LXo2X2wzb1JDdVNjSnNIMzgxeHczVGl5dVJkRE1kTE95ZHNBN0VhU1lpcVFaY2ZnRGxpMXNsSEZLN2pxVk9DWGRiN0p2THpVMTJ0eVdyblJ1czJ2VUR6akRENmhER1pLckd6Y1RkUHYtaWRxN0hOSjBGb1AzeTg0WEVUSjdxRGpUWktMa2RXSVZTV1k1SFllNnZlYTJGRHBldThzUUk3V01ZY3BrVGY2N0xuQUdqcWZsUVBsdjlBeVNmbGFESUs4M1BHTmhwRkNSNVVWYkdmTGxPbW9MOHpzcUxRQ1kxa3diRm9hMVJkTXB6SGpsYVVtQjZEWFpjZlczSVpIT3J4NDktSGtFc0lXQ011N1FJYjhtN2JIZEtYY3JVZ05KcnN4RmR1M2l1TFpoQ1BZVThuTklhQ21IY0hKVGxQYVNEa1E2WktTMnE2OFU3aldwbmZ5Mi1MYnBmOUhLeDFteU9qZW5aNHMzcDJkc1RtUERnbGF4MkZZT3ozR3JmOTI2QkYwWUN3a0RPdkNTZUxEZ0djMjlydVpsVVJFVll5bnlyWHZBN1ZLOWFhTGtkN0xRYlF1ZmlXTEROUGtxS0VOUERzcDZzdmlHTk9Qa1F0UzJqS1V5US1XOVJxcGdlQldxbEgxMlpEWF9adUYtLTM4aE1SNE5yX25VN3ZGeGY0dGtPeGxROEkwdU42bnZJbmJmRW45WFFZWUtVLUZ4Skh3ZmZqTzJOYkJIVjNXdnRMdWlmWG5LU2ZDNVpjdDAxcHNLQ0x6YmpQSWc5dlFrVW1MdGhVQnlJb0E0Mlg3M0p2TFBOanlmNnM5Ty1iWlA5ajg5T1FOZ2czQVRNc1JCUjBoN25MeUlpQVQzYzdadjdYT2hic0tmMkZaUldiV1pSbzJDSVFjZ0o1Rl9XTnZvdTJiTHlQY2RJdE83ZE9WUEJvblZhYWplSkR3SXJIVXBOclpWd1BqU0VIdXBFUnZJaE5PRFN4UmI0TUF4Tmd5T1Q1RDM5NllaZVllU2hEQ2s3b0tKOHprcGpTQ3Jvc0RxTzZmTkFWZ01BNXZ4RG11dHdMR1AxbXRJSzgyUkVQendZV05Ndk9lNFZ3YzUyOUkwMDJTWWhDb0dIaTdiNHpmUjBmRHV4dTFhRkJ5cmxmNFRlektkTENNc2NreUJUbldiQU1mNVF4bmYyellUTzRvcmVod1pHUzIwa2NVNEJ4eGtsVGtBOVpQQ0ZzLWhBdUxadk9GZDN4MVpRcmk1V1NPWmlrcGwybWNJdk9udVFqUkM4UlJsWjdzeTczSl9kUkhrZ09zUXkxYmthY2tBSFE0S2djazJucVNmODZzMUNpYUZvQ1B2bWdlT2h0bVNvYkVvV1RFQmN4Z3RkdHNfX2JUR1BjY3h4bTdZWldCOS1EMXJuSUZIaF9MeS03TVVfb0xISzlCYVFKUmRjSU9LRFh4RjZjREhkRl9qc2xNNU1nRXlDYkdHVU1EampDWHJvd2dqNVFHanRDV3hEaDY0blZaRWNENTkxNEdRZ2doX1F1RGVhT0EyTlNSbnFVLWktYVZtLS1mXzhmT0FzYkNPZG9URV9vQjBpR1hNbUE3SDhzc18tLVExOGhkY2hQcHg5NS1CNEpGWkNDdWNTMTVoekpaaDFUSFg1akIxZEp5Z3BaOVpfMGJ3Wk9aTGJRWHN6NG9IS1Jpckxvci1lbE52MnFKd094SG5GbE95OFQ2MTJ3bGZ2aTU5MUh4R2YycEMtblFyN3V1NGpFODkuSzg2Qk5tM1JMWEtfWWtlc29PMTNNdw"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['12512']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['12598']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -390,28 +391,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [446126be-52df-11e7-a565-5065f34efe31]
+      x-ms-client-request-id: [e2176411-9414-11e7-9a47-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"zw0pC_r4l9hurzpN2viSOCcehX16tPF_s5Gs1li7VBh5GbcArYPpiGW8JH2OE-YUkSpEwxvQslAvPtyGJ2f7yCvgoE7CtxvFpI1HjGUURcg11Gs02HLA4IOS0t4aYTP8o-m5LUQTy0TFNgGj9KiEumJxbqWDd96WrHVmYRJUXf_WY4mLwkMsIgKQYzDu2jRCA_0xB28E-UdwLjS5SriILOWJzmx5PnpbaaeJU_ex1vnelgyLR5_6wRE-vH4jAoQwGAgD3PSdSJ9Drek3URt0GN-qmjaffNlWN8GLDBn-4SdwXuZrlFHW8JWXSGJ_D5wRJ_WN9EmSb4Q26L35-VfYIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1497650449,"updated":1497650454,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['632']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['632']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -420,59 +421,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [449bab28-52df-11e7-8116-5065f34efe31]
+      x-ms-client-request-id: [e24997a1-9414-11e7-8d02-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnRfTVF4eS15LWN3cW5lRkthem9iWURuMWZSRUpFZVFoT0hPTTlJb2xKR2dYblRRWEp1cktNMEVlQVBHOURGVDdqRXV1SFozaUJTUEJBaGRJRV92NERUOGRESzhDalppZ1Q5dmg1eFVqTWZTMThFbHhyVTBaWGNrMDRtOUcxb21CRmU2VmxUaFdGZDNWM3NZanBuQXlGUXI1bDdUZmVLS1lsVnJjT21tMUF5cTBFNFE0QXNiNGx0aTNhNTNiNFNJMUxOWUlrcFpwTFllOEtwTW9aek9QaWV2UHNEckJqMk01cEdBWUNGYTBGTWItODBkRzJtX1BkMWxKT19rVzVzTTBmUjd2NEtSWmpwOU1lWUtEdFgxLTR5elBmQjljV21QU2k1YnpSRFpoYlF0cHhCZmItc3ZpblFUNW9JMUJTMm9GQUhGcDN6bUd5SHVmNXZWbFgwRmdNUS5haEpjbjZZaXFZMlRPWll1eW5CX2F3Lm1oa3lTNWxQUnRvUmZFVlkzUkZneGFydk5fOEJDOVIweHhCbUZRYUs1N0djZE40TEdyRkpsalRSNnVhMmpHN1ZWdUh6UGRnRGs0Y3N2ZHlDNU9URTBuRlMybWMwdXR5dXA4ejNURVVXZnI4Z05Tb2dWVVR1RlpNSk5ncDZYci1xdEU3SWprX0tnRTFEZzh0M1g3LXQ0ZVdlZi1CeWlIYllvMjNING5OVzJKbG9tNnNYY2ZjbkkwZmVmR25tNk5VekJZWG5qWHc5YkdhdnhqZDhEQU5FZkhuTGFCWUxDV0tERDRhQ3dXOVg5encwV0I2QUJYZVg5andmazU5d2VEMFFGdVNud250Q2FhcTdSR1d2WGhRQTlfVXIyYmZlYi05bU40RVl2UWx2V2FtRXVBUjVWODNmRWhjM1Z5R25KVDdscWVpZzI5YWJEa2ltOHhjUC1VUEF6VlktTlo5Ny1UTERtMjJXcmI3M1lhazZKaFJLcnotT2RNbXNGdWdyWEFvdm45YWhycFloVzlEVFlhNzBDNkFWR1hLM29yTHkzLWlqUmJ0Y3JYRmNUV0pObWJNM2c0SXJRZEVPWTJES0c4WmNldS1hdk5fR2RRVDhCTEdmV0ZENVdhbnJIcWpwWG42OFJPaFN1VFdGS3h3Q01WZ1lsb1k1U3RhRURQd202OE9mVmVIdVJnNlAzeTJmMjViNU5DZm1TdDNwbnVjYzNaczZLY3ZYWlRXRHJsTDRKNGJLTGZBd2swbzFOanRmeU53MmNZSWd3S1Zpc2wxcVZwV2Fpem10OEE1WU5rSFNHNHpMaUFzTWU3TExBa2ZXenJ1ZHlETDFJbURGbXlVeF9GdjdzUi1oVDBaZGpnTVpXOENPSXlVM2VEVG4yOW9UbEtnbzRHTlZ3SGktZWNDOU1kWmtDNGNvODFFcUlXTm95NVdrOVpmM0RsdWNpUG9mWXc5TjZyQkhLcktWekxKSHYzbDc4MnJzWHp3TjVscmpia2RvRkJDR1FURkhQREU4VS1VZmEyc3JHZGd5emdzUHJUMk92ODM0eFpvenA0Q0d3SlpVV2pGZDVobG5ZVTAwajktWDl4a1UxYjN5UTZfUThFMnRuYWVsdnFTUkNXbEI3a2hZMW4xa3dKeER2X3U3aGlGSll4RDEwc19XTjl3cjM4UEtWMlVlMzdrdjYzYy0yS05qRm5zZUE0WUNabFpScWpmSWdHT3NydXNIWFQzRUhlVG5maUVFS3dPaXljZWxmS3JaaGREMDRGaWs3bEtlMDNPZXM4d3dscVV4bkowd0FzM2t4d1VLN1BkcmNYUm1COWtROGIzYVg5Q0dDcmRVUzB1b3FDM2dKdWxZWWI3al9nU0xaYlpLdjJXSUJ6TnM3LVNLZFg3YlRRdXotSUx0eWRublI1LTBuUmZDdlNSSE5hMFY2OUFVaEMxVGxHclcxSzVnTnNJc0s4djZwZU1ZM2lTZWZuMElIVEtFV1JoSjVBLXlMT0xIbUYxVmIwR2x5NlBnZ21NbFFSX0taWU1yM0ZzdFNFS0s5bHE5Q3JkYVJnWXUzekxGeW5WS3VIZ1g5aDE3T2RNcmJ4MTBpQ0FNQmJPaGc1VGhjbVNsZkE4a09hdTk5bmxVdDZhdy1NRmVFLXhKZ1VmS2dDNGVnTy13YTBTSTVlM0s5cU1ubTV4MmVKc2thM1lfcFhBZVdWYVNNOW1CUjJPWjFSUG1OUWVCZzRFVktqM3RXbVBEcmdpVFlIOHpLcHpSRGsxWUlUTVVKcjFjRzZHX2FvODllY1gwTWtZeFVGUV9YY29sbEt2VElUdnlDMDdlZFlzaFhrYzF2aEQ2cnJUbkYzZmRuN0xUWE9xWnl3V2tVamJDejNhVVhIeVdqdjlHM2RFQ3B0d1ZDWTNqT3dpbUY4eFpBVFBjRU81ckg0bElyNWNmOEgzMXlya2lLM2RxdXVvWU5mNVd6S0xSckFxVkpBTy1zTmFaVGZ4eGoxcHNrV1UxTFBWb3RUV3R5MW1zeU5oY1FQT194dUVMQnpEZkpRaHBKZnBSVDBtQzhRN2g1ODNHRFlGcmpxZlAwX0h6VGVFelZBaS1rekRqV1VuX1U3QVQ4cnJsaXpELUpGMDZhR1FLOGR1WGlSRkpoX3g1aUwyQmhKLWZWTDFMb2VFRTNqV2tYTXRJdnBBaXhpNlBxeGdaZWN3NWpjLU1CN0ZIbUE0eXMySG9MVFZWS19tUjl5Qlp6Qjk2RzRZTWR5dWJFWGp3aDVvNG5GLWJmOGtOeF9LeHZfWDFVZElVSzIyS0QzTG4yYS1SWUhlUWtBckNneEFiRndVY0p4RC1TYlEwSW91aWpPZkgzS2g0UGwweW4xWm1HTnJldURuOEgzVDZ2THF4bHNrWFVNSU5ZMnJldmtwVFlZeWIxVW13blB1bTYzeTZsOEJaVDVxbmFYY0RzNU1OaXpjTHJjRkdGQkQySVdqMTFrTE5QRXVRMDlDQ2lEZWQxSzEwTkt1UUUtaTlsT29mMDF2d3hmRTBjVElueXBIdWRFQ1BGdmxuQ3ZuTUNScEQzUnBuQmQ1dlpoUTVjYms0WHNBYUlvRE9kUk1BT3Y4U29veEMzbWZFNFN0R0cyQ21oWUZFYkY3LWQzbk5rYW9zTFVmbTJxLXZyRDZLX1pJdHhxbmt0MGRENWE5ZzlNU2VVSnZsVFhpMmFiMFEzUzlFTXhxeFM2bEVRbmdrbTNnV3hvS0pMd25jQjd0WHF1ZjQxeDljTXJSRHBoSHNWcU1pM3NvcmU1czg1VUVKZ2tFRTFBQWRQcW5kWGM3V3BuSHluaGFsTUtYeEJYMjBkcjdXVzRrYVNINWVVRnJrZXRUeHhFT1RBa194Ukx6SmlSVXE0ZUh4MXVmRVpCTzN1MGxQUGlDUGhxZTJmTkNnUERsTEtQSFNPbklJcEJHa2xjZzZscHNTcG5YSkRiSG9pV3ltbkw5b05rb2dGZGhWb0E3UVJsRHhJWE1ieGFUSmVtekxhcXk4WkU4VkpYamQzSXVwbWFNcHhFbFNLd3ItejBvODlJSU10U0xVVmd1ZjhmT2x5VllkS3RjdEgxSC03djlxeGduWEgtbW0xdUVodVRNY0tGcTk0QWx6Z2RZTHdheTlRaldOOW9VWENQWkV2Yzdxd0gxMC1xZUViUGFDdHFXREIwOUxkU29XVldzd2dJNjByd2U4bWRNQ0owd25uMXdXYk5ZbTdJcHlfcUVOeXFGU3Fta0w1bUpRM0Z5d2d6aGFDM3NpVmFWTmhvTnl4aXRYRkZYYzNYWHRTTGp6ZnZKQTJ6a2NJUUpLT0dtVVl5RjhzUEJGaXVKMlQ5ZGluLUlWcU82V0NJckFJNlU4SGVjUkROTVBURXgwcGFYYzl6a0Zpa0F0SW1saEs2Mm5TY2hqZUJYUlJqWWRocDlMSG1oTmVSd0Z3MThud1ZkVlhoM3ZkYmxXRzI0MDNCUzFRUEJrTGNlRjN1Q21mUTV4bXRvdEgzWGlQb2IzMVptRUtyOS10Y0NoUnZFc3p1dXFpYmR1dGprV3o0M0pvS0tJcTRuQ1ljS3RDdDdicnZ6V0txTEpDcGpPU2NFNWZ5c0NZM2JrSTRHVFJBbndUcXI5OGdVN1VkcEttSk9OX3BPSVZfaFZuS2dNOEhCZ01SNk1NYVlmcjE5MzFsU1FaTjhSZU1RRlluazNpRzVHTllIZXZBWWJfWW14QXc2NnBraWs3dmtsLXFDWGZxb1VoS29BNGdiNm5uU3BleWFnOUdka3J2eVJQbEdwYzRHNWlta20xLWZXZ003M3k3Z19YV0REaTF6QkVaWjc2VVhkMno1VWd3M3hZYTdKZjJWT0l4T1M4SmpFREVXdkxlSF84NTFMQ3FMWm1oNEh5S05xZ0pKa2xpQm80eS15VVFCSTZHeE51WngxbmhkVzhBRmxqWGNIT2tILUZNWFFfMG1KUmRwUXZhdkdnNm1iWjRvR3R3Nk5Va1hLRWxnTGt1SEpvQ0IwOUhOMUp3NTA4cU9pU1BvQWNBMFVMWTk2YVdtRGNZRWlPb3EtcTNPX0tIcVZ5Q1BtUkxzZXhwT1JCTDdsOU5YZTFybnhLbVZyS25UUElwY0JuY1BwRWZ6MWRSdF9aWW9zUE10STZyQWhhdUpjcVZKZnZaamRVNC1PakFreEswMmZoN1dTM3FVWTVWQTFBeXFWbEd6WEFEdHk4SFktY1l0VWRnekR4WTd4Y0dUVFpvdU5qbDlaOEtQaTZzanZkQWF0SHAzRFhTNmxWcUhCMEVHYjVkbXJBYVdVTEFuSWp4QXNHdXdsRmI1R1M0OFZVSDhpU1d1TWZiekoySEFnY29oT2dBWC1OYUF1VXRvY0p4SG80dlMtaWJaMEJfWjQzWXo0V1BkQ2FZdUROVVE4UDU3b0d1RVE5a1BxbDZScXZLaVV3YVBiWTFuU211ZEdRMmRkYVJrcTRRTHJndzBNcnBFUFFaNDZoZjB0Wk9WUmJJOENuOElGVU85Q184aVB1M0hkVW9iazd3a2tmaEplYldMSE8yVzY1ZGhKc2N2My13eVRnSEg0aHFMZTc1cGl2N1RLeHFKQlJ2eXlFbTExa0s5NGdaN2o2SDhBTkt4VmlDU290UThSUkZaWTBiSElEZFRYTGlSRm5ZdjlUcjl3V0NJaEdudGcwZEpyTVlUZFM2bFhoYkdnTlpIVzhhRjVfX0h1Vl9IN0RleExQVXBRMW5rRm5INmdnaVNzNmt2SkFjLXBMOV9hTHJla2I4d0I0UE5Ycm95YWJmcTRGTGlkSWV0ZEQ4Vmo0V2I2SHQweGE3WlJKbUhCVFlWX2tmSGJrUUFDY2FfVExwYzlCejRPOGUyN0FNRkpVbVBpYkNfdGZxQUtPUnI0VmhwLVJnTVFmVGY5emN6NnBFbjhNN1EzMWhyQzNEUkFIWWZBYm12UUl6WWZmc0FIcnZ4MU9fcG1HWUtEaDNvdkF5dEhaVVF0VHBTZVBCS0FiQUJLcmVpeXU4R0Zrb0Z3cUhZVG5YbW9DQklBS1FERHdfYUhEbUlXU3N5em5tLXpnaFNjYzBOYmZmVm8zMlVhWjlPY0FldUF2RGg2eWo4cnlPRWJYaEhLY3ItQW5RaGd6SjN2Vm1QaXE1RVhGUWJWOEFWdTFVX0FITzI4XzJIUWpOb2FtV056SGc3c1VYX1NnN0EzblVoSFBLUWdvaUNUbi0wT2RVR1FZV21jMkdwc2JfQk1kQnB4OHJxMGt5TFJsSVRFYVpwd25QUHpaSFpfNXNHNGdYQ01QTG9RT3VZS3RhTWRqcTBsMGVsbGV5NmszeS16QmY3QVR0cEE1bkdTQzc1YTBoZzdRUEk1TnFlRVRVYnZCbFJPTXpab1pja2lwMU80Z19CWVo0ZkJnT3BhQnRFS192azh1QTVRYnJUWW9FbXViZWZ4T0prVlNmS3UzdzZQWUpObW5Zb2d3SlI5ZkdPQ1oteTdnVkt5RDdBN2VFbjAzalpSR2pyTXI3Vk15c3hCNVp6aWt5NDZCZlR2eV8tMUl2bWtkSHZSZi1fVVdvWjRDZVJBYURKV3drRzM3M0h4OFBlcFM2QURpUi1MTm45cDkxU2lMM0dLRnRqR2FFaE1wN2FGNHpYVkg5bWFXUm9qRzgyMkpGSTUzelVEVzJOREtnZDVVRnRZcEtWeS1MVWpjTkg0VXpkRHRIdGxFNnB6YzgtQUZ5MjlZTk8xLXFoR0Eta2Q4UENtcmViS1hwSEllWFlDUkV2eUM2cUZrR2R4cVlNNFp0bmlPQUhqQnZ2cXBEaUluNENwc0NkOW5yY0pENGlmSmRPR19lcDlOQzhPM3N0R0NIV21jTFpjY1NwdlNDMTFSdFQ0YUliMjlzTEg0cEUyMGprNFRjeXIxY1U1ZW4xMVRlelR6Rno4Smg2Tk0zT29nSzczTldjV3U4RTFEbmxFNGFCcDkwN0Fod1RTUUFKemlTWmdIbWhvcTAyUTNYWjhsU3k4UjdOQ3V5X045bzh1UjhZa2JEUG1qRlFoT25uWkt4MGhIWmFDYzBlRHFYQ20xeWY5ckxrTzhpWmJFLWNCeXBBYmpDelB3MnltVXBlbkhua1U4TEZIMTlhbVFhTUpVQ3Y0QXVLWFBRVkJ2NllId05xY1R2cVBRZDNHcTN3Ym5KYlJNN2V0VkU2dUtuR2UzdERGRVhtVjhhMzhUT1Nvc1RXNTJteGZzb3NMRmktcmptdDlOakozYkgtMU1YWWJ2OXNQd0pKUzMwdUhWUjFnb2pVQnlKS0pMcC1IQ1NmVUJNUnlseHppOXBMV25aOHdpX0VzMXlLUjZRbHNtRXJiS0NkQ2k2WVFqS3JDUXNUbFk4U09Yb3lPVC1odkdKanQtb2VWRDNSaVB0M1VKdUo5N3BCR3h0TEJHTmRlb3l4MTgtcE9EODVjdF9JYzFCNnZrQTFTb2VjMVU4WHNhTnRVVFJVNDVzcVdCMzB1VlZPV2NrUXFMVFp0UXlWbnlKZmtCNmRxdDRNeS1jWFVua0ltalBFNjdGUlJkN0hJSmZsb2JndU5PUTJsM1NkMXRXRTlKbkRGSFZGQmozZHZ5N2lIZlZXd0xDUkhxQml3NkdEcDRUY1F6elBVNVM1Q0hNUEFrcEVRbllmZTVVZF9RUElYTUNmd3JJaEdMbFE4RXZlVUhQaWVQc0FreEg2blJ0dlhJQlBfa0dzX1RWSGlyNlR1cW5WdFFPblNVQXhaUVNZRWVaUXFYTHJjcXpDQlFMc2R2aHpQSkJNanlpYU9SOEVXMjM0NGgwa3V6R1FHMWw0M3Fkb0U0Rl9oek1RUUN3cVBwTjFBQ1pMRXRqRmJZRXJLa3NOVV8tQjNWQ012N0dEb0VMYlV1S0hHUjBpTC1UQUNNOWlNUnVveDRQS25pR1JOT01wWExNZFliSFVCWDNRUUVGS0Y4SHFKQ3ptSV9SZjNEajNZeXA5bGZNRFdIYmk4T2VhRGt5b2szYllpaHozY2NKbXFmMkRHMEdDOU1SMDJ0VVJZTFU0LWpaUDEybkJVWkFjMkFrQ2xpY3F1TV9IeGpYVkJDdFVRb1k0dk1FRkxiWUY5cHpLMkZZMlVWcXhPU0lYRUdwM2dNR2RHWE9saUg4V3QxTEN1dTE5a1dsY1NWY1pQVDh3NU5scmp3ZVhhYV9lNWFBaDJDcXhPNm5ESjRYN3VsZWxlSmIwZGVGME95SDdQdVZNZ0JVcVZwNlZFc0ItbU5leXZGQVRYRG9RNGJxdndza0NmZ3RiOENSWkpjTzB4cjl6b29TYTVONlM3cVliQVdocWF1cEVlTGxJR0dfNklKVHNOUVE2ekRLdUNFeDhxVHk0N1R2MXBYb0ZfRUk1X3lZZzRGcllIRFpSMUIzQUJQR0MwdjhyYV9Xd0xOd1Nwdi1UNHpBUjJZRXUwMDFwazY3SVFXc3BpNDdvQU1Mc3hveTg0c21yakZzNHZ1YVNtbzQ4NFhlaXBLOWh2dUpGbUkyWEF3Zlp5T0c2Z2lRVXVQU2w0V0xqTVFqdVl6R2lTcEV4aE55SWtCSjRTSUhoRzFVV0hqRW53MDNLcndQTlNXTlFCYmVESWttR3hreGl4bHJMS01xNmZCRU54R3RLbWlrRXBPSlM2NTdBa0Q0MzhRbGo3V0VoLUxySXNDMWR2WDdKM2wwdE8xclZSQjhMMi1WeHNleGEzQ1IxU1h0d245RWJ5NnFRSWh2LUtNNmRReldab2ZEalA0Y1VrbWM0ZnFlYUZOZmxIcHJxSFJVQTN0NGZwNDFkdWdRU0FTMWZFc2RTZjNBNTBwYlFoSGVja1N6dzVKeEYxdGRJS1VfZTRqaUI5SWRNYXRPR0R0NDE3NTg5UWFaVVIyeGpQVm82cVAtWEp5akplZFc4RWFsTEQ1QzRsS1FrakI4c0JTcEJjN3pxUEE3elJfZXB2aWpfczh1c0pBbzNQcGY4aUNqN0lhWERWVjJXSzJ5MWJael92NzV1YTdKczNSQVpRaVBET3BOVzRLN0JLWFNmaG5SZEpGREFaZkZiczBrQ0w2LUVaTG1Ya3BIQmw4NEJibG9HbUlVLWVKZ1hIbkxuQ3RBR2NrUUhmVW1SNXpXVmxUTXFlMThLTjF4QlRkZU5MQW1ITHlwNF9HdDl4bFdNekdOM3h1VWM5SmdsT0JXOEdDQUR6N1h4QjVKb0VpZy1ENW1IclpFdGZNSU5oem50cF9BU2dGWE1SLVF1YllOS0hpYzNsRXBNUVZuT2RGWGxaRXYtRzlia1VpSmdOMUM2cnBpZUsxS284S1ozYmE1a3AwQ3RNQzdyWjl5cXI3YUVJdlJFNUp5OUlmUVRDZDl1Nk9FUFAtM3B2X1FQQzlhTEJBdVlQcWVfcmpLcGRvVWJISjhpMkdoNnR5QU01LWFSTzB0YnpTaFlYVUl1ekRTY0J1VjlUXzlZRm1aT1hNVDZjMEY0VFVUX2hOOW40RzUtTEFmbmh4OFh5WjNjYnZzcEMwa29acVAzT280b0Q4OE9UZ2FxNHYtZURReURzU2JRWEQ5Q1EwSG1tek9fb0Q2dGVXZ2JFeTA1RmxZRUdNbUtORk94THFSRldOUVZVUnBpVTNrVmJndmd0aEZsWTdDYW4zMjF3VFVjOFluaDhkZUdYNzJpUVNpU01obFFxWFJPMFpBTUpzU0hyd2ZYMTZWMlVmYjZhdWM1WWt5N2s4MDBtT1N4anFwLUJJYjJIWUtFbEdVNGNnc1lRNExxdGZ1b211TVRtcDd0eHdvSnk3TnNLalVndmZEWTFBYTNHTEFzdUs1MzRrbzg5MWFQeWJQbUtERHd0dDN0cEFzc3BuVU03Mm9OWnlvUllDVFVoOERUMXdIWi15aldBZU9OYllNdFdBX2FfTGNUUjduWVBNQW9OcmhwRVhyTGJ1dFRXSktXRjVlc3BBMDVTQUl0YkJDTE5udUsxSUlnSXNZWmM3T0FsR2VYNHIzSm1oeFNvYkJDUTIyMXJqSjItbFZXeDlSaDROVVNUWFI2Vndpbmh0eFFlb3dhbGh1WTlMaWdqckU2ZUlUUjFnaW9qeW13VXNPWWFBalQ5THo0aXVBUG40RnkyNHdhaWpNcEphN0RnWlhpbW5ZTTNPU045NzUwNnJfNGxyc3hiTXhyQjZrNlZ2N21YbjNSTkMyVkxyN2FxLWFGVXY1YzlWMDdsOFpicnAta3RzN1VzM1FXUmtabzg2MEtPVE1xeDdaX2JJTjdMUlBQSEhfNGdjTUVQN2QyUU9IbXJ5b2xLeS16ZjFpeERfcm1qd1M5NGtkYi1GX1dyQXh2dlpWV2lPOFNlV0Rockktd0VmTFhFS3hRNUlQLTJEZmFSdENrYnJXNzJZbFJlNHdfMlZJWkRSekxlV1lFS2RvTlJBTWwxSU5lQmQxYV9WaVpILXk0ZExPUWZrUzJEMXo4NUEycHkwMkhEbFcyQnhhWUpVZE96dlZYMkNRYmJNc1Z4aXRmRGFuVGRESDNVRFllUzVSQlRmX3BmcE1Wb1RHN2liN0pvZjRYWWNVdFNXRWV6RnNmaWNvanhJQU1FZUlMZWh1WFNrR0RpMTdGdUVzZjBGekkyYmY1STlrMVYxUFlkUFZ3Z1lmTHprOWRucTFmQXBNRDFWZzRzNmQtbkVHcE9ySDdKeHMySVFNanozdENsQVk0SzF4cEM3ckZhT3BXVmpWb3JLdk5KOE05TFAzUVdRRVpzNnNoVXhiU2E1ZFVOSXlCTzdZZ1Z5MWtEcXRKTTBhcjVkOENjM2E2YmVBTC11NDZmNURGbG9KQTIxdHRWckp2cmlPNjY3c2FVX21kUzdkYjhJRllVWU9RNmR4UmpBVzJjNkV6dGNaa2YzZC1pT194eE9FOVBsNmFDSGxjdWdnbzFuY2VYU2k3TWNHQk9VVzBGVzVQOTR3N1AzTkxIbTJjazlrUkoyZUQ2dkxIbWhfcnlranJlVWtxQnNkTkpXblNVSWtkWmVfX0JLWmY4dTBQMzBuTnRDWDdBUzBNMWl3NzRJYTB3OW9PTUJ6bEYtVGJhejFnRFNRU3RMZjVaXzNnYWgySTVTM0p6Um8tQldYTnZoOGtaOTVDaEZTRm9lWDR1VXNEMVhzRERSUkxuSXlNZ3FoV1lHQThHbkEyd3M1T1ZfOTlMWVpsM0ZqbjBfbk1lZ0VFT0tWelMyZW5faHZNYXZUdmVQQ3BmRnNhekYwWEFVblJJcW1NUUhiaVpfRXd3Zk5RT0VFejEzaXF5cndkTms3UDJxVndoaWphYktqN3BWQmFYMUlmRDRPbUFZenhjVThLZ2VvVTlTTGZKUWxrUk1fbGtxR1hZdlJMQjlxYy1yYk5PNDZDUzAzVjhsbzRocTRuUUtjaTV3LXAwRzl6Vm9nQ05VWHQzVkJqRlB4cm5JNmhQbE83Y296SWREWjN1a2JydlJtdmpLbjFnY0p6QWN5VmpXUnYxS3dsMWRlQkppbjg4OVVkWHAtYTJweXdITVZ4TUNUbmR3aldhY0NWOFlVd2U0NlZUR0l0RlNCc0prUGpnWjRBSWh2MEFVNmFpaE5vT1VnalRQbkNZQzN1OEQ1MGFwNGljaHc5Umttd0w0QU56LVdjYkkwbV85U0liY2dPNmJoWENpWFh0eHFpZldrNDJxdU01ZjRHNzByd2ZyckdmUjBtQlFva2pNVGpDTHM1c3ByMF9FZVNLNjNWbWNNcG9tenU4NlJxTWFpNkljbldNWTFBMGFNdXdNbXBycVU5UGdHR1NpV28xM1NyUTdWeE9XcGtiNzdfR1JEN19oblZleGk0MXh1SERSdEk2T1ZycnloZzgtNno3MDM1YzFMT1VzLUdKQ2FhTVJWd1dBbTBfa3g0TnYzT1lRd1h2Rlg3Sl9BNHYtNVExNFpPZjczazhndkttVFdQS1l2TEhmckZTOVFfMVRiWUhKMnZEdkZMX1ZMOFdLVURRakNzdU02ci1vcS01WWZMX1FGUGREeHhJcUIybk5Xcm02MWlobUFRdDNHSzhmVmhvZmdQZnFVellGVmU4VDlFYllGam56dUhtVUxuMjMwNkJScVRZRG5wWFNndXZnMWgtaFRUSFZfMzVpM0tIcWJkUDc1WnhHNW5pX2VDQUFVRTJsUkpUU0EydmYtdmxZVmhucXh1dXVtOWNoRnRWSk1BR055ZnNza05mWWhuNDk1bFd3eHl4U2J6N3lVcEp6SUJEQV9idk80cjhyTmJWNHgyaU95UkFJZ0x3VG9XdnlmYTN5MWdNUXN4dHFXMlBZN2lkOWpJbGJQcjJTaWg1d3B3MVo0RktzTTNseDFsdmt6cmllREdSTGtUZDRnVmFaYzhSVXVBcWZfdXNmQ3pUVUpWWS03OFBKcENhOHU0QXJBTzlTU1h6aUwyb2k4ZUhBWEZCdWZ1aFZ0N0c1VVN5WnRMcjV1M25WandnRDBuZHBuSXltaEtrSFZlb3ZnbVJSWnNQNVlZNm1YRlloZFJvQjRPR3ZmeEhFMVpYeFM1Zk1VQ2VGMnh0VEpicWV3bFBjM1FNMm9LX0lsU3ZnSU9YbTNPTUZ1LTROaHNaaTUzR2NjNEdEMFdhWTIyVnIweUZXLVZyS3BBZUFBS3FITXgxN1dzN3g5Z3NILUVzbC11bEEzamYxaG1OWnVWbHlnWXZKR3owM3ZTMGtOYW9YSGhvM3BPTXJvOTZqQmZWUFY0UWNZMklfclQ4S19ZNVNOT25OQ1pvQmctT290SGpDTEVQZGtqY1JQdXc4VUhYMW9nOXBIM212V3NXeGlCS0xVQk9fWFNyRnZDUkhYd3Jleld4YThnNS5wZ0wzZnNxX00wWlFXSnFLT1hhNXVR"}'
+    body: !!python/unicode '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkZfenBGemJ2TGRDQVExVW1oOVNMSVVQVWFpMmtQanNRWVNVVHZqdVFObWg2ZDFlUXNEbmN5VHBXS2w2QzVuTHJBMDZRUmZhQm9MQy1yN25Xc2JBZTY5Y1BiOV9GR0pzZGlLd1BZYURpWlNVdWVSbHNEQUF3UDM4bGVYbWtKUXM2RnVjd1ZIZ2JDaThYNEZkYmpCS3hlWW1ZQVlZNUZTMzhZM3JHbHRKTzlUNU5WUWU5cmNjOVFOOGJWTzNvWURUUG8tejBjMUtoMUJiS3p6bHRIZktGYWYyZDFPSnlfX3hHa3RiQ1g3LTAxNmZlTm9lbHM0Vkk2RUNzV19wY2Vlb3l4RHdsR3FCOE1lVkVpQWktY0F0T0dXWXF6N1BxOUQ3TXJCNGJCcExaSS1kQzNyV2g5RkdYLWpqXzBDNU41bmpGTlRBQXlnWnZvY19lSlR6d19qeUZrQS5qcHpNSTVQYjFQRGd0ak4wWllQZnRRLmlYZUduZEs3ZnVnZmZwZ2lmcU1UbFFYQjhvc0tKNlFiU2pIWjFRZnhzQTZMMmpFTWE5NUw0cUxiMFZtbURGbmN3Y3RIazB1bU05Z1JMT1RMbEVlN2YwaDhlbDBTV1M1TUVpS0huTng1SWg2Unp4NUVxWU84MGY3VmRvbWdQdUx2NGNqbUZzWmhhNC11Z1FTU25zZDhJYUhKWGlDZUkySkxMNUNZLUpNTUlaX3R3Q21lcHZUTzBxZmVkcE82aUFmS2I3SU01c3lhRUdOb0s2d21jVEIwdEVBWXFySWx6VFl4WGF2cHR2MHhYUmQ1ekdBTGdnR3Y1aURlSDVjbW13UncySElyR294YVItaEs5OXZfY04xcVhuVEJQYXdNLTJjVTVxM3FTYkZlTkhiMDctZjFUUnNEM21ScHQ4YWRrWm4tcTNBazNQbmw1d1NmQUtZeVBoa0pVZUgwbjlWVHdPT05jRTRHMVhFTUstRGxHVXlCeTktazdXanRuc0hSZ3hPeVVXaTU2Ujc3ZnR0NzkzcVNjODg2a0l6clpfSFprZVRZYVU3aUdZeGRRMklMaVVIVFk2ZGJLN3VHd19nTHkzNWwtbEtVczdyakdqTEJrZjJiLVdJUS1DRjVKRlNYcEU4bnlnYW1WOW5USzZsM1BBY2RVM1F3OEc4WFhQMS1DV3JZc0wwNjB3MmM5cnlxdTNxZ0g5WUpyQS1MbU1keklWYld2dVZ2UkVlMWlMbDhyczViaEFENG9zdk1TckU1cEFoTmcxeFZKYnFWMlJfSTZLYmdSS0RzLUM4WkFmWjJaSzl2RW0tY2ZBOVgtZVdIazFRa04tRkxKalpNcm9KUXlYRXRlSUpYejFGa3hVS28tUHpYTVktV1JiUV9POXNpNGMzb3VnVzkxWm5SNV91bUxkdmY5VENiZ1haMDdCeHF6U3Z3X3hGY3liWTFCa05yZllDa3h2ZF9iZ0VOQ0VtQS1RU2NOcFdOSk5ZOU16djBHSDhxd29HTmowYlVlR3ZJcGZzS3dWWnFnd3FVTFFuVEIzbk1yWDRDaGpCUTRaUGNyNVRaRW11OUxNaGZManZxejIyQWVXclV6S1gtTmd5OUFadWc0SC10M215Z1hJYXIxeU5fdWtzZ2h2aXNHcWFhYXdfLWRMOUNnQlEtYThabDNOYkt3cmpBVFNKLVhFV3BwV01hcnFaZVlaS3B5SDJ4eWlXQ1VTR1B1ZjdzUXlfakk3bzZtSHRlSFozX1pTVDJrWEtLY3QtYWJWU2VaeWpzYTJFZU40NE5SajItVlgwSTNPN0ZBTUZxVzJxVTFEM2doeGpUMEh2N3l2cHBRa1FTRzlLZ2J0czdwS3owZ29oUmFuWFh5QlNHbkdXX2pvZ2d1bDd3X01Ca283X2lnbmZnNVlZX2N4RU5VMzJyakdjckJ1NmtBZVFkSko1dTNzSXlOeFl4Q193V3BaMUJsTVlWaVJvVGhobl9JUktudHdLMmJZU0JSQVBxdFJpZExOakFGSWZuWXFhSEtpbzlTQ3hHMHNUUjdJMWR2SldJeFpjSHc5WHFGc3V0MVpGSE1SbVlOZktoNnZCXzVvNW5jUk85R2FYT2FPd3VWUnBkU29KYUg4YmM4dWdLWUU2OXU0V2lyVmRzVDI0b05USGNrOFhQM21PbnhHNjcyOEVxMFcxamszTEQtSXlrU0sxSnJadDJaXzdQelNDRmMzTzY2MWFST0gxNVJOMUxnal8yT3ZIdkJNUWQzVW1vYS1vX202T092WTR2Tzk0Z2FkaXo0TUh4eDBVRmZVRmxlNmZqUU5NMTBWREdMNFRNQ1VHYTFSZmI2MnVMd01ILUdMSFBSeTc2emFra2I4OXQ3cGpMZWdQNXlhckxtc1czakVuN1ZJLW9jekRLLXBzNFZ2SHBoR2N0M1JwN2gtSTBsWDdUb243YkxXN3MwQThyNGY0R08zc2pXRzhFR1BfMEV1cXA5MzBRV203MHFtb195QVhNRDI2Q2dzcU9KNGxscThNLXNXR3B2X21SQU45RTY2dS1UZUxqdlVUOWFBakZfcGp3bHZKLWVsbFowZDlFYnpBS1FUdUplTjUxSVJZV1RfZ2RzSURNR3J3UGpKcnVFTVUxSkpTbjJXbWpzYmlScURRZnVVQWZlOThGLUtJTnc3SE5fcV9xQk4wOWdoQTJkVzFla0Mzb3pNV3BFT095MHEwNVQzaEFWZHFHWjNUS3NIQVptNzZ5US16eDlrMk1KTlJNRHU0TVNkamhKclFXTTBEbzU1bVBKbVVyM002TElDV2Uza2FoNkJPeXhYdmctd2V2UnBTQ09CU21JNUhhYkNnNjRBLU5fdi1jMndnbnl6WXFDR0JiTVczaWRLeUVzeXliWXlIUHVXR1I2SUNTb3BLY1lWVWV1Undyb0xEQTZxMXZWVUtBTkN3cGxmRDFpckQ3eDFqczI1X2dGQWV4ekpnQUhrLTdsUnBjdFZIVk1HVnB5Vk91TXg1bWgzTk5zS3FzZ2hreE1mb3JodkZhYUNPcjFISlFwd0ViSzZrRmZxXzhjR0dPZ1p3blVoXzBfRkZHRFRiSHh1LXR0TGtuU0ttdWJpQmNRYjJ1MzB2R1VwcWNjcFgtdlUwakl1dmVWbXZLWGM5aV9CeWVaalRYd3U2czVqTDd4UTdnMkdab1VHcFBxUE9qY0FFdHl1amNTR1NXMDRRWjZpbzRiUVY4M2pTb013WmhNOEJDeVQ0ZnpWaGJ6UV9oYlhhcnlTZFhnM1dobzRSSGtsRXRxdDBjX2wwTEhFNkNobzFtMVRlMXNSVDAzWTNheUlyUEtDZjV1YjdGM21LdV81b1loWmRwM09WWkwwM3dwaW1aaEgzVVh3RWRmWk5KUkF0WE04RDdjY0kwM2NRNGFyRGxpa3FEdy1vT3dYODZBSHVST3JzQ1ppU1ZjV2ZzLWdoN3lGcmlKdEoxa1dqMmhlUmFCMHFXekcwZDhULW54NUJkM2Y1eUxGRW1hUkJ5bEVVMTlWN184UENpTmdQSnB6a056VFpGTUlaM2w5NEpseG5GVHp3ck5aa0hjMnlCaWE2ZDNqWFc4S0RSclUzVEUxNGE4MXRJX213SmxuWllZTnlENlU3YXp0eXVNVU1nWHhOeThMRGhoaGg0bk5jRGlFc213VTVJR3pvZWNfcGdVMmZBWUxzczFNcGswUnFCVUJfbEVlZkdUMmtUQmttVU9rZ1dhdEVzdWpTc0tTemNvUXVuWDQ0SFJ1VTFqdVl6eE15MFFMVVNoTnBlVkFXUGk5VVFvMTc2YThka0JId2E5UEg4QzZNZ2t6enptMGZNWU5aNVlYcXdEemRMSlZFV2RMcVlnanFQUmpCeWJnWGFaQUtyNDdOX1pkaXc1cUVEbldmNFNqZk9HN2p6TVVZRk5Icl9hLW9aaVgyT2tLT3RJTlE0TGRlb3lnVzBHV2JnLUJIa1NISUh6SUlab25VSkt3V2Z1T0tPY0MxUUp3bjJqdURNMGp3NkZJOTU3YkpLYTdaWVlEdjAzMThpelAzd1BHZEtEcGM1TWY3alBjOFA0QmhaTTNrOGNIb0hycjZLaWV2c2lFYksyQ2JwRGRPOVZCTEdIQ1pyTlc5Mlk5d3dKQU1BUFBVcXpZMndlcVFCT1lPMldfQXNjWGFqSHhVZkNCOHhIQnhEWEZYdXpRZHgxNXZXNDJkRVdEWl9CQzZiTGpaOFdPczA2dW55X3loU2VSS0FaVDhhNmZiNDN4RjU3ZGpqNFBVOGl1OEFVZ2cxUXlmeTBjcGZMVHB1RUVBQno3QUg4RjV1VE9VUTYyZ3NIMWxyNmxaOEI1Q2ZhVUFxeTZmSy1XRVRSeEQzcFBybVNfVEs1TS1sYkR4elVkN3ZNNUw0eWJPSDU3STIwenQ1Z3pSRjc4eldyRzN3NWN2LWRWNmNiNTJOVGdxWTBGaHZNdXE2ejFZLUd0cmRXRXoyZ01jMHlvak1BS3pfSnl4d3JERnZUeGRIOEZNbnU4Rk4yUjVfWEt5eEpuYlViMTNDamhPaEtHNUdJQUNFUXVRc2RWaWNyYXFUOXVkMGs4czVqN2dvRTc4dTJSZEVrMTVET2JDb05OZFJISG9fS2V5ekNJSlMxWV9NeTVNamFmWlg3UVJfc3dwQjQzbDVBZWFTRFZndjRWTV9sT2RydnV3RGxDdEM4anNCMzJrNldxSFBySWtNWG1RNnVIQjhWNlM3ZW1rSjNweEYwT3ByNnBxOXV0NVpGajRkSEhOMGI1V01jbnlmZjM1ejlSSjVwR2FDRlgzdG0yZW1lOTBBXzdFZWlod3Zaa1lQczVBWnhrbksxRTlhYk5nWjFSUTBiWHYtU21vM3M4U2FsQ0VrcE8wMXg0VEZmVGdJRjBRaHdiUFZIQVZrdTdLM1hnYWQ3VV9RdjBQTG1ISXJhMVQxY1pYajBfQnlMMWFxOE5kWVpPaE5mX0hQX2d6Ylh4TXFFazRRckJLSzE3NXh6V3ZlXzAzeVluWXM5c0pBb0hma2J6RFJUS2tEMWZvVkRIYl9QWTBBUGdoc1czS1VMVHJCbkJPYkNRZzFiSmRFZm5XUGlzTHlaM2xQSktORWUyMHFCSXgxX2VfVmRNbXpXNE84Ylc2UHIwZ1lHTWdUZDRqeUlXRVMtZlVkeFZTUnUxUVhONE5iUVBZTVM5aE4zcUpxLTFsamR4dUlyd2xEU1lVdWM0UTVZd21XUVZrb0p2dDNHY1F3VWJ1WU9DM2lxZTVlMlRJSE1ZcXRaTlpPMGRZc3NwaTJTLWNTYmpXTFg2b3diMG43eHNOdjRHekI0WXJKVlNDRkxQZm10UXR5ZjE5N0t5RTdVQnNYT1lQM2dDV0NGOTA5Ym92WmY4OUhrNFlfV3FJcV9vdWhVbXZDYzl5MVVvNlVRTlBNVjJkelBDUGozRG5zLUQ3Tk1NN2d3RVhmX3NOU2JtbFBBX0J2M3ZVcWFYOGJRa3ZIMUNoT19mak1ZcmRDYjZTeEROYjlGQUZHb041Tnp5OWQ1VTlXSlhOa1M5S1J1R3lmaXBJR2NtVFkwUm9lUE5jS0JUb05TR3o0Z2RLUFN4U29aZVZmX3g3SUZFX002WGVFSXo3ZzFLb1R3Q2dOSXViZlhRQ3QtaDllazA2X0F1SDBsbGpSLXU4b3lTdzUtZmtFYm9ORFMxeWFFU0hYOGZjRTBXVkR0QU5xLWRwbHBFTnlmVS1NeHZuNmxSWnlXY0d4aVQzZm9pQWtsR0NrLWc0Y1B6cS1fUHhMZkF1cDBkSE5xdXNBMmRYQU8xaXJmZ0J2OTJqSXVRVXVrdVEtRzJUeFNObjRyM05vWDM3SkREMnJfTGVNa3ZCTFRsSThBME1CSGdzZHdOWFV5Vld0bEdVcW5NTjM2aHREcy1ka1hWNkVVRUxleUV1dkNoUTUxU3FaZFBjeGk0eGtoVGxfaHg4cXhsUFdPUVNmZnZOc2tMS3BIY3VnN0ctYUdXSGI3alREaEtLLXVvOFZoYkM4NG01dlJaLTBaekJpT2hlQk1HczRyYkcyVmtZTkVka1hXQWNqQXFwNURFYlZBX0d5Q1UtcTQ1dEc2cHdtanpxUVdZdk5SaUlQejZUdnFMTElXbzd2M015b2VYeHBybDBveEZWSkxoT0Y1ZE1GVE5VYURVRVZHWXlqYUIzSFBhSDNKQkxxVGhKVjNNS2VuQklSLXdZZncwZlRWQnZCUVFzV3VuSWRmN3FJTmY0TTM2NThSMTJHemljSXI1ZEY4UWt1azdlWmlMLXFmc2VUN2xkVjJwSW9YVUJlOFllM0RCRFlWZElMSGpfcGxEOTJBa1V4c0YzQ2ZNRkNYTDBJYXJuTUNvcnJ1dnFSMEtsSWE0MkNVVDF6bjN4bU5SODNxN2RSUXp0NGZGN1M0ZllVdEY3eHlaMzdwcVZ4VDNoUnFMY19MU2lMTFNhcXJNcmFZcElHXzBMSU1KY3d5RUo1NVlNaHI5cGdXQVFRUjF0djJua295UV91OTdRQXl4Z08zUHFQNzdMMG1ySGVCMlVOY1FaRlhud09oNXZyMEwzRmZra09IUXN5RXUyRTBvRGZ3b3pyZXpxTXVTakkxSDE0WUpmbE12TnlRemJqbjNjcDRCaUo1NWV1WjgwV0lNaElHcWF2OWNwMjFPRDZHRUhiaGk3N0FyWkEtX05sQV9iR1gzM2l1ZVBaS05ucW1mbU9HVkdKTXphaXNGR0hVRzB5TGFqR0VQeHBPM094WkYyNU5xMWhHcUhXNzFqcWw3YkVXV3V6UExsbWFOMC1IRlZNbi1qUkd3U0VSS0tTbk1ZUVdyUEdZS1F5dEh3eDdxT05hRUwtdE5sdHlPTkdEbDhkTy1rTlc2bmVUZXZObGFqeTh1WFJwYXdmeXJUS0F4R19CYzFRUzBYcVgxWW5iNXk3WEM2dTBMcDB6bE51LUQxZGxOZS1naXBkbFBUbUN1bmwxU2lFbExudzRRenJVSmN1Wm1BclhBT29EbEhabzM4dWlnS1hmdUZYN3BRWExwMENsQXk4RWVoUm5xSEhHLTRERDVUdlYyYUh1TFRNYmR1M29VcVlSd01aMnRsaWFKLXN6aktoV3M1QzFhckVTTHMxTFFIeW85QUhaSmUtaTZ3TzVveHZIdmMwV05vVG5WTlpFVHdoYlg2aGt3aUdhWVY4aWxkSUktS20wTWUtNlJmMlRzR1VJd1hkZS1VNTVMdzl5WnpJS01JQWdkN2x5c2ZDQTM5N2ZNME5XSTFiNVlOYW83ejIwWGFwY0tFOVhPZGtSNEI3MmZNcHdCVzFxY21yS2VQcExfWG5XZ29md3QtQ2dGU2RYbEw2S3pVNlhKRGQ3b0FMQ3V5dldWYVdKYnRFUkpweksxbDdQTy1wckpMa2VqZTEyOG1sZTFZTnUyMkdsV1BfUTAtQmVTaTV0SHAwX0dBZ3hvdUxGVWxvbW5RRXJuN3laSWlORHo5NTRGTjdoZVh4UFdIbm01V2F4ekF5MG52Q016Y2k1cE13Ym9pMjcxZVNtZ0NHbmNjT3BOUXlmcllxM1Q2UHZxYUZqaVhpY3JQTHI1OGNJOUM0VEY4cUdsOFRsbmh2U2x4MFVzZHl1dzI0MnJDYzVVc1ZMM203QXk1b3c2ZDkwd05zdWVxWDhqY25FNW9WS2ZnYVB2djZHVkpxNEtrcmg5Ukc0Mi02UnllNEdkRGdIand5bjdhcDhVNkZOdTEyUERoSVlScDJuWXBPRDhzTzZHVDM0djFsdUNhNVJxbWJISnpkaVZ5U2x3bzhPLWcwMHhDZzJnOUpGeEMxWEtoZFJaMklBUi11Q2tiQTl4S1Rxb1ZFQVVIeFQ5TWQ2T0ZPalF6cHdWRndWN0dzVGpGblFkYXk5cjRDTWtIWlU1OVpRaHFYeWJPaU4wdDRXY1hTYzBaeUxHOG5SbTYwMjdEOTVLczZ6Rzl4bjlwM21Hb2tCQUQxY2YteDYxdG85b2lwWUZzTTV5cjdIZWtHMmJsWmhFZ1pfWHE1MUt0N3dhSkRzV0tHQzZiWVVIelZTbXljWWNER2EzNnJUOUFUWjNCTmI4OTNtcXNxQ3ZkVU1Ua3lPT2JmY3A1Z3l2R1VTZjRYSHlNT2tZR2hzNC04Z3Q1cjhZSDhDY1RCNXJKaHVoYlJlS05YbWoyTXpiZFhNU1EySk5PdVNBeFk1bEVSU2UycUtldUowUHhjWHBTRHg1Z3ljeTVPekZ5RmU3SnV6Unp6RWZxVm5OUUhacG5pNDAtX2xLSm1UdEVZTnNud3JaVDZHNk9MbUdESE54WXJCVWVaZVctcEIyaXpycDVMWVhwejlWV2Uxa1c2UFBNQzdNYjRyU3hscl9UVmtkUUxaa3N4YktnbXBVNXRxUVQyOEdCcm9NdG5HRk5kbDNVRlM3M3JpV3JHUWxWbVNMVUM3MjR1dGYwWFZEQi1BOTdWazhlTEFmbFh2NEx0eEdLUUhKaEI1OEJHaDhzZDFXVnl6TzdhWm9KNktodEp2ekl6SGxYSmxDLWZiYmVHaTBhYkxuR0lRX0drNVNSM0JfMjUyWTN6Z1NmeVd6ZHl5U0xPN1lDbktuRHgzYl9YUDFVd2M3QXBoM1ZFbmp4ZUNxbUJmWlhWSDNwdDdxd1k4RS1Bcy02TGFicHNzTHZMcmF5RUd3Y1BDOUZVVEJkRjRBdFZHRUJLa0hGcVZST2VfQlJlVmJMZVpxTTBlOG1mNFVnYUQ2TXFZa21GelJjQkRvamh3MVRFVC1aV096T0E5NGhOY1NQOHZ6T2luenk1NHp6TER4Vkg5ejJaTG9LWjQzQVJKTDdwUUR1U2Q1enFONlJOcmRFZTNJdTRGcFRWVWZQbGFzWl9sTDBueTIwMXZiU2E2RXQ2RHFXb05wV1FLUGlnME5ubEtSa0llNy0zb1dRczRpWjJpdklEeUVUWVhCUUVOcDR4OHBuRGhXQUFuNWhfVWJQdXZ4NUs0cWJTOTktM2x4X29NcVdmc0EtaVp5eVV3OXc0R3ZnWVA3TU50RThFNVVBT1pWVElUX3BBWElxaDdLaVlNMWxad01uLUJQeFdaaVJDNGp5SHN2cUUtSXJsNm1BN1dRanNiUW0zaDBMX2RTS3g0UEhTRTBYQnF5OU9GX2xjcjJTYkg0WHlRNlA0SUFrcUMwYjRlX251UUZ1Y3Q3c2Y0M2hObXJRZTk1RC1BQ0dVamFFZ3dkYmFqMGhEUV9pRy1vU3JEeDEzVTFLNVE2R21RTnpsUDM4QmlwVFN2b09NRVVIdngySUd2cmtoeHRyX2t4d0o4ZG5JV19Ed1pkZWptT05zUjljLUV3Sjhhc3NzMmYwSkt1ckdPZUxZZFNidnBHeUJ1YTVST1Y0MUtWanFtb0NsTXlJZllSVk1zVWMwSmJ3SHpoUGpTZGJONUVCVlVYUzlibE5oeHVXUnF2SnhVQkNEN0ktUmdDbVlSZm16RTVUcjlXODBGSDRVTzN4UU1TdFBQTjAtc0xXanBtcFZfWHd4aHhzQjZIbTNxTkxUaVdOZVU3TlRUZG5ZeEVZMWh5ajd0M0MxNy1KR0NtY2l1OFJYRVBIWGt3MFJ5d085VV91X1BjWTRLejRyRllfR1IxYWhaMFdWZU10R3BLS1k5Y0swRG1HTEpoOGNKQ0FBMXUyZW5wUUZCMzhPeHVTRWVzX181RklnZ2dWU2RvaVc1M0ZMT0tLZXc3b1FhLTRnaC05OWFYZEJFbHpmbk5vSnNuX0hOQ2NVZ3dTYmNuWFgzYWlRSnJxZVhoLUN0UnhRVzZHZm42X25pejJvc0Mxc0E5elBKanpubF9WVHU0dGNOUm0wa2lIQWpOazRXNjFPVkNGLXNmcXNmQWw3UkFEU0NtUWZ1TjdndWlnVWJWWXpSRFVHbHhRM2dKSDRoZ1Z4WU0xVHZuWC02M21pRUU2VUNlLVFDN3hOTjV6WEx4d2JQOFdJVmxNaVpLdjdyNlNLQTJtWWFLNmhESGQ4WnZpVWdKQUZZUjhJb3YxbkZObS1qU2dvdlpjdkVsUjlMVXBWZ1dOMU1OSU90TnZfbkhMUG00TklVNEJ0ekdWdmhiNHdaVVJ5dVhnU0pDN08yZzV6YkdUdHBVdEcxS291bHNJMjRTMUxST3VFYVdvUDZlX2l2Qm8wYWc1aEFOM0dodFBuc1J2RzFNZ2VxcUZqTkpFaFM4NEVyWG9mUHdWbUVRdUdYMGxZRkJYd2d1OWVndHlCdVN0Wl9sdnlPTDhHOFZXQjgtMHZtOG1pS2dCVk81bnVMbnFNbS02QmRodHNqTmNkMTFrRm5kWjI5Wk55VkFDVl84UGJVN2w0SFNyUzlCMm5aOUo5c1FPUmFqSDFSMVdNNWduR3JUX2Fwd1NaY2xyMFR1TFNOS1NQUzlIMm9XbXAtX0RCSXAyYXhhNzFjZ3lzWjVRNjdSdGd6a3RaMnZQRXdxQ0tmd05GS2l2TWxMTTJjZE5iQ3FVVUFVNjFUS0lrN0xUVDFPLXRrZlk5cUg4QjZSeVVZNUhhRmZ3cElWX3ZKampNZW02OUc1TXpJRExNajRJZjQwckZnWmY4LUFXcGM0UGtoeHYxcDFVYk9OZ1ZQUDB3WkFwMmhMRS04WDhuQThhbWMzRS1OVTdJVk00LXo2X2wzb1JDdVNjSnNIMzgxeHczVGl5dVJkRE1kTE95ZHNBN0VhU1lpcVFaY2ZnRGxpMXNsSEZLN2pxVk9DWGRiN0p2THpVMTJ0eVdyblJ1czJ2VUR6akRENmhER1pLckd6Y1RkUHYtaWRxN0hOSjBGb1AzeTg0WEVUSjdxRGpUWktMa2RXSVZTV1k1SFllNnZlYTJGRHBldThzUUk3V01ZY3BrVGY2N0xuQUdqcWZsUVBsdjlBeVNmbGFESUs4M1BHTmhwRkNSNVVWYkdmTGxPbW9MOHpzcUxRQ1kxa3diRm9hMVJkTXB6SGpsYVVtQjZEWFpjZlczSVpIT3J4NDktSGtFc0lXQ011N1FJYjhtN2JIZEtYY3JVZ05KcnN4RmR1M2l1TFpoQ1BZVThuTklhQ21IY0hKVGxQYVNEa1E2WktTMnE2OFU3aldwbmZ5Mi1MYnBmOUhLeDFteU9qZW5aNHMzcDJkc1RtUERnbGF4MkZZT3ozR3JmOTI2QkYwWUN3a0RPdkNTZUxEZ0djMjlydVpsVVJFVll5bnlyWHZBN1ZLOWFhTGtkN0xRYlF1ZmlXTEROUGtxS0VOUERzcDZzdmlHTk9Qa1F0UzJqS1V5US1XOVJxcGdlQldxbEgxMlpEWF9adUYtLTM4aE1SNE5yX25VN3ZGeGY0dGtPeGxROEkwdU42bnZJbmJmRW45WFFZWUtVLUZ4Skh3ZmZqTzJOYkJIVjNXdnRMdWlmWG5LU2ZDNVpjdDAxcHNLQ0x6YmpQSWc5dlFrVW1MdGhVQnlJb0E0Mlg3M0p2TFBOanlmNnM5Ty1iWlA5ajg5T1FOZ2czQVRNc1JCUjBoN25MeUlpQVQzYzdadjdYT2hic0tmMkZaUldiV1pSbzJDSVFjZ0o1Rl9XTnZvdTJiTHlQY2RJdE83ZE9WUEJvblZhYWplSkR3SXJIVXBOclpWd1BqU0VIdXBFUnZJaE5PRFN4UmI0TUF4Tmd5T1Q1RDM5NllaZVllU2hEQ2s3b0tKOHprcGpTQ3Jvc0RxTzZmTkFWZ01BNXZ4RG11dHdMR1AxbXRJSzgyUkVQendZV05Ndk9lNFZ3YzUyOUkwMDJTWWhDb0dIaTdiNHpmUjBmRHV4dTFhRkJ5cmxmNFRlektkTENNc2NreUJUbldiQU1mNVF4bmYyellUTzRvcmVod1pHUzIwa2NVNEJ4eGtsVGtBOVpQQ0ZzLWhBdUxadk9GZDN4MVpRcmk1V1NPWmlrcGwybWNJdk9udVFqUkM4UlJsWjdzeTczSl9kUkhrZ09zUXkxYmthY2tBSFE0S2djazJucVNmODZzMUNpYUZvQ1B2bWdlT2h0bVNvYkVvV1RFQmN4Z3RkdHNfX2JUR1BjY3h4bTdZWldCOS1EMXJuSUZIaF9MeS03TVVfb0xISzlCYVFKUmRjSU9LRFh4RjZjREhkRl9qc2xNNU1nRXlDYkdHVU1EampDWHJvd2dqNVFHanRDV3hEaDY0blZaRWNENTkxNEdRZ2doX1F1RGVhT0EyTlNSbnFVLWktYVZtLS1mXzhmT0FzYkNPZG9URV9vQjBpR1hNbUE3SDhzc18tLVExOGhkY2hQcHg5NS1CNEpGWkNDdWNTMTVoekpaaDFUSFg1akIxZEp5Z3BaOVpfMGJ3Wk9aTGJRWHN6NG9IS1Jpckxvci1lbE52MnFKd094SG5GbE95OFQ2MTJ3bGZ2aTU5MUh4R2YycEMtblFyN3V1NGpFODkuSzg2Qk5tM1JMWEtfWWtlc29PMTNNdw"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['12513']
+      Content-Length: ['12599']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44c4f192-52df-11e7-8a3b-5065f34efe31]
+      x-ms-client-request-id: [e275b0ae-9414-11e7-8918-a0b3ccf7272a]
     method: POST
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/restore?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"zw0pC_r4l9hurzpN2viSOCcehX16tPF_s5Gs1li7VBh5GbcArYPpiGW8JH2OE-YUkSpEwxvQslAvPtyGJ2f7yCvgoE7CtxvFpI1HjGUURcg11Gs02HLA4IOS0t4aYTP8o-m5LUQTy0TFNgGj9KiEumJxbqWDd96WrHVmYRJUXf_WY4mLwkMsIgKQYzDu2jRCA_0xB28E-UdwLjS5SriILOWJzmx5PnpbaaeJU_ex1vnelgyLR5_6wRE-vH4jAoQwGAgD3PSdSJ9Drek3URt0GN-qmjaffNlWN8GLDBn-4SdwXuZrlFHW8JWXSGJ_D5wRJ_WN9EmSb4Q26L35-VfYIQ","e":"AQAB"},"attributes":{"enabled":true,"created":1497650449,"updated":1497650454,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['632']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['632']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -481,103 +482,103 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4524c748-52df-11e7-bb54-5065f34efe31]
+      x-ms-client-request-id: [e2a3c58f-9414-11e7-84c8-a0b3ccf7272a]
     method: GET
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/02b0ac2cc0794c1cbe139c9ee83da4f8","attributes":{"enabled":true,"created":1497650450,"updated":1497650450,"recoverylevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/f3724ba7374b489e9e11d1cb2111bbbb","attributes":{"enabled":true,"created":1497650449,"updated":1497650454,"recoverylevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['447']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:57 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['447']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"Hsm": false, "key": {"d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
+    body: !!python/unicode '{"attributes": {"enabled": true}, "key": {"q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
+      "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
+      "e": "AQAB", "kty": "RSA", "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0",
+      "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
       "dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
-      "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0",
       "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
-      "q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
-      "kty": "RSA", "e": "AQAB", "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1",
-      "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM"},
-      "attributes": {"enabled": true}}'
+      "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1"},
+      "Hsm": false}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['926']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45788c9c-52df-11e7-bff3-5065f34efe31]
+      x-ms-client-request-id: [e2cb98e1-9414-11e7-9d30-a0b3ccf7272a]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/c3309a29141f45bebd1d835e9c64dca3","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1497650456,"updated":1497650456,"recoverylevel":"Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/c39a67c7cd2242d5b16f8169497386b6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1504820308,"updated":1504820308,"recoveryLevel":"Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['490']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['490']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"Hsm": false, "key": {"d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
+    body: !!python/unicode '{"attributes": {"enabled": true}, "key": {"q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
+      "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
+      "e": "AQAB", "kty": "RSA", "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL",
+      "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
       "dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
-      "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL",
       "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
-      "q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
-      "kty": "RSA", "e": "AQAB", "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE",
-      "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ"},
-      "attributes": {"enabled": true}}'
+      "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE"},
+      "Hsm": false}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1693']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [45b5cf00-52df-11e7-9ffb-5065f34efe31]
+      x-ms-client-request-id: [e2f986b0-9414-11e7-bfd9-a0b3ccf7272a]
     method: PUT
     uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/110c5b3bee1c46129df467aa4f228682","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1497650456,"updated":1497650456,"recoverylevel":"Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/8653c606c69e41c1b050ff6694404ce5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1504820308,"updated":1504820308,"recoveryLevel":"Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['665']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 16 Jun 2017 22:00:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['665']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:38:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_key.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_key.yaml
@@ -1,32 +1,58 @@
 interactions:
 - request:
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_key000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_key000001","name":"cli_test_keyvault_key000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 23:07:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [8553ae00-9414-11e7-895c-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:35:51 GMT']
-      duration: ['544998']
+      date: ['Thu, 07 Sep 2017 23:07:57 GMT']
+      duration: ['768077']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [DRh1E8KpzyDQ2JIEbQFJYUEDvVJ2kaqlg9shn22LEv0=]
-      ocp-aad-session-key: [VOaE6sd63ucCmZk7x2cxWVk1y9GjR6MVFmBMtFz6ynh6AOsyvuQoUuH8GWYKX1H26zazy5cdqOyyh5GP5n7zmDGaffZROX-WV2v_BeF35QrVlg7mg9SKKPg3McSnQPDf.uC8VQ0UcFxHvmXAhAlQKvNE5i5BNYmMY0K_7O84uWcY]
+      ocp-aad-diagnostics-server-name: [SU5fdDwsCqc7z2lm5DqXdq4BDcpBb/7KVd8B1LQCIVs=]
+      ocp-aad-session-key: [i0KqX9-sjO6pMi5x8ctT7Y87QuLjCtjrblhpfXfXcXbzEDApxYe6m_9uX3ZK5OHXqgyeWuo5j-VVYIT-msmp6T7AyawPqkVIpd3aQjwMrVRuZ7ySQaExILlazqCDVcyw.psX0sedJd1T0C0gJW8q1JRt5yP4c5sN5DbBzmkPq4Vs]
       pragma: [no-cache]
-      request-id: [f1c6e49b-266b-4284-98f1-d06113f43397]
+      request-id: [5f82cbe3-ab1d-402b-935d-4f01bdfcc287]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -35,42 +61,39 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
-      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
-      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
-      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
-      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
-      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
-      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "premium"},
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies": [{"tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "permissions": {"keys": ["get", "create",
+      "delete", "list", "update", "import", "backup", "restore", "recover"], "certificates":
+      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "storage":
+      ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
+      "getsas", "deletesas"], "secrets": ["get", "list", "set", "delete", "backup",
+      "restore", "recover"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}]}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8574ca8f-9414-11e7-8ef1-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_key000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-test-key.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_key000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"secrets":["get","list","set","delete","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-000002.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1011']
+      content-length: ['1068']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:52 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
@@ -84,18 +107,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e040a840-9414-11e7-8c49-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:38:23 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -115,19 +137,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e040a840-9414-11e7-8c49-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
+    body: {string: '{"value":null,"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:25 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -139,26 +160,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "kty": "RSA"}'
+    body: '{"attributes": {"enabled": true}, "kty": "RSA"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0848f0f-9414-11e7-b86d-a0b3ccf7272a]
     method: POST
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ndb-XyULSUqs9aUsAkhjbmFwq8cEq6O8HhKahejHN6_G1R2iQbXXk26tpjghcdDOKyxGwUaTZfy44qPaucKrdlHUev2BBF6W84GI9qAse3b4uVtpb99cMC0NLoda29nrLWBhRNmkjIAt6zQC3o2sYs6Ji_FD6ReTAMNIXY2DQn9xd9S8LqUfITFk7lzn7r7HAPovKknFVVZP4-ZEop8q-gSY7Qu9UnjEuXbDRRJa0NNpAGM4RaHvDBJiBtOBLb57aZNZguiX1Nb6yRujUYprobTBSsxrKHgyiW_rav3v0--w24fCiK6w0YfwuZVSJev9S1HinQgShTytig6UssfL6Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/affe336fa23444eb8dea212f3b66c8ab","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"u0nL-bKIZBgSPT-C2dJvStCJYQJtn0V8PMOcGBFjO8xlCfNdopDwyJtU7PBfV83RbKrCCaTn3QhbXHeqxpBLVEcSdCEEckH-xWC5UKF7qJ9C7ZovI9ox6WVHg4JdbDZPChYPy_mS3naVj_BeODcHRG9DT4JArdHOmPTZBnZiYDny8Ardu6me0W6c8Q-QGJyvYBfKpVCdoCq7VtBUpPxlb1DiJubG1Oj7kXG-802RMwpTPGYcv-fSKJnOw06qx8OZtlDzweOEk_cVCNLHjyEAvthXwQYUM8WHwRPShegJgzz1NoL_vUSTvPAICyBjGYlJZpU9OLrtBoZf08YJVLHlow","e":"AQAB"},"attributes":{"enabled":true,"created":1504825712,"updated":1504825712,"recoveryLevel":"Purgeable"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['648']
+      content-length: ['651']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:24 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -176,19 +196,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0d2d621-9414-11e7-814b-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504825712,"updated":1504825712,"recoveryLevel":"Purgeable"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['193']
+      content-length: ['196']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:24 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -200,27 +219,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": false}, "key_ops": ["encrypt",
-      "decrypt"], "kty": "RSA", "tags": {"test": "foo"}}'
+    body: '{"attributes": {"enabled": false}, "kty": "RSA", "tags": {"test": "foo"},
+      "key_ops": ["encrypt", "decrypt"]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['108']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e0f1f6e1-9414-11e7-b931-a0b3ccf7272a]
     method: POST
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/create?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"30woU5cp96sQuKd-sO5Tjb1ClkNUinYnUtpX8v-JX9KMk78P-f_I8bZQ-QR2w_tToFbD7p3XDhA-ZfWyviYjSVsj2H8H733BQn6ZkNrsPCBU15ESpqgBWjIx7UW2Qz2psHxgvTuPQsJKR_PByhHvx-8j3fNrSvnlsNWKAnsn8_ryFRG3IDjJKnCtRHJtNLsM9HX37tksaimu9Dhd-WBtWce9PC8ue1yaCwU_plDNtSwQGGUKKxNoiRAg2jxns9jr-m7-Ur6N675fzBu4v6WtqjiBD2eUSVPWuevN2Qb7vI_sX8YwCMOIxKE3aRVWSd3JdzVR-EbL4H-g7P9IfzKnTQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504825713,"updated":1504825713,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['633']
+      content-length: ['636']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:25 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -238,19 +256,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1408c0f-9414-11e7-907d-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","attributes":{"enabled":false,"created":1504825713,"updated":1504825713,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}},{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/affe336fa23444eb8dea212f3b66c8ab","attributes":{"enabled":true,"created":1504825712,"updated":1504825712,"recoveryLevel":"Purgeable"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['448']
+      content-length: ['454']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -268,19 +285,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e165ee61-9414-11e7-8775-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504820305,"updated":1504820305,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"30woU5cp96sQuKd-sO5Tjb1ClkNUinYnUtpX8v-JX9KMk78P-f_I8bZQ-QR2w_tToFbD7p3XDhA-ZfWyviYjSVsj2H8H733BQn6ZkNrsPCBU15ESpqgBWjIx7UW2Qz2psHxgvTuPQsJKR_PByhHvx-8j3fNrSvnlsNWKAnsn8_ryFRG3IDjJKnCtRHJtNLsM9HX37tksaimu9Dhd-WBtWce9PC8ue1yaCwU_plDNtSwQGGUKKxNoiRAg2jxns9jr-m7-Ur6N675fzBu4v6WtqjiBD2eUSVPWuevN2Qb7vI_sX8YwCMOIxKE3aRVWSd3JdzVR-EbL4H-g7P9IfzKnTQ","e":"AQAB"},"attributes":{"enabled":false,"created":1504825713,"updated":1504825713,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['633']
+      content-length: ['636']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -298,19 +314,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1870af0-9414-11e7-a782-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/affe336fa23444eb8dea212f3b66c8ab?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"ndb-XyULSUqs9aUsAkhjbmFwq8cEq6O8HhKahejHN6_G1R2iQbXXk26tpjghcdDOKyxGwUaTZfy44qPaucKrdlHUev2BBF6W84GI9qAse3b4uVtpb99cMC0NLoda29nrLWBhRNmkjIAt6zQC3o2sYs6Ji_FD6ReTAMNIXY2DQn9xd9S8LqUfITFk7lzn7r7HAPovKknFVVZP4-ZEop8q-gSY7Qu9UnjEuXbDRRJa0NNpAGM4RaHvDBJiBtOBLb57aZNZguiX1Nb6yRujUYprobTBSsxrKHgyiW_rav3v0--w24fCiK6w0YfwuZVSJev9S1HinQgShTytig6UssfL6Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/affe336fa23444eb8dea212f3b66c8ab","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"u0nL-bKIZBgSPT-C2dJvStCJYQJtn0V8PMOcGBFjO8xlCfNdopDwyJtU7PBfV83RbKrCCaTn3QhbXHeqxpBLVEcSdCEEckH-xWC5UKF7qJ9C7ZovI9ox6WVHg4JdbDZPChYPy_mS3naVj_BeODcHRG9DT4JArdHOmPTZBnZiYDny8Ardu6me0W6c8Q-QGJyvYBfKpVCdoCq7VtBUpPxlb1DiJubG1Oj7kXG-802RMwpTPGYcv-fSKJnOw06qx8OZtlDzweOEk_cVCNLHjyEAvthXwQYUM8WHwRPShegJgzz1NoL_vUSTvPAICyBjGYlJZpU9OLrtBoZf08YJVLHlow","e":"AQAB"},"attributes":{"enabled":true,"created":1504825712,"updated":1504825712,"recoveryLevel":"Purgeable"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['648']
+      content-length: ['651']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -322,26 +337,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}}'
+    body: '{"attributes": {"enabled": true}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['33']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1a9d530-9414-11e7-85b8-a0b3ccf7272a]
     method: PATCH
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"30woU5cp96sQuKd-sO5Tjb1ClkNUinYnUtpX8v-JX9KMk78P-f_I8bZQ-QR2w_tToFbD7p3XDhA-ZfWyviYjSVsj2H8H733BQn6ZkNrsPCBU15ESpqgBWjIx7UW2Qz2psHxgvTuPQsJKR_PByhHvx-8j3fNrSvnlsNWKAnsn8_ryFRG3IDjJKnCtRHJtNLsM9HX37tksaimu9Dhd-WBtWce9PC8ue1yaCwU_plDNtSwQGGUKKxNoiRAg2jxns9jr-m7-Ur6N675fzBu4v6WtqjiBD2eUSVPWuevN2Qb7vI_sX8YwCMOIxKE3aRVWSd3JdzVR-EbL4H-g7P9IfzKnTQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504825713,"updated":1504825715,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['632']
+      content-length: ['635']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -360,19 +374,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e1e2e68f-9414-11e7-9081-a0b3ccf7272a]
     method: POST
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/backup?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/backup?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkZfenBGemJ2TGRDQVExVW1oOVNMSVVQVWFpMmtQanNRWVNVVHZqdVFObWg2ZDFlUXNEbmN5VHBXS2w2QzVuTHJBMDZRUmZhQm9MQy1yN25Xc2JBZTY5Y1BiOV9GR0pzZGlLd1BZYURpWlNVdWVSbHNEQUF3UDM4bGVYbWtKUXM2RnVjd1ZIZ2JDaThYNEZkYmpCS3hlWW1ZQVlZNUZTMzhZM3JHbHRKTzlUNU5WUWU5cmNjOVFOOGJWTzNvWURUUG8tejBjMUtoMUJiS3p6bHRIZktGYWYyZDFPSnlfX3hHa3RiQ1g3LTAxNmZlTm9lbHM0Vkk2RUNzV19wY2Vlb3l4RHdsR3FCOE1lVkVpQWktY0F0T0dXWXF6N1BxOUQ3TXJCNGJCcExaSS1kQzNyV2g5RkdYLWpqXzBDNU41bmpGTlRBQXlnWnZvY19lSlR6d19qeUZrQS5qcHpNSTVQYjFQRGd0ak4wWllQZnRRLmlYZUduZEs3ZnVnZmZwZ2lmcU1UbFFYQjhvc0tKNlFiU2pIWjFRZnhzQTZMMmpFTWE5NUw0cUxiMFZtbURGbmN3Y3RIazB1bU05Z1JMT1RMbEVlN2YwaDhlbDBTV1M1TUVpS0huTng1SWg2Unp4NUVxWU84MGY3VmRvbWdQdUx2NGNqbUZzWmhhNC11Z1FTU25zZDhJYUhKWGlDZUkySkxMNUNZLUpNTUlaX3R3Q21lcHZUTzBxZmVkcE82aUFmS2I3SU01c3lhRUdOb0s2d21jVEIwdEVBWXFySWx6VFl4WGF2cHR2MHhYUmQ1ekdBTGdnR3Y1aURlSDVjbW13UncySElyR294YVItaEs5OXZfY04xcVhuVEJQYXdNLTJjVTVxM3FTYkZlTkhiMDctZjFUUnNEM21ScHQ4YWRrWm4tcTNBazNQbmw1d1NmQUtZeVBoa0pVZUgwbjlWVHdPT05jRTRHMVhFTUstRGxHVXlCeTktazdXanRuc0hSZ3hPeVVXaTU2Ujc3ZnR0NzkzcVNjODg2a0l6clpfSFprZVRZYVU3aUdZeGRRMklMaVVIVFk2ZGJLN3VHd19nTHkzNWwtbEtVczdyakdqTEJrZjJiLVdJUS1DRjVKRlNYcEU4bnlnYW1WOW5USzZsM1BBY2RVM1F3OEc4WFhQMS1DV3JZc0wwNjB3MmM5cnlxdTNxZ0g5WUpyQS1MbU1keklWYld2dVZ2UkVlMWlMbDhyczViaEFENG9zdk1TckU1cEFoTmcxeFZKYnFWMlJfSTZLYmdSS0RzLUM4WkFmWjJaSzl2RW0tY2ZBOVgtZVdIazFRa04tRkxKalpNcm9KUXlYRXRlSUpYejFGa3hVS28tUHpYTVktV1JiUV9POXNpNGMzb3VnVzkxWm5SNV91bUxkdmY5VENiZ1haMDdCeHF6U3Z3X3hGY3liWTFCa05yZllDa3h2ZF9iZ0VOQ0VtQS1RU2NOcFdOSk5ZOU16djBHSDhxd29HTmowYlVlR3ZJcGZzS3dWWnFnd3FVTFFuVEIzbk1yWDRDaGpCUTRaUGNyNVRaRW11OUxNaGZManZxejIyQWVXclV6S1gtTmd5OUFadWc0SC10M215Z1hJYXIxeU5fdWtzZ2h2aXNHcWFhYXdfLWRMOUNnQlEtYThabDNOYkt3cmpBVFNKLVhFV3BwV01hcnFaZVlaS3B5SDJ4eWlXQ1VTR1B1ZjdzUXlfakk3bzZtSHRlSFozX1pTVDJrWEtLY3QtYWJWU2VaeWpzYTJFZU40NE5SajItVlgwSTNPN0ZBTUZxVzJxVTFEM2doeGpUMEh2N3l2cHBRa1FTRzlLZ2J0czdwS3owZ29oUmFuWFh5QlNHbkdXX2pvZ2d1bDd3X01Ca283X2lnbmZnNVlZX2N4RU5VMzJyakdjckJ1NmtBZVFkSko1dTNzSXlOeFl4Q193V3BaMUJsTVlWaVJvVGhobl9JUktudHdLMmJZU0JSQVBxdFJpZExOakFGSWZuWXFhSEtpbzlTQ3hHMHNUUjdJMWR2SldJeFpjSHc5WHFGc3V0MVpGSE1SbVlOZktoNnZCXzVvNW5jUk85R2FYT2FPd3VWUnBkU29KYUg4YmM4dWdLWUU2OXU0V2lyVmRzVDI0b05USGNrOFhQM21PbnhHNjcyOEVxMFcxamszTEQtSXlrU0sxSnJadDJaXzdQelNDRmMzTzY2MWFST0gxNVJOMUxnal8yT3ZIdkJNUWQzVW1vYS1vX202T092WTR2Tzk0Z2FkaXo0TUh4eDBVRmZVRmxlNmZqUU5NMTBWREdMNFRNQ1VHYTFSZmI2MnVMd01ILUdMSFBSeTc2emFra2I4OXQ3cGpMZWdQNXlhckxtc1czakVuN1ZJLW9jekRLLXBzNFZ2SHBoR2N0M1JwN2gtSTBsWDdUb243YkxXN3MwQThyNGY0R08zc2pXRzhFR1BfMEV1cXA5MzBRV203MHFtb195QVhNRDI2Q2dzcU9KNGxscThNLXNXR3B2X21SQU45RTY2dS1UZUxqdlVUOWFBakZfcGp3bHZKLWVsbFowZDlFYnpBS1FUdUplTjUxSVJZV1RfZ2RzSURNR3J3UGpKcnVFTVUxSkpTbjJXbWpzYmlScURRZnVVQWZlOThGLUtJTnc3SE5fcV9xQk4wOWdoQTJkVzFla0Mzb3pNV3BFT095MHEwNVQzaEFWZHFHWjNUS3NIQVptNzZ5US16eDlrMk1KTlJNRHU0TVNkamhKclFXTTBEbzU1bVBKbVVyM002TElDV2Uza2FoNkJPeXhYdmctd2V2UnBTQ09CU21JNUhhYkNnNjRBLU5fdi1jMndnbnl6WXFDR0JiTVczaWRLeUVzeXliWXlIUHVXR1I2SUNTb3BLY1lWVWV1Undyb0xEQTZxMXZWVUtBTkN3cGxmRDFpckQ3eDFqczI1X2dGQWV4ekpnQUhrLTdsUnBjdFZIVk1HVnB5Vk91TXg1bWgzTk5zS3FzZ2hreE1mb3JodkZhYUNPcjFISlFwd0ViSzZrRmZxXzhjR0dPZ1p3blVoXzBfRkZHRFRiSHh1LXR0TGtuU0ttdWJpQmNRYjJ1MzB2R1VwcWNjcFgtdlUwakl1dmVWbXZLWGM5aV9CeWVaalRYd3U2czVqTDd4UTdnMkdab1VHcFBxUE9qY0FFdHl1amNTR1NXMDRRWjZpbzRiUVY4M2pTb013WmhNOEJDeVQ0ZnpWaGJ6UV9oYlhhcnlTZFhnM1dobzRSSGtsRXRxdDBjX2wwTEhFNkNobzFtMVRlMXNSVDAzWTNheUlyUEtDZjV1YjdGM21LdV81b1loWmRwM09WWkwwM3dwaW1aaEgzVVh3RWRmWk5KUkF0WE04RDdjY0kwM2NRNGFyRGxpa3FEdy1vT3dYODZBSHVST3JzQ1ppU1ZjV2ZzLWdoN3lGcmlKdEoxa1dqMmhlUmFCMHFXekcwZDhULW54NUJkM2Y1eUxGRW1hUkJ5bEVVMTlWN184UENpTmdQSnB6a056VFpGTUlaM2w5NEpseG5GVHp3ck5aa0hjMnlCaWE2ZDNqWFc4S0RSclUzVEUxNGE4MXRJX213SmxuWllZTnlENlU3YXp0eXVNVU1nWHhOeThMRGhoaGg0bk5jRGlFc213VTVJR3pvZWNfcGdVMmZBWUxzczFNcGswUnFCVUJfbEVlZkdUMmtUQmttVU9rZ1dhdEVzdWpTc0tTemNvUXVuWDQ0SFJ1VTFqdVl6eE15MFFMVVNoTnBlVkFXUGk5VVFvMTc2YThka0JId2E5UEg4QzZNZ2t6enptMGZNWU5aNVlYcXdEemRMSlZFV2RMcVlnanFQUmpCeWJnWGFaQUtyNDdOX1pkaXc1cUVEbldmNFNqZk9HN2p6TVVZRk5Icl9hLW9aaVgyT2tLT3RJTlE0TGRlb3lnVzBHV2JnLUJIa1NISUh6SUlab25VSkt3V2Z1T0tPY0MxUUp3bjJqdURNMGp3NkZJOTU3YkpLYTdaWVlEdjAzMThpelAzd1BHZEtEcGM1TWY3alBjOFA0QmhaTTNrOGNIb0hycjZLaWV2c2lFYksyQ2JwRGRPOVZCTEdIQ1pyTlc5Mlk5d3dKQU1BUFBVcXpZMndlcVFCT1lPMldfQXNjWGFqSHhVZkNCOHhIQnhEWEZYdXpRZHgxNXZXNDJkRVdEWl9CQzZiTGpaOFdPczA2dW55X3loU2VSS0FaVDhhNmZiNDN4RjU3ZGpqNFBVOGl1OEFVZ2cxUXlmeTBjcGZMVHB1RUVBQno3QUg4RjV1VE9VUTYyZ3NIMWxyNmxaOEI1Q2ZhVUFxeTZmSy1XRVRSeEQzcFBybVNfVEs1TS1sYkR4elVkN3ZNNUw0eWJPSDU3STIwenQ1Z3pSRjc4eldyRzN3NWN2LWRWNmNiNTJOVGdxWTBGaHZNdXE2ejFZLUd0cmRXRXoyZ01jMHlvak1BS3pfSnl4d3JERnZUeGRIOEZNbnU4Rk4yUjVfWEt5eEpuYlViMTNDamhPaEtHNUdJQUNFUXVRc2RWaWNyYXFUOXVkMGs4czVqN2dvRTc4dTJSZEVrMTVET2JDb05OZFJISG9fS2V5ekNJSlMxWV9NeTVNamFmWlg3UVJfc3dwQjQzbDVBZWFTRFZndjRWTV9sT2RydnV3RGxDdEM4anNCMzJrNldxSFBySWtNWG1RNnVIQjhWNlM3ZW1rSjNweEYwT3ByNnBxOXV0NVpGajRkSEhOMGI1V01jbnlmZjM1ejlSSjVwR2FDRlgzdG0yZW1lOTBBXzdFZWlod3Zaa1lQczVBWnhrbksxRTlhYk5nWjFSUTBiWHYtU21vM3M4U2FsQ0VrcE8wMXg0VEZmVGdJRjBRaHdiUFZIQVZrdTdLM1hnYWQ3VV9RdjBQTG1ISXJhMVQxY1pYajBfQnlMMWFxOE5kWVpPaE5mX0hQX2d6Ylh4TXFFazRRckJLSzE3NXh6V3ZlXzAzeVluWXM5c0pBb0hma2J6RFJUS2tEMWZvVkRIYl9QWTBBUGdoc1czS1VMVHJCbkJPYkNRZzFiSmRFZm5XUGlzTHlaM2xQSktORWUyMHFCSXgxX2VfVmRNbXpXNE84Ylc2UHIwZ1lHTWdUZDRqeUlXRVMtZlVkeFZTUnUxUVhONE5iUVBZTVM5aE4zcUpxLTFsamR4dUlyd2xEU1lVdWM0UTVZd21XUVZrb0p2dDNHY1F3VWJ1WU9DM2lxZTVlMlRJSE1ZcXRaTlpPMGRZc3NwaTJTLWNTYmpXTFg2b3diMG43eHNOdjRHekI0WXJKVlNDRkxQZm10UXR5ZjE5N0t5RTdVQnNYT1lQM2dDV0NGOTA5Ym92WmY4OUhrNFlfV3FJcV9vdWhVbXZDYzl5MVVvNlVRTlBNVjJkelBDUGozRG5zLUQ3Tk1NN2d3RVhmX3NOU2JtbFBBX0J2M3ZVcWFYOGJRa3ZIMUNoT19mak1ZcmRDYjZTeEROYjlGQUZHb041Tnp5OWQ1VTlXSlhOa1M5S1J1R3lmaXBJR2NtVFkwUm9lUE5jS0JUb05TR3o0Z2RLUFN4U29aZVZmX3g3SUZFX002WGVFSXo3ZzFLb1R3Q2dOSXViZlhRQ3QtaDllazA2X0F1SDBsbGpSLXU4b3lTdzUtZmtFYm9ORFMxeWFFU0hYOGZjRTBXVkR0QU5xLWRwbHBFTnlmVS1NeHZuNmxSWnlXY0d4aVQzZm9pQWtsR0NrLWc0Y1B6cS1fUHhMZkF1cDBkSE5xdXNBMmRYQU8xaXJmZ0J2OTJqSXVRVXVrdVEtRzJUeFNObjRyM05vWDM3SkREMnJfTGVNa3ZCTFRsSThBME1CSGdzZHdOWFV5Vld0bEdVcW5NTjM2aHREcy1ka1hWNkVVRUxleUV1dkNoUTUxU3FaZFBjeGk0eGtoVGxfaHg4cXhsUFdPUVNmZnZOc2tMS3BIY3VnN0ctYUdXSGI3alREaEtLLXVvOFZoYkM4NG01dlJaLTBaekJpT2hlQk1HczRyYkcyVmtZTkVka1hXQWNqQXFwNURFYlZBX0d5Q1UtcTQ1dEc2cHdtanpxUVdZdk5SaUlQejZUdnFMTElXbzd2M015b2VYeHBybDBveEZWSkxoT0Y1ZE1GVE5VYURVRVZHWXlqYUIzSFBhSDNKQkxxVGhKVjNNS2VuQklSLXdZZncwZlRWQnZCUVFzV3VuSWRmN3FJTmY0TTM2NThSMTJHemljSXI1ZEY4UWt1azdlWmlMLXFmc2VUN2xkVjJwSW9YVUJlOFllM0RCRFlWZElMSGpfcGxEOTJBa1V4c0YzQ2ZNRkNYTDBJYXJuTUNvcnJ1dnFSMEtsSWE0MkNVVDF6bjN4bU5SODNxN2RSUXp0NGZGN1M0ZllVdEY3eHlaMzdwcVZ4VDNoUnFMY19MU2lMTFNhcXJNcmFZcElHXzBMSU1KY3d5RUo1NVlNaHI5cGdXQVFRUjF0djJua295UV91OTdRQXl4Z08zUHFQNzdMMG1ySGVCMlVOY1FaRlhud09oNXZyMEwzRmZra09IUXN5RXUyRTBvRGZ3b3pyZXpxTXVTakkxSDE0WUpmbE12TnlRemJqbjNjcDRCaUo1NWV1WjgwV0lNaElHcWF2OWNwMjFPRDZHRUhiaGk3N0FyWkEtX05sQV9iR1gzM2l1ZVBaS05ucW1mbU9HVkdKTXphaXNGR0hVRzB5TGFqR0VQeHBPM094WkYyNU5xMWhHcUhXNzFqcWw3YkVXV3V6UExsbWFOMC1IRlZNbi1qUkd3U0VSS0tTbk1ZUVdyUEdZS1F5dEh3eDdxT05hRUwtdE5sdHlPTkdEbDhkTy1rTlc2bmVUZXZObGFqeTh1WFJwYXdmeXJUS0F4R19CYzFRUzBYcVgxWW5iNXk3WEM2dTBMcDB6bE51LUQxZGxOZS1naXBkbFBUbUN1bmwxU2lFbExudzRRenJVSmN1Wm1BclhBT29EbEhabzM4dWlnS1hmdUZYN3BRWExwMENsQXk4RWVoUm5xSEhHLTRERDVUdlYyYUh1TFRNYmR1M29VcVlSd01aMnRsaWFKLXN6aktoV3M1QzFhckVTTHMxTFFIeW85QUhaSmUtaTZ3TzVveHZIdmMwV05vVG5WTlpFVHdoYlg2aGt3aUdhWVY4aWxkSUktS20wTWUtNlJmMlRzR1VJd1hkZS1VNTVMdzl5WnpJS01JQWdkN2x5c2ZDQTM5N2ZNME5XSTFiNVlOYW83ejIwWGFwY0tFOVhPZGtSNEI3MmZNcHdCVzFxY21yS2VQcExfWG5XZ29md3QtQ2dGU2RYbEw2S3pVNlhKRGQ3b0FMQ3V5dldWYVdKYnRFUkpweksxbDdQTy1wckpMa2VqZTEyOG1sZTFZTnUyMkdsV1BfUTAtQmVTaTV0SHAwX0dBZ3hvdUxGVWxvbW5RRXJuN3laSWlORHo5NTRGTjdoZVh4UFdIbm01V2F4ekF5MG52Q016Y2k1cE13Ym9pMjcxZVNtZ0NHbmNjT3BOUXlmcllxM1Q2UHZxYUZqaVhpY3JQTHI1OGNJOUM0VEY4cUdsOFRsbmh2U2x4MFVzZHl1dzI0MnJDYzVVc1ZMM203QXk1b3c2ZDkwd05zdWVxWDhqY25FNW9WS2ZnYVB2djZHVkpxNEtrcmg5Ukc0Mi02UnllNEdkRGdIand5bjdhcDhVNkZOdTEyUERoSVlScDJuWXBPRDhzTzZHVDM0djFsdUNhNVJxbWJISnpkaVZ5U2x3bzhPLWcwMHhDZzJnOUpGeEMxWEtoZFJaMklBUi11Q2tiQTl4S1Rxb1ZFQVVIeFQ5TWQ2T0ZPalF6cHdWRndWN0dzVGpGblFkYXk5cjRDTWtIWlU1OVpRaHFYeWJPaU4wdDRXY1hTYzBaeUxHOG5SbTYwMjdEOTVLczZ6Rzl4bjlwM21Hb2tCQUQxY2YteDYxdG85b2lwWUZzTTV5cjdIZWtHMmJsWmhFZ1pfWHE1MUt0N3dhSkRzV0tHQzZiWVVIelZTbXljWWNER2EzNnJUOUFUWjNCTmI4OTNtcXNxQ3ZkVU1Ua3lPT2JmY3A1Z3l2R1VTZjRYSHlNT2tZR2hzNC04Z3Q1cjhZSDhDY1RCNXJKaHVoYlJlS05YbWoyTXpiZFhNU1EySk5PdVNBeFk1bEVSU2UycUtldUowUHhjWHBTRHg1Z3ljeTVPekZ5RmU3SnV6Unp6RWZxVm5OUUhacG5pNDAtX2xLSm1UdEVZTnNud3JaVDZHNk9MbUdESE54WXJCVWVaZVctcEIyaXpycDVMWVhwejlWV2Uxa1c2UFBNQzdNYjRyU3hscl9UVmtkUUxaa3N4YktnbXBVNXRxUVQyOEdCcm9NdG5HRk5kbDNVRlM3M3JpV3JHUWxWbVNMVUM3MjR1dGYwWFZEQi1BOTdWazhlTEFmbFh2NEx0eEdLUUhKaEI1OEJHaDhzZDFXVnl6TzdhWm9KNktodEp2ekl6SGxYSmxDLWZiYmVHaTBhYkxuR0lRX0drNVNSM0JfMjUyWTN6Z1NmeVd6ZHl5U0xPN1lDbktuRHgzYl9YUDFVd2M3QXBoM1ZFbmp4ZUNxbUJmWlhWSDNwdDdxd1k4RS1Bcy02TGFicHNzTHZMcmF5RUd3Y1BDOUZVVEJkRjRBdFZHRUJLa0hGcVZST2VfQlJlVmJMZVpxTTBlOG1mNFVnYUQ2TXFZa21GelJjQkRvamh3MVRFVC1aV096T0E5NGhOY1NQOHZ6T2luenk1NHp6TER4Vkg5ejJaTG9LWjQzQVJKTDdwUUR1U2Q1enFONlJOcmRFZTNJdTRGcFRWVWZQbGFzWl9sTDBueTIwMXZiU2E2RXQ2RHFXb05wV1FLUGlnME5ubEtSa0llNy0zb1dRczRpWjJpdklEeUVUWVhCUUVOcDR4OHBuRGhXQUFuNWhfVWJQdXZ4NUs0cWJTOTktM2x4X29NcVdmc0EtaVp5eVV3OXc0R3ZnWVA3TU50RThFNVVBT1pWVElUX3BBWElxaDdLaVlNMWxad01uLUJQeFdaaVJDNGp5SHN2cUUtSXJsNm1BN1dRanNiUW0zaDBMX2RTS3g0UEhTRTBYQnF5OU9GX2xjcjJTYkg0WHlRNlA0SUFrcUMwYjRlX251UUZ1Y3Q3c2Y0M2hObXJRZTk1RC1BQ0dVamFFZ3dkYmFqMGhEUV9pRy1vU3JEeDEzVTFLNVE2R21RTnpsUDM4QmlwVFN2b09NRVVIdngySUd2cmtoeHRyX2t4d0o4ZG5JV19Ed1pkZWptT05zUjljLUV3Sjhhc3NzMmYwSkt1ckdPZUxZZFNidnBHeUJ1YTVST1Y0MUtWanFtb0NsTXlJZllSVk1zVWMwSmJ3SHpoUGpTZGJONUVCVlVYUzlibE5oeHVXUnF2SnhVQkNEN0ktUmdDbVlSZm16RTVUcjlXODBGSDRVTzN4UU1TdFBQTjAtc0xXanBtcFZfWHd4aHhzQjZIbTNxTkxUaVdOZVU3TlRUZG5ZeEVZMWh5ajd0M0MxNy1KR0NtY2l1OFJYRVBIWGt3MFJ5d085VV91X1BjWTRLejRyRllfR1IxYWhaMFdWZU10R3BLS1k5Y0swRG1HTEpoOGNKQ0FBMXUyZW5wUUZCMzhPeHVTRWVzX181RklnZ2dWU2RvaVc1M0ZMT0tLZXc3b1FhLTRnaC05OWFYZEJFbHpmbk5vSnNuX0hOQ2NVZ3dTYmNuWFgzYWlRSnJxZVhoLUN0UnhRVzZHZm42X25pejJvc0Mxc0E5elBKanpubF9WVHU0dGNOUm0wa2lIQWpOazRXNjFPVkNGLXNmcXNmQWw3UkFEU0NtUWZ1TjdndWlnVWJWWXpSRFVHbHhRM2dKSDRoZ1Z4WU0xVHZuWC02M21pRUU2VUNlLVFDN3hOTjV6WEx4d2JQOFdJVmxNaVpLdjdyNlNLQTJtWWFLNmhESGQ4WnZpVWdKQUZZUjhJb3YxbkZObS1qU2dvdlpjdkVsUjlMVXBWZ1dOMU1OSU90TnZfbkhMUG00TklVNEJ0ekdWdmhiNHdaVVJ5dVhnU0pDN08yZzV6YkdUdHBVdEcxS291bHNJMjRTMUxST3VFYVdvUDZlX2l2Qm8wYWc1aEFOM0dodFBuc1J2RzFNZ2VxcUZqTkpFaFM4NEVyWG9mUHdWbUVRdUdYMGxZRkJYd2d1OWVndHlCdVN0Wl9sdnlPTDhHOFZXQjgtMHZtOG1pS2dCVk81bnVMbnFNbS02QmRodHNqTmNkMTFrRm5kWjI5Wk55VkFDVl84UGJVN2w0SFNyUzlCMm5aOUo5c1FPUmFqSDFSMVdNNWduR3JUX2Fwd1NaY2xyMFR1TFNOS1NQUzlIMm9XbXAtX0RCSXAyYXhhNzFjZ3lzWjVRNjdSdGd6a3RaMnZQRXdxQ0tmd05GS2l2TWxMTTJjZE5iQ3FVVUFVNjFUS0lrN0xUVDFPLXRrZlk5cUg4QjZSeVVZNUhhRmZ3cElWX3ZKampNZW02OUc1TXpJRExNajRJZjQwckZnWmY4LUFXcGM0UGtoeHYxcDFVYk9OZ1ZQUDB3WkFwMmhMRS04WDhuQThhbWMzRS1OVTdJVk00LXo2X2wzb1JDdVNjSnNIMzgxeHczVGl5dVJkRE1kTE95ZHNBN0VhU1lpcVFaY2ZnRGxpMXNsSEZLN2pxVk9DWGRiN0p2THpVMTJ0eVdyblJ1czJ2VUR6akRENmhER1pLckd6Y1RkUHYtaWRxN0hOSjBGb1AzeTg0WEVUSjdxRGpUWktMa2RXSVZTV1k1SFllNnZlYTJGRHBldThzUUk3V01ZY3BrVGY2N0xuQUdqcWZsUVBsdjlBeVNmbGFESUs4M1BHTmhwRkNSNVVWYkdmTGxPbW9MOHpzcUxRQ1kxa3diRm9hMVJkTXB6SGpsYVVtQjZEWFpjZlczSVpIT3J4NDktSGtFc0lXQ011N1FJYjhtN2JIZEtYY3JVZ05KcnN4RmR1M2l1TFpoQ1BZVThuTklhQ21IY0hKVGxQYVNEa1E2WktTMnE2OFU3aldwbmZ5Mi1MYnBmOUhLeDFteU9qZW5aNHMzcDJkc1RtUERnbGF4MkZZT3ozR3JmOTI2QkYwWUN3a0RPdkNTZUxEZ0djMjlydVpsVVJFVll5bnlyWHZBN1ZLOWFhTGtkN0xRYlF1ZmlXTEROUGtxS0VOUERzcDZzdmlHTk9Qa1F0UzJqS1V5US1XOVJxcGdlQldxbEgxMlpEWF9adUYtLTM4aE1SNE5yX25VN3ZGeGY0dGtPeGxROEkwdU42bnZJbmJmRW45WFFZWUtVLUZ4Skh3ZmZqTzJOYkJIVjNXdnRMdWlmWG5LU2ZDNVpjdDAxcHNLQ0x6YmpQSWc5dlFrVW1MdGhVQnlJb0E0Mlg3M0p2TFBOanlmNnM5Ty1iWlA5ajg5T1FOZ2czQVRNc1JCUjBoN25MeUlpQVQzYzdadjdYT2hic0tmMkZaUldiV1pSbzJDSVFjZ0o1Rl9XTnZvdTJiTHlQY2RJdE83ZE9WUEJvblZhYWplSkR3SXJIVXBOclpWd1BqU0VIdXBFUnZJaE5PRFN4UmI0TUF4Tmd5T1Q1RDM5NllaZVllU2hEQ2s3b0tKOHprcGpTQ3Jvc0RxTzZmTkFWZ01BNXZ4RG11dHdMR1AxbXRJSzgyUkVQendZV05Ndk9lNFZ3YzUyOUkwMDJTWWhDb0dIaTdiNHpmUjBmRHV4dTFhRkJ5cmxmNFRlektkTENNc2NreUJUbldiQU1mNVF4bmYyellUTzRvcmVod1pHUzIwa2NVNEJ4eGtsVGtBOVpQQ0ZzLWhBdUxadk9GZDN4MVpRcmk1V1NPWmlrcGwybWNJdk9udVFqUkM4UlJsWjdzeTczSl9kUkhrZ09zUXkxYmthY2tBSFE0S2djazJucVNmODZzMUNpYUZvQ1B2bWdlT2h0bVNvYkVvV1RFQmN4Z3RkdHNfX2JUR1BjY3h4bTdZWldCOS1EMXJuSUZIaF9MeS03TVVfb0xISzlCYVFKUmRjSU9LRFh4RjZjREhkRl9qc2xNNU1nRXlDYkdHVU1EampDWHJvd2dqNVFHanRDV3hEaDY0blZaRWNENTkxNEdRZ2doX1F1RGVhT0EyTlNSbnFVLWktYVZtLS1mXzhmT0FzYkNPZG9URV9vQjBpR1hNbUE3SDhzc18tLVExOGhkY2hQcHg5NS1CNEpGWkNDdWNTMTVoekpaaDFUSFg1akIxZEp5Z3BaOVpfMGJ3Wk9aTGJRWHN6NG9IS1Jpckxvci1lbE52MnFKd094SG5GbE95OFQ2MTJ3bGZ2aTU5MUh4R2YycEMtblFyN3V1NGpFODkuSzg2Qk5tM1JMWEtfWWtlc29PMTNNdw"}'}
+    body: {string: '{"value":"JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLmNrZS11R1VzcWpwbFJXX1NqZlBnT05zV3BNN2J6cl81YjQ1NTRwV3BpUnk5cUxpZWpINzBGLUVIUXc2MnhlUGx4dkFHUFAzOUh3OENZT0xWRnpyYkRnR2FXVmdPMWV2TGxtZWZpNUVuUXY3cTBvVEw2SklQa3p3akJxd2drTTFmWW4wOWdhRzlMUTBBOUtTUmZCTUhjd3gwQXhqSG5acENMc0xtdG1KZDRFdGZiTGhJcGYxVW9rS2tOeExpRTVqaDhtQ1Q3c2hudldjSGdsSWc4X21Zck1UR2JjQkV1b1BfeG1lNGtQMXB4V09uaXl4TWh2ak1MaWV0dzQydVVCSnc1T2xVQnFrYV9iRHpuWDN6YlA5TWFQZDlQNHhFZlF5V2k3SFVJTWZ1bXFSN3JIMXdVWXNMMDEtVzZBbW9nMGpzV1RjLWVDME43M0RmOUtKdnRHZ2NHQS4wU0JEeUxxMUJZUWJ4RHBzUkw4Tk1RLm05cnhnRXdkU1RjQjZvUXlycFVkRmFsZ0dFUTlhMGtMcUJiWjFUbVJ4WHVPcnJxQXZua21FeUU2SXlCeS1PYk40cFJ1cnNTZ2dyRmlPQTV4WUdvSllZbFFuSGVzMXJLVUdCbldFbFZ6ZHRnYUpUYXA3dkQ4NEttaVRtcjZMMlZ5eFU5MnJmRjhsaDVBWmpNTkpVQXVKWGJOSmoyMXJkRHltSGh2R3g1VFV5Ri1NM3pHdWk0U0dldk5zT2ZpeGJIQVZDRUlNS01WR3RYUVJnX3VQQzYxb0E1WjMzc3BmUlpnWkFzLUZkdnNrbVRrRmFEZkxFdUV4Z1BfZzJrYVFaVlRoeTBCbjlucHg4eFEtU2dUUE1JRlg4R200aGhiTHNLOG1NM1o2MzZmSEtiUm1fSnJWRll1bXltZ0IzUm1RalNUQWoxTUg3VTlscndoSXVZTVJySUM4dVU1ODVoZzU2ajNST0ZGYnlYRm1HNGJPbDg5S3FjTExuU1lnbnk1cWd6OFJIYlhsczU1c29mUVl5Z1ItZENjRWZQUUdXUWpkd2p0cEhaM1dqeU1pTXdvTUlaWmt5cHJwdngzRHVQcmo0T2ZTaGNLOEJKWGY4V0dJUFY5aXNUOTk5Z25sdnBXc2U4VUZGb2ZfOS1TbkY1OXRyLW1qZElxVXAwbjhReU1UTXFwanBZbXR5Rnh0b3d2eHY3UGg3Y2lrSFFQelZ1cVYzb2hmZGZPajVkaEd0YXFSRWt2SXprRWR3Q0VPeUEyXzFoa3R4SFZETXJqc0NlX19pbjlfeThTdldfOWhha0ktbWVDSlJzdTYtQ0ppa0lXa25LVWNBZThTYXNHZk9mNF9WLVFyOHVIdkJBRTRMMXFma2daUlEtSEJGeXZVUmRZYXlkZExTbTFIR3hqVnFmZmVSbDRPNjBROThMYjRqaFRjQzdBNFZQek9RMXRHOVZZeHE3MUpiM2lXYTgxajd4Q3Q2M2YxbFNVelR0SEtodnBNRmFMVDhLQ0xjOXFMaEd6NGZ2Ty1ydDYyODdkMWFiM2JoamJlVHVmZzZremtwdFp0VzdLcndfV2IzcmNacmR1VGhvM0prTWpoLU05RUJvbnNwNE9EVExlU3lmYjVDMXRCOU5oYXJGVWQ3ZnhYUnVrSFhEUmpoWll4OGxJaEIySmdFTHhmblBZclBWRTd5T2lpMkZjTXpSTHo5clo1SjNZeWNIZGdueDlFazA3Z3psTWVFcWlUNFhra2hFZUZfVU5uRXVCandSVUY3U0NUaVR0WFJnMTVQVGdhZUZiOUZpLWFsRk85ZDVEQk1lMjFrTVpGaEhkb1lMd0QtaFRLQ1FrdTJUdHpfdFNxS3VyU0g4eW12UVAzN1FIYk9KbXR1SW45RGlMVVZiWlIyS1U3OUlBOXhOVVJPX1laWktEZUh3TFBtV1FKX2prel9BaFRIdmFsanV2TlNDLUpBaEcyUlY0Z2ItRERjY1BpcXUtM3dXaU0xbHJiaUVkWU5NeENaMjk5RUpaOUVvdW1uV25nS1k3ZnpURDNiYnJHSENPemRRSXVTaVRhT3F3RUt6YTVZLW1WUm5JS1hLcWp1ZmNkNzMwM3d0X2JWZUpTU094ejV0cUVTTXV6MTZhTk9CQmhlX00xZXVuN3l0N0JVNGd1NEdMNkFQRTc2eW9VbzNxYnFiRFdWWTRjblBJRkZhQ19QUm83MWFOclotMTNJbTJMbDIyN0hEYl9rNXpuc0U4c1JUQUYyb1czbk9aVE44MnJ4V3E5OXJuckZYbXg4TjA5NmwxbXQ2UUI2YVp3Rkp6YUxmYmE1dmxMMmNmZHRfS1NWdzZDZ1pyLW84LVl3Uk5kQkQ2WjdRR2pYQnpySVJaMk1PcmFieVdOaE1PemZYbktMdVBoMi1VamNRUzgzRS15Y0xGNUpmeWJWVXhtVUUzNjg1OFktMy1OcmVZaXdsR1FYOHRobVVRNHlxZ2ZMLVZQSzluQ2lkRHYwekdqVlZDM1ZQRDBKQTEyUFVyVWVoeXBEcmtucDBXekhCUzRyb21YcWJCVGZBaXo5YmNjdS1RSG5TclJzU3JMbkVEcFc2aXdQT3BLaTVXRHphOGQ1ZVBndjVEMXpUejVweUg0Z2hXTmNLSFVTVnVMT3p6ZFdDbVE0LWZNUEVoZy1GZlFDYmJXNjlLMlM5a1NZb0diaVdVcjdDdmxISnpBMzRCYndBQ3hYMDh4em1CY0RRbjJJYnpsU0xZcWZFTkZMSGVlUEpFTzViMmNhMVBBRlRPVmM0b3R0NlRESmFTRnZ1NXU1RS1sa3cxT0xHVWVHXy1zOElLX2czMzkxZVREWlRyMWNGbE1PeGpCbjRwOWdfOTlsQnp5bVQyUDRCRzhtTDB1R24wUHZJZTRtSzZxcFM2WXhJMC1uQVhGQjdYNG55bWZ2NU43QTN4SEo5YzRCUU5NRXJoX05FQWFIamNkc3JrRng5M1ZoajhnQTlIT3ZWSll2VmgxbWtfY1Nqd2NhMm1JZmpnRVNjSVpHNmRjV0NtOXpJSW5SUS1fZFVUZGd5UGo0dnBJdE5PbHViajc2MmxMempHQ3ZXLS15Xzl4LWVxcEt1bkNNLVVjN0s1cnBUOGhzY3BvRGxqWmF5X3BMLWhCcVE2cGF0WHlkRzZxc0VNN0Q3Qi1NVFRRU1VBblUzcmpVZG9ZZ3pjQTN6WW1feHV2UDY3bER5cDZzb2hacTJBWHprSGcxOGx1N1laV25uWGlTellHX2xNa3JkR1BqODNrYWlYcmNMZEExaXplbDVVUjJyVFNURVJUWjg0eFFUWnlRd0trN1hEMHBvNDFoaldYRTMzWVBYUmo4TTZWNmtNX2FiZXB1RWhaY25nbzR4RmRZdTFCLThsVlJXUFN4LTJZQmozbXlHZ0FDaVZrZjQ2NC1aYW1SWFBaamRmV3lvSThsdVBnVmZwZ2FxQ1RqVjRXSk13WTc0akdlTDV6UFp0bmN3NW9la3ZtZEJTZGptOHdkeWQxcTByUl9ZWlFIVHplcnhGeWV6dk1BS1VITWo3aGxUX1ctZFFMeU5EeG1CcmlqQTNBejV3bzhpUWRlcEMwWlRjclRNelFWQ2E2RC1YLWFVTlBzRmZRX0VZandYeFdobnlaX3FzeGlSelNHSDF1OGlLSXdRUmMyVmxDaUZQOHItZ25MTk1GLVhTaDh3a0VRU0k2SEtVdzhEdFJoMHFWLVVlVXZJTWdXa3l5bFNZVzVuMmFtV3g1R0F6VDBmYmxlVjIxR0F6VkpUNEhNWVRHcTJCVmVGbnZWLWgxRFNHYkljamd6MU1tZGhBd1NxMHZlVUM3Wkg1N0pKaG1QbmhCenNZZXhVeWF1Nm5pOEU2bHhDOHc1TmJkM1ZrTm1SZHR4eXNBVy1fR01HcXRDU2c3RFYzTUR2SFNJdndjOUhXMVRJWkV6RGxaUHNxaTdCOW1janhhOWkxbGRjVTZLQm5xQ2FNSlpNdkNfa3NReW12amswU0ZfcWNXTDgwdFl0c3ZYY3dwWlpZYll6Nk5WZGtzRmZTQ3NkSm91Wmc1a1FfeXBDWTFRcEtYMzQyRDVoLUFXVFoxeHRSSmxrMXNtYWl1dzk1ZGo0M25zVWF0clZOX0F1VXFFQ2MzRU5leXJCY3lrTGlUeXVvdGhnSWwzZmZiMXItRmJrRmdhbjg5ZHBkUjRHenpBNzhqVHBBbTFUQ1oxOG40aks2QkJEQ3JKdVBRSGdLS2RpWVpIamYzRTVnaXN2YTJtWFlWQ0VUVjhmN1NRTDNNRUVlajdGdWljZWEzbUZqVW02MTBHMzFzMFZjQkplZGdvTS05eDE2MF9TUHZqQkVjT0ZNU1lrd0NMZVpRamVVYUdQejhvNldHMjhsellyVDhxOGlWcUFHdGVOTDJ1bWZpcVlQODNkMG95VjJCSGRMNmxUTzVDcW1zcVN4ZC1QZ3J3Z1VzN2V1RFdrWXFKRnJUdm00eVFXc0tjeVNwVVU1TlJDZ0F5REw4VS0yaGRMbWFtaHd6cGYxakc1MURxeWxSdzFhWkZ2N2xGUmFoTlpUTkdCODJvZDB6SlV1VW9NZmpKMUl2M3NsaXBacWFNanNRUDEwOVFhTVlZeG9ONWt3VnNfc2hvMmxIbkdZcDJIT2JnRGJDLVhfV29wdjREVU9OeGVGTDRjYmRfSW1ia3Z1aERVMHNEV0JaZ3k5V01xazRJNmUwOFJvUF9Dc0ZWZC1GSGpoNFhhVWU0QUpQREhpbDZSSmFaZFBUQUplTW1wNER2RUhqRV9hRkhGQ0pmYjVYd2dNaE5zMTQ4LVI0eXIwMmVlZlRoUjNmRW1JX1hPcVh1VUZWRUFuWHY0Qk9JS2dnWEhzSzdaMFpwNi1SMTV6UENHNG8yMmN4S2V0ZU1YZ3FBN1VDaElwWTIyTVdrVUNZdmdZQ3R2VWxNTlctazdXb3VvcGJSWTR5N3loQ3YzT091Ml9iVkJ1bjJWZnJFelZzMDR6cEVzbC1DekRFZkF6UGZYZlFLYTFXdFh6NGpRZFJKWWZ2elRLVTZGUm9HLUMwazRGTXBaYlg1Y1BWOGM5YmJ5RDVNczJhYXhzMDRWSXBJOXNzbHh3S0s2ZkJNb0QyVy15X0x2RlBqbU1YY2x5YzlrZlYxM0dqQ3Z5R2FTbGtvVkVHeWZXY190Q2R6RUZwR2hfYXhkWms1eTd6aTJ1anBpeU9uUDZRLTFhSVFRYzBZdVh5M0NTQTk0M2JJOGNsOWRoTE5Gc2dLVldGdWdUUk9GX01NRnNDTVplU2tnVU81SVY3dEstaWNwVjBzTVJheFg0UmEtdXlMSzJKR3hkNEd5dGZibmdSZ1p1eGNncFU3dmNKWDhWSkZWcVFmanJDMnVjN09DbnF2aTJQTnAwR1BTc25XQm1kdF9JWjlOakxTZzZELTNGQ1NpdmhzVVZCSXFGb0ktQnZ0NG05WTVBdzBlNm4yM3drbGRJT184bjktaC1DTVY4SWIycTVDNEdiLXJ4RDI5ZWN3dWN5bmFZOGhUcTlhWm16b2NtN3dQQllQNEtaMERfcml6QWFBS0drLW1XWkhNNHRPY0MtX1puSEljbFlxcmV5aEpCNTJkbHF3aUxzSGlwcmh4Qkp4ZG03bWNDZnRNM1h1TGE2S05SREtQcEJ4TFdHSlJoaUlnbGJmYmtzNTJYSXE4U2RxWDM5eDM5SWdTaE11R0lBVzdLOEdWX0pxSE5uSTZxZDRIMEhxejN2bkFvY1pXeURna2dwSHpuLWFEMWdtXzBPUHpTSVBnS09rWER5VUNBd1VIWk1yT21pZ2V4amRsX3RLUEUxUWRoNTBtTEVVcTNTdlNIOEdVM2JXQ3J2UWdKQ1Bja2hUX2lXUzFrVHVwWmYzYkVsQTA1d2I2b2luZkZYVjJJTnh5dF83RnRhMEczU2VYVFpscmx6MXBadmxPNURwbThNaWYxenpFWmpYbndfYzY1ejRwT21ZREpDSDB2cXo1Z0J2NHgyRklyV0hvcHdNSEhsbkVSWTB5UkY5cE04NGdfRWUwbzF0TkhzcTM4VDJtczBVMnZLYnltanJ1LVdQc25OQVVhY3NUSWljNnotNmlaRDh2dnN5ejVBb0E4a0Zvci1Mam1lc094ampjWVZLU0k1a1h5M0M4MEJlYzlYdDRqeWtjRkhoVDlULWxWYXNTZF9HWER1ellEZ3A1R1NsRV9FX2JUT1JrZ1VkR3gyQkVIVDlvV3N2QWxnbmcyaFl5aUE3Wk5ldUlIVHI3RnA2ZGJteEhJUkZnU0JOQVk2Y0tYRlBFSjl4UDhJS2UwQVhuYUVBYWsyZ2xsSHdoM2tzYWJPcTVNZnh1bExIazVtcjFZa2RjYnVfTEg1RDRYYTlVVi10VEIzalI1R3dFU09uOU9jRnM1ZndtZnRMWGd1dTZGSUpSOFRsTGZyeWtNV1ZqVUM5S1ZSMzgzVzBqVmdla2NGTHo2bE1xQURiTkJ6dWpSVkZfd1pYLV9MR3ZSVzhPNWItNUdFb1FOVzdWdnFyTjRzdTdJNENHU2YybERVZmQxbW5YYWZsVUNoMzJudkJ4UXROUzRLWFFFZjNpOHdGNWFIdUwwLWhEMnpueGNGWFQ0U2VoeGI2bURJZnB4THE3OHVKeFNsRnBsTURPLXY4bFNLYS0xbmV0LWZxMGhuam96M0x6SWd0ZWRON1padGtPS3NfQTdwaDhJUHNlZ09OMUtRa25XZTJNZy1nUU1Ud0FOLWZKcTVPaGhvdVhWaDRQSE5QZ05Yb0VFWURuVjE2S3JWSWFna1h0emZ4RFZpS1d5em9OTjh3cElSRHdWOUdUbTRkRlFqMngta3pFbGpOVFRRLXpvRHh4LUxfZ0ZvZHR2M3dmem1ZOVYxRjBnSE5lN3dMbFV4ZHN4b0hUQS1RTTFuYUUydUoyZHRya254eHBNWHYzRHk0dGo3Wk8wd0R3TUx1Z3BCT1NfM0tmWFpKa3lPT1pKOUZRYlk3ZHJrY1QzZVZmam0yMDJVeTJSNE5vVWdiSkltbjd2THFjY1B0UUQ0TkpVT0xYLW9IdWNCOVNBLUVfYVBlNU5wRnFKREczQ0dJOWFVNXJ2TkxEc3ZFdnlkT2hEWk9ET3ctWG5sTEFNMGlBMG5UVGlwdmtPeG1SOTM5dklHU3g0RlpZQjQwMERfbENGS0dzbmRCbkhjektlajBZRVRxalI3WkpjUTlVaEltZk9GdW9SX2U1MVFHSXZKeUNKSjZ2RFJZUThVVWtTYUdTeFBvSXZaN0E2NFJKek01MHJFSWZQSFAzOWMwSTZXczU5MDlHTm9Da29nWE5KMTJQbEpLZHc1elVianNFcl84YlRVWFFSellBOG91TWV4RS1aRWh6TFdOMGpIQlgyNFJSRTR1ZzdSQ2FjY2VkOGxYYkZtZ3VoQW5pbGVQTFFfODJEWHRvVXR5Zkp6Uy1aV2RMUDRXdEV5NXAyZUxIVWQtZ2I2NGR0UlVFRWpfZ0N3Y1RxbEVfbFJlQWR2TDhPV3FCQXM5SzhmUjF3bUk5cklCYnZQVW1vU2VLRm9ZMzZIaGFZczN6aU5pQUNKZjlCYnF5am05clJDZmFXUVdqV3M2cFhCcjVSbVlVSk1UVG9pY3RYZFU0Z1dsMC1vUDBQR0FLRGlIMWgwYUNUU0tjVTZKeGh3N0dQSWdvUXg1WUVzSDljdTIzNE54NmxpM19SRWc5WEdVNm55WDZNMl9NVWNiMzRoQ19Ld2Nrbi1XQnMwbVZ2Tm9FdE1YOElqb2xGRUw2dXM0ZzlPLXBicGFXTkdZcEpoaTVxaTZCTzRaUWJRWkRFV1FncE5SVzZIalI3RnJjbmxkUHVwTmgtQjdxQmVTaDZMdFdZeFhIeWNUM3ZIZGNSaUhnZE51ZkdJY0dXdVU2eVRxcG1DWUx0ZG9lbDJLdlczZFMzTWtFQ0ZLTjdKQ05rWlZwRGtQbjQycTEwOWQ3OFV6WUY0a2VYNHFoZ1Z4Q1ZpOXUzdGtPMURUNXgyVDd0b3VNSW1tMmh5NEl2SWxNMmF0OFpwMURPaF9WMXdDN3QzRmxTOGhBU1BWRTVuckxEUEN1c2V0VE5VUTlpSmExU0ZuWUwtck9wUG1DMy05S2M0YVp3TlJkQlpRUTFfdDBLYW54SnhQbHZhdWVCN0ViX3M4TnNGbHIxVkhCcVNKd18xQTc4d1ZmRHFLNm9BWmdZTFRieDNRNm5reXJFV1o0U1M2WmdOMUVNYXVHYkxOdXZNR0N5Vk1fdGlBNVhJNjE0ZmJLejM5VVN6TlQ4Rjd4Y04yYjJsSGhZNHF0b0JYbkdZTlZmbF8yWks0Q0RQVzc2TThwby1IcnBOb3lyZUI3anBBMkQwWnJST0RCTnk2WjNiN01salNTUl9NMmxVMVdkVFBadENZUm5lemVvZ0E1WjVTd1ctYU9YMDFCTnBqeFJBX3o5SlgzVi1RWGFRbjM1OVpkckFWN0lzeDROclpVMUpvN1F3WnlGUHIwSDhEekVWZHptRmlBV1dDbzYzLWZhN09YY284OFp3S2FzcjVnLWJTTmZHd1FHTlFqRlh2WjdVdFBSWWdBNGtCeWFiSThzNkNkNnE0bWUwaC1EUkhjTmVIOGNIcTZ5OXZ5NGhFeGg3SjgzZG9JVVpqZ1BTTDZ2RDQ5ZnJpMFZjTFdiTTFrUk5nZmQtNDIwWmdkNkpfUDRkNFJ5TlY1NGMzaUN5dUdhNXVYajM3aGE0ekIxQkg0ZHJWTS0xSGFNeWdqR0NqcXpaMk41cTFoRnZvWnlxeDE4NWpVZmRoQnpFY01XUFFoRDlpSjRXcFVKWkp2aUNWeENsTWwtTk5NSUMwX3BIZkI1aVZFdnYxMWVtYjV0VVJ1SzNQRWJScE41dzR0eE1MLWhkY2ZPTGxvRElfOVFZZmVRSWlpQWJtMHdZUE1DZlhyREg1dVY3cG41Z1VGNGg1R2NLQm1KODkzZDJtbHI4Z3lIdGttWDNlVDFMNXhyWFlGRzZhc2tNUTBtNFl5Tl8zMnNNTkxvXzRfdmtJMEktX0pzYzdqOGI0YXNnekNncUtPbXNfOGVrZHd3VkVWZHJaMDFQTk1hakl2WXItc0RqaGtidTAzaHdHZm9IbF9hMm1VaFNfNGFpdmstMjg3ZXI3amh0aE9PYkZvQ1FidVFNQ1o5cVN0UjFQZUd2em9mLWszU0lybXJfMTRkWmZjT29oYXZSWlhiWjc2Z2pRaTNuejRFX3doaFdGcUU1UGxCWjNtTWc0RVFYeExTa2MzZFVXY2lSTFBIbXZIbEY5XzdEU0JsRmtubFUzV1pHdnI5aF9KZHhEVnl0QUNjSVBiTGZMb0VwTkkwNFVZb1RNbFo4VE16UDNjMDNqRWlIUVN1eDExRlZsa3pIdEtNUnBpMEJScm5IYWMzcXpsaEstS2JZOGNKalVWd0tVZVRnLVNWZjBLSXp1WUxXbXd5bjVTdVlrYjhkOHQxd1ZUYXhZMTQ4Z0lmUGY1bzR4cDBPdk5YaHcyaGMyRmpDb05vNVB0U3ZEbVJXMU1QWnJrRGxfWm5xMVpBdTdmeWtKdF9wWnpYRUp0RVF0cS1fM1kzR0RGV2xnaHZaM2JmdEM3b1pVSlhseWtkVUlTaG9YWkJ0X2VDUTRtTVpJZkY3OTQ0LVdiQUFraGpBUVFFZWhKX1VlZ1BFanNFVG9uV05KNUxYMnVpNThHa2hDV0pVbHl2ZE9QOVd5T0pDLXRwRHUtR3RUbDZKcUliZzEwdkRGYWpBM2Q0V09fM09STmgwYWZrdnBGYXdXZkw3OWUyaktiSy0xSWRibExIOENPWWF5bnEyWGFzakg1cjdrZmNZMl9wajZmNjJhWjlLUUl6RnJEemV0QS1mbFI1Zk1qd2x3Z3pqbXdibGVHQmVobWhNQWw5WW1iWm9rc3JjOTQ3THVpX3hUVXFMQjVvdG9sN1VPcjR1MlZlMzJqTlFhWXkzOEFpR1dYYjVfSXlXM1gxLVNaV0laRHdrUzRBa0hxNGFnRXQyV1RFOHVaSDBlUDdqY29ILUJNMVpsMG1FSXN6empJUXM4UGNzNkQ4ZTJBRUMxV2k3OUNKLVEzLWUyWTJKU0psTVFoQmxfU2lrc1FsRm1WS3NWX3RWb3B4V3hWYmFMODc4Z1k4X1QyVC1LWUM3RHZWeURiM1h1bGFPbzBMTGJZNDEwdVJ3YnUwYWFsS2UwN3NWRExuQ2oxTWdsYkRKb25XbWNfWExkMUJ5UTVmcmhTS2t6RnQ4QUw1WXVLUm1zVkZod3lrd3N3ZG9CUWdoZFBpeEE4UmVMWUU5X0Zaa2J1c25lVDZHNjhnaGhqS3ZUYllYY0QyY3p0dWxoSkJ3dVNkVElfaF9xb0hGM3FEOHlIQ0otUkdNVTlKVFh1angxZC1iQXd2d3FYREpOcldITjF4NzJocmIzejZWa3hFdm4tLTRWSkNLNU90SkQ1TXNQNG1FVE54VGdTU3Vnc2htcXFScDQ2Ym5LcklaYXQwUTI1b2YydXBKUllvbzBFZDFWajAyTlVmQm5PS3ZKNXZDYmVSVlVILUpLSmNHN29WbTNJSVcwM3M2UW5PVWtFVUJmU3NYWGdYTE1JTlJjRGlYRzFtazBUWk5EdnJlNkk1V0xzLVdFbGhLX3NNYUJWc09PUDU1cW9uN1EtNXMtY0pfMUtYZWZ5aFhkZWJHcUhNRUszMGpVSzBJLWhpWlFJMHdFQUNnZHRuRlRrLUVScFNBbGt5dGZOeUFGdVoweHo0SW9LY1VubEptZVRnYTByM0hpWHVoaV9fNUxYT1VFNGtacE1pRS1vMUlyVTU1Y3RBbkNYbWN1aFdLTnBRT2NDcGUtbWhyQVc4aFlPX05abzQ1eDlwWlQ4NUlpWFRZX0UtZVNhZVpyVk5xN05pUW5TQ0FmUXlaWnVvNVhlNlppSnRBWTlYdEtxcU10cGJMTVRRQlNiaENFSUM0X1RMVWpSOEtwZnUySFBYUU5nY3FrZ25GWExqRDZ5TV9pSXNDUzF2WnJUaVh4M1lUOUVRQkJRRGdBSUxHd3hPUlRNWXluM0dCS3pSVjl4N1VOQzhIaXFueXAtZHFkTHd5cXNOeWF1OU1CLWQ2b0NDdFhiWXByR0d2NGxwSUM2MlpqVlBnM19oMFphdzZaczU1OVkwVmN1ekhCTHJXTUJId1NEaHVodGhpUVQ5R0pIYlF2SlVNU2R6Y0x5ZmZ6Mm10T0d6OHVIRG1jdkVpOE5ONGZORTFLY3dCSWZXdFhhODR2cGtmTi15TFhtdEgwMjBYX2NRa1RkSC1hOGNSQ0Zhc0g1aVl2WS1ZTTBPaTdpQ1NnMFJVOGJ5eWd6cHBnSDVKcWxVTDJzd2I0cV93aGFZRDVBQ2t0RVpLeEZxenBPSjNwVkJKTVRiVkttd2lTQ2RQMVhMemFoc1VJZWsxMjN5WHpqQ1BnazhOSE0wSDF6RWstQjRfLTJDV2lqS3pnVTZBVG1Vbk1IQ0RmdUNWTDh2RHo1V2ltU3RpVGVvNjRyMFQtZHZTMnZXWlc3YkZXUVN3NE53d0ZLaW81aVFDR1BOMktOSDl6LUxQT2VVNkl6Z1RhSUFKd3hlQmlFWkxST1F6bmszd01rd285dzB5N3Zibm9xeU95N0poMVZaNjFSSUV0WVl2M1lHQnN4Z3RCdG5BM3ZFdk00TGJCZkJQMm9xc3QyZjB6THdhR1k0ZHE4Qlpfc2RrZUNreU0xRU5iYkdqSjJwV3pUSUl2SGlQNjVKeGFGZUZNM1g2YmJ4TFFGZ2FlT0xpVjkwVGIxUjMtVkpSVnN2NVBHWnlYY0VTU3hlcDZpMXp4b25paWl2RmppN2dnbFNtNkRQNHFULWxKYW82dElDU2R3YTA0d3JSVG5YdDlKallZX1JVQlB0VEkyMTE4QkJjOVcxOFZCUXNIdlZORWxvX2doSGdSR2tDZlVjeXo0N1RyVVU0RW8tME94OXZaaFV4RHF4UFZkTTRmRWY3WFk3UzN1V2dNQmZuT1RJWUxQUVlXRWU3WWgtNTBmUVF4OW5qVlNHaUpSVE43RlVmU0tVMV8xSTI1RnVjTVRkNDZYcHJmNkM0LVJPYjdwTnNNbmlIZFJscVVjSUpZME5oZi1MRWMtamFOVkRGNFZqeEdZRHREM0dwWHZjU2JfcWtNZWd1S1JyMFJwbDJhLWV6ZmtINldWUUdTVnlGWnB6Z05Yei1GMEdINFR2VklCR2tkR05nUjhCYXVZNXpNSEpvcjVDSWt3YkREem1KTHJXYUN0djNhdF9GV182TlhjWFNUdXQwc1dfSS15azRxNkgxWUJVNk1tck9HWFJ2LVpHc3gxLWlnQTgzN0x0QUF4SlRCQmNUbFBWSHdEeTRseDJxU28tRUl4YmkzYjlkenNTTTRUR0dJUDBScW1hN04ydEtOcjdTMHlKZzRHeFhYT2ppM3pRV3ByemlNZjRpSEpub3ZWcUo2RWQ2eTVqR21pRUl0U2ZYYk12RHhWdE5LUlQ2bHJ6ZDA1LVE5TEplUS51WjZfQmRHWDh1UnBhbWxkVHFQT1F3"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['12598']
+      content-length: ['12712']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -391,19 +404,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2176411-9414-11e7-9a47-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"30woU5cp96sQuKd-sO5Tjb1ClkNUinYnUtpX8v-JX9KMk78P-f_I8bZQ-QR2w_tToFbD7p3XDhA-ZfWyviYjSVsj2H8H733BQn6ZkNrsPCBU15ESpqgBWjIx7UW2Qz2psHxgvTuPQsJKR_PByhHvx-8j3fNrSvnlsNWKAnsn8_ryFRG3IDjJKnCtRHJtNLsM9HX37tksaimu9Dhd-WBtWce9PC8ue1yaCwU_plDNtSwQGGUKKxNoiRAg2jxns9jr-m7-Ur6N675fzBu4v6WtqjiBD2eUSVPWuevN2Qb7vI_sX8YwCMOIxKE3aRVWSd3JdzVR-EbL4H-g7P9IfzKnTQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504825713,"updated":1504825715,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['632']
+      content-length: ['635']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:27 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -421,19 +433,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e24997a1-9414-11e7-8d02-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    body: {string: '{"value":[],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['28']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -445,26 +456,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkZfenBGemJ2TGRDQVExVW1oOVNMSVVQVWFpMmtQanNRWVNVVHZqdVFObWg2ZDFlUXNEbmN5VHBXS2w2QzVuTHJBMDZRUmZhQm9MQy1yN25Xc2JBZTY5Y1BiOV9GR0pzZGlLd1BZYURpWlNVdWVSbHNEQUF3UDM4bGVYbWtKUXM2RnVjd1ZIZ2JDaThYNEZkYmpCS3hlWW1ZQVlZNUZTMzhZM3JHbHRKTzlUNU5WUWU5cmNjOVFOOGJWTzNvWURUUG8tejBjMUtoMUJiS3p6bHRIZktGYWYyZDFPSnlfX3hHa3RiQ1g3LTAxNmZlTm9lbHM0Vkk2RUNzV19wY2Vlb3l4RHdsR3FCOE1lVkVpQWktY0F0T0dXWXF6N1BxOUQ3TXJCNGJCcExaSS1kQzNyV2g5RkdYLWpqXzBDNU41bmpGTlRBQXlnWnZvY19lSlR6d19qeUZrQS5qcHpNSTVQYjFQRGd0ak4wWllQZnRRLmlYZUduZEs3ZnVnZmZwZ2lmcU1UbFFYQjhvc0tKNlFiU2pIWjFRZnhzQTZMMmpFTWE5NUw0cUxiMFZtbURGbmN3Y3RIazB1bU05Z1JMT1RMbEVlN2YwaDhlbDBTV1M1TUVpS0huTng1SWg2Unp4NUVxWU84MGY3VmRvbWdQdUx2NGNqbUZzWmhhNC11Z1FTU25zZDhJYUhKWGlDZUkySkxMNUNZLUpNTUlaX3R3Q21lcHZUTzBxZmVkcE82aUFmS2I3SU01c3lhRUdOb0s2d21jVEIwdEVBWXFySWx6VFl4WGF2cHR2MHhYUmQ1ekdBTGdnR3Y1aURlSDVjbW13UncySElyR294YVItaEs5OXZfY04xcVhuVEJQYXdNLTJjVTVxM3FTYkZlTkhiMDctZjFUUnNEM21ScHQ4YWRrWm4tcTNBazNQbmw1d1NmQUtZeVBoa0pVZUgwbjlWVHdPT05jRTRHMVhFTUstRGxHVXlCeTktazdXanRuc0hSZ3hPeVVXaTU2Ujc3ZnR0NzkzcVNjODg2a0l6clpfSFprZVRZYVU3aUdZeGRRMklMaVVIVFk2ZGJLN3VHd19nTHkzNWwtbEtVczdyakdqTEJrZjJiLVdJUS1DRjVKRlNYcEU4bnlnYW1WOW5USzZsM1BBY2RVM1F3OEc4WFhQMS1DV3JZc0wwNjB3MmM5cnlxdTNxZ0g5WUpyQS1MbU1keklWYld2dVZ2UkVlMWlMbDhyczViaEFENG9zdk1TckU1cEFoTmcxeFZKYnFWMlJfSTZLYmdSS0RzLUM4WkFmWjJaSzl2RW0tY2ZBOVgtZVdIazFRa04tRkxKalpNcm9KUXlYRXRlSUpYejFGa3hVS28tUHpYTVktV1JiUV9POXNpNGMzb3VnVzkxWm5SNV91bUxkdmY5VENiZ1haMDdCeHF6U3Z3X3hGY3liWTFCa05yZllDa3h2ZF9iZ0VOQ0VtQS1RU2NOcFdOSk5ZOU16djBHSDhxd29HTmowYlVlR3ZJcGZzS3dWWnFnd3FVTFFuVEIzbk1yWDRDaGpCUTRaUGNyNVRaRW11OUxNaGZManZxejIyQWVXclV6S1gtTmd5OUFadWc0SC10M215Z1hJYXIxeU5fdWtzZ2h2aXNHcWFhYXdfLWRMOUNnQlEtYThabDNOYkt3cmpBVFNKLVhFV3BwV01hcnFaZVlaS3B5SDJ4eWlXQ1VTR1B1ZjdzUXlfakk3bzZtSHRlSFozX1pTVDJrWEtLY3QtYWJWU2VaeWpzYTJFZU40NE5SajItVlgwSTNPN0ZBTUZxVzJxVTFEM2doeGpUMEh2N3l2cHBRa1FTRzlLZ2J0czdwS3owZ29oUmFuWFh5QlNHbkdXX2pvZ2d1bDd3X01Ca283X2lnbmZnNVlZX2N4RU5VMzJyakdjckJ1NmtBZVFkSko1dTNzSXlOeFl4Q193V3BaMUJsTVlWaVJvVGhobl9JUktudHdLMmJZU0JSQVBxdFJpZExOakFGSWZuWXFhSEtpbzlTQ3hHMHNUUjdJMWR2SldJeFpjSHc5WHFGc3V0MVpGSE1SbVlOZktoNnZCXzVvNW5jUk85R2FYT2FPd3VWUnBkU29KYUg4YmM4dWdLWUU2OXU0V2lyVmRzVDI0b05USGNrOFhQM21PbnhHNjcyOEVxMFcxamszTEQtSXlrU0sxSnJadDJaXzdQelNDRmMzTzY2MWFST0gxNVJOMUxnal8yT3ZIdkJNUWQzVW1vYS1vX202T092WTR2Tzk0Z2FkaXo0TUh4eDBVRmZVRmxlNmZqUU5NMTBWREdMNFRNQ1VHYTFSZmI2MnVMd01ILUdMSFBSeTc2emFra2I4OXQ3cGpMZWdQNXlhckxtc1czakVuN1ZJLW9jekRLLXBzNFZ2SHBoR2N0M1JwN2gtSTBsWDdUb243YkxXN3MwQThyNGY0R08zc2pXRzhFR1BfMEV1cXA5MzBRV203MHFtb195QVhNRDI2Q2dzcU9KNGxscThNLXNXR3B2X21SQU45RTY2dS1UZUxqdlVUOWFBakZfcGp3bHZKLWVsbFowZDlFYnpBS1FUdUplTjUxSVJZV1RfZ2RzSURNR3J3UGpKcnVFTVUxSkpTbjJXbWpzYmlScURRZnVVQWZlOThGLUtJTnc3SE5fcV9xQk4wOWdoQTJkVzFla0Mzb3pNV3BFT095MHEwNVQzaEFWZHFHWjNUS3NIQVptNzZ5US16eDlrMk1KTlJNRHU0TVNkamhKclFXTTBEbzU1bVBKbVVyM002TElDV2Uza2FoNkJPeXhYdmctd2V2UnBTQ09CU21JNUhhYkNnNjRBLU5fdi1jMndnbnl6WXFDR0JiTVczaWRLeUVzeXliWXlIUHVXR1I2SUNTb3BLY1lWVWV1Undyb0xEQTZxMXZWVUtBTkN3cGxmRDFpckQ3eDFqczI1X2dGQWV4ekpnQUhrLTdsUnBjdFZIVk1HVnB5Vk91TXg1bWgzTk5zS3FzZ2hreE1mb3JodkZhYUNPcjFISlFwd0ViSzZrRmZxXzhjR0dPZ1p3blVoXzBfRkZHRFRiSHh1LXR0TGtuU0ttdWJpQmNRYjJ1MzB2R1VwcWNjcFgtdlUwakl1dmVWbXZLWGM5aV9CeWVaalRYd3U2czVqTDd4UTdnMkdab1VHcFBxUE9qY0FFdHl1amNTR1NXMDRRWjZpbzRiUVY4M2pTb013WmhNOEJDeVQ0ZnpWaGJ6UV9oYlhhcnlTZFhnM1dobzRSSGtsRXRxdDBjX2wwTEhFNkNobzFtMVRlMXNSVDAzWTNheUlyUEtDZjV1YjdGM21LdV81b1loWmRwM09WWkwwM3dwaW1aaEgzVVh3RWRmWk5KUkF0WE04RDdjY0kwM2NRNGFyRGxpa3FEdy1vT3dYODZBSHVST3JzQ1ppU1ZjV2ZzLWdoN3lGcmlKdEoxa1dqMmhlUmFCMHFXekcwZDhULW54NUJkM2Y1eUxGRW1hUkJ5bEVVMTlWN184UENpTmdQSnB6a056VFpGTUlaM2w5NEpseG5GVHp3ck5aa0hjMnlCaWE2ZDNqWFc4S0RSclUzVEUxNGE4MXRJX213SmxuWllZTnlENlU3YXp0eXVNVU1nWHhOeThMRGhoaGg0bk5jRGlFc213VTVJR3pvZWNfcGdVMmZBWUxzczFNcGswUnFCVUJfbEVlZkdUMmtUQmttVU9rZ1dhdEVzdWpTc0tTemNvUXVuWDQ0SFJ1VTFqdVl6eE15MFFMVVNoTnBlVkFXUGk5VVFvMTc2YThka0JId2E5UEg4QzZNZ2t6enptMGZNWU5aNVlYcXdEemRMSlZFV2RMcVlnanFQUmpCeWJnWGFaQUtyNDdOX1pkaXc1cUVEbldmNFNqZk9HN2p6TVVZRk5Icl9hLW9aaVgyT2tLT3RJTlE0TGRlb3lnVzBHV2JnLUJIa1NISUh6SUlab25VSkt3V2Z1T0tPY0MxUUp3bjJqdURNMGp3NkZJOTU3YkpLYTdaWVlEdjAzMThpelAzd1BHZEtEcGM1TWY3alBjOFA0QmhaTTNrOGNIb0hycjZLaWV2c2lFYksyQ2JwRGRPOVZCTEdIQ1pyTlc5Mlk5d3dKQU1BUFBVcXpZMndlcVFCT1lPMldfQXNjWGFqSHhVZkNCOHhIQnhEWEZYdXpRZHgxNXZXNDJkRVdEWl9CQzZiTGpaOFdPczA2dW55X3loU2VSS0FaVDhhNmZiNDN4RjU3ZGpqNFBVOGl1OEFVZ2cxUXlmeTBjcGZMVHB1RUVBQno3QUg4RjV1VE9VUTYyZ3NIMWxyNmxaOEI1Q2ZhVUFxeTZmSy1XRVRSeEQzcFBybVNfVEs1TS1sYkR4elVkN3ZNNUw0eWJPSDU3STIwenQ1Z3pSRjc4eldyRzN3NWN2LWRWNmNiNTJOVGdxWTBGaHZNdXE2ejFZLUd0cmRXRXoyZ01jMHlvak1BS3pfSnl4d3JERnZUeGRIOEZNbnU4Rk4yUjVfWEt5eEpuYlViMTNDamhPaEtHNUdJQUNFUXVRc2RWaWNyYXFUOXVkMGs4czVqN2dvRTc4dTJSZEVrMTVET2JDb05OZFJISG9fS2V5ekNJSlMxWV9NeTVNamFmWlg3UVJfc3dwQjQzbDVBZWFTRFZndjRWTV9sT2RydnV3RGxDdEM4anNCMzJrNldxSFBySWtNWG1RNnVIQjhWNlM3ZW1rSjNweEYwT3ByNnBxOXV0NVpGajRkSEhOMGI1V01jbnlmZjM1ejlSSjVwR2FDRlgzdG0yZW1lOTBBXzdFZWlod3Zaa1lQczVBWnhrbksxRTlhYk5nWjFSUTBiWHYtU21vM3M4U2FsQ0VrcE8wMXg0VEZmVGdJRjBRaHdiUFZIQVZrdTdLM1hnYWQ3VV9RdjBQTG1ISXJhMVQxY1pYajBfQnlMMWFxOE5kWVpPaE5mX0hQX2d6Ylh4TXFFazRRckJLSzE3NXh6V3ZlXzAzeVluWXM5c0pBb0hma2J6RFJUS2tEMWZvVkRIYl9QWTBBUGdoc1czS1VMVHJCbkJPYkNRZzFiSmRFZm5XUGlzTHlaM2xQSktORWUyMHFCSXgxX2VfVmRNbXpXNE84Ylc2UHIwZ1lHTWdUZDRqeUlXRVMtZlVkeFZTUnUxUVhONE5iUVBZTVM5aE4zcUpxLTFsamR4dUlyd2xEU1lVdWM0UTVZd21XUVZrb0p2dDNHY1F3VWJ1WU9DM2lxZTVlMlRJSE1ZcXRaTlpPMGRZc3NwaTJTLWNTYmpXTFg2b3diMG43eHNOdjRHekI0WXJKVlNDRkxQZm10UXR5ZjE5N0t5RTdVQnNYT1lQM2dDV0NGOTA5Ym92WmY4OUhrNFlfV3FJcV9vdWhVbXZDYzl5MVVvNlVRTlBNVjJkelBDUGozRG5zLUQ3Tk1NN2d3RVhmX3NOU2JtbFBBX0J2M3ZVcWFYOGJRa3ZIMUNoT19mak1ZcmRDYjZTeEROYjlGQUZHb041Tnp5OWQ1VTlXSlhOa1M5S1J1R3lmaXBJR2NtVFkwUm9lUE5jS0JUb05TR3o0Z2RLUFN4U29aZVZmX3g3SUZFX002WGVFSXo3ZzFLb1R3Q2dOSXViZlhRQ3QtaDllazA2X0F1SDBsbGpSLXU4b3lTdzUtZmtFYm9ORFMxeWFFU0hYOGZjRTBXVkR0QU5xLWRwbHBFTnlmVS1NeHZuNmxSWnlXY0d4aVQzZm9pQWtsR0NrLWc0Y1B6cS1fUHhMZkF1cDBkSE5xdXNBMmRYQU8xaXJmZ0J2OTJqSXVRVXVrdVEtRzJUeFNObjRyM05vWDM3SkREMnJfTGVNa3ZCTFRsSThBME1CSGdzZHdOWFV5Vld0bEdVcW5NTjM2aHREcy1ka1hWNkVVRUxleUV1dkNoUTUxU3FaZFBjeGk0eGtoVGxfaHg4cXhsUFdPUVNmZnZOc2tMS3BIY3VnN0ctYUdXSGI3alREaEtLLXVvOFZoYkM4NG01dlJaLTBaekJpT2hlQk1HczRyYkcyVmtZTkVka1hXQWNqQXFwNURFYlZBX0d5Q1UtcTQ1dEc2cHdtanpxUVdZdk5SaUlQejZUdnFMTElXbzd2M015b2VYeHBybDBveEZWSkxoT0Y1ZE1GVE5VYURVRVZHWXlqYUIzSFBhSDNKQkxxVGhKVjNNS2VuQklSLXdZZncwZlRWQnZCUVFzV3VuSWRmN3FJTmY0TTM2NThSMTJHemljSXI1ZEY4UWt1azdlWmlMLXFmc2VUN2xkVjJwSW9YVUJlOFllM0RCRFlWZElMSGpfcGxEOTJBa1V4c0YzQ2ZNRkNYTDBJYXJuTUNvcnJ1dnFSMEtsSWE0MkNVVDF6bjN4bU5SODNxN2RSUXp0NGZGN1M0ZllVdEY3eHlaMzdwcVZ4VDNoUnFMY19MU2lMTFNhcXJNcmFZcElHXzBMSU1KY3d5RUo1NVlNaHI5cGdXQVFRUjF0djJua295UV91OTdRQXl4Z08zUHFQNzdMMG1ySGVCMlVOY1FaRlhud09oNXZyMEwzRmZra09IUXN5RXUyRTBvRGZ3b3pyZXpxTXVTakkxSDE0WUpmbE12TnlRemJqbjNjcDRCaUo1NWV1WjgwV0lNaElHcWF2OWNwMjFPRDZHRUhiaGk3N0FyWkEtX05sQV9iR1gzM2l1ZVBaS05ucW1mbU9HVkdKTXphaXNGR0hVRzB5TGFqR0VQeHBPM094WkYyNU5xMWhHcUhXNzFqcWw3YkVXV3V6UExsbWFOMC1IRlZNbi1qUkd3U0VSS0tTbk1ZUVdyUEdZS1F5dEh3eDdxT05hRUwtdE5sdHlPTkdEbDhkTy1rTlc2bmVUZXZObGFqeTh1WFJwYXdmeXJUS0F4R19CYzFRUzBYcVgxWW5iNXk3WEM2dTBMcDB6bE51LUQxZGxOZS1naXBkbFBUbUN1bmwxU2lFbExudzRRenJVSmN1Wm1BclhBT29EbEhabzM4dWlnS1hmdUZYN3BRWExwMENsQXk4RWVoUm5xSEhHLTRERDVUdlYyYUh1TFRNYmR1M29VcVlSd01aMnRsaWFKLXN6aktoV3M1QzFhckVTTHMxTFFIeW85QUhaSmUtaTZ3TzVveHZIdmMwV05vVG5WTlpFVHdoYlg2aGt3aUdhWVY4aWxkSUktS20wTWUtNlJmMlRzR1VJd1hkZS1VNTVMdzl5WnpJS01JQWdkN2x5c2ZDQTM5N2ZNME5XSTFiNVlOYW83ejIwWGFwY0tFOVhPZGtSNEI3MmZNcHdCVzFxY21yS2VQcExfWG5XZ29md3QtQ2dGU2RYbEw2S3pVNlhKRGQ3b0FMQ3V5dldWYVdKYnRFUkpweksxbDdQTy1wckpMa2VqZTEyOG1sZTFZTnUyMkdsV1BfUTAtQmVTaTV0SHAwX0dBZ3hvdUxGVWxvbW5RRXJuN3laSWlORHo5NTRGTjdoZVh4UFdIbm01V2F4ekF5MG52Q016Y2k1cE13Ym9pMjcxZVNtZ0NHbmNjT3BOUXlmcllxM1Q2UHZxYUZqaVhpY3JQTHI1OGNJOUM0VEY4cUdsOFRsbmh2U2x4MFVzZHl1dzI0MnJDYzVVc1ZMM203QXk1b3c2ZDkwd05zdWVxWDhqY25FNW9WS2ZnYVB2djZHVkpxNEtrcmg5Ukc0Mi02UnllNEdkRGdIand5bjdhcDhVNkZOdTEyUERoSVlScDJuWXBPRDhzTzZHVDM0djFsdUNhNVJxbWJISnpkaVZ5U2x3bzhPLWcwMHhDZzJnOUpGeEMxWEtoZFJaMklBUi11Q2tiQTl4S1Rxb1ZFQVVIeFQ5TWQ2T0ZPalF6cHdWRndWN0dzVGpGblFkYXk5cjRDTWtIWlU1OVpRaHFYeWJPaU4wdDRXY1hTYzBaeUxHOG5SbTYwMjdEOTVLczZ6Rzl4bjlwM21Hb2tCQUQxY2YteDYxdG85b2lwWUZzTTV5cjdIZWtHMmJsWmhFZ1pfWHE1MUt0N3dhSkRzV0tHQzZiWVVIelZTbXljWWNER2EzNnJUOUFUWjNCTmI4OTNtcXNxQ3ZkVU1Ua3lPT2JmY3A1Z3l2R1VTZjRYSHlNT2tZR2hzNC04Z3Q1cjhZSDhDY1RCNXJKaHVoYlJlS05YbWoyTXpiZFhNU1EySk5PdVNBeFk1bEVSU2UycUtldUowUHhjWHBTRHg1Z3ljeTVPekZ5RmU3SnV6Unp6RWZxVm5OUUhacG5pNDAtX2xLSm1UdEVZTnNud3JaVDZHNk9MbUdESE54WXJCVWVaZVctcEIyaXpycDVMWVhwejlWV2Uxa1c2UFBNQzdNYjRyU3hscl9UVmtkUUxaa3N4YktnbXBVNXRxUVQyOEdCcm9NdG5HRk5kbDNVRlM3M3JpV3JHUWxWbVNMVUM3MjR1dGYwWFZEQi1BOTdWazhlTEFmbFh2NEx0eEdLUUhKaEI1OEJHaDhzZDFXVnl6TzdhWm9KNktodEp2ekl6SGxYSmxDLWZiYmVHaTBhYkxuR0lRX0drNVNSM0JfMjUyWTN6Z1NmeVd6ZHl5U0xPN1lDbktuRHgzYl9YUDFVd2M3QXBoM1ZFbmp4ZUNxbUJmWlhWSDNwdDdxd1k4RS1Bcy02TGFicHNzTHZMcmF5RUd3Y1BDOUZVVEJkRjRBdFZHRUJLa0hGcVZST2VfQlJlVmJMZVpxTTBlOG1mNFVnYUQ2TXFZa21GelJjQkRvamh3MVRFVC1aV096T0E5NGhOY1NQOHZ6T2luenk1NHp6TER4Vkg5ejJaTG9LWjQzQVJKTDdwUUR1U2Q1enFONlJOcmRFZTNJdTRGcFRWVWZQbGFzWl9sTDBueTIwMXZiU2E2RXQ2RHFXb05wV1FLUGlnME5ubEtSa0llNy0zb1dRczRpWjJpdklEeUVUWVhCUUVOcDR4OHBuRGhXQUFuNWhfVWJQdXZ4NUs0cWJTOTktM2x4X29NcVdmc0EtaVp5eVV3OXc0R3ZnWVA3TU50RThFNVVBT1pWVElUX3BBWElxaDdLaVlNMWxad01uLUJQeFdaaVJDNGp5SHN2cUUtSXJsNm1BN1dRanNiUW0zaDBMX2RTS3g0UEhTRTBYQnF5OU9GX2xjcjJTYkg0WHlRNlA0SUFrcUMwYjRlX251UUZ1Y3Q3c2Y0M2hObXJRZTk1RC1BQ0dVamFFZ3dkYmFqMGhEUV9pRy1vU3JEeDEzVTFLNVE2R21RTnpsUDM4QmlwVFN2b09NRVVIdngySUd2cmtoeHRyX2t4d0o4ZG5JV19Ed1pkZWptT05zUjljLUV3Sjhhc3NzMmYwSkt1ckdPZUxZZFNidnBHeUJ1YTVST1Y0MUtWanFtb0NsTXlJZllSVk1zVWMwSmJ3SHpoUGpTZGJONUVCVlVYUzlibE5oeHVXUnF2SnhVQkNEN0ktUmdDbVlSZm16RTVUcjlXODBGSDRVTzN4UU1TdFBQTjAtc0xXanBtcFZfWHd4aHhzQjZIbTNxTkxUaVdOZVU3TlRUZG5ZeEVZMWh5ajd0M0MxNy1KR0NtY2l1OFJYRVBIWGt3MFJ5d085VV91X1BjWTRLejRyRllfR1IxYWhaMFdWZU10R3BLS1k5Y0swRG1HTEpoOGNKQ0FBMXUyZW5wUUZCMzhPeHVTRWVzX181RklnZ2dWU2RvaVc1M0ZMT0tLZXc3b1FhLTRnaC05OWFYZEJFbHpmbk5vSnNuX0hOQ2NVZ3dTYmNuWFgzYWlRSnJxZVhoLUN0UnhRVzZHZm42X25pejJvc0Mxc0E5elBKanpubF9WVHU0dGNOUm0wa2lIQWpOazRXNjFPVkNGLXNmcXNmQWw3UkFEU0NtUWZ1TjdndWlnVWJWWXpSRFVHbHhRM2dKSDRoZ1Z4WU0xVHZuWC02M21pRUU2VUNlLVFDN3hOTjV6WEx4d2JQOFdJVmxNaVpLdjdyNlNLQTJtWWFLNmhESGQ4WnZpVWdKQUZZUjhJb3YxbkZObS1qU2dvdlpjdkVsUjlMVXBWZ1dOMU1OSU90TnZfbkhMUG00TklVNEJ0ekdWdmhiNHdaVVJ5dVhnU0pDN08yZzV6YkdUdHBVdEcxS291bHNJMjRTMUxST3VFYVdvUDZlX2l2Qm8wYWc1aEFOM0dodFBuc1J2RzFNZ2VxcUZqTkpFaFM4NEVyWG9mUHdWbUVRdUdYMGxZRkJYd2d1OWVndHlCdVN0Wl9sdnlPTDhHOFZXQjgtMHZtOG1pS2dCVk81bnVMbnFNbS02QmRodHNqTmNkMTFrRm5kWjI5Wk55VkFDVl84UGJVN2w0SFNyUzlCMm5aOUo5c1FPUmFqSDFSMVdNNWduR3JUX2Fwd1NaY2xyMFR1TFNOS1NQUzlIMm9XbXAtX0RCSXAyYXhhNzFjZ3lzWjVRNjdSdGd6a3RaMnZQRXdxQ0tmd05GS2l2TWxMTTJjZE5iQ3FVVUFVNjFUS0lrN0xUVDFPLXRrZlk5cUg4QjZSeVVZNUhhRmZ3cElWX3ZKampNZW02OUc1TXpJRExNajRJZjQwckZnWmY4LUFXcGM0UGtoeHYxcDFVYk9OZ1ZQUDB3WkFwMmhMRS04WDhuQThhbWMzRS1OVTdJVk00LXo2X2wzb1JDdVNjSnNIMzgxeHczVGl5dVJkRE1kTE95ZHNBN0VhU1lpcVFaY2ZnRGxpMXNsSEZLN2pxVk9DWGRiN0p2THpVMTJ0eVdyblJ1czJ2VUR6akRENmhER1pLckd6Y1RkUHYtaWRxN0hOSjBGb1AzeTg0WEVUSjdxRGpUWktMa2RXSVZTV1k1SFllNnZlYTJGRHBldThzUUk3V01ZY3BrVGY2N0xuQUdqcWZsUVBsdjlBeVNmbGFESUs4M1BHTmhwRkNSNVVWYkdmTGxPbW9MOHpzcUxRQ1kxa3diRm9hMVJkTXB6SGpsYVVtQjZEWFpjZlczSVpIT3J4NDktSGtFc0lXQ011N1FJYjhtN2JIZEtYY3JVZ05KcnN4RmR1M2l1TFpoQ1BZVThuTklhQ21IY0hKVGxQYVNEa1E2WktTMnE2OFU3aldwbmZ5Mi1MYnBmOUhLeDFteU9qZW5aNHMzcDJkc1RtUERnbGF4MkZZT3ozR3JmOTI2QkYwWUN3a0RPdkNTZUxEZ0djMjlydVpsVVJFVll5bnlyWHZBN1ZLOWFhTGtkN0xRYlF1ZmlXTEROUGtxS0VOUERzcDZzdmlHTk9Qa1F0UzJqS1V5US1XOVJxcGdlQldxbEgxMlpEWF9adUYtLTM4aE1SNE5yX25VN3ZGeGY0dGtPeGxROEkwdU42bnZJbmJmRW45WFFZWUtVLUZ4Skh3ZmZqTzJOYkJIVjNXdnRMdWlmWG5LU2ZDNVpjdDAxcHNLQ0x6YmpQSWc5dlFrVW1MdGhVQnlJb0E0Mlg3M0p2TFBOanlmNnM5Ty1iWlA5ajg5T1FOZ2czQVRNc1JCUjBoN25MeUlpQVQzYzdadjdYT2hic0tmMkZaUldiV1pSbzJDSVFjZ0o1Rl9XTnZvdTJiTHlQY2RJdE83ZE9WUEJvblZhYWplSkR3SXJIVXBOclpWd1BqU0VIdXBFUnZJaE5PRFN4UmI0TUF4Tmd5T1Q1RDM5NllaZVllU2hEQ2s3b0tKOHprcGpTQ3Jvc0RxTzZmTkFWZ01BNXZ4RG11dHdMR1AxbXRJSzgyUkVQendZV05Ndk9lNFZ3YzUyOUkwMDJTWWhDb0dIaTdiNHpmUjBmRHV4dTFhRkJ5cmxmNFRlektkTENNc2NreUJUbldiQU1mNVF4bmYyellUTzRvcmVod1pHUzIwa2NVNEJ4eGtsVGtBOVpQQ0ZzLWhBdUxadk9GZDN4MVpRcmk1V1NPWmlrcGwybWNJdk9udVFqUkM4UlJsWjdzeTczSl9kUkhrZ09zUXkxYmthY2tBSFE0S2djazJucVNmODZzMUNpYUZvQ1B2bWdlT2h0bVNvYkVvV1RFQmN4Z3RkdHNfX2JUR1BjY3h4bTdZWldCOS1EMXJuSUZIaF9MeS03TVVfb0xISzlCYVFKUmRjSU9LRFh4RjZjREhkRl9qc2xNNU1nRXlDYkdHVU1EampDWHJvd2dqNVFHanRDV3hEaDY0blZaRWNENTkxNEdRZ2doX1F1RGVhT0EyTlNSbnFVLWktYVZtLS1mXzhmT0FzYkNPZG9URV9vQjBpR1hNbUE3SDhzc18tLVExOGhkY2hQcHg5NS1CNEpGWkNDdWNTMTVoekpaaDFUSFg1akIxZEp5Z3BaOVpfMGJ3Wk9aTGJRWHN6NG9IS1Jpckxvci1lbE52MnFKd094SG5GbE95OFQ2MTJ3bGZ2aTU5MUh4R2YycEMtblFyN3V1NGpFODkuSzg2Qk5tM1JMWEtfWWtlc29PMTNNdw"}'
+    body: '{"value": "JkF6dXJlS2V5VmF1bHRLZXlCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLmNrZS11R1VzcWpwbFJXX1NqZlBnT05zV3BNN2J6cl81YjQ1NTRwV3BpUnk5cUxpZWpINzBGLUVIUXc2MnhlUGx4dkFHUFAzOUh3OENZT0xWRnpyYkRnR2FXVmdPMWV2TGxtZWZpNUVuUXY3cTBvVEw2SklQa3p3akJxd2drTTFmWW4wOWdhRzlMUTBBOUtTUmZCTUhjd3gwQXhqSG5acENMc0xtdG1KZDRFdGZiTGhJcGYxVW9rS2tOeExpRTVqaDhtQ1Q3c2hudldjSGdsSWc4X21Zck1UR2JjQkV1b1BfeG1lNGtQMXB4V09uaXl4TWh2ak1MaWV0dzQydVVCSnc1T2xVQnFrYV9iRHpuWDN6YlA5TWFQZDlQNHhFZlF5V2k3SFVJTWZ1bXFSN3JIMXdVWXNMMDEtVzZBbW9nMGpzV1RjLWVDME43M0RmOUtKdnRHZ2NHQS4wU0JEeUxxMUJZUWJ4RHBzUkw4Tk1RLm05cnhnRXdkU1RjQjZvUXlycFVkRmFsZ0dFUTlhMGtMcUJiWjFUbVJ4WHVPcnJxQXZua21FeUU2SXlCeS1PYk40cFJ1cnNTZ2dyRmlPQTV4WUdvSllZbFFuSGVzMXJLVUdCbldFbFZ6ZHRnYUpUYXA3dkQ4NEttaVRtcjZMMlZ5eFU5MnJmRjhsaDVBWmpNTkpVQXVKWGJOSmoyMXJkRHltSGh2R3g1VFV5Ri1NM3pHdWk0U0dldk5zT2ZpeGJIQVZDRUlNS01WR3RYUVJnX3VQQzYxb0E1WjMzc3BmUlpnWkFzLUZkdnNrbVRrRmFEZkxFdUV4Z1BfZzJrYVFaVlRoeTBCbjlucHg4eFEtU2dUUE1JRlg4R200aGhiTHNLOG1NM1o2MzZmSEtiUm1fSnJWRll1bXltZ0IzUm1RalNUQWoxTUg3VTlscndoSXVZTVJySUM4dVU1ODVoZzU2ajNST0ZGYnlYRm1HNGJPbDg5S3FjTExuU1lnbnk1cWd6OFJIYlhsczU1c29mUVl5Z1ItZENjRWZQUUdXUWpkd2p0cEhaM1dqeU1pTXdvTUlaWmt5cHJwdngzRHVQcmo0T2ZTaGNLOEJKWGY4V0dJUFY5aXNUOTk5Z25sdnBXc2U4VUZGb2ZfOS1TbkY1OXRyLW1qZElxVXAwbjhReU1UTXFwanBZbXR5Rnh0b3d2eHY3UGg3Y2lrSFFQelZ1cVYzb2hmZGZPajVkaEd0YXFSRWt2SXprRWR3Q0VPeUEyXzFoa3R4SFZETXJqc0NlX19pbjlfeThTdldfOWhha0ktbWVDSlJzdTYtQ0ppa0lXa25LVWNBZThTYXNHZk9mNF9WLVFyOHVIdkJBRTRMMXFma2daUlEtSEJGeXZVUmRZYXlkZExTbTFIR3hqVnFmZmVSbDRPNjBROThMYjRqaFRjQzdBNFZQek9RMXRHOVZZeHE3MUpiM2lXYTgxajd4Q3Q2M2YxbFNVelR0SEtodnBNRmFMVDhLQ0xjOXFMaEd6NGZ2Ty1ydDYyODdkMWFiM2JoamJlVHVmZzZremtwdFp0VzdLcndfV2IzcmNacmR1VGhvM0prTWpoLU05RUJvbnNwNE9EVExlU3lmYjVDMXRCOU5oYXJGVWQ3ZnhYUnVrSFhEUmpoWll4OGxJaEIySmdFTHhmblBZclBWRTd5T2lpMkZjTXpSTHo5clo1SjNZeWNIZGdueDlFazA3Z3psTWVFcWlUNFhra2hFZUZfVU5uRXVCandSVUY3U0NUaVR0WFJnMTVQVGdhZUZiOUZpLWFsRk85ZDVEQk1lMjFrTVpGaEhkb1lMd0QtaFRLQ1FrdTJUdHpfdFNxS3VyU0g4eW12UVAzN1FIYk9KbXR1SW45RGlMVVZiWlIyS1U3OUlBOXhOVVJPX1laWktEZUh3TFBtV1FKX2prel9BaFRIdmFsanV2TlNDLUpBaEcyUlY0Z2ItRERjY1BpcXUtM3dXaU0xbHJiaUVkWU5NeENaMjk5RUpaOUVvdW1uV25nS1k3ZnpURDNiYnJHSENPemRRSXVTaVRhT3F3RUt6YTVZLW1WUm5JS1hLcWp1ZmNkNzMwM3d0X2JWZUpTU094ejV0cUVTTXV6MTZhTk9CQmhlX00xZXVuN3l0N0JVNGd1NEdMNkFQRTc2eW9VbzNxYnFiRFdWWTRjblBJRkZhQ19QUm83MWFOclotMTNJbTJMbDIyN0hEYl9rNXpuc0U4c1JUQUYyb1czbk9aVE44MnJ4V3E5OXJuckZYbXg4TjA5NmwxbXQ2UUI2YVp3Rkp6YUxmYmE1dmxMMmNmZHRfS1NWdzZDZ1pyLW84LVl3Uk5kQkQ2WjdRR2pYQnpySVJaMk1PcmFieVdOaE1PemZYbktMdVBoMi1VamNRUzgzRS15Y0xGNUpmeWJWVXhtVUUzNjg1OFktMy1OcmVZaXdsR1FYOHRobVVRNHlxZ2ZMLVZQSzluQ2lkRHYwekdqVlZDM1ZQRDBKQTEyUFVyVWVoeXBEcmtucDBXekhCUzRyb21YcWJCVGZBaXo5YmNjdS1RSG5TclJzU3JMbkVEcFc2aXdQT3BLaTVXRHphOGQ1ZVBndjVEMXpUejVweUg0Z2hXTmNLSFVTVnVMT3p6ZFdDbVE0LWZNUEVoZy1GZlFDYmJXNjlLMlM5a1NZb0diaVdVcjdDdmxISnpBMzRCYndBQ3hYMDh4em1CY0RRbjJJYnpsU0xZcWZFTkZMSGVlUEpFTzViMmNhMVBBRlRPVmM0b3R0NlRESmFTRnZ1NXU1RS1sa3cxT0xHVWVHXy1zOElLX2czMzkxZVREWlRyMWNGbE1PeGpCbjRwOWdfOTlsQnp5bVQyUDRCRzhtTDB1R24wUHZJZTRtSzZxcFM2WXhJMC1uQVhGQjdYNG55bWZ2NU43QTN4SEo5YzRCUU5NRXJoX05FQWFIamNkc3JrRng5M1ZoajhnQTlIT3ZWSll2VmgxbWtfY1Nqd2NhMm1JZmpnRVNjSVpHNmRjV0NtOXpJSW5SUS1fZFVUZGd5UGo0dnBJdE5PbHViajc2MmxMempHQ3ZXLS15Xzl4LWVxcEt1bkNNLVVjN0s1cnBUOGhzY3BvRGxqWmF5X3BMLWhCcVE2cGF0WHlkRzZxc0VNN0Q3Qi1NVFRRU1VBblUzcmpVZG9ZZ3pjQTN6WW1feHV2UDY3bER5cDZzb2hacTJBWHprSGcxOGx1N1laV25uWGlTellHX2xNa3JkR1BqODNrYWlYcmNMZEExaXplbDVVUjJyVFNURVJUWjg0eFFUWnlRd0trN1hEMHBvNDFoaldYRTMzWVBYUmo4TTZWNmtNX2FiZXB1RWhaY25nbzR4RmRZdTFCLThsVlJXUFN4LTJZQmozbXlHZ0FDaVZrZjQ2NC1aYW1SWFBaamRmV3lvSThsdVBnVmZwZ2FxQ1RqVjRXSk13WTc0akdlTDV6UFp0bmN3NW9la3ZtZEJTZGptOHdkeWQxcTByUl9ZWlFIVHplcnhGeWV6dk1BS1VITWo3aGxUX1ctZFFMeU5EeG1CcmlqQTNBejV3bzhpUWRlcEMwWlRjclRNelFWQ2E2RC1YLWFVTlBzRmZRX0VZandYeFdobnlaX3FzeGlSelNHSDF1OGlLSXdRUmMyVmxDaUZQOHItZ25MTk1GLVhTaDh3a0VRU0k2SEtVdzhEdFJoMHFWLVVlVXZJTWdXa3l5bFNZVzVuMmFtV3g1R0F6VDBmYmxlVjIxR0F6VkpUNEhNWVRHcTJCVmVGbnZWLWgxRFNHYkljamd6MU1tZGhBd1NxMHZlVUM3Wkg1N0pKaG1QbmhCenNZZXhVeWF1Nm5pOEU2bHhDOHc1TmJkM1ZrTm1SZHR4eXNBVy1fR01HcXRDU2c3RFYzTUR2SFNJdndjOUhXMVRJWkV6RGxaUHNxaTdCOW1janhhOWkxbGRjVTZLQm5xQ2FNSlpNdkNfa3NReW12amswU0ZfcWNXTDgwdFl0c3ZYY3dwWlpZYll6Nk5WZGtzRmZTQ3NkSm91Wmc1a1FfeXBDWTFRcEtYMzQyRDVoLUFXVFoxeHRSSmxrMXNtYWl1dzk1ZGo0M25zVWF0clZOX0F1VXFFQ2MzRU5leXJCY3lrTGlUeXVvdGhnSWwzZmZiMXItRmJrRmdhbjg5ZHBkUjRHenpBNzhqVHBBbTFUQ1oxOG40aks2QkJEQ3JKdVBRSGdLS2RpWVpIamYzRTVnaXN2YTJtWFlWQ0VUVjhmN1NRTDNNRUVlajdGdWljZWEzbUZqVW02MTBHMzFzMFZjQkplZGdvTS05eDE2MF9TUHZqQkVjT0ZNU1lrd0NMZVpRamVVYUdQejhvNldHMjhsellyVDhxOGlWcUFHdGVOTDJ1bWZpcVlQODNkMG95VjJCSGRMNmxUTzVDcW1zcVN4ZC1QZ3J3Z1VzN2V1RFdrWXFKRnJUdm00eVFXc0tjeVNwVVU1TlJDZ0F5REw4VS0yaGRMbWFtaHd6cGYxakc1MURxeWxSdzFhWkZ2N2xGUmFoTlpUTkdCODJvZDB6SlV1VW9NZmpKMUl2M3NsaXBacWFNanNRUDEwOVFhTVlZeG9ONWt3VnNfc2hvMmxIbkdZcDJIT2JnRGJDLVhfV29wdjREVU9OeGVGTDRjYmRfSW1ia3Z1aERVMHNEV0JaZ3k5V01xazRJNmUwOFJvUF9Dc0ZWZC1GSGpoNFhhVWU0QUpQREhpbDZSSmFaZFBUQUplTW1wNER2RUhqRV9hRkhGQ0pmYjVYd2dNaE5zMTQ4LVI0eXIwMmVlZlRoUjNmRW1JX1hPcVh1VUZWRUFuWHY0Qk9JS2dnWEhzSzdaMFpwNi1SMTV6UENHNG8yMmN4S2V0ZU1YZ3FBN1VDaElwWTIyTVdrVUNZdmdZQ3R2VWxNTlctazdXb3VvcGJSWTR5N3loQ3YzT091Ml9iVkJ1bjJWZnJFelZzMDR6cEVzbC1DekRFZkF6UGZYZlFLYTFXdFh6NGpRZFJKWWZ2elRLVTZGUm9HLUMwazRGTXBaYlg1Y1BWOGM5YmJ5RDVNczJhYXhzMDRWSXBJOXNzbHh3S0s2ZkJNb0QyVy15X0x2RlBqbU1YY2x5YzlrZlYxM0dqQ3Z5R2FTbGtvVkVHeWZXY190Q2R6RUZwR2hfYXhkWms1eTd6aTJ1anBpeU9uUDZRLTFhSVFRYzBZdVh5M0NTQTk0M2JJOGNsOWRoTE5Gc2dLVldGdWdUUk9GX01NRnNDTVplU2tnVU81SVY3dEstaWNwVjBzTVJheFg0UmEtdXlMSzJKR3hkNEd5dGZibmdSZ1p1eGNncFU3dmNKWDhWSkZWcVFmanJDMnVjN09DbnF2aTJQTnAwR1BTc25XQm1kdF9JWjlOakxTZzZELTNGQ1NpdmhzVVZCSXFGb0ktQnZ0NG05WTVBdzBlNm4yM3drbGRJT184bjktaC1DTVY4SWIycTVDNEdiLXJ4RDI5ZWN3dWN5bmFZOGhUcTlhWm16b2NtN3dQQllQNEtaMERfcml6QWFBS0drLW1XWkhNNHRPY0MtX1puSEljbFlxcmV5aEpCNTJkbHF3aUxzSGlwcmh4Qkp4ZG03bWNDZnRNM1h1TGE2S05SREtQcEJ4TFdHSlJoaUlnbGJmYmtzNTJYSXE4U2RxWDM5eDM5SWdTaE11R0lBVzdLOEdWX0pxSE5uSTZxZDRIMEhxejN2bkFvY1pXeURna2dwSHpuLWFEMWdtXzBPUHpTSVBnS09rWER5VUNBd1VIWk1yT21pZ2V4amRsX3RLUEUxUWRoNTBtTEVVcTNTdlNIOEdVM2JXQ3J2UWdKQ1Bja2hUX2lXUzFrVHVwWmYzYkVsQTA1d2I2b2luZkZYVjJJTnh5dF83RnRhMEczU2VYVFpscmx6MXBadmxPNURwbThNaWYxenpFWmpYbndfYzY1ejRwT21ZREpDSDB2cXo1Z0J2NHgyRklyV0hvcHdNSEhsbkVSWTB5UkY5cE04NGdfRWUwbzF0TkhzcTM4VDJtczBVMnZLYnltanJ1LVdQc25OQVVhY3NUSWljNnotNmlaRDh2dnN5ejVBb0E4a0Zvci1Mam1lc094ampjWVZLU0k1a1h5M0M4MEJlYzlYdDRqeWtjRkhoVDlULWxWYXNTZF9HWER1ellEZ3A1R1NsRV9FX2JUT1JrZ1VkR3gyQkVIVDlvV3N2QWxnbmcyaFl5aUE3Wk5ldUlIVHI3RnA2ZGJteEhJUkZnU0JOQVk2Y0tYRlBFSjl4UDhJS2UwQVhuYUVBYWsyZ2xsSHdoM2tzYWJPcTVNZnh1bExIazVtcjFZa2RjYnVfTEg1RDRYYTlVVi10VEIzalI1R3dFU09uOU9jRnM1ZndtZnRMWGd1dTZGSUpSOFRsTGZyeWtNV1ZqVUM5S1ZSMzgzVzBqVmdla2NGTHo2bE1xQURiTkJ6dWpSVkZfd1pYLV9MR3ZSVzhPNWItNUdFb1FOVzdWdnFyTjRzdTdJNENHU2YybERVZmQxbW5YYWZsVUNoMzJudkJ4UXROUzRLWFFFZjNpOHdGNWFIdUwwLWhEMnpueGNGWFQ0U2VoeGI2bURJZnB4THE3OHVKeFNsRnBsTURPLXY4bFNLYS0xbmV0LWZxMGhuam96M0x6SWd0ZWRON1padGtPS3NfQTdwaDhJUHNlZ09OMUtRa25XZTJNZy1nUU1Ud0FOLWZKcTVPaGhvdVhWaDRQSE5QZ05Yb0VFWURuVjE2S3JWSWFna1h0emZ4RFZpS1d5em9OTjh3cElSRHdWOUdUbTRkRlFqMngta3pFbGpOVFRRLXpvRHh4LUxfZ0ZvZHR2M3dmem1ZOVYxRjBnSE5lN3dMbFV4ZHN4b0hUQS1RTTFuYUUydUoyZHRya254eHBNWHYzRHk0dGo3Wk8wd0R3TUx1Z3BCT1NfM0tmWFpKa3lPT1pKOUZRYlk3ZHJrY1QzZVZmam0yMDJVeTJSNE5vVWdiSkltbjd2THFjY1B0UUQ0TkpVT0xYLW9IdWNCOVNBLUVfYVBlNU5wRnFKREczQ0dJOWFVNXJ2TkxEc3ZFdnlkT2hEWk9ET3ctWG5sTEFNMGlBMG5UVGlwdmtPeG1SOTM5dklHU3g0RlpZQjQwMERfbENGS0dzbmRCbkhjektlajBZRVRxalI3WkpjUTlVaEltZk9GdW9SX2U1MVFHSXZKeUNKSjZ2RFJZUThVVWtTYUdTeFBvSXZaN0E2NFJKek01MHJFSWZQSFAzOWMwSTZXczU5MDlHTm9Da29nWE5KMTJQbEpLZHc1elVianNFcl84YlRVWFFSellBOG91TWV4RS1aRWh6TFdOMGpIQlgyNFJSRTR1ZzdSQ2FjY2VkOGxYYkZtZ3VoQW5pbGVQTFFfODJEWHRvVXR5Zkp6Uy1aV2RMUDRXdEV5NXAyZUxIVWQtZ2I2NGR0UlVFRWpfZ0N3Y1RxbEVfbFJlQWR2TDhPV3FCQXM5SzhmUjF3bUk5cklCYnZQVW1vU2VLRm9ZMzZIaGFZczN6aU5pQUNKZjlCYnF5am05clJDZmFXUVdqV3M2cFhCcjVSbVlVSk1UVG9pY3RYZFU0Z1dsMC1vUDBQR0FLRGlIMWgwYUNUU0tjVTZKeGh3N0dQSWdvUXg1WUVzSDljdTIzNE54NmxpM19SRWc5WEdVNm55WDZNMl9NVWNiMzRoQ19Ld2Nrbi1XQnMwbVZ2Tm9FdE1YOElqb2xGRUw2dXM0ZzlPLXBicGFXTkdZcEpoaTVxaTZCTzRaUWJRWkRFV1FncE5SVzZIalI3RnJjbmxkUHVwTmgtQjdxQmVTaDZMdFdZeFhIeWNUM3ZIZGNSaUhnZE51ZkdJY0dXdVU2eVRxcG1DWUx0ZG9lbDJLdlczZFMzTWtFQ0ZLTjdKQ05rWlZwRGtQbjQycTEwOWQ3OFV6WUY0a2VYNHFoZ1Z4Q1ZpOXUzdGtPMURUNXgyVDd0b3VNSW1tMmh5NEl2SWxNMmF0OFpwMURPaF9WMXdDN3QzRmxTOGhBU1BWRTVuckxEUEN1c2V0VE5VUTlpSmExU0ZuWUwtck9wUG1DMy05S2M0YVp3TlJkQlpRUTFfdDBLYW54SnhQbHZhdWVCN0ViX3M4TnNGbHIxVkhCcVNKd18xQTc4d1ZmRHFLNm9BWmdZTFRieDNRNm5reXJFV1o0U1M2WmdOMUVNYXVHYkxOdXZNR0N5Vk1fdGlBNVhJNjE0ZmJLejM5VVN6TlQ4Rjd4Y04yYjJsSGhZNHF0b0JYbkdZTlZmbF8yWks0Q0RQVzc2TThwby1IcnBOb3lyZUI3anBBMkQwWnJST0RCTnk2WjNiN01salNTUl9NMmxVMVdkVFBadENZUm5lemVvZ0E1WjVTd1ctYU9YMDFCTnBqeFJBX3o5SlgzVi1RWGFRbjM1OVpkckFWN0lzeDROclpVMUpvN1F3WnlGUHIwSDhEekVWZHptRmlBV1dDbzYzLWZhN09YY284OFp3S2FzcjVnLWJTTmZHd1FHTlFqRlh2WjdVdFBSWWdBNGtCeWFiSThzNkNkNnE0bWUwaC1EUkhjTmVIOGNIcTZ5OXZ5NGhFeGg3SjgzZG9JVVpqZ1BTTDZ2RDQ5ZnJpMFZjTFdiTTFrUk5nZmQtNDIwWmdkNkpfUDRkNFJ5TlY1NGMzaUN5dUdhNXVYajM3aGE0ekIxQkg0ZHJWTS0xSGFNeWdqR0NqcXpaMk41cTFoRnZvWnlxeDE4NWpVZmRoQnpFY01XUFFoRDlpSjRXcFVKWkp2aUNWeENsTWwtTk5NSUMwX3BIZkI1aVZFdnYxMWVtYjV0VVJ1SzNQRWJScE41dzR0eE1MLWhkY2ZPTGxvRElfOVFZZmVRSWlpQWJtMHdZUE1DZlhyREg1dVY3cG41Z1VGNGg1R2NLQm1KODkzZDJtbHI4Z3lIdGttWDNlVDFMNXhyWFlGRzZhc2tNUTBtNFl5Tl8zMnNNTkxvXzRfdmtJMEktX0pzYzdqOGI0YXNnekNncUtPbXNfOGVrZHd3VkVWZHJaMDFQTk1hakl2WXItc0RqaGtidTAzaHdHZm9IbF9hMm1VaFNfNGFpdmstMjg3ZXI3amh0aE9PYkZvQ1FidVFNQ1o5cVN0UjFQZUd2em9mLWszU0lybXJfMTRkWmZjT29oYXZSWlhiWjc2Z2pRaTNuejRFX3doaFdGcUU1UGxCWjNtTWc0RVFYeExTa2MzZFVXY2lSTFBIbXZIbEY5XzdEU0JsRmtubFUzV1pHdnI5aF9KZHhEVnl0QUNjSVBiTGZMb0VwTkkwNFVZb1RNbFo4VE16UDNjMDNqRWlIUVN1eDExRlZsa3pIdEtNUnBpMEJScm5IYWMzcXpsaEstS2JZOGNKalVWd0tVZVRnLVNWZjBLSXp1WUxXbXd5bjVTdVlrYjhkOHQxd1ZUYXhZMTQ4Z0lmUGY1bzR4cDBPdk5YaHcyaGMyRmpDb05vNVB0U3ZEbVJXMU1QWnJrRGxfWm5xMVpBdTdmeWtKdF9wWnpYRUp0RVF0cS1fM1kzR0RGV2xnaHZaM2JmdEM3b1pVSlhseWtkVUlTaG9YWkJ0X2VDUTRtTVpJZkY3OTQ0LVdiQUFraGpBUVFFZWhKX1VlZ1BFanNFVG9uV05KNUxYMnVpNThHa2hDV0pVbHl2ZE9QOVd5T0pDLXRwRHUtR3RUbDZKcUliZzEwdkRGYWpBM2Q0V09fM09STmgwYWZrdnBGYXdXZkw3OWUyaktiSy0xSWRibExIOENPWWF5bnEyWGFzakg1cjdrZmNZMl9wajZmNjJhWjlLUUl6RnJEemV0QS1mbFI1Zk1qd2x3Z3pqbXdibGVHQmVobWhNQWw5WW1iWm9rc3JjOTQ3THVpX3hUVXFMQjVvdG9sN1VPcjR1MlZlMzJqTlFhWXkzOEFpR1dYYjVfSXlXM1gxLVNaV0laRHdrUzRBa0hxNGFnRXQyV1RFOHVaSDBlUDdqY29ILUJNMVpsMG1FSXN6empJUXM4UGNzNkQ4ZTJBRUMxV2k3OUNKLVEzLWUyWTJKU0psTVFoQmxfU2lrc1FsRm1WS3NWX3RWb3B4V3hWYmFMODc4Z1k4X1QyVC1LWUM3RHZWeURiM1h1bGFPbzBMTGJZNDEwdVJ3YnUwYWFsS2UwN3NWRExuQ2oxTWdsYkRKb25XbWNfWExkMUJ5UTVmcmhTS2t6RnQ4QUw1WXVLUm1zVkZod3lrd3N3ZG9CUWdoZFBpeEE4UmVMWUU5X0Zaa2J1c25lVDZHNjhnaGhqS3ZUYllYY0QyY3p0dWxoSkJ3dVNkVElfaF9xb0hGM3FEOHlIQ0otUkdNVTlKVFh1angxZC1iQXd2d3FYREpOcldITjF4NzJocmIzejZWa3hFdm4tLTRWSkNLNU90SkQ1TXNQNG1FVE54VGdTU3Vnc2htcXFScDQ2Ym5LcklaYXQwUTI1b2YydXBKUllvbzBFZDFWajAyTlVmQm5PS3ZKNXZDYmVSVlVILUpLSmNHN29WbTNJSVcwM3M2UW5PVWtFVUJmU3NYWGdYTE1JTlJjRGlYRzFtazBUWk5EdnJlNkk1V0xzLVdFbGhLX3NNYUJWc09PUDU1cW9uN1EtNXMtY0pfMUtYZWZ5aFhkZWJHcUhNRUszMGpVSzBJLWhpWlFJMHdFQUNnZHRuRlRrLUVScFNBbGt5dGZOeUFGdVoweHo0SW9LY1VubEptZVRnYTByM0hpWHVoaV9fNUxYT1VFNGtacE1pRS1vMUlyVTU1Y3RBbkNYbWN1aFdLTnBRT2NDcGUtbWhyQVc4aFlPX05abzQ1eDlwWlQ4NUlpWFRZX0UtZVNhZVpyVk5xN05pUW5TQ0FmUXlaWnVvNVhlNlppSnRBWTlYdEtxcU10cGJMTVRRQlNiaENFSUM0X1RMVWpSOEtwZnUySFBYUU5nY3FrZ25GWExqRDZ5TV9pSXNDUzF2WnJUaVh4M1lUOUVRQkJRRGdBSUxHd3hPUlRNWXluM0dCS3pSVjl4N1VOQzhIaXFueXAtZHFkTHd5cXNOeWF1OU1CLWQ2b0NDdFhiWXByR0d2NGxwSUM2MlpqVlBnM19oMFphdzZaczU1OVkwVmN1ekhCTHJXTUJId1NEaHVodGhpUVQ5R0pIYlF2SlVNU2R6Y0x5ZmZ6Mm10T0d6OHVIRG1jdkVpOE5ONGZORTFLY3dCSWZXdFhhODR2cGtmTi15TFhtdEgwMjBYX2NRa1RkSC1hOGNSQ0Zhc0g1aVl2WS1ZTTBPaTdpQ1NnMFJVOGJ5eWd6cHBnSDVKcWxVTDJzd2I0cV93aGFZRDVBQ2t0RVpLeEZxenBPSjNwVkJKTVRiVkttd2lTQ2RQMVhMemFoc1VJZWsxMjN5WHpqQ1BnazhOSE0wSDF6RWstQjRfLTJDV2lqS3pnVTZBVG1Vbk1IQ0RmdUNWTDh2RHo1V2ltU3RpVGVvNjRyMFQtZHZTMnZXWlc3YkZXUVN3NE53d0ZLaW81aVFDR1BOMktOSDl6LUxQT2VVNkl6Z1RhSUFKd3hlQmlFWkxST1F6bmszd01rd285dzB5N3Zibm9xeU95N0poMVZaNjFSSUV0WVl2M1lHQnN4Z3RCdG5BM3ZFdk00TGJCZkJQMm9xc3QyZjB6THdhR1k0ZHE4Qlpfc2RrZUNreU0xRU5iYkdqSjJwV3pUSUl2SGlQNjVKeGFGZUZNM1g2YmJ4TFFGZ2FlT0xpVjkwVGIxUjMtVkpSVnN2NVBHWnlYY0VTU3hlcDZpMXp4b25paWl2RmppN2dnbFNtNkRQNHFULWxKYW82dElDU2R3YTA0d3JSVG5YdDlKallZX1JVQlB0VEkyMTE4QkJjOVcxOFZCUXNIdlZORWxvX2doSGdSR2tDZlVjeXo0N1RyVVU0RW8tME94OXZaaFV4RHF4UFZkTTRmRWY3WFk3UzN1V2dNQmZuT1RJWUxQUVlXRWU3WWgtNTBmUVF4OW5qVlNHaUpSVE43RlVmU0tVMV8xSTI1RnVjTVRkNDZYcHJmNkM0LVJPYjdwTnNNbmlIZFJscVVjSUpZME5oZi1MRWMtamFOVkRGNFZqeEdZRHREM0dwWHZjU2JfcWtNZWd1S1JyMFJwbDJhLWV6ZmtINldWUUdTVnlGWnB6Z05Yei1GMEdINFR2VklCR2tkR05nUjhCYXVZNXpNSEpvcjVDSWt3YkREem1KTHJXYUN0djNhdF9GV182TlhjWFNUdXQwc1dfSS15azRxNkgxWUJVNk1tck9HWFJ2LVpHc3gxLWlnQTgzN0x0QUF4SlRCQmNUbFBWSHdEeTRseDJxU28tRUl4YmkzYjlkenNTTTRUR0dJUDBScW1hN04ydEtOcjdTMHlKZzRHeFhYT2ppM3pRV3ByemlNZjRpSEpub3ZWcUo2RWQ2eTVqR21pRUl0U2ZYYk12RHhWdE5LUlQ2bHJ6ZDA1LVE5TEplUS51WjZfQmRHWDh1UnBhbWxkVHFQT1F3"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['12599']
+      Content-Length: ['12713']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e275b0ae-9414-11e7-8918-a0b3ccf7272a]
     method: POST
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/restore?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/restore?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"twp5TkU7Z8D-uYg4WvuaToF9MQSj5P_DbSLc3Fdofg_RkwmuaVUh64dypT_Hp1Y84-Zsnj1F_Qw5HENv0FoIlEjyycrG6W1s1tzzoxRyV1e-rn51NW1Y74WiNt5D9wEvP5U5tD8-Meg81l6KJENeS8-UuJEOCNGhIJ4IfN3q0eLRDJe2gjcIP9TJDZ7MJpUIz-FJtglt3qnlJkdEMsbJd90V6RV42LszB1uvMFUk-5B_tPOzwr0xsahGxoX-3OT88j1DBrVUlRv9Mw0ecDDL0yjM7FBlxk-BaaObt4zpZZ8BPt8-SuyPUzDiQt_z7tiz46IT1SMwAUvzz0zCf-29dQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","kty":"RSA","key_ops":["encrypt","decrypt"],"n":"30woU5cp96sQuKd-sO5Tjb1ClkNUinYnUtpX8v-JX9KMk78P-f_I8bZQ-QR2w_tToFbD7p3XDhA-ZfWyviYjSVsj2H8H733BQn6ZkNrsPCBU15ESpqgBWjIx7UW2Qz2psHxgvTuPQsJKR_PByhHvx-8j3fNrSvnlsNWKAnsn8_ryFRG3IDjJKnCtRHJtNLsM9HX37tksaimu9Dhd-WBtWce9PC8ue1yaCwU_plDNtSwQGGUKKxNoiRAg2jxns9jr-m7-Ur6N675fzBu4v6WtqjiBD2eUSVPWuevN2Qb7vI_sX8YwCMOIxKE3aRVWSd3JdzVR-EbL4H-g7P9IfzKnTQ","e":"AQAB"},"attributes":{"enabled":true,"created":1504825713,"updated":1504825715,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['632']
+      content-length: ['635']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:27 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -482,19 +492,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2a3c58f-9414-11e7-84c8-a0b3ccf7272a]
     method: GET
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/key1/versions?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/versions?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/2ada263cefea403fbda6ca0ae9e4cc73","attributes":{"enabled":true,"created":1504820304,"updated":1504820304,"recoveryLevel":"Purgeable"}},{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/key1/867a6f24add14733a11d64f0a94a00ed","attributes":{"enabled":true,"created":1504820305,"updated":1504820307,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/2e8393d69c7c4452a15a9a62a3b32578","attributes":{"enabled":true,"created":1504825713,"updated":1504825715,"recoveryLevel":"Purgeable"},"tags":{"test":"foo"}},{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/affe336fa23444eb8dea212f3b66c8ab","attributes":{"enabled":true,"created":1504825712,"updated":1504825712,"recoveryLevel":"Purgeable"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['447']
+      content-length: ['453']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:26 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -506,33 +515,31 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "key": {"q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
-      "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
-      "e": "AQAB", "kty": "RSA", "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0",
+    body: '{"attributes": {"enabled": true}, "Hsm": false, "key": {"dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
+      "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1",
+      "e": "AQAB", "kty": "RSA", "d": "aY2BCD3ejBI4MWflWmq0pCZGgh_THwe5kpL2xX1-0vdGkX4CXVkpg0YLaZ4T_9y_pzWRPccvchcpvP6LkpAe1R_jsmfP8QedT2yDTf4T-mE1hyl4D5zyObHjQ-g6uUMT6FpeTgoSkcU90PK-lF31igCitfVgeSNIC7Fq-9ZywWE",
+      "q": "ANhW82o27OBdW0x-m5r5Eoa6kW8flyFv6p2zrRrO3bNlSHKkCMDOXPGNWL6gSp-iz-Z3f6gQJr1Y0gDHYe99_Nk",
       "qi": "AM5DzFUUIHcmr3ei8K_Zob3s77aBWvQASGEsxuSNBf0Euh1raEEYLK5fZBoLzRL2SD2hRgmptcltLcZJ7zs59hM",
       "dq": "ALrLoROF51P2590NuLe_9fIk52xGn4y8gJy4RnBOS_kZK8vovLIVvQTIYeb-qlBaGR7K8YugnoKBTZpkjbhnVUk",
-      "dp": "OWxWym28y_4zUTOnaqxaUh3MLmR8M36lAhWZeWo1fcanHjD5GMB9yXSxSwH8wsiQg85EuGC7SMwwzMj49wF-tQ",
-      "n": "AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1"},
-      "Hsm": false}'
+      "p": "APLv_Xe805-80_tsAX4jFYH6Dj-Rpqlenjq1nER6NMhtJpGG67focXb6A3cntR4_WRinHefdBqbvJ1Swyb7lcD0"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['926']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2cb98e1-9414-11e7-9d30-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/import-key-plain?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-plain/c39a67c7cd2242d5b16f8169497386b6","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1504820308,"updated":1504820308,"recoveryLevel":"Purgeable"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/import-key-plain/cf7691e5bafc4c3c88c59c18080a290a","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AM1NAXrGowNPjl4x_2zKPXSjH--EDC2EDtFJYUKIrr9eRlBPh72nilzS3jnrg5jUqtqPlQ07COgMq-N3N7yPyXdH3FOYFWpi3pMQ5oHZOMmZAWRzpVBWgnUXsOwpUyCk33lvRKFXgn7vs5ZKRqDj5LKLUqnPZlrUthm5ztprwS-1","e":"AQAB"},"attributes":{"enabled":true,"created":1504825717,"updated":1504825717,"recoveryLevel":"Purgeable"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['490']
+      content-length: ['493']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:28 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -544,33 +551,31 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "key": {"q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
-      "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
-      "e": "AQAB", "kty": "RSA", "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL",
+    body: '{"attributes": {"enabled": true}, "Hsm": false, "key": {"dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
+      "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE",
+      "e": "AQAB", "kty": "RSA", "d": "U8ohMChjSPuNpXMGEGjDQAIeo5WAHtsDWIaxMYXUHQ6J_D8DQrz1eBeeWDxhiHUxnmqfYaTAzX_0tNJ8hqheTRuPhzno310GmljpeWeJS53L5D1PzwJnzEZHsaq4KE-bxbcUnS5xHCpuUEaKRo5k7UQGf8oxb6Y0SOAJeG3N5bhdgwQP7CiLFktZ_I1Y18teLBjAQbY53sGwTRTVOTcPRGXHDfxo_MVFNU4J6Lk_rr996-J6eO-m0e8mJDloPJ22lS3rNu50Uz4Bki59HDlrQ2SIuNPTtKK1sNccQ4kpogAw46zjk0mR8Q-Xsu82ocNvWE-z7_-4bRsTnw8sRpQ0xQ",
+      "q": "AMA5dNKjhUNVzgBuIw5CrcxLU6vV5FpKrosa7yA-gLi6LFSKTmrdVI5SEOjqE6NW8FPLSaMIcEHLoEQWMdgQX3tNb-1C7Y7Hcw53RecT5L7qqEdyfYwkLucDK-7vMMhqFavQSiNZhcmLpFGbCSGHhBiYVleEtTvNKIO3qGxDPwYD",
       "qi": "AJThs8HPMV2J2NX7UjjkBQJ-ZwK5c_9gQzCFLtCnvjqX4qughFu21Kol8v55qThLcmKlxpjfojQOyisMIJxCcGsY0Il4pH2LCIA5YRgn12wUX_iaR5XBqFDXWYFh22mmZ-2ILwj-advBzZfslC8b7XpWb4Nylfm2AcgYs75BXhCJ",
       "dq": "L2a7wSmjthwVpZODP4P_2a4Fnw0qt31NF25340qmcWcvgVVtyvpzXHkuRFFcsF3C-9bYfMSa8g6locSbW_2FniFVZXuomxnh7IJLEZWdRdsVzjCUdxeBHWRx1ATV0cYfO_QsJBVyYWX3Ckyh7su9Lld6izBlhK6tu_VxKelXREM",
-      "dp": "ANsen1THZ3WXk3X6og7pi1nWuFhesWF6LxApnlo2bDA3EIJQ5TjGMLUfUR45-zEkotPQ9865KUA9X73uf4GAXdMEiEzDrvpf7wkqIFx8UYLAEIclPmtyBoS6plzBmum4b4c34MUI9LVBbdjyomEkZUtBc9nudBg875w51lyoPjZz",
-      "n": "AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE"},
-      "Hsm": false}'
+      "p": "AOK-ubu5LtLwQpq3gS40NYwvblm1AmwDDtsw7IdE07BRjo8rcmtMxzF2ro2oHy99gP15DEyHil0VqWP9tbre_DfW4XeLuzH12AL6zc-3K0BDmPy8sVrpy-RXJQLn-e8gIssQ4kgs0341NwsMkHLS4zkCVjdQThauNPsWKlTGH9KL"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['1693']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e2f986b0-9414-11e7-bfd9-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/import-key-encrypted?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-keyvault-test-key.vault.azure.net/keys/import-key-encrypted/8653c606c69e41c1b050ff6694404ce5","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1504820308,"updated":1504820308,"recoveryLevel":"Purgeable"}}'}
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/import-key-encrypted/fbabcb66b9994699b63d637495d2712e","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"AKpB7z0jIj6FOUZyyNr-xFuTL3x3Dmy_0CaPN6ploCgm2mhRt80DS6ySglgkFLT9qLwdWa9f4KZe5jvjV2PluC38wDLfj66kdaAAytS12Q2a7Fb4Uzd1kKFFA5xsLurUWo8BEvrjjBrrZAnplu941ykA4REse2xE5Q_GG8Snx7SOmJMfGAcIU7LhS1pnL5-BL3ixkAcDF2X8EIpdajTC3GbFRmZaTZLn6SxtATuezBE6OvddCt6tgiLPN5ocpWOngo6gHlbV_UIuZbeDM_IH11eXLAzNrO8POC9Lc_P1aWgvK0KoMgdere89CzDjyAhJDg5kPFiJ0nwHKuycNkKDuaE","e":"AQAB"},"attributes":{"enabled":true,"created":1504825717,"updated":1504825717,"recoveryLevel":"Purgeable"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['665']
+      content-length: ['668']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:38:28 GMT']
+      date: ['Thu, 07 Sep 2017 23:08:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -581,4 +586,31 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.821]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_key000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 23:08:38 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGS0VZVkFVTFQ6NUZLRVlCQlpJWkNMSTdLWlZFQ0tFRFlNSXw5RDEyNjg0RkU5QTcwODE4LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1125']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_mgmt.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_mgmt.yaml
@@ -1,32 +1,58 @@
 interactions:
 - request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_mgmt000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001","name":"cli_test_keyvault_mgmt000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 22:45:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1118']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [44649a30-9414-11e7-9d2e-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:34:02 GMT']
-      duration: ['1853423']
+      date: ['Thu, 07 Sep 2017 22:45:10 GMT']
+      duration: ['522960']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [7akEoJBB3jXdCcddmuqIriGupZolWpVIrAvUTJndNgo=]
-      ocp-aad-session-key: [9lA79ZKlHZU9AarHE3MDrEjWjn-mKRKQy3dHEXsm3BVUExBCIk47Sk50rq6KfaLN4nGvBQj8j3boGDC6OU74-7B8CUOPy5d_Zj3-oFRePOau4WmFaEE7Li8BSb7OvJ3_.e31xTPRNQuI-p4HhuyxQJGG1aMQTIqDf5Ql3AtOSIQ0]
+      ocp-aad-diagnostics-server-name: [4QNX61j6pooq22+BFVvaz7k51+Cai/QsoVwfLYwcLzM=]
+      ocp-aad-session-key: [1zKI74Td3K3Jqxnu678M1vc-21Q71tMKBzIv4QOmDPXZBQpdqQB5lIcfAAHOw2JO8P_oNMhdjgb7mxlotA_mezGdr6_-DuhEvIkzKsSVc1y-TsQhugLRA69pCJtHJ_kH.UNAAsG_v-0YLTCEgrD7S_jZXfh7ILUSkI5gaQX810jo]
       pragma: [no-cache]
-      request-id: [fddd50e8-7bb1-4638-a922-32253fda035a]
+      request-id: [991e284f-8bb6-47ee-b20d-ebfed43b399f]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -35,36 +61,35 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
-      "A"}, "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete",
-      "list", "update", "import", "backup", "restore", "recover"], "secrets": ["get",
-      "list", "set", "delete", "backup", "restore", "recover"], "certificates": ["get",
-      "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "storage":
-      ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
-      "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "standard"},
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "storage": ["get", "list",
+      "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"],
+      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
+      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
+      "recover"]}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId":
+      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['746']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [44993ec0-9414-11e7-a0f2-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1010']
+      content-length: ['1069']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:03 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -74,7 +99,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1125']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -82,22 +107,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [45918170-9414-11e7-819e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_6wog_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3037']
+      content-length: ['2834']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:03 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -108,54 +133,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault show]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [45a5578f-9414-11e7-ae4a-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1011']
+      content-length: ['1070']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-service-version: [1.0.0.179]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [45dcbb40-9414-11e7-b717-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA="}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['1259']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:05 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -172,22 +165,54 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4621655e-9414-11e7-883e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA=
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LXkzNW1xenJqbG1n"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['1369']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 22:45:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault list]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LXkzNW1xenJqbG1n
+  response:
+    body: {string: '{"value":[]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:05 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -204,22 +229,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault update]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [46639e80-9414-11e7-bef9-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1011']
+      content-length: ['1070']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -232,37 +257,36 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
-      "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/", "enabledForDeployment":
-      false, "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete",
-      "list", "update", "import", "backup", "restore", "recover"], "secrets": ["get",
-      "list", "set", "delete", "backup", "restore", "recover"], "certificates": ["get",
-      "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "storage":
-      ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
-      "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: 'b''{"location": "westus", "properties": {"enabledForDeployment": false,
+      "sku": {"family": "A", "name": "premium"}, "vaultUri": "https://cli-keyvault-000002.vault.azure.net/",
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "storage": ["get", "list",
+      "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"],
+      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
+      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
+      "recover"]}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId":
+      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault update]
       Connection: [keep-alive]
-      Content-Length: ['837']
+      Content-Length: ['841']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [468c5c2e-9414-11e7-ab76-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1010']
+      content-length: ['1069']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -272,7 +296,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1123']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -280,22 +304,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault set-policy]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [46e26b70-9414-11e7-bd3d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1010']
+      content-length: ['1069']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -308,34 +332,33 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
-      "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": [{"permissions": {"keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
-      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
-      "certificates": ["get", "list"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: 'b''{"location": "westus", "tags": {}, "properties": {"enabledForDeployment":
+      false, "sku": {"family": "A", "name": "premium"}, "vaultUri": "https://cli-keyvault-000002.vault.azure.net/",
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list"]},
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}],
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault set-policy]
       Connection: [keep-alive]
-      Content-Length: ['587']
+      Content-Length: ['591']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [47127c1e-9414-11e7-bf7f-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['770']
+      content-length: ['829']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -345,7 +368,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1132']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -353,22 +376,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete-policy]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [47494391-9414-11e7-868d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['770']
+      content-length: ['829']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -381,30 +404,29 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
-      "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: 'b''{"location": "westus", "tags": {}, "properties": {"enabledForDeployment":
+      false, "sku": {"family": "A", "name": "premium"}, "vaultUri": "https://cli-keyvault-000002.vault.azure.net/",
+      "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete-policy]
       Connection: [keep-alive]
-      Content-Length: ['259']
+      Content-Length: ['263']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [477eab70-9414-11e7-99af-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['467']
+      content-length: ['526']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -414,7 +436,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1117']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -422,22 +444,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [47c48e0f-9414-11e7-8c95-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_6wog_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002","name":"cli-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['3037']
+      content-length: ['2834']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:08 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -448,22 +470,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [47dbbf8f-9414-11e7-bd2e-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:34:09 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -471,7 +493,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1123']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -479,51 +501,50 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [48e31d70-9414-11e7-86b3-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[]}'}
+    body: {string: '{"value":[]}'}
     headers:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:09 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
-      "A"}, "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "standard"},
+      "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['156']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [48fce700-9414-11e7-9ef3-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000003?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000003","name":"cli-keyvault-000003","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000003.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['467']
+      content-length: ['526']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:10 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -533,7 +554,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1096']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -543,27 +564,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [49ad724f-9414-11e7-b9fb-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:34:11 GMT']
-      duration: ['533369']
+      date: ['Thu, 07 Sep 2017 22:45:20 GMT']
+      duration: ['615172']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [6jK4XfmKxcTjGA4F0kismAWyAzj8N/JPhQDwsSuw5/U=]
-      ocp-aad-session-key: [ZjLBfE-gNlI9Z43yqew5YEzrR2t4rGJOkxsYsz-fJxUoWvpW8QOd3b7EVKnPxz08UGe5Buc6HwF55qdlS-XxNvK3LUZwHu52pGJX5u8kE-vkahmPdTYVObXStKyTjHDU.kIUWvZvAKSkzFr7GOp-Ih_bgQ0OMzUCf2RRtwCPLw4c]
+      ocp-aad-diagnostics-server-name: [1zUcSmQ9yL9uo4nCeJtYPKgXP91dgaA3ctXbiNs0HGs=]
+      ocp-aad-session-key: [F9Wv0NiROzdiCK5lGkN1Zo6l-owYcOzSNUXtGkPLuds-eCyQQebOvA1fictrOT0aa7EkWEJEV7p5PaGLagVNeU9u7QqeHr3uvrIJAaEP5EBiVgr67NzHnDX-4mInKwdK.Y-f7S2od-8dsdzaoiUMotqSMHk0XPTOCM5RP_QQ835w]
       pragma: [no-cache]
-      request-id: [c86da0a0-7599-4402-93fc-e861f0686572]
+      request-id: [1540c0e7-f5c4-44b4-85db-5ee76865076f]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -572,37 +592,36 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
-      "A"}, "enabledForDiskEncryption": true, "enabledForTemplateDeployment": true,
-      "enabledForDeployment": true, "accessPolicies": [{"permissions": {"keys": ["get",
+    body: '{"location": "westus", "properties": {"enabledForTemplateDeployment": true,
+      "enabledForDiskEncryption": true, "enabledForDeployment": true, "sku": {"family":
+      "A", "name": "standard"}, "accessPolicies": [{"permissions": {"keys": ["get",
       "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
       "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
-      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
-      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
-      "recover"], "storage": ["get", "list", "delete", "set", "update", "regeneratekey",
-      "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+      "storage": ["get", "list", "delete", "set", "update", "regeneratekey", "setsas",
+      "listsas", "getsas", "deletesas"], "certificates": ["get", "list", "delete",
+      "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"]}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['848']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [49d03c91-9414-11e7-baad-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000004?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2","name":"cli-keyvault-12345-2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-12345-2.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000004","name":"cli-keyvault-000004","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-000004.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1077']
+      content-length: ['1136']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:12 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -612,7 +631,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1124']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -622,27 +641,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a74b9ee-9414-11e7-9318-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:34:11 GMT']
-      duration: ['612328']
+      date: ['Thu, 07 Sep 2017 22:45:21 GMT']
+      duration: ['941860']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [2DD9Uu67ybR8Pd6jBxWLoYGX++26Si/Rh4KiODEAByo=]
-      ocp-aad-session-key: [qQeSb6gLUkR9fZ9CXryyawkzKL_FXOWajfKky0E7jOZhTdZbF9Jv_xNH1xKRWtI2A_zU6nlt8tSkmn3D3QToeXYuwi8C73WoUVBrAmR17QdCcGG7GYW67dmdyXIXreZx._cVRbyPF0_HPG-WMBGjfSwhmH7zhA3xBn2y9ufAH7-M]
+      ocp-aad-diagnostics-server-name: [B2xtiv2K5IgQFGC/nGmvRhzAlzhH3jWJuI9eil0hCCk=]
+      ocp-aad-session-key: [AvV7DQ-okhMlwhfm4NQD49481wUgjNwRIV3ZWi_wxmxiKTUbqaR9xrLQe7FQAblCLKngj6xQhq0DPSNfjQ_clJWDV1YaMIM22FICz4uRTZ0awEABBQ938GUmLqyeM_SO.a3K-hLSgCUGY5AS3smhc59DcdksCKvzqwIcSZSqZIWE]
       pragma: [no-cache]
-      request-id: [7a03c2fd-20f2-4f37-9312-a86b72cf7c95]
+      request-id: [912a4b56-031a-4092-8e35-a7c67b066a5a]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -651,36 +669,35 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "premium"},
       "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
       "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
-      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
-      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
-      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
-      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+      "set", "delete", "backup", "restore", "recover"], "storage": ["get", "list",
+      "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"],
+      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
+      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
+      "recover"]}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId":
+      "5963f50c-7c43-405c-af7e-53294de76abd"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a964bb0-9414-11e7-9902-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000005?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3","name":"cli-keyvault-12345-3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-3.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_mgmt000001/providers/Microsoft.KeyVault/vaults/cli-keyvault-000005","name":"cli-keyvault-000005","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-000005.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1009']
+      content-length: ['1068']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:13 GMT']
+      date: ['Thu, 07 Sep 2017 22:45:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -690,7 +707,34 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1144']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_mgmt000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 22:45:23 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGS0VZVkFVTFQ6NUZNR01UN0dUUjVRVTVVT1FQUFlOV09YQ3xFNUFGQ0NDM0UyMTg0Q0Q0LVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1135']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_mgmt.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_mgmt.yaml
@@ -6,75 +6,76 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [9f8170da-4fc9-11e7-930f-5065f34efe31]
+      x-ms-client-request-id: [44649a30-9414-11e7-9d2e-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:48:24 GMT']
-      Duration: ['747113']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [GjCMXKa3HsHeM5vaznJZEr4rL5Uy2lVax5jMDQ/7r4c=]
-      ocp-aad-session-key: [iKva7ZwOpN0go6BV2HMl9a2RItTkIqKpwF6z19-QYkZIOdbuzjvVzzpzk_rr_KNmn3xD60gHTN4kRugHZTYS9GyegZ9ZqhVSIv41du9psDfKlO6tzHmP0dyphwRgICpE.8xsV5Ve_lYhSRySReYPNkZEs3n3lXIFfugSZY8LXUDI]
-      request-id: [f6b5c8bd-17d0-4861-862d-4e237ef55454]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:34:02 GMT']
+      duration: ['1853423']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [7akEoJBB3jXdCcddmuqIriGupZolWpVIrAvUTJndNgo=]
+      ocp-aad-session-key: [9lA79ZKlHZU9AarHE3MDrEjWjn-mKRKQy3dHEXsm3BVUExBCIk47Sk50rq6KfaLN4nGvBQj8j3boGDC6OU74-7B8CUOPy5d_Zj3-oFRePOau4WmFaEE7Li8BSb7OvJ3_.e31xTPRNQuI-p4HhuyxQJGG1aMQTIqDf5Ql3AtOSIQ0]
+      pragma: [no-cache]
+      request-id: [fddd50e8-7bb1-4638-a922-32253fda035a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "accessPolicies":
-      [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "7541419d-883d-452f-a823-56aa8bf0749f",
-      "permissions": {"secrets": ["get", "list", "set", "delete", "backup", "restore",
-      "recover"], "certificates": ["get", "list", "delete", "create", "import", "update",
-      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
-      "manageissuers", "recover"], "storage": ["get", "list", "delete", "set", "update",
-      "regeneratekey", "setsas", "listsas", "getsas", "deletesas"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover"]}}]}}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
+      "A"}, "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete",
+      "list", "update", "import", "backup", "restore", "recover"], "secrets": ["get",
+      "list", "set", "delete", "backup", "restore", "recover"], "certificates": ["get",
+      "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "storage":
+      ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
+      "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['746']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9fdcc24c-4fc9-11e7-8db7-5065f34efe31]
+      x-ms-client-request-id: [44993ec0-9414-11e7-a0f2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1010']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -83,24 +84,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0ef37ca-4fc9-11e7-9fcd-5065f34efe31]
+      x-ms-client-request-id: [45918170-9414-11e7-819e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azkv-pytest/providers/Microsoft.KeyVault/vaults/pytest-shared-vault","name":"pytest-shared-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_5izo_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/cli-vault","name":"cli-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/froyo","name":"froyo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/softserve","name":"softserve","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault2","name":"tempvault2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault3","name":"tempvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault4","name":"tempvault4","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_6wog_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['2028']
+      cache-control: [no-cache]
+      content-length: ['3037']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -109,30 +110,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a106941a-4fc9-11e7-a4d8-5065f34efe31]
+      x-ms-client-request-id: [45a5578f-9414-11e7-ae4a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:26 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1011']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -141,30 +142,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1549d62-4fc9-11e7-8c9f-5065f34efe31]
+      x-ms-client-request-id: [45dcbb40-9414-11e7-b717-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA="}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA="}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1259']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -173,30 +174,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a194e366-4fc9-11e7-8a35-5065f34efe31]
+      x-ms-client-request-id: [4621655e-9414-11e7-883e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01&$skiptoken=Y2xpLWtleXZhdWx0LTEyMzQ1LTA=
   response:
-    body: {string: '{"value":[]}'}
+    body: {string: !!python/unicode '{"value":[]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['12']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -205,73 +206,74 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1d0a246-4fc9-11e7-a0be-5065f34efe31]
+      x-ms-client-request-id: [46639e80-9414-11e7-bef9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1011']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "sku": {"name": "premium", "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "objectId": "7541419d-883d-452f-a823-56aa8bf0749f", "permissions": {"secrets":
-      ["get", "list", "set", "delete", "backup", "restore", "recover"], "certificates":
-      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+      "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/", "enabledForDeployment":
+      false, "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete",
+      "list", "update", "import", "backup", "restore", "recover"], "secrets": ["get",
+      "list", "set", "delete", "backup", "restore", "recover"], "certificates": ["get",
+      "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
       "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"], "storage":
       ["get", "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas",
-      "getsas", "deletesas"], "keys": ["get", "create", "delete", "list", "update",
-      "import", "backup", "restore", "recover"]}}]}}'
+      "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['837']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1fd9102-4fc9-11e7-b845-5065f34efe31]
+      x-ms-client-request-id: [468c5c2e-9414-11e7-ab76-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1010']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -280,70 +282,71 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a24fe61a-4fc9-11e7-8382-5065f34efe31]
+      x-ms-client-request-id: [46e26b70-9414-11e7-bd3d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1010']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "sku": {"name": "premium", "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "objectId": "7541419d-883d-452f-a823-56aa8bf0749f", "permissions": {"secrets":
-      ["get", "list", "set", "delete", "backup", "restore", "recover"], "certificates":
-      ["get", "list"], "keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore", "recover"]}}]}}'
+    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
+      "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "enabledForDeployment": false, "accessPolicies": [{"permissions": {"keys": ["get",
+      "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
+      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
+      "certificates": ["get", "list"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a26b9830-4fc9-11e7-92a0-5065f34efe31]
+      x-ms-client-request-id: [47127c1e-9414-11e7-bf7f-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['770']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -352,66 +355,67 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2b527a2-4fc9-11e7-81f4-5065f34efe31]
+      x-ms-client-request-id: [47494391-9414-11e7-868d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['770']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "sku": {"name": "premium", "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": []}}'
+    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
+      "family": "A"}, "vaultUri": "https://cli-keyvault-12345-0.vault.azure.net/",
+      "enabledForDeployment": false, "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['259']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2eb803e-4fc9-11e7-b2c1-5065f34efe31]
+      x-ms-client-request-id: [477eab70-9414-11e7-99af-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-0.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['467']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -420,24 +424,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a335b436-4fc9-11e7-8f32-5065f34efe31]
+      x-ms-client-request-id: [47c48e0f-9414-11e7-8c95-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azkv-pytest/providers/Microsoft.KeyVault/vaults/pytest-shared-vault","name":"pytest-shared-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_5izo_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret_i8fi_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/cli-vault","name":"cli-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/froyo","name":"froyo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/softserve","name":"softserve","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault2","name":"tempvault2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault3","name":"tempvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault4","name":"tempvault4","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-key_6wog_/providers/Microsoft.KeyVault/vaults/cli-keyvault-test-key","name":"cli-keyvault-test-key","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0","name":"cli-keyvault-12345-0","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['2295']
+      cache-control: [no-cache]
+      content-length: ['3037']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -447,28 +451,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a34ee4de-4fc9-11e7-ad69-5065f34efe31]
+      x-ms-client-request-id: [47dbbf8f-9414-11e7-bd2e-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-0?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:48:31 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.164]
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:34:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -477,60 +481,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a3e6070c-4fc9-11e7-9e99-5065f34efe31]
+      x-ms-client-request-id: [48e31d70-9414-11e7-86b3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults?api-version=2016-10-01
   response:
-    body: {string: '{"value":[]}'}
+    body: {string: !!python/unicode '{"value":[]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:30 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['12']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "accessPolicies":
-      []}}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
+      "A"}, "accessPolicies": [], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['156']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a408ff5c-4fc9-11e7-9741-5065f34efe31]
+      x-ms-client-request-id: [48fce700-9414-11e7-9ef3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-1","name":"cli-keyvault-12345-1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-1.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['467']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -539,77 +543,77 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4dd922e-4fc9-11e7-97f3-5065f34efe31]
+      x-ms-client-request-id: [49ad724f-9414-11e7-b9fb-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:48:33 GMT']
-      Duration: ['877495']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [gdPeG8vlAoXJJTvPwlSqp8/04VJcbqMhvRxuxdwiu20=]
-      ocp-aad-session-key: [--W46rdObBLXLiAINquwjwlA9yDUw9fKYgmEzeMnIAI-QkI8qjFtRevkf3xnb_ttGZr_wOj_cOhpQis2pUY-g9q9q3h8iGIFIJAHRmPx4eI6nHA51oOdvgIiQ8q43_BS.k3MupnnmC2HB-LgywcdcBel6F-cDFqky_VS_JE0UC-E]
-      request-id: [6adb9860-4797-460e-aba1-cade83262709]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:34:11 GMT']
+      duration: ['533369']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [6jK4XfmKxcTjGA4F0kismAWyAzj8N/JPhQDwsSuw5/U=]
+      ocp-aad-session-key: [ZjLBfE-gNlI9Z43yqew5YEzrR2t4rGJOkxsYsz-fJxUoWvpW8QOd3b7EVKnPxz08UGe5Buc6HwF55qdlS-XxNvK3LUZwHu52pGJX5u8kE-vkahmPdTYVObXStKyTjHDU.kIUWvZvAKSkzFr7GOp-Ih_bgQ0OMzUCf2RRtwCPLw4c]
+      pragma: [no-cache]
+      request-id: [c86da0a0-7599-4402-93fc-e861f0686572]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "standard", "family":
-      "A"}, "enabledForDeployment": true, "enabledForDiskEncryption": true, "tenantId":
-      "72f988bf-86f1-41af-91ab-2d7cd011db47", "enabledForTemplateDeployment": true,
-      "accessPolicies": [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId":
-      "7541419d-883d-452f-a823-56aa8bf0749f", "permissions": {"secrets": ["get", "list",
-      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
-      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
-      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
-      "deletesas"], "keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore", "recover"]}}]}}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "standard", "family":
+      "A"}, "enabledForDiskEncryption": true, "enabledForTemplateDeployment": true,
+      "enabledForDeployment": true, "accessPolicies": [{"permissions": {"keys": ["get",
+      "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
+      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
+      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
+      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
+      "recover"], "storage": ["get", "list", "delete", "set", "update", "regeneratekey",
+      "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['848']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a507fc30-4fc9-11e7-a4b6-5065f34efe31]
+      x-ms-client-request-id: [49d03c91-9414-11e7-baad-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2","name":"cli-keyvault-12345-2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-12345-2.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-2","name":"cli-keyvault-12345-2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForDiskEncryption":true,"enabledForTemplateDeployment":true,"vaultUri":"https://cli-keyvault-12345-2.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1077']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -618,74 +622,75 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5b2d9c6-4fc9-11e7-a569-5065f34efe31]
+      x-ms-client-request-id: [4a74b9ee-9414-11e7-9318-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:48:35 GMT']
-      Duration: ['777617']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [KfpHv/tTsCuYsStrx4ngjHRX/ZOZzLliag85OKlTX/o=]
-      ocp-aad-session-key: [o8RSnkvdOmaGK2zMWQZzUAuF2IJP9k2y4-DxF838QPRw4wsgaIP4vORlT2UOfyMPZcU-c5F3ii0ihHudlNgvOmXE7zY_tIxUXJfwEBmMCe69PvG55rKRpzKgwGSzfI0I.g6w7YHmXfmvg2PN6soZo8Lur5Uk_eoWzkQg8yhFfBV0]
-      request-id: [4991bc7b-f374-44cc-aea4-aa2f9f917e52]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:34:11 GMT']
+      duration: ['612328']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [2DD9Uu67ybR8Pd6jBxWLoYGX++26Si/Rh4KiODEAByo=]
+      ocp-aad-session-key: [qQeSb6gLUkR9fZ9CXryyawkzKL_FXOWajfKky0E7jOZhTdZbF9Jv_xNH1xKRWtI2A_zU6nlt8tSkmn3D3QToeXYuwi8C73WoUVBrAmR17QdCcGG7GYW67dmdyXIXreZx._cVRbyPF0_HPG-WMBGjfSwhmH7zhA3xBn2y9ufAH7-M]
+      pragma: [no-cache]
+      request-id: [7a03c2fd-20f2-4f37-9312-a86b72cf7c95]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"name": "premium", "family":
-      "A"}, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "accessPolicies":
-      [{"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "7541419d-883d-452f-a823-56aa8bf0749f",
-      "permissions": {"secrets": ["get", "list", "set", "delete", "backup", "restore",
-      "recover"], "certificates": ["get", "list", "delete", "create", "import", "update",
-      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
-      "manageissuers", "recover"], "storage": ["get", "list", "delete", "set", "update",
-      "regeneratekey", "setsas", "listsas", "getsas", "deletesas"], "keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover"]}}]}}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
+      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
+      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
+      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5d94eb4-4fc9-11e7-9dbe-5065f34efe31]
+      x-ms-client-request-id: [4a964bb0-9414-11e7-9902-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3","name":"cli-keyvault-12345-3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"keys":["get","create","delete","list","update","import","backup","restore","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-3.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-mgmt/providers/Microsoft.KeyVault/vaults/cli-keyvault-12345-3","name":"cli-keyvault-12345-3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-keyvault-12345-3.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:48:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1009']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_secret.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_secret.yaml
@@ -6,76 +6,76 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d2b41114-4fc9-11e7-bb0f-5065f34efe31]
+      x-ms-client-request-id: [4c8dfd00-9414-11e7-9bfb-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:49:49 GMT']
-      Duration: ['607242']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [rqcY0nmvey+I04pOmSqr6OSkbMJRkNkwjyKasHeEj1U=]
-      ocp-aad-session-key: [VYZsd9Z9w7TN8yjM_nw_grfbjWwBJZazOvTziLndDehiCLodl88iI8JyAHn7AhQMGxl5bLvL3NuZTYkWCh6QHoG5SqxCY5I-T3KGUPTSTKHFjWAgh4xVWpo3gLyxCzmK.82_KlsCI2YpyFbGemPF8J1vZvCiYOJqd_FZakl54zcQ]
-      request-id: [d0360407-f9ee-41a0-8e80-549f39a4bcc6]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:34:15 GMT']
+      duration: ['564789']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U=]
+      ocp-aad-session-key: [zYFxJsaiE_i_kDh2Jn8AfDNW--bYTgSxagOzvaAuEQlLYO3xqKReeTK-3OETqt5frl658gTnJe-zO-2GNxH5EdkP1FZOxrVsg7HTq2KTqG3zq0PoBTTCZdiawPsDb0os.IS1gP_04Db22wymNC6PaNBe2DPI08av7R3ouKuVV6pA]
+      pragma: [no-cache]
+      request-id: [c20233c8-4d99-4a1d-b39b-44f3c8ac2251]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"accessPolicies": [{"objectId": "7541419d-883d-452f-a823-56aa8bf0749f",
-      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
-      "backup", "restore", "recover"], "storage": ["get", "list", "delete", "set",
-      "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"], "secrets":
-      ["get", "list", "set", "delete", "backup", "restore", "recover"], "certificates":
-      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover"]},
-      "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}], "sku": {"family": "A",
-      "name": "premium"}, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}, "location":
-      "westus"}'
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
+      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
+      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
+      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
+      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
+      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
+      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d2d52d98-4fc9-11e7-8dac-5065f34efe31]
+      x-ms-client-request-id: [4caf40a1-9414-11e7-848d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-secret.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-secret.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:49:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['1023']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:34:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -84,29 +84,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f79d24b6-4fc9-11e7-bbc5-5065f34efe31]
+      x-ms-client-request-id: [730fc6c0-9414-11e7-aac1-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:50:51 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:35:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      www-authenticate: ['Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
           resource="https://vault.azure.net"']
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 401, message: Unauthorized}
 - request:
     body: null
@@ -115,60 +115,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f79d24b6-4fc9-11e7-bbc5-5065f34efe31]
+      x-ms-client-request-id: [730fc6c0-9414-11e7-aac1-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":null,"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['30']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-8"}, "value":
-      "ABC123"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "ABC123", "tags":
+      {"file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f857775c-4fc9-11e7-a539-5065f34efe31]
+      x-ms-client-request-id: [73505230-9414-11e7-8b4b-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/a59f19c25abb4702a030d207aada45b7","attributes":{"enabled":true,"created":1497311454,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['256']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['256']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -177,60 +177,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f88db06e-4fc9-11e7-8c8c-5065f34efe31]
+      x-ms-client-request-id: [767c8bde-9414-11e7-aa20-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1497311454,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['234']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['234']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"contentType": "test type", "attributes": {"enabled": true}, "tags": {"test":
-      "foo", "file-encoding": "utf-8"}, "value": "DEF456"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "contentType": "test
+      type", "value": "DEF456", "tags": {"test": "foo", "file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f8b19924-4fc9-11e7-9a56-5065f34efe31]
+      x-ms-client-request-id: [76a1ee30-9414-11e7-8d4b-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":true,"created":1497311452,"updated":1497311452,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['295']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['295']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -239,28 +239,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f8e92c36-4fc9-11e7-b25e-5065f34efe31]
+      x-ms-client-request-id: [76d3104f-9414-11e7-b5b4-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":true,"created":1497311452,"updated":1497311452,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/a59f19c25abb4702a030d207aada45b7","attributes":{"enabled":true,"created":1497311454,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['546']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['546']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -269,28 +269,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9239a6c-4fc9-11e7-b189-5065f34efe31]
+      x-ms-client-request-id: [76f935ee-9414-11e7-8429-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":true,"created":1497311452,"updated":1497311452,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['295']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['295']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -299,59 +299,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f94cc124-4fc9-11e7-a791-5065f34efe31]
+      x-ms-client-request-id: [77187dc0-9414-11e7-8824-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/a59f19c25abb4702a030d207aada45b7?api-version=2016-10-01
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/a59f19c25abb4702a030d207aada45b7","attributes":{"enabled":true,"created":1497311454,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['256']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['256']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": false}}'
+    body: !!python/unicode '{"attributes": {"enabled": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f978f840-4fc9-11e7-bcd0-5065f34efe31]
+      x-ms-client-request-id: [773c0b51-9414-11e7-812f-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":false,"created":1497311452,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['279']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['279']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -361,28 +361,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9a8d882-4fc9-11e7-a8a2-5065f34efe31]
+      x-ms-client-request-id: [777320de-9414-11e7-8585-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/backup?api-version=2016-10-01
   response:
-    body: {string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLlpxMWNJbHgtamwxMWhWT3J5TjBCUFpNeFF0REY1LWtpVVdEVzhrYTFRa1lfb2FkU3RqZXhCdEFvUFVnNXZIalh5WUx2QWdhY2RwSWVTZl9McUNRaDdVaVlyZHBvS2pvVjR5ckdFaGRmcTFTLUNuNW9GMUU0SWppSnpvQm81ZG15c1FXb1o3WlZwM1h6c0lncEUzeC1PY1JSMHc4ak1yMEFlN05Ib1hORl9OYlIwUnBTanowa1pOSDN6X1JBRTlndXo1R2tzeEVHd09VblExTkVYbTBnVTRoajZCMl81SmR4LVZmN0w4eDlIdVhFdHRxdzRjTDUtWVQxdnphaEpuT3l1ZUtpZFRvQ3dWa1V6U1IycHFNcjRrajhyR2NTS1dIS2M5R0gtM3Vsc3dqQy1JVnNJNUNaSEg5aWY2RFNvMk5nNGVQWXZUYmNhbUhjV1dnR2swcEFtZy5yR1RJcUNUQm1RQ0lDR3I3S0RNOHJRLi05bmE0NTNTcDRDMnFMRnVUWllZVElmQTRHdTdBNmk5WnF6YU5JN0d6elA2XzgyYmtFTjhjMXVwUHk5c29IbDdmNVMtMThjSkVmUU8tNGdvSjJwTTZGZXVQc0FWTXMyRTJSMFNqbFpLQi14U0NnZ3U0aUVKQXl6U1Zxa25BMkprN19TNUJ0Tmg0Ri1JN1VoS3NLV2lUUzhhYk5pSmVJdXFrYXdqMFgxcGN2MmJ4Q2ZEbzJ1NTBnWVZ1ZDZFTXhpbW1neHhwRUEwUFd2bl81aXpFNGxHR2xvT2ZDV3h6Y2pfZ3l5TzJkdi1yVU5Na1lxWTlWNl9zTVBtVFQydXBOODVUSkdRWEhYeTdYOU1zMXFqZFlFS0pLRWhmLUdXaGpOdE5EMjl1dzU1Ty1XWDVtOG55WG9OMjRjdml5aWFZaVNRSHBvTlVheHJrczRnRGFyRnJ3dW9YNFQxYmZiOHNPOGlCRjQ1QUtiaml1QWRmLW5LOEw1bzNHak1MN1gzRUlxSlRlSGQ3NzdESk1PSjducEdybmthVmh4UDQyeWlBMTlaaGhqcVo3bm9WVUtwRmZJa25DT0hsTWkydGRvaU9tdF9KU0dWWHg0eGE0NzBOUjhBSjdCLWxXcXo5ZklPWHdWcEgxWlpsU01rRXBzVkJrX2NzVlJnN0VEMVJBQkstX09aSWQySWtHTXprQ3VjOUhKUnBMbUN2aU81UlVGa2tOWWhKWE1CZUowOU55SU1QbjNDaW85d0FTSy1jeVZFWUNMYWNYUDkyRlE1SllmcWZocGVRM1VUMlJwdzZCRF8ybGVwTmk4a0tXM2tRbF9BbVdXR3pqLTFVRzlLRElRcG1nSThiXzZ3cVZ0a0RQdzkycXlQa3BYU1RMVWw3N1hXUy1jNVhfUkR3VVM0T09mQm41ZkFwakw1am1mN1B0QVZIMV8wMV9zNEJJSWJqa3JCcl9vWHptcE9QT01QcFNDZEJ4NTBOY29DbHFVM1FqbzZGSkozZnEtTTVMRGU3WHlkYTFTRWlHN09mRXVaZHF4UTYyUnpiWTZkRklkNEh3dkpveUxJRzZKVjV1blU2dnJ0RGpRTXlOVnUwUkZUMkxIUTg1VHZvUjFabGhURWlma3A3QjJJQlRfZDZPUmdRTE4zNG5BQi1SMlBDQjVELTRSeVJzNDFHalRxWmJVbFhGRFJrOGxfN2FHa054VW9BeDZlMXY4SXIwOEtMNTd0QWhzMEFjOGxNYTJ4OTRmTy05NC00LVhfelMxZE1ubnNLZ3RqSGNsNkZ1dVJYbVd6dDlVZXNkTWMtdzlBUVJRMURGSWxJSFVZX2xqOHlwTWk0Rjd4THc2XzFGUWtIY2Fyc3B4ZFl3dy16dklyWkc5eGJNMGo5WHNxSHVPMTlsSk9aZnpIU09CQkxLWFRhcUR1VDRjTDdVNXBPSVNaenlZdlJ4MUtvQTlPVHZKVkRwYTdiVTdXQ1pQS3lTVXkxS1pfMEJqYmxGcVRydWllUm40Z005MTdtTk9heXc3OHpBYnRMUHVIbDNtejdnZEk2RmczeGs0SXNWSUw2cmIwUWRQRWtkb0JzVFc1cjNrMXBxYUZfWWhwbTd2N3hDb25tM0ZYN2lWNHRwR1pFVmZNeE5EdzV4V1BSbTRJYmpNZFdiSFJVMThJeG5ma2lMSXRPeDBqd1RBNnhaQlZDWmRuSzJRdVU3UmRHeU5CUWVtbXNkQi05ZUJFTzhRRlJGT0F2MW0yVzZvNmVlSXQ1OHpocWdYZ3RxWUZJSUxUcHVtN1ZwOWd5b25kT0dkSS1IUy1FcEo4R29FNWFCMmJYZkd4SWtlT1lrdjl3UGVjcDFLcUNWaXlNVU4xSFZtTzk4LThETjVJSXhkNWRRbW54RUl1ejNtMjdHck8zSUt4QWNiVGtHWHJ4OVZmRmg3djNscm1TdWtnMjluOW5lZkFsS084ZnE1alA3RGVIYnBhT1pvM1l6TGdmZDgxcUpYQ1I0NHRlNnMyY2hGbXZIMWFBbTdMTlI3VkVyVGdCbzE4VVk1ZWpnMFExRGZfZGhCMUhadmV3dlRGeGkyU0MwRlZRZVpkQ1VOSThCMGZlaGVkY3BTYVljSG1sck9ZeHk4VUktSGFXYkJHcVZHWXJCS2ROX05DNkdGbU5kdDRiaFNMVDNuVVBJbWpWZTJhT2xCU0NYZnlodkJXbUFfbWFjU0NDVXpJUjE0ZVdsMXRkUUZmREN4REl3cnh4VXNLcWk2dVRGWUc0SlFvUF9JLTN6Qloyamp6M1A5cUUyRXp6cnpSUXJDeXdfYUkwYW90bE0zbG55TXNDWFRrZjN1aVlUU0hCYk9SamlEYUtWWlF2X3RLYmtZdFY2c2dSY0YtQlJFSFNaQ09fXzY4WGgwbFQySmFCNUtYTHM2RnlTeEs4eDR4RTRfNzc1cmYwbFBtZkQtaUZSSk4tZmJ4Nkloblotbmd2M2M5OFFYaFcxYlYzZlUwWWlieEg5ZEl2bXNJbkVsWlgwMkEwaVJQdjlDaklQMGd6THpDeGFkTUc5ZWZUWlFUa2lRTDFrR3dtMXU2RGRnNGRDWTlldkpJbVBuQ1pNanY1QURhSWpjQ0hEbUZweE05TnBZUUdqV1NyVUI3OEI5Zkw1S181NjQzZHU1MmRyTV9Cc2kzMmtVQnl0XzlDY2VXaGV1YTlubzRwektVSWxtMzczSDBaVmpGcmpfZ3dleURfQmotV212OXlfbWtyOVRNZ0ljaXduaVlpN1A3THpjb3VSRTNWdnlUV0gxX1Q5WVFJYWx3c3NHalk2MlNxRjlUV1NnZjdXbDRNYm5ScXBralFnXzdsbkV4d3VGcHR4ZS04NG54STJnYl9xZC1NdFpyWG9Cdm9oWVhNVUV6YkNycnV2LThqWVJJQ2NLS0xEX2ROalV2VTZPajFTWGItSDJRcHFKV2tTODc4Q1FRSHN3TThQWHVoRzE2M3M4M3h6MDlNOGlSVzRNRXZJUXE5ZGlYc0Y2Z2otaTMtQWhvdWtJNnFSQlZfY0IxamlQUG5ZNFJVanlJRVltVUNDbDRUQ1ltQkVQc1hBbXV1YnRnMzkyWXNQOFc3R2J1TDc1UHlUUUQtTXljQldqUVZKNVNyZHI1ZFktblR3QjN4TU1UeG1Xc2VvbkI0RVRGRXNWYWhyNVFpUlZVVS13Q2R5ZHdCZnlUTi1NMXZNTXo3Q2R0ME9LREwxRjhKMlNSekhsQjRwQW0zY2FVWXdzdW5BdmdzMXRSNXg4WXB3d0o5VGpLcHlpNl9pNmdpOWd4dmxlNWc1eHVMRVZzc0xEUVBTMk1CcFYxUS1kU2pXUFpmd3dWUVNOT1FVbnVyX3RtSHVyVll5MHV2bXh1S290NWdhV1hYczNmS1M4YXpUdDNYSVFoVERIV3Zxby1ER2tJVzVTakZDRTRUeUd0OWxfSzhhbzU4VWRORVo4aEUxVGgzSWJPdTlVWHRKMzVidWktZnFfU2dTMzNiYVJjTnc5Nmh5Xy1hclBBeExhMlJvNnFyNUlfbkVNRVo0U29jaXl5dnVHQllueWxUa1hRV3FwSFk0dmU5TzgtaXVzTE5pTzlYSnpDUzV4RHdzVXZfbnh2N2xBZTJXMW84OTFnbHE2V1U3enUxb0FXNnhHcVp6OXRkNE5nelptVkt2NDJKOExKb0VVX093bUlwc2hWOTBicl9CWTlfZ3MxeFpsNzhfclZyN1M3WElNdFJ0bjRGOTNBbEw1YTdWRS1GaHVrdE1nQ2xFMnJKdWpuZjR6U3FNVnFaaGRTcU1PaktpMnNkeUZFYk1Uek91bDlpTVEtd0ZydWk4NTJWQjdmVEt6ZkFQM19PRWVqcXFvRlhRYXpaSjZnYmkzU3ZpZFNBNlRHQzItYVc2S3Btcl9uSkcxRUdON092ajA2U2EtX1pBSmlSY0c4TTN1dUYwV2djWFRIZnJpUHBjODlnNWhKU2xIc1c0UlR5R2wxcU1DRGl1anJ1T3A1VDZocERnWjRMSk5xZXFMelI3Z1Nia2ZMbUtYY1lIY0FhM3JSUkdnZXZoMXp5akFKaktNaXdHSkUwRzlqZkJnVFVHM3E4MUE5enJXTHhRX3VkQ005Zy1HZ001cGRqS3pseDA5UEF2TkRrRU4zUGxjMF9SY3lHYi15QzNoZXlTbFVIT043NUE2dlVfci1QdHI2dC1uZUFSNEprRGNIRXgtYk9CMW1XVGc0YVdMSEZMX2htZ0lyTDgwaGk4WnljSzRWX19TTUZ1enJyV2tfZlc4MjhkZ1I5elpuMm9fZXF0VVAtd3dWZ3dpbHNaWmJiZEg5UFBvMzBzZHVwT3g3Q0h0ZU5CNU5ZZlZJdEVyN2xEQzJBQjFPT044NmVDUXE2SGkyc2VrNU53M1RIYlRpN1EuN0FwbzR4YXFXbXdOd0pmYmxfcU9mUQ"}'}
+    body: {string: !!python/unicode '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnNoaEMzQjNHdjdYeTZnNVBwTm1hSE92Y1VhU0wyUFFhLVAzQ2xzUkxGM0paR0x6UTJUSVRBYXlTam5naFRncFJLcnZGbi1ITXhxUktyVnRfdWpjTGxYb3p3V3VaWE8zWTZlOUY4T1hjUXZPX09GN1ZTcXc4NktjSm90aEJwQUp0N0E4SVFDMlBkQmNBQV93SnFnMXVrTU5pYlNiWTE4YVhockZtME9ab0REbGRfbTZXSkEwX3FrYXZ1OFFHSDZyc1lmV0FFcFJLZzdiMThBNjlMRnVBN2kzblJVSHQwMGE3V0pvR09rTjc1Y21kMmtSaWc2MWl5SHFDbFJ6YjJDdm1aMnB4VExJRkNhVkhYYzh2TmpoYnlGMHNnR3FBNDBqeUdCVHBDbUFFdXpnekVPeHEzcVA2dGRWVG5SVzV3djZuQlo0MVg4NE5FNnBBRW94bV9neTJKUS5lN1NzOWs2QnRIYjRibGpDZXM4eURRLnhOa21nSE5WQkREWnNvUmQ4bnEweEp4a1RxUGl0Z25MbHdSVjIwR1VCOV9zTjRSUEk5cVktN2lmOS0xeEJ0UlRGQ0RFR01xVUIwVnJibC1oeFB0RlpGa2JIcVZqZnpkSWI1SmJnbXJTVGZDcGhlcG5jY2w2dENsd2ZZSEFRSTNiYXBlYzBOcUdsM1AwR29xSlBEZDRjQmg1SDYzOW1WeEptUU5lSXFZOUFzRjAzLWc3X2pxNDh0YTlfZ0pzejBGSGNGODMxeVhvaWdYTlAyN0RKTVBDT1Z2c05WVHYybnluOW01U2dRMFFZS0ljV096NG1DM1lGYUo1LXVUZHNrcGEwaDl6N1F1Ul95cUVIMUpuQmx0M2ZzTkV0cHJLNW9YbU14c1A5bDByelFQR2xYQXpRLW9vU2tUN3B4bVpnUGpKRG5xT3p0WTFxLU1wRFA2TkFWVEhqNW5iOU9MeVducFBEREZUcU5vUU94UjRYM19zc1JUZlBSRmZ6SVNWOHY1MUJ5bEtramlaQTBzYzNmcDBpZ09rRW9KNWI4NVhUUjktVUR5WHJKYzdPUVJ3dWk1eUtEUHlqaWZXUzZQZ1cxbVFNcnFnbEtJSnB0cUxXajVTVThadFJ1MU1CaS0yM1BFT2lFMkZGa2FwMktnNzI0OUx4QmtYX0V2ZnZ2MnZJLTVUTlRvV09QdmtxVVp1WEZTeEwwR0hIY09mQlNDYUl2OTY3WlRhalRSdFdQaTJMNF8ydmx0cklWbzRsUzA3dzZlRUF3Y1hpcDhSUXNwSC1lbGpNNmpCak5VUHBpdlZTMlNyckZQTlphRnE3eW9nT1pfUXhDXzJ2QzZlZWNHTGEyRlVCb0NBNE1NRU5McmRabTR0QWQ2ZHY4d1lxX0R3OUV6Y2NKS3ZOUDZRSkY5T0xvTGFkMjF6bXM5LXA5NTgwN2tvN0RlWnZxNDhHOFJNdWo3RktVVGtMQXdJYzVRNGlibVA3SXFrSFJ4N1FRRkE1VGlNRTR0S085T2dNSUpBYllwcW5udVBGaTlOLVpCVTR4UWZFN0dCOUhyd2dzclFYUm96QXFiNV9seG9WQXBKTTg4SHQwOGZ6UU5BMFdEY3M5RE5wR0ppYzdXNzBCWEVESzdzS0VNSU5yU2pPMHZuSkpzVnl5TTBLeHkzRGtOU2pNQTNuR281d1BtOFkwcmg5NlR2Y2JQRENzc3RMZXRQU09QUm5MeXlRNVJJWGhoWE9McnFUckI2RF9nNUJqb3pJVjg1Rzc2NTVWR3FVTEQ2S0hyNmpidTJvMElPRXV1NURucmpheG01aE1YZVpyN243cWhEcE80a3N3SVpXM0JTcXNGTUdqdkhKcEdXb19XOVMwYnpRdEdoQXdFQm9GNE1SOVF6R3l4cVhCbmVUc0NLTVZXMXZfTDRHM2NtUDBoWnd3RGg5UmRRbERhOUNpbDhzRm1GTUpCR1ZVckdwdTBYT2dfMjM3SU5Bd1Z5SnRyWXhuWVJKSDFqb29EUDFMLThib01NanN2U0xQR2FFY2J6a0pnMnB0aGFoYU9Nd2o2elUtQzN1eWJKNFc4YVNqN0hUeXlWY084aXROaUV3V3pWQVJHbFZFWjgxUnBKZl9XNUdLWmxva0FjNDc5dklldTl5c19xTjBUYnVvOTVoTmdndHNzNDIxVTlHc1dFTWpxRGpzUDhqeVQ2VlVscFFsa0FEMW5CNGxnV0FLd2pxM0lxSGVHVENLVDRya2xaNjhfa2FaOWNKQWl1eUNDYUJVX0lNSE9zUjhmeXRsNm9IcmI4SWFUMTVHSGRNdVJubXdSUkZaS0dZc0RZcHBSWW9yLVNhUUJyVFJaTUlwUFZ4bnZST2dkRjctblFhcllFbmhlQUlacDkzVXEwNzhJcmpfOTU4OTdiZG9rME1lOFBwLXJDbDhwV2RzUXFxamlFVlpNdUpMSmpCd2NFckZJZ0thVWE4dGxxNld0NzZqSkxUUE5TTEpGeE9nZ1FBVm1IT0J4NUJtRUFhMnhCQjlDQzlzMkJ2V25xV2ItYlM0Zy0yc2l3Qm1fa1AtTkxhRzZxWnlGcmh1amtiYXdqUzhSS3hWSWVGTjIzU3RDMmtweU9Pc01fRnZjaXdmOUZ0TjFnaVpUSFhMbW5qNk9HY0YxX2Y1VXZRRGRHSlBXWkpEeklUbFZrRnUwQS05cTRyal8xZWFoR0ZDNUVpZFBOQ0VoNXJzNno5WWdMNElwVXlXUDJodmQ4MTI1QWxfeFJadldGTlZ6OVNfVDJuZ0VaRTMzc3BZVFJoZzNFYzNHWXRGWmo1MWY3YkZmUkpFYnphT29MTUI4Nkg4cDF6cUhQYWJUcjU5WGZMOHZRU2tzbXBucUFBOVpoc2lXWFNuU2FzMXpWalZxZlpZSWVLU1BoSnExbl92eURGSEY1c2lMLWV4NTBZVk1lRVJPVDlVa3lCWUlSRXhfQmIzZnJTdm56N3p5Q2xzbkJ1Q2drNnBjaFMyVlVFQldhRkp6WWdTc1M3TUJmb3FaMm1hb1g4WTc5ZXpyYks5Mm00MGVldl80dEo0Z1FBMFc3UUcxcGY4OWdKVnlpVlhfdzZwRnVmQUE5WjFsRWN1MkhfSFI1TmtWazhJa1RjdExNeUhuMHRSV3hqWkpIM1ZrUXhscVQ2WEtvUWZjWWhPQzFnd2lvQTdsbk1EOGhuZWZaSVhJUlRmNzdlRU5pV1J1dXA5VzgxZ3dOaEFxZ2owQ0twMEw3ZlB0eFRHdFVyUFZxNE9nSWctbERHQklTZkJvU3Q1a1MxQVVBb0ZQVExObHNMWjVPMVo2TG9aTmtqbnJic3ZBc3lJWkQ0UnRvRW5xcGFPNHl6MWFoSWZ0LXJHMlFTdGdkN2U3MW1ESGFBYXpOVC05NHNGYUVWUUcxNDBaaHk3TXVTc1VEamlyQlgyV01jMFQ3Zkhabzg0ODJQYi16T21RMlNrT1RvU3pjV0hva0kxZUxFQm1pWlpNdWRkc3FMMGVWejZLRmpndU1oSXpPdnZueXY3RWJRSzRJTVJkN0owQ290X2FXLThfTkg3WHdNcUN5NW1tdzdLVkhzcjNqRGdVRGxPMk83U3FnUl9makxNR0g2Y0RzcjdQSTJQV3AtLVVVcTQyM1BWckNOa1R4R3JhcHNHR2ZQcEk0WHJ1aUVlZjB5NGFlV0ozeGQtel9tN2M4RXItSm1MQ19ZSGF3cXhQM2d0UVpsejFDVDJBc2JTS0o5ZUtHaXJoRTlrWWhfMHVMUWZnazY3djRrNTRRS3JRQ3czRmlCUGEwdHlrdmE0OENGQ0w0SlNDajA2ejdVT0l5b2Y0QXlqQjhGdC1GYTFJb1Y5Y2M1eURpUkQxMlVxWHMzTTg4RnF3TTNDSE9MdGhhM1B2MUpVSE1Xd01kUUo2ZlRjN0R0U3pEdlVaT2ZYLS1GM0ZpZHdUN1RDaFcyaWJqQjlNSjBUMUJOY2p6N3JIdHYyRUlfdWpZd0g2Zkd3RXgtemV4X3Bzak5hS3dzbFNMYlFVclN3Yndxbm5fWmxNTEgtOGJHUTVZbUhMMUd0TE9kX29nRHdkU2F5V0JKQ1ZyT3JqTFFwWkhVNktGZmE2eXR3NXFUV1JYQWtudUt3UFJLeTJpSzg1aVI3UmRTdVB2d01id3NVMlhHOXBMeUw3d1NVVHUzekNoRUZlbTZjdEQwcXl1a3JQWWprN1M1SlFucGV3aHloc0o5X2ctaDh1X2pBWUs5U2FKbUJFUVg2UWhJRzVKaUlFdXVQZTFmUVJ4X19ES1dEU3E5VTRJVDZDRm5tR3FFRDh4dDVTYjhORnhHUi15ZzNNVHZGQmJPdEM2eUtYWkwwaXZQRHVXSmZKdVB1VExMeG1vZGxMdmdIN0RCQ1kwNHNHc01Kb1VzNmszZG94ODZ2V3lvQi03cW5VWUlMaWRweFZaQmt6RHc5NzczYUdSRmVkaFdXRk81V2ZqOGtiS25rUjJUTWN4bDZXYVNISkZJV01Dbks5M1FKdUl2QS01U3VpMTJqblBieTVfNmU4cFJ2Y3RvT000QzhlbWotTWs3NXJNS0t0YU5Da0ViY1VvLVcyWURFZUdYbDBvRFhHXzRUQzl4cll2T0JFakN5d21xRlRHNmNYeGZaUFQxbjhueXN1bW5SdVdrUTcwcTZDTzhLOWVuSkV2M2ZHX1JoRDFlN1VtaXBDU1pwa1prLTM1MDktWTZQWmlaZDVrZ0pHN3JOdHFuZEMxRUZ4VEg3cW93ZGw1b1Rhd2pmdE1PYjVSSGFFRVZvdzhNa3FQTEcwblFreGVVUGpkcUZPVG9uaUxMdVpwbFBneFBwaUc2Nnk0bjhGMmttYlhsTzkyQUxtOVJEaUJTTUpBMTNfQ0tyQ0tRcVRzazVRZVplWTRqdDlHYXcuLVd4YnBYU0Z3dGZoMkxmdFlPX2ZQUQ"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['5122']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['5122']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -392,28 +392,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9d60380-4fc9-11e7-8a1b-5065f34efe31]
+      x-ms-client-request-id: [77ad6ac0-9414-11e7-a85a-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":false,"created":1497311452,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['279']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['279']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -422,59 +422,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa074630-4fc9-11e7-80c8-5065f34efe31]
+      x-ms-client-request-id: [77d64f80-9414-11e7-98d0-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLlpxMWNJbHgtamwxMWhWT3J5TjBCUFpNeFF0REY1LWtpVVdEVzhrYTFRa1lfb2FkU3RqZXhCdEFvUFVnNXZIalh5WUx2QWdhY2RwSWVTZl9McUNRaDdVaVlyZHBvS2pvVjR5ckdFaGRmcTFTLUNuNW9GMUU0SWppSnpvQm81ZG15c1FXb1o3WlZwM1h6c0lncEUzeC1PY1JSMHc4ak1yMEFlN05Ib1hORl9OYlIwUnBTanowa1pOSDN6X1JBRTlndXo1R2tzeEVHd09VblExTkVYbTBnVTRoajZCMl81SmR4LVZmN0w4eDlIdVhFdHRxdzRjTDUtWVQxdnphaEpuT3l1ZUtpZFRvQ3dWa1V6U1IycHFNcjRrajhyR2NTS1dIS2M5R0gtM3Vsc3dqQy1JVnNJNUNaSEg5aWY2RFNvMk5nNGVQWXZUYmNhbUhjV1dnR2swcEFtZy5yR1RJcUNUQm1RQ0lDR3I3S0RNOHJRLi05bmE0NTNTcDRDMnFMRnVUWllZVElmQTRHdTdBNmk5WnF6YU5JN0d6elA2XzgyYmtFTjhjMXVwUHk5c29IbDdmNVMtMThjSkVmUU8tNGdvSjJwTTZGZXVQc0FWTXMyRTJSMFNqbFpLQi14U0NnZ3U0aUVKQXl6U1Zxa25BMkprN19TNUJ0Tmg0Ri1JN1VoS3NLV2lUUzhhYk5pSmVJdXFrYXdqMFgxcGN2MmJ4Q2ZEbzJ1NTBnWVZ1ZDZFTXhpbW1neHhwRUEwUFd2bl81aXpFNGxHR2xvT2ZDV3h6Y2pfZ3l5TzJkdi1yVU5Na1lxWTlWNl9zTVBtVFQydXBOODVUSkdRWEhYeTdYOU1zMXFqZFlFS0pLRWhmLUdXaGpOdE5EMjl1dzU1Ty1XWDVtOG55WG9OMjRjdml5aWFZaVNRSHBvTlVheHJrczRnRGFyRnJ3dW9YNFQxYmZiOHNPOGlCRjQ1QUtiaml1QWRmLW5LOEw1bzNHak1MN1gzRUlxSlRlSGQ3NzdESk1PSjducEdybmthVmh4UDQyeWlBMTlaaGhqcVo3bm9WVUtwRmZJa25DT0hsTWkydGRvaU9tdF9KU0dWWHg0eGE0NzBOUjhBSjdCLWxXcXo5ZklPWHdWcEgxWlpsU01rRXBzVkJrX2NzVlJnN0VEMVJBQkstX09aSWQySWtHTXprQ3VjOUhKUnBMbUN2aU81UlVGa2tOWWhKWE1CZUowOU55SU1QbjNDaW85d0FTSy1jeVZFWUNMYWNYUDkyRlE1SllmcWZocGVRM1VUMlJwdzZCRF8ybGVwTmk4a0tXM2tRbF9BbVdXR3pqLTFVRzlLRElRcG1nSThiXzZ3cVZ0a0RQdzkycXlQa3BYU1RMVWw3N1hXUy1jNVhfUkR3VVM0T09mQm41ZkFwakw1am1mN1B0QVZIMV8wMV9zNEJJSWJqa3JCcl9vWHptcE9QT01QcFNDZEJ4NTBOY29DbHFVM1FqbzZGSkozZnEtTTVMRGU3WHlkYTFTRWlHN09mRXVaZHF4UTYyUnpiWTZkRklkNEh3dkpveUxJRzZKVjV1blU2dnJ0RGpRTXlOVnUwUkZUMkxIUTg1VHZvUjFabGhURWlma3A3QjJJQlRfZDZPUmdRTE4zNG5BQi1SMlBDQjVELTRSeVJzNDFHalRxWmJVbFhGRFJrOGxfN2FHa054VW9BeDZlMXY4SXIwOEtMNTd0QWhzMEFjOGxNYTJ4OTRmTy05NC00LVhfelMxZE1ubnNLZ3RqSGNsNkZ1dVJYbVd6dDlVZXNkTWMtdzlBUVJRMURGSWxJSFVZX2xqOHlwTWk0Rjd4THc2XzFGUWtIY2Fyc3B4ZFl3dy16dklyWkc5eGJNMGo5WHNxSHVPMTlsSk9aZnpIU09CQkxLWFRhcUR1VDRjTDdVNXBPSVNaenlZdlJ4MUtvQTlPVHZKVkRwYTdiVTdXQ1pQS3lTVXkxS1pfMEJqYmxGcVRydWllUm40Z005MTdtTk9heXc3OHpBYnRMUHVIbDNtejdnZEk2RmczeGs0SXNWSUw2cmIwUWRQRWtkb0JzVFc1cjNrMXBxYUZfWWhwbTd2N3hDb25tM0ZYN2lWNHRwR1pFVmZNeE5EdzV4V1BSbTRJYmpNZFdiSFJVMThJeG5ma2lMSXRPeDBqd1RBNnhaQlZDWmRuSzJRdVU3UmRHeU5CUWVtbXNkQi05ZUJFTzhRRlJGT0F2MW0yVzZvNmVlSXQ1OHpocWdYZ3RxWUZJSUxUcHVtN1ZwOWd5b25kT0dkSS1IUy1FcEo4R29FNWFCMmJYZkd4SWtlT1lrdjl3UGVjcDFLcUNWaXlNVU4xSFZtTzk4LThETjVJSXhkNWRRbW54RUl1ejNtMjdHck8zSUt4QWNiVGtHWHJ4OVZmRmg3djNscm1TdWtnMjluOW5lZkFsS084ZnE1alA3RGVIYnBhT1pvM1l6TGdmZDgxcUpYQ1I0NHRlNnMyY2hGbXZIMWFBbTdMTlI3VkVyVGdCbzE4VVk1ZWpnMFExRGZfZGhCMUhadmV3dlRGeGkyU0MwRlZRZVpkQ1VOSThCMGZlaGVkY3BTYVljSG1sck9ZeHk4VUktSGFXYkJHcVZHWXJCS2ROX05DNkdGbU5kdDRiaFNMVDNuVVBJbWpWZTJhT2xCU0NYZnlodkJXbUFfbWFjU0NDVXpJUjE0ZVdsMXRkUUZmREN4REl3cnh4VXNLcWk2dVRGWUc0SlFvUF9JLTN6Qloyamp6M1A5cUUyRXp6cnpSUXJDeXdfYUkwYW90bE0zbG55TXNDWFRrZjN1aVlUU0hCYk9SamlEYUtWWlF2X3RLYmtZdFY2c2dSY0YtQlJFSFNaQ09fXzY4WGgwbFQySmFCNUtYTHM2RnlTeEs4eDR4RTRfNzc1cmYwbFBtZkQtaUZSSk4tZmJ4Nkloblotbmd2M2M5OFFYaFcxYlYzZlUwWWlieEg5ZEl2bXNJbkVsWlgwMkEwaVJQdjlDaklQMGd6THpDeGFkTUc5ZWZUWlFUa2lRTDFrR3dtMXU2RGRnNGRDWTlldkpJbVBuQ1pNanY1QURhSWpjQ0hEbUZweE05TnBZUUdqV1NyVUI3OEI5Zkw1S181NjQzZHU1MmRyTV9Cc2kzMmtVQnl0XzlDY2VXaGV1YTlubzRwektVSWxtMzczSDBaVmpGcmpfZ3dleURfQmotV212OXlfbWtyOVRNZ0ljaXduaVlpN1A3THpjb3VSRTNWdnlUV0gxX1Q5WVFJYWx3c3NHalk2MlNxRjlUV1NnZjdXbDRNYm5ScXBralFnXzdsbkV4d3VGcHR4ZS04NG54STJnYl9xZC1NdFpyWG9Cdm9oWVhNVUV6YkNycnV2LThqWVJJQ2NLS0xEX2ROalV2VTZPajFTWGItSDJRcHFKV2tTODc4Q1FRSHN3TThQWHVoRzE2M3M4M3h6MDlNOGlSVzRNRXZJUXE5ZGlYc0Y2Z2otaTMtQWhvdWtJNnFSQlZfY0IxamlQUG5ZNFJVanlJRVltVUNDbDRUQ1ltQkVQc1hBbXV1YnRnMzkyWXNQOFc3R2J1TDc1UHlUUUQtTXljQldqUVZKNVNyZHI1ZFktblR3QjN4TU1UeG1Xc2VvbkI0RVRGRXNWYWhyNVFpUlZVVS13Q2R5ZHdCZnlUTi1NMXZNTXo3Q2R0ME9LREwxRjhKMlNSekhsQjRwQW0zY2FVWXdzdW5BdmdzMXRSNXg4WXB3d0o5VGpLcHlpNl9pNmdpOWd4dmxlNWc1eHVMRVZzc0xEUVBTMk1CcFYxUS1kU2pXUFpmd3dWUVNOT1FVbnVyX3RtSHVyVll5MHV2bXh1S290NWdhV1hYczNmS1M4YXpUdDNYSVFoVERIV3Zxby1ER2tJVzVTakZDRTRUeUd0OWxfSzhhbzU4VWRORVo4aEUxVGgzSWJPdTlVWHRKMzVidWktZnFfU2dTMzNiYVJjTnc5Nmh5Xy1hclBBeExhMlJvNnFyNUlfbkVNRVo0U29jaXl5dnVHQllueWxUa1hRV3FwSFk0dmU5TzgtaXVzTE5pTzlYSnpDUzV4RHdzVXZfbnh2N2xBZTJXMW84OTFnbHE2V1U3enUxb0FXNnhHcVp6OXRkNE5nelptVkt2NDJKOExKb0VVX093bUlwc2hWOTBicl9CWTlfZ3MxeFpsNzhfclZyN1M3WElNdFJ0bjRGOTNBbEw1YTdWRS1GaHVrdE1nQ2xFMnJKdWpuZjR6U3FNVnFaaGRTcU1PaktpMnNkeUZFYk1Uek91bDlpTVEtd0ZydWk4NTJWQjdmVEt6ZkFQM19PRWVqcXFvRlhRYXpaSjZnYmkzU3ZpZFNBNlRHQzItYVc2S3Btcl9uSkcxRUdON092ajA2U2EtX1pBSmlSY0c4TTN1dUYwV2djWFRIZnJpUHBjODlnNWhKU2xIc1c0UlR5R2wxcU1DRGl1anJ1T3A1VDZocERnWjRMSk5xZXFMelI3Z1Nia2ZMbUtYY1lIY0FhM3JSUkdnZXZoMXp5akFKaktNaXdHSkUwRzlqZkJnVFVHM3E4MUE5enJXTHhRX3VkQ005Zy1HZ001cGRqS3pseDA5UEF2TkRrRU4zUGxjMF9SY3lHYi15QzNoZXlTbFVIT043NUE2dlVfci1QdHI2dC1uZUFSNEprRGNIRXgtYk9CMW1XVGc0YVdMSEZMX2htZ0lyTDgwaGk4WnljSzRWX19TTUZ1enJyV2tfZlc4MjhkZ1I5elpuMm9fZXF0VVAtd3dWZ3dpbHNaWmJiZEg5UFBvMzBzZHVwT3g3Q0h0ZU5CNU5ZZlZJdEVyN2xEQzJBQjFPT044NmVDUXE2SGkyc2VrNU53M1RIYlRpN1EuN0FwbzR4YXFXbXdOd0pmYmxfcU9mUQ"}'
+    body: !!python/unicode '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnNoaEMzQjNHdjdYeTZnNVBwTm1hSE92Y1VhU0wyUFFhLVAzQ2xzUkxGM0paR0x6UTJUSVRBYXlTam5naFRncFJLcnZGbi1ITXhxUktyVnRfdWpjTGxYb3p3V3VaWE8zWTZlOUY4T1hjUXZPX09GN1ZTcXc4NktjSm90aEJwQUp0N0E4SVFDMlBkQmNBQV93SnFnMXVrTU5pYlNiWTE4YVhockZtME9ab0REbGRfbTZXSkEwX3FrYXZ1OFFHSDZyc1lmV0FFcFJLZzdiMThBNjlMRnVBN2kzblJVSHQwMGE3V0pvR09rTjc1Y21kMmtSaWc2MWl5SHFDbFJ6YjJDdm1aMnB4VExJRkNhVkhYYzh2TmpoYnlGMHNnR3FBNDBqeUdCVHBDbUFFdXpnekVPeHEzcVA2dGRWVG5SVzV3djZuQlo0MVg4NE5FNnBBRW94bV9neTJKUS5lN1NzOWs2QnRIYjRibGpDZXM4eURRLnhOa21nSE5WQkREWnNvUmQ4bnEweEp4a1RxUGl0Z25MbHdSVjIwR1VCOV9zTjRSUEk5cVktN2lmOS0xeEJ0UlRGQ0RFR01xVUIwVnJibC1oeFB0RlpGa2JIcVZqZnpkSWI1SmJnbXJTVGZDcGhlcG5jY2w2dENsd2ZZSEFRSTNiYXBlYzBOcUdsM1AwR29xSlBEZDRjQmg1SDYzOW1WeEptUU5lSXFZOUFzRjAzLWc3X2pxNDh0YTlfZ0pzejBGSGNGODMxeVhvaWdYTlAyN0RKTVBDT1Z2c05WVHYybnluOW01U2dRMFFZS0ljV096NG1DM1lGYUo1LXVUZHNrcGEwaDl6N1F1Ul95cUVIMUpuQmx0M2ZzTkV0cHJLNW9YbU14c1A5bDByelFQR2xYQXpRLW9vU2tUN3B4bVpnUGpKRG5xT3p0WTFxLU1wRFA2TkFWVEhqNW5iOU9MeVducFBEREZUcU5vUU94UjRYM19zc1JUZlBSRmZ6SVNWOHY1MUJ5bEtramlaQTBzYzNmcDBpZ09rRW9KNWI4NVhUUjktVUR5WHJKYzdPUVJ3dWk1eUtEUHlqaWZXUzZQZ1cxbVFNcnFnbEtJSnB0cUxXajVTVThadFJ1MU1CaS0yM1BFT2lFMkZGa2FwMktnNzI0OUx4QmtYX0V2ZnZ2MnZJLTVUTlRvV09QdmtxVVp1WEZTeEwwR0hIY09mQlNDYUl2OTY3WlRhalRSdFdQaTJMNF8ydmx0cklWbzRsUzA3dzZlRUF3Y1hpcDhSUXNwSC1lbGpNNmpCak5VUHBpdlZTMlNyckZQTlphRnE3eW9nT1pfUXhDXzJ2QzZlZWNHTGEyRlVCb0NBNE1NRU5McmRabTR0QWQ2ZHY4d1lxX0R3OUV6Y2NKS3ZOUDZRSkY5T0xvTGFkMjF6bXM5LXA5NTgwN2tvN0RlWnZxNDhHOFJNdWo3RktVVGtMQXdJYzVRNGlibVA3SXFrSFJ4N1FRRkE1VGlNRTR0S085T2dNSUpBYllwcW5udVBGaTlOLVpCVTR4UWZFN0dCOUhyd2dzclFYUm96QXFiNV9seG9WQXBKTTg4SHQwOGZ6UU5BMFdEY3M5RE5wR0ppYzdXNzBCWEVESzdzS0VNSU5yU2pPMHZuSkpzVnl5TTBLeHkzRGtOU2pNQTNuR281d1BtOFkwcmg5NlR2Y2JQRENzc3RMZXRQU09QUm5MeXlRNVJJWGhoWE9McnFUckI2RF9nNUJqb3pJVjg1Rzc2NTVWR3FVTEQ2S0hyNmpidTJvMElPRXV1NURucmpheG01aE1YZVpyN243cWhEcE80a3N3SVpXM0JTcXNGTUdqdkhKcEdXb19XOVMwYnpRdEdoQXdFQm9GNE1SOVF6R3l4cVhCbmVUc0NLTVZXMXZfTDRHM2NtUDBoWnd3RGg5UmRRbERhOUNpbDhzRm1GTUpCR1ZVckdwdTBYT2dfMjM3SU5Bd1Z5SnRyWXhuWVJKSDFqb29EUDFMLThib01NanN2U0xQR2FFY2J6a0pnMnB0aGFoYU9Nd2o2elUtQzN1eWJKNFc4YVNqN0hUeXlWY084aXROaUV3V3pWQVJHbFZFWjgxUnBKZl9XNUdLWmxva0FjNDc5dklldTl5c19xTjBUYnVvOTVoTmdndHNzNDIxVTlHc1dFTWpxRGpzUDhqeVQ2VlVscFFsa0FEMW5CNGxnV0FLd2pxM0lxSGVHVENLVDRya2xaNjhfa2FaOWNKQWl1eUNDYUJVX0lNSE9zUjhmeXRsNm9IcmI4SWFUMTVHSGRNdVJubXdSUkZaS0dZc0RZcHBSWW9yLVNhUUJyVFJaTUlwUFZ4bnZST2dkRjctblFhcllFbmhlQUlacDkzVXEwNzhJcmpfOTU4OTdiZG9rME1lOFBwLXJDbDhwV2RzUXFxamlFVlpNdUpMSmpCd2NFckZJZ0thVWE4dGxxNld0NzZqSkxUUE5TTEpGeE9nZ1FBVm1IT0J4NUJtRUFhMnhCQjlDQzlzMkJ2V25xV2ItYlM0Zy0yc2l3Qm1fa1AtTkxhRzZxWnlGcmh1amtiYXdqUzhSS3hWSWVGTjIzU3RDMmtweU9Pc01fRnZjaXdmOUZ0TjFnaVpUSFhMbW5qNk9HY0YxX2Y1VXZRRGRHSlBXWkpEeklUbFZrRnUwQS05cTRyal8xZWFoR0ZDNUVpZFBOQ0VoNXJzNno5WWdMNElwVXlXUDJodmQ4MTI1QWxfeFJadldGTlZ6OVNfVDJuZ0VaRTMzc3BZVFJoZzNFYzNHWXRGWmo1MWY3YkZmUkpFYnphT29MTUI4Nkg4cDF6cUhQYWJUcjU5WGZMOHZRU2tzbXBucUFBOVpoc2lXWFNuU2FzMXpWalZxZlpZSWVLU1BoSnExbl92eURGSEY1c2lMLWV4NTBZVk1lRVJPVDlVa3lCWUlSRXhfQmIzZnJTdm56N3p5Q2xzbkJ1Q2drNnBjaFMyVlVFQldhRkp6WWdTc1M3TUJmb3FaMm1hb1g4WTc5ZXpyYks5Mm00MGVldl80dEo0Z1FBMFc3UUcxcGY4OWdKVnlpVlhfdzZwRnVmQUE5WjFsRWN1MkhfSFI1TmtWazhJa1RjdExNeUhuMHRSV3hqWkpIM1ZrUXhscVQ2WEtvUWZjWWhPQzFnd2lvQTdsbk1EOGhuZWZaSVhJUlRmNzdlRU5pV1J1dXA5VzgxZ3dOaEFxZ2owQ0twMEw3ZlB0eFRHdFVyUFZxNE9nSWctbERHQklTZkJvU3Q1a1MxQVVBb0ZQVExObHNMWjVPMVo2TG9aTmtqbnJic3ZBc3lJWkQ0UnRvRW5xcGFPNHl6MWFoSWZ0LXJHMlFTdGdkN2U3MW1ESGFBYXpOVC05NHNGYUVWUUcxNDBaaHk3TXVTc1VEamlyQlgyV01jMFQ3Zkhabzg0ODJQYi16T21RMlNrT1RvU3pjV0hva0kxZUxFQm1pWlpNdWRkc3FMMGVWejZLRmpndU1oSXpPdnZueXY3RWJRSzRJTVJkN0owQ290X2FXLThfTkg3WHdNcUN5NW1tdzdLVkhzcjNqRGdVRGxPMk83U3FnUl9makxNR0g2Y0RzcjdQSTJQV3AtLVVVcTQyM1BWckNOa1R4R3JhcHNHR2ZQcEk0WHJ1aUVlZjB5NGFlV0ozeGQtel9tN2M4RXItSm1MQ19ZSGF3cXhQM2d0UVpsejFDVDJBc2JTS0o5ZUtHaXJoRTlrWWhfMHVMUWZnazY3djRrNTRRS3JRQ3czRmlCUGEwdHlrdmE0OENGQ0w0SlNDajA2ejdVT0l5b2Y0QXlqQjhGdC1GYTFJb1Y5Y2M1eURpUkQxMlVxWHMzTTg4RnF3TTNDSE9MdGhhM1B2MUpVSE1Xd01kUUo2ZlRjN0R0U3pEdlVaT2ZYLS1GM0ZpZHdUN1RDaFcyaWJqQjlNSjBUMUJOY2p6N3JIdHYyRUlfdWpZd0g2Zkd3RXgtemV4X3Bzak5hS3dzbFNMYlFVclN3Yndxbm5fWmxNTEgtOGJHUTVZbUhMMUd0TE9kX29nRHdkU2F5V0JKQ1ZyT3JqTFFwWkhVNktGZmE2eXR3NXFUV1JYQWtudUt3UFJLeTJpSzg1aVI3UmRTdVB2d01id3NVMlhHOXBMeUw3d1NVVHUzekNoRUZlbTZjdEQwcXl1a3JQWWprN1M1SlFucGV3aHloc0o5X2ctaDh1X2pBWUs5U2FKbUJFUVg2UWhJRzVKaUlFdXVQZTFmUVJ4X19ES1dEU3E5VTRJVDZDRm5tR3FFRDh4dDVTYjhORnhHUi15ZzNNVHZGQmJPdEM2eUtYWkwwaXZQRHVXSmZKdVB1VExMeG1vZGxMdmdIN0RCQ1kwNHNHc01Kb1VzNmszZG94ODZ2V3lvQi03cW5VWUlMaWRweFZaQmt6RHc5NzczYUdSRmVkaFdXRk81V2ZqOGtiS25rUjJUTWN4bDZXYVNISkZJV01Dbks5M1FKdUl2QS01U3VpMTJqblBieTVfNmU4cFJ2Y3RvT000QzhlbWotTWs3NXJNS0t0YU5Da0ViY1VvLVcyWURFZUdYbDBvRFhHXzRUQzl4cll2T0JFakN5d21xRlRHNmNYeGZaUFQxbjhueXN1bW5SdVdrUTcwcTZDTzhLOWVuSkV2M2ZHX1JoRDFlN1VtaXBDU1pwa1prLTM1MDktWTZQWmlaZDVrZ0pHN3JOdHFuZEMxRUZ4VEg3cW93ZGw1b1Rhd2pmdE1PYjVSSGFFRVZvdzhNa3FQTEcwblFreGVVUGpkcUZPVG9uaUxMdVpwbFBneFBwaUc2Nnk0bjhGMmttYlhsTzkyQUxtOVJEaUJTTUpBMTNfQ0tyQ0tRcVRzazVRZVplWTRqdDlHYXcuLVd4YnBYU0Z3dGZoMkxmdFlPX2ZQUQ"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['5123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa2c76e8-4fc9-11e7-911e-5065f34efe31]
+      x-ms-client-request-id: [77f5221e-9414-11e7-9e0e-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/restore?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":false,"created":1497311452,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['279']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['279']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -483,28 +483,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa7617be-4fc9-11e7-b019-5065f34efe31]
+      x-ms-client-request-id: [783cb270-9414-11e7-a5ee-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":false,"created":1497311452,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/a59f19c25abb4702a030d207aada45b7","attributes":{"enabled":true,"created":1497311454,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['547']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['547']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -514,28 +514,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [faa4ac4a-4fc9-11e7-beaa-5065f34efe31]
+      x-ms-client-request-id: [785f2e91-9414-11e7-a0bb-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/80cb6ffccc3b41b9af3329f9c2cf805b","attributes":{"enabled":false,"created":1497311452,"updated":1497311454,"recoverylevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['279']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['279']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -544,60 +544,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [faecc33a-4fc9-11e7-b983-5065f34efe31]
+      x-ms-client-request-id: [78a2a030-9414-11e7-a926-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:57 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-8"}, "value":
-      "TestSecretTestSecretTestSecretTestSecret\n"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb13898a-4fc9-11e7-90de-5065f34efe31]
+      x-ms-client-request-id: [78c8509e-9414-11e7-9333-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/2f152bb11a6944cd90d421c85c8bea66","attributes":{"enabled":true,"created":1497311459,"updated":1497311459,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/4f44bad3c50f478691975ee91015616e","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['299']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['299']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -606,60 +606,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb43ca1c-4fc9-11e7-a824-5065f34efe31]
+      x-ms-client-request-id: [78f0991e-9414-11e7-90a2-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/2f152bb11a6944cd90d421c85c8bea66","attributes":{"enabled":true,"created":1497311459,"updated":1497311459,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/4f44bad3c50f478691975ee91015616e","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['299']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['299']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-16le"},
-      "value": "TestSecretTestSecretTestSecretTestSecret\n"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-16le"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb695a86-4fc9-11e7-a624-5065f34efe31]
+      x-ms-client-request-id: [79102f0f-9414-11e7-a32d-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/677729d88d024779a2088a07161a60e5","attributes":{"enabled":true,"created":1497311459,"updated":1497311459,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/7cf588a6188947549ceddba8c72a57c9","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['305']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['305']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -668,60 +668,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb99c564-4fc9-11e7-aa00-5065f34efe31]
+      x-ms-client-request-id: [793b36b0-9414-11e7-8153-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/677729d88d024779a2088a07161a60e5","attributes":{"enabled":true,"created":1497311459,"updated":1497311459,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/7cf588a6188947549ceddba8c72a57c9","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['305']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['305']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "utf-16be"},
-      "value": "TestSecretTestSecretTestSecretTestSecret\n"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "utf-16be"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fbc28aa2-4fc9-11e7-a3d3-5065f34efe31]
+      x-ms-client-request-id: [795e4f0f-9414-11e7-94a2-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/56ffc2487a8a4dd9ae7361171b2c6640","attributes":{"enabled":true,"created":1497311460,"updated":1497311460,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/fc24d37e83d14cdebcb4be57899fa773","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['305']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['305']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -730,60 +730,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fbf1e41e-4fc9-11e7-9770-5065f34efe31]
+      x-ms-client-request-id: [79a01300-9414-11e7-bdce-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/56ffc2487a8a4dd9ae7361171b2c6640","attributes":{"enabled":true,"created":1497311460,"updated":1497311460,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/fc24d37e83d14cdebcb4be57899fa773","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['305']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['305']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "ascii"}, "value":
-      "TestSecretTestSecretTestSecretTestSecret\n"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
+      "tags": {"file-encoding": "ascii"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fc1a1018-4fc9-11e7-b11f-5065f34efe31]
+      x-ms-client-request-id: [79e30f6e-9414-11e7-876a-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/a92bb2b42d8c41be9435c060a00faca3","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/2cd7520c59df406397a0312cf8f36e34","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['299']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['299']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -792,60 +792,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fc4d3930-4fc9-11e7-b345-5065f34efe31]
+      x-ms-client-request-id: [7a1cbd0f-9414-11e7-9777-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/a92bb2b42d8c41be9435c060a00faca3","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/2cd7520c59df406397a0312cf8f36e34","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['299']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['299']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "base64"},
-      "value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n",
+      "tags": {"file-encoding": "base64"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fc740626-4fc9-11e7-bf93-5065f34efe31]
+      x-ms-client-request-id: [7a421f61-9414-11e7-976b-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/831fb00ee8734595afb44ab87c455432","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
+    body: {string: !!python/unicode '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/64402a0bb04a411d8278b72e2d40fcba","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['317']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['317']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -854,60 +854,60 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fca7ca36-4fc9-11e7-877d-5065f34efe31]
+      x-ms-client-request-id: [7a6fbf11-9414-11e7-b79c-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/831fb00ee8734595afb44ab87c455432","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
+    body: {string: !!python/unicode '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/64402a0bb04a411d8278b72e2d40fcba","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['317']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['317']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "tags": {"file-encoding": "hex"}, "value":
-      "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a",
+      "tags": {"file-encoding": "hex"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['164']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fccdaa48-4fc9-11e7-9426-5065f34efe31]
+      x-ms-client-request-id: [7a956f80-9414-11e7-b795-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/2f3039a002264a22aeec7d8773f6182e","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
+    body: {string: !!python/unicode '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/63fa7a77d557497697a9e8eb9dd97835","attributes":{"enabled":true,"created":1504820133,"updated":1504820133,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['337']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['337']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -916,27 +916,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd080c38-4fc9-11e7-b3e5-5065f34efe31]
+      x-ms-client-request-id: [7ac02900-9414-11e7-868e-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/?api-version=2016-10-01
   response:
-    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/2f3039a002264a22aeec7d8773f6182e","attributes":{"enabled":true,"created":1497311461,"updated":1497311461,"recoverylevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
+    body: {string: !!python/unicode '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/63fa7a77d557497697a9e8eb9dd97835","attributes":{"enabled":true,"created":1504820133,"updated":1504820133,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['337']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['337']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_secret.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_secret.yaml
@@ -1,32 +1,58 @@
 interactions:
 - request:
+    body: '{"location": "westus", "tags": {"use": "az-test"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_secret000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001","name":"cli_test_keyvault_secret000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 15:23:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [4c8dfd00-9414-11e7-9bfb-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:34:15 GMT']
-      duration: ['564789']
+      date: ['Fri, 08 Sep 2017 15:23:18 GMT']
+      duration: ['1122335']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U=]
-      ocp-aad-session-key: [zYFxJsaiE_i_kDh2Jn8AfDNW--bYTgSxagOzvaAuEQlLYO3xqKReeTK-3OETqt5frl658gTnJe-zO-2GNxH5EdkP1FZOxrVsg7HTq2KTqG3zq0PoBTTCZdiawPsDb0os.IS1gP_04Db22wymNC6PaNBe2DPI08av7R3ouKuVV6pA]
+      ocp-aad-diagnostics-server-name: [PHA+MZLp3HM+MiVXTghBS0Om6GJiS3JCb0/eer+s+cI=]
+      ocp-aad-session-key: [dPWzwDZ6smV5nfn6AdULh9WreJAQ4RFmMppGNKraovhxJ6tJzKBFzWqm4_akGCe_wybB4LiTg_dnZ1rahOitKP1n5SCKYlSRhYkrks_JRbJWB_bNqnovJORw-RxcoOOY.zqYziAovn8NnSfNen07xUOBUMFke3NMM3QBZ1vGSA7Y]
       pragma: [no-cache]
-      request-id: [c20233c8-4d99-4a1d-b39b-44f3c8ac2251]
+      request-id: [9a6ea288-7b5d-43a8-aa0e-0b66187f8e06]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -35,36 +61,35 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
-      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
-      "update", "import", "backup", "restore", "recover"], "secrets": ["get", "list",
-      "set", "delete", "backup", "restore", "recover"], "certificates": ["get", "list",
-      "delete", "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "storage": ["get",
-      "list", "delete", "set", "update", "regeneratekey", "setsas", "listsas", "getsas",
-      "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"properties": {"sku": {"family": "A", "name": "premium"}, "tenantId":
+      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "accessPolicies": [{"permissions": {"keys":
+      ["get", "create", "delete", "list", "update", "import", "backup", "restore",
+      "recover"], "storage": ["get", "list", "delete", "set", "update", "regeneratekey",
+      "setsas", "listsas", "getsas", "deletesas"], "secrets": ["get", "list", "set",
+      "delete", "backup", "restore", "recover"], "certificates": ["get", "list", "delete",
+      "create", "import", "update", "managecontacts", "getissuers", "listissuers",
+      "setissuers", "deleteissuers", "manageissuers", "recover"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]}, "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['745']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4caf40a1-9414-11e7-848d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kevault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-keyvault-secret.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kevault-000002","name":"cli-test-kevault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"]}}],"enabledForDeployment":false,"vaultUri":"https://cli-test-kevault-000002.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1023']
+      content-length: ['1068']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:34:20 GMT']
+      date: ['Fri, 08 Sep 2017 15:23:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -74,7 +99,7 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
@@ -84,18 +109,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [730fc6c0-9414-11e7-aac1-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:35:20 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -115,19 +139,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [730fc6c0-9414-11e7-aac1-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
+    body: {string: '{"value":null,"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:20 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -139,27 +162,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "ABC123", "tags":
-      {"file-encoding": "utf-8"}}'
+    body: '{"value": "ABC123", "attributes": {"enabled": true}, "tags": {"file-encoding":
+      "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [73505230-9414-11e7-8b4b-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/3383b4cdedc7416485addde0cf45826b","attributes":{"enabled":true,"created":1504884292,"updated":1504884292,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['256']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -177,19 +199,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [767c8bde-9414-11e7-aa20-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504884292,"updated":1504884292,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['234']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -201,27 +222,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "contentType": "test
-      type", "value": "DEF456", "tags": {"test": "foo", "file-encoding": "utf-8"}}'
+    body: '{"value": "DEF456", "attributes": {"enabled": true}, "contentType": "test
+      type", "tags": {"test": "foo", "file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76a1ee30-9414-11e7-8d4b-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":true,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['295']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -239,19 +259,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76d3104f-9414-11e7-b5b4-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/3383b4cdedc7416485addde0cf45826b","attributes":{"enabled":true,"created":1504884292,"updated":1504884292,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}},{"contentType":"test
+        type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":true,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['546']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -269,19 +289,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76f935ee-9414-11e7-8429-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":true,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['295']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:26 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -299,19 +318,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77187dc0-9414-11e7-8824-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/3383b4cdedc7416485addde0cf45826b?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/3383b4cdedc7416485addde0cf45826b","attributes":{"enabled":true,"created":1504884292,"updated":1504884292,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['256']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -323,26 +341,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": false}}'
+    body: '{"attributes": {"enabled": false}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [773c0b51-9414-11e7-812f-a0b3ccf7272a]
     method: PATCH
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":false,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['279']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:27 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:52 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -361,19 +378,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [777320de-9414-11e7-8585-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/backup?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/backup?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnNoaEMzQjNHdjdYeTZnNVBwTm1hSE92Y1VhU0wyUFFhLVAzQ2xzUkxGM0paR0x6UTJUSVRBYXlTam5naFRncFJLcnZGbi1ITXhxUktyVnRfdWpjTGxYb3p3V3VaWE8zWTZlOUY4T1hjUXZPX09GN1ZTcXc4NktjSm90aEJwQUp0N0E4SVFDMlBkQmNBQV93SnFnMXVrTU5pYlNiWTE4YVhockZtME9ab0REbGRfbTZXSkEwX3FrYXZ1OFFHSDZyc1lmV0FFcFJLZzdiMThBNjlMRnVBN2kzblJVSHQwMGE3V0pvR09rTjc1Y21kMmtSaWc2MWl5SHFDbFJ6YjJDdm1aMnB4VExJRkNhVkhYYzh2TmpoYnlGMHNnR3FBNDBqeUdCVHBDbUFFdXpnekVPeHEzcVA2dGRWVG5SVzV3djZuQlo0MVg4NE5FNnBBRW94bV9neTJKUS5lN1NzOWs2QnRIYjRibGpDZXM4eURRLnhOa21nSE5WQkREWnNvUmQ4bnEweEp4a1RxUGl0Z25MbHdSVjIwR1VCOV9zTjRSUEk5cVktN2lmOS0xeEJ0UlRGQ0RFR01xVUIwVnJibC1oeFB0RlpGa2JIcVZqZnpkSWI1SmJnbXJTVGZDcGhlcG5jY2w2dENsd2ZZSEFRSTNiYXBlYzBOcUdsM1AwR29xSlBEZDRjQmg1SDYzOW1WeEptUU5lSXFZOUFzRjAzLWc3X2pxNDh0YTlfZ0pzejBGSGNGODMxeVhvaWdYTlAyN0RKTVBDT1Z2c05WVHYybnluOW01U2dRMFFZS0ljV096NG1DM1lGYUo1LXVUZHNrcGEwaDl6N1F1Ul95cUVIMUpuQmx0M2ZzTkV0cHJLNW9YbU14c1A5bDByelFQR2xYQXpRLW9vU2tUN3B4bVpnUGpKRG5xT3p0WTFxLU1wRFA2TkFWVEhqNW5iOU9MeVducFBEREZUcU5vUU94UjRYM19zc1JUZlBSRmZ6SVNWOHY1MUJ5bEtramlaQTBzYzNmcDBpZ09rRW9KNWI4NVhUUjktVUR5WHJKYzdPUVJ3dWk1eUtEUHlqaWZXUzZQZ1cxbVFNcnFnbEtJSnB0cUxXajVTVThadFJ1MU1CaS0yM1BFT2lFMkZGa2FwMktnNzI0OUx4QmtYX0V2ZnZ2MnZJLTVUTlRvV09QdmtxVVp1WEZTeEwwR0hIY09mQlNDYUl2OTY3WlRhalRSdFdQaTJMNF8ydmx0cklWbzRsUzA3dzZlRUF3Y1hpcDhSUXNwSC1lbGpNNmpCak5VUHBpdlZTMlNyckZQTlphRnE3eW9nT1pfUXhDXzJ2QzZlZWNHTGEyRlVCb0NBNE1NRU5McmRabTR0QWQ2ZHY4d1lxX0R3OUV6Y2NKS3ZOUDZRSkY5T0xvTGFkMjF6bXM5LXA5NTgwN2tvN0RlWnZxNDhHOFJNdWo3RktVVGtMQXdJYzVRNGlibVA3SXFrSFJ4N1FRRkE1VGlNRTR0S085T2dNSUpBYllwcW5udVBGaTlOLVpCVTR4UWZFN0dCOUhyd2dzclFYUm96QXFiNV9seG9WQXBKTTg4SHQwOGZ6UU5BMFdEY3M5RE5wR0ppYzdXNzBCWEVESzdzS0VNSU5yU2pPMHZuSkpzVnl5TTBLeHkzRGtOU2pNQTNuR281d1BtOFkwcmg5NlR2Y2JQRENzc3RMZXRQU09QUm5MeXlRNVJJWGhoWE9McnFUckI2RF9nNUJqb3pJVjg1Rzc2NTVWR3FVTEQ2S0hyNmpidTJvMElPRXV1NURucmpheG01aE1YZVpyN243cWhEcE80a3N3SVpXM0JTcXNGTUdqdkhKcEdXb19XOVMwYnpRdEdoQXdFQm9GNE1SOVF6R3l4cVhCbmVUc0NLTVZXMXZfTDRHM2NtUDBoWnd3RGg5UmRRbERhOUNpbDhzRm1GTUpCR1ZVckdwdTBYT2dfMjM3SU5Bd1Z5SnRyWXhuWVJKSDFqb29EUDFMLThib01NanN2U0xQR2FFY2J6a0pnMnB0aGFoYU9Nd2o2elUtQzN1eWJKNFc4YVNqN0hUeXlWY084aXROaUV3V3pWQVJHbFZFWjgxUnBKZl9XNUdLWmxva0FjNDc5dklldTl5c19xTjBUYnVvOTVoTmdndHNzNDIxVTlHc1dFTWpxRGpzUDhqeVQ2VlVscFFsa0FEMW5CNGxnV0FLd2pxM0lxSGVHVENLVDRya2xaNjhfa2FaOWNKQWl1eUNDYUJVX0lNSE9zUjhmeXRsNm9IcmI4SWFUMTVHSGRNdVJubXdSUkZaS0dZc0RZcHBSWW9yLVNhUUJyVFJaTUlwUFZ4bnZST2dkRjctblFhcllFbmhlQUlacDkzVXEwNzhJcmpfOTU4OTdiZG9rME1lOFBwLXJDbDhwV2RzUXFxamlFVlpNdUpMSmpCd2NFckZJZ0thVWE4dGxxNld0NzZqSkxUUE5TTEpGeE9nZ1FBVm1IT0J4NUJtRUFhMnhCQjlDQzlzMkJ2V25xV2ItYlM0Zy0yc2l3Qm1fa1AtTkxhRzZxWnlGcmh1amtiYXdqUzhSS3hWSWVGTjIzU3RDMmtweU9Pc01fRnZjaXdmOUZ0TjFnaVpUSFhMbW5qNk9HY0YxX2Y1VXZRRGRHSlBXWkpEeklUbFZrRnUwQS05cTRyal8xZWFoR0ZDNUVpZFBOQ0VoNXJzNno5WWdMNElwVXlXUDJodmQ4MTI1QWxfeFJadldGTlZ6OVNfVDJuZ0VaRTMzc3BZVFJoZzNFYzNHWXRGWmo1MWY3YkZmUkpFYnphT29MTUI4Nkg4cDF6cUhQYWJUcjU5WGZMOHZRU2tzbXBucUFBOVpoc2lXWFNuU2FzMXpWalZxZlpZSWVLU1BoSnExbl92eURGSEY1c2lMLWV4NTBZVk1lRVJPVDlVa3lCWUlSRXhfQmIzZnJTdm56N3p5Q2xzbkJ1Q2drNnBjaFMyVlVFQldhRkp6WWdTc1M3TUJmb3FaMm1hb1g4WTc5ZXpyYks5Mm00MGVldl80dEo0Z1FBMFc3UUcxcGY4OWdKVnlpVlhfdzZwRnVmQUE5WjFsRWN1MkhfSFI1TmtWazhJa1RjdExNeUhuMHRSV3hqWkpIM1ZrUXhscVQ2WEtvUWZjWWhPQzFnd2lvQTdsbk1EOGhuZWZaSVhJUlRmNzdlRU5pV1J1dXA5VzgxZ3dOaEFxZ2owQ0twMEw3ZlB0eFRHdFVyUFZxNE9nSWctbERHQklTZkJvU3Q1a1MxQVVBb0ZQVExObHNMWjVPMVo2TG9aTmtqbnJic3ZBc3lJWkQ0UnRvRW5xcGFPNHl6MWFoSWZ0LXJHMlFTdGdkN2U3MW1ESGFBYXpOVC05NHNGYUVWUUcxNDBaaHk3TXVTc1VEamlyQlgyV01jMFQ3Zkhabzg0ODJQYi16T21RMlNrT1RvU3pjV0hva0kxZUxFQm1pWlpNdWRkc3FMMGVWejZLRmpndU1oSXpPdnZueXY3RWJRSzRJTVJkN0owQ290X2FXLThfTkg3WHdNcUN5NW1tdzdLVkhzcjNqRGdVRGxPMk83U3FnUl9makxNR0g2Y0RzcjdQSTJQV3AtLVVVcTQyM1BWckNOa1R4R3JhcHNHR2ZQcEk0WHJ1aUVlZjB5NGFlV0ozeGQtel9tN2M4RXItSm1MQ19ZSGF3cXhQM2d0UVpsejFDVDJBc2JTS0o5ZUtHaXJoRTlrWWhfMHVMUWZnazY3djRrNTRRS3JRQ3czRmlCUGEwdHlrdmE0OENGQ0w0SlNDajA2ejdVT0l5b2Y0QXlqQjhGdC1GYTFJb1Y5Y2M1eURpUkQxMlVxWHMzTTg4RnF3TTNDSE9MdGhhM1B2MUpVSE1Xd01kUUo2ZlRjN0R0U3pEdlVaT2ZYLS1GM0ZpZHdUN1RDaFcyaWJqQjlNSjBUMUJOY2p6N3JIdHYyRUlfdWpZd0g2Zkd3RXgtemV4X3Bzak5hS3dzbFNMYlFVclN3Yndxbm5fWmxNTEgtOGJHUTVZbUhMMUd0TE9kX29nRHdkU2F5V0JKQ1ZyT3JqTFFwWkhVNktGZmE2eXR3NXFUV1JYQWtudUt3UFJLeTJpSzg1aVI3UmRTdVB2d01id3NVMlhHOXBMeUw3d1NVVHUzekNoRUZlbTZjdEQwcXl1a3JQWWprN1M1SlFucGV3aHloc0o5X2ctaDh1X2pBWUs5U2FKbUJFUVg2UWhJRzVKaUlFdXVQZTFmUVJ4X19ES1dEU3E5VTRJVDZDRm5tR3FFRDh4dDVTYjhORnhHUi15ZzNNVHZGQmJPdEM2eUtYWkwwaXZQRHVXSmZKdVB1VExMeG1vZGxMdmdIN0RCQ1kwNHNHc01Kb1VzNmszZG94ODZ2V3lvQi03cW5VWUlMaWRweFZaQmt6RHc5NzczYUdSRmVkaFdXRk81V2ZqOGtiS25rUjJUTWN4bDZXYVNISkZJV01Dbks5M1FKdUl2QS01U3VpMTJqblBieTVfNmU4cFJ2Y3RvT000QzhlbWotTWs3NXJNS0t0YU5Da0ViY1VvLVcyWURFZUdYbDBvRFhHXzRUQzl4cll2T0JFakN5d21xRlRHNmNYeGZaUFQxbjhueXN1bW5SdVdrUTcwcTZDTzhLOWVuSkV2M2ZHX1JoRDFlN1VtaXBDU1pwa1prLTM1MDktWTZQWmlaZDVrZ0pHN3JOdHFuZEMxRUZ4VEg3cW93ZGw1b1Rhd2pmdE1PYjVSSGFFRVZvdzhNa3FQTEcwblFreGVVUGpkcUZPVG9uaUxMdVpwbFBneFBwaUc2Nnk0bjhGMmttYlhsTzkyQUxtOVJEaUJTTUpBMTNfQ0tyQ0tRcVRzazVRZVplWTRqdDlHYXcuLVd4YnBYU0Z3dGZoMkxmdFlPX2ZQUQ"}'}
+    body: {string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnFYM1dWWVp6OUh4U3YtV0FsVXgzMHpIbGxuZ1JCbWFVU185SlZqaDJsLUFQMHhELVg2c3NMXzZ4ckQ0UDM0ZWVJRm1xZmtwQVBHalZaNEQtQm9XRzk5NERJVmN6U2VuTDJfZldMNjZzNW9pcTVmTGVYM253cm5RMG9tOVBEeUZOZ0dWRWZzb2hJMXhKOXhBTXhXYUFETk8wVHN2ZmlnZWo0UkhxVk1OWFJFeHZBY2dJamF6Y3Z5N0dGcVNYbFNpbEpZYXlzUTI0R05HajNqVHBuV3laU29rakpsd0NBelJVbDBiY21GOWFJdFVkTE9nOTZGbXo3Mzd5a2pfQnlqalVrOGJJZlZ5VHZtMmNQUGt0VnpDMVYtREI1S1h0THlRWHh4Z1Q3ZHhuNUVDTGl4YjZSUV80c0R6VVVGZ0VvOFRBNkJTVHR0SzlUREljZ0ZoZEtlMEc5dy5sOUtPSF9wSXdHcnhOTEY2R1VBYVJRLno2cHIxVFFqUWdhZGVQbzFydkQ1Qy04LVVfWmV1Rmc3Um5ENEtuMVV0YmhtWWJJMk41ZVhWZ3lPQ0N0dHhwa3FJS19OeDZQZTV3a0prVUJhWVE1M1lyVUdIX3VIS1lJakZOX1pHeXhXRWh3OV9IWU1NUlVxY0JTejVlMW5Eb3hua3dSb2hfNnFFSWRGMXh1OTB6dTJDSXpIc0JjZVAtNVJFcWhmanJtSmZPNE5WMjdHdjd6YTFJVW9oQmJYbDlQd0pkUnFRZnRVN0F3Rl9MSDZ0V01NRkZXWEhfMDg2d3ZPN3EtTC1TY1V6NDhQZlRTNkNHXzJTNWFXLTNlTXpyTkR4aFhaZTN3NjlBTXQ3Mmt3RVhpdVdkeEZydnNFaklIU2lRWE8zSUo2OFVEWjdvTkdtOC1ncTdoUU9Xcnc4cWZUVVQ3MGxQUVUtM0xBbDAzSkw1RXIwbTgydTRLRGp2blk0VE9LbnFac3NfaHJPdWo5YnJhNmdacklfdUtod0p6V09XUVZKQjVPZ0pMUndhWEJYVmpvd09WZThrbHl3NUYxWUR6VVo3WE0yWmxnTEZUWjhCd1V6MGlpZlEwdFpYRDYwNE8ybm1makt1YlhqbHVGTWdoY0IySUM1VlB4ZEhrUGFRWm9uWTM2LVFGQzJiMG5sVThnWXVLUlZOS1NjR0ZxVXpSVHpxandxbkdkZld4eEZINlVORWZrNHFlQnJYQ2I0aHY3U3ZWOTlMRXlvb3dfeFktYm5oeXVhSldtTklLUEJXdy1VSV9aTUxKem8zTkEwQjQ4NWlXLUpYUGtYNkRoQnhzU2pVVThZQzAwZFZRLUVDUWlJcU9YOXBPZjBPRlgwNHdlZWNuLTZrejVCWFpRU1dwQjlrTFVhN2tXQnpMamVKbllGcVpOLWotUGF1MTNRTDd3cXphZU9sY0Z1Z3B2Uk4wSkdRbjRLem5ZN3JMV01GUzhuSWRfUHB4TVEyQi0yZks3VjdzM3BYYTRMVzB0OEJMbmhYdHc1UEVWN3M1VlZNOTYzV1dCck02b0lNUjh0T1c5MnlyWGJrTWp4NXZCdXI5aEVlYm4yYUt4Z2d3OWJrWlY0OXpESjNUdk1SdFpBal83QVlOSy1ZX3gyaUlfaEpzWVBYMWNYemJZVDNvV2JwMENWRTFZWDJKeGVNMWFhbGpHajhFb2ZUWVhGa19Wd1V0TUtYaGM3YThrN0QtQVZHWjJMLTNCUU40NUlXbC15Q0g5bnRDblRsWGZOOXpha21wVDl1MjUtdGVIdWVwVF9leW02dWRqVVhlbllYUEpXQ0NHRzAtTjJ3STlSNllfeXlTa0J5V1pqMTdyenBVYXlrRXp2akFKa2xObXhCMlZhN2UwLTEtLV8wV0xPRWNoWUVqUzhaMTF3Mm5LQzM2amZyQ1BxMENZbGN1U3dycmROVmdhMVhPWXNaQTlkTHAzU1ZYUXFmSjhScTFSTUtLVUxzY0NFSzdheW1ua0JUQ0xLaWVxVk55elNERUJDUWM4cU9PbmxHNDJOUk12YlJmMVZ4T24xNnZ1VHhUUmpjaVk0blZVMDhLMW5adU8zRUFJclkwNjJIeXdsV09zWWtfNnRqQ2tHNHpxLUVfNWlWYW9xbENnN181cElDbTlGcEtQdXdJeGI0ZXJ0c1BRLWtsRHlKUDNzYU9sQ2pyS2d3YWJad0t4VEJwVGl3WWhHNkdyZFRIX0tnTVZSZXpSZ0V2dlpnbnktU2hYY3BBZUdqRkNLRVc2b0phd2NBT0JrVmlxZjQybDU0aDR1NDBaMmplVGdqTldjRlRLQkVsM3A4UUtnMWRYZkd0TElXVk1xOXZaMWd5TnRUSFhfUDFIS1JQNFZMOHlNQnd3Q01Ra2oxNm53bEY2SGZieW1xNWdhQzlESXNyTF84aGVtWUkxazc2UHk0dVVHN21ZZkN1ODFFdUc5TTE4dkpJQzJlWVY1M3RYN3E0QWFnLW0xVFVPSmdfOTM5cDViZFJfQ3FNU3ZfUWlsVFJReTEtV0hzTzZsVS02R0Z1VW82NUpwU2lpSHFCTmxrWXRzZURDQThXQXQ0OUFua3QtTjVqWkwzdFh3SDBkNVhXVmlteGoxZkFHTmV3RnhOV3dNLVJLOU4yM1BsbHpWaHFMS0lUeV9pbHkzM2F2YmNhVUNzYTZsVHdhN3FEekxPMDdqaHl5NGtNLUdkeFI3MXZmZEtEd05CQlpvTjAzZWV1Mnh4dDk1anVJbzJzLVlvT3lkblZRYzlLVmtLaHd2a0R3blBkTlU4R1ZSVDdIQV9lOHcwVTNpR29NMWRHblVFS2JtczQ5SjBuZ0tDNHNxeTVudFdTTG05RTJ5aUpsUFRlS1FXWFg0OVNRNXBGRF9yZVRUZnYwbkNETEJHNVdmVUlUc2VkcElvTERobVZ1VXlCcGZpWF9Gem1LTEZUM0xSYWZLU0J6aW5Xa1VkOVlvdUVKM1lxMUcxUHg4c3d6amdxZmg4YXBjRkhKcEd2blR3TXYtMk5lamloQVhfT0tZT1pVeG1BalRVVXA4UXNURDRfTm5zWjZCQlRlVURXdkoySEJYaW0zMnBwbUFObUotODJld3BjWERoeWxjVXFaVG9wNGJBZmlxbG00Z3VNb2xlaWpuNzFHWTFYaG9VWHp1OXRzT19xb3FLLXN3THR2TV8xN0RVcnZ6RFU2SzFGLVZlLXhkM3FlZ0t1YVVCbnBiZUpPbEZOUGxYSjFVd2p1TnVmN0ZRZVhMSTVmbV91ZlJDVWFWZUxqM1EyTUY0ZDBqeGRzeENQZTlydDQ0aXQxUVNlN1lOUlphMkRUc3hpMVlaZVdUc3JmNTZlLTZJN2s5bjJZNFpKQkFMQUFHU0ZKNEFhbFdaX2JYNGJDMnktSDRpenJUV24xaGRTUVlsNzZEa3oyVnBOLUtpaHVWTUE5NnNJQzEwRS1xWWlKNFhzSHJjd2xVRkRlcld3VkdkaFBlMzBBQ3pzQUdWenVWWDdHcTE0Wk1YUHhQOXhVaG1qUklNVzVfRk11YVdlU21QdlVhTFh0UlZYX29nbUk5QkpManpZa2ZBcFpxWjNMZk1jRUZoMkRITnlhSDdraFhhaURVVzJOMHJ2MVRGOTEyVVZBTTFROENaVlBvcFl4b19rdll1UjdwQXFwWWVxeDBPTEhNWHRrUllENndjRkZRdnFyNTdTTGhWLW95TklHcGZOR09pWVhuU0R2NUpxend3QUxndEswMkFjX3dDcHduaUF6Yk02MzJ0Q1YyaW5GRVMyd2lxVlJwaE5OWEdQY3NwamU5cDg1YWZHMDVxUmpUdDJaS3prVTRqWGEzbGpKZk9hTGdLa1UzTlB0cUp0TE9SSU9WbUQxOUw3SXFLQVdqWVh1M2swXzN2NF9fX3o3N2hpZGgxbk9EYWpHLVVWZHV3dlNJWE1Qb0lpcmdPV3pEWmZuTFBzakFNWldjak15YW1qR1loOEZXZmJjUHhFOVl4c1RxUHpVbFBNLVpJTlNHM2E2d0s1bHpaNzNHczJsSVFscTlPcThVU1JMMUtSZ21iakFzTTlGRVJOa1JRcjNYbTlYSE9FbVBBb01tYlRKX0FXOGV2WkhBejVQTUM2dEJjS0E2bWpwaUJRVXp3WmNDMEpOdTJYMzhjd01UWnhlWDVMLUFXTW5GSC1MMS1VVnNkWUpaRXZRMFdNM19oMWRDemphMHhTLWNQUjZEVHpGV2FTNzBOMzVXSE1nZzJURHItR01pR3FQNUpHaTBjckt3bjRoeUVpdTJmT3FxWUVyM3c0U29mMkgzTDhzaE93aWRMbHlDU01Xc0huWXZXZTJweFFQY1ZSaEJ4VlNYUG9vV3NRS2FwM3pydjlZQU1naThhdTVUTHcyVGtPSGFLb08zRGlNNF9xZy05c2Z5S2JwZG5GUXRqUFZQV05iYTVxcXZUNmdNZVdXWTdYeUp0LTZReDhLQmdWcEQzczFNbTA5bXdMRF9ST1lTQTdDak03VUFFUXNXLWpUS0Q4ZlVSWWZtQ3JuTDZtMzVZLTFDUVVZWHNvTmc5ZFBrM0xJal9yWDMxTkdRRDIxdm9vdS1JQm9kQmduQ3Bvb0paTGF3NlFaWjFIUWNRazExMmc5UWhaeGhVTS0yd3dsbDJxcGNIaDV1b2ZOS0JxazZLdTJkLWxaYWRPa1d5UmVJbE02aVBCdU5Dd0ZpQzVpNHZ4dGZCOEJhc1ZYZDNoMlNfR2Q0NUxNMXNJMlM4dU9iZFVfbE5qLXlUUlVfd0tPeEx3amRxWXFjQWRITTdaNnV3X3RVSW1pRlE4MUpjelFwZFpTMUFkeFFQc1FObTFfQzdFVEFPYzRiSnNYWWo0OUh5YkhQQkVPbm5ad3JBd1dxeEFFbjZTN3huUmItY3ZQb3kxV2hTdmtEMTMzMjVhTkYtSjdyQnctS3FwTFhBX3djb1ZLWDdCck1lTms5d1VUblh4NVJVb01WRFF2WHZsaG53Lk1UOERLQ1ZIM3lKVXFVRlJ6UVZ6dGc"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['5122']
+      content-length: ['5207']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -392,19 +408,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77ad6ac0-9414-11e7-a85a-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":false,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['279']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -422,19 +437,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77d64f80-9414-11e7-98d0-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    body: {string: '{"value":[],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['28']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -446,26 +460,25 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnNoaEMzQjNHdjdYeTZnNVBwTm1hSE92Y1VhU0wyUFFhLVAzQ2xzUkxGM0paR0x6UTJUSVRBYXlTam5naFRncFJLcnZGbi1ITXhxUktyVnRfdWpjTGxYb3p3V3VaWE8zWTZlOUY4T1hjUXZPX09GN1ZTcXc4NktjSm90aEJwQUp0N0E4SVFDMlBkQmNBQV93SnFnMXVrTU5pYlNiWTE4YVhockZtME9ab0REbGRfbTZXSkEwX3FrYXZ1OFFHSDZyc1lmV0FFcFJLZzdiMThBNjlMRnVBN2kzblJVSHQwMGE3V0pvR09rTjc1Y21kMmtSaWc2MWl5SHFDbFJ6YjJDdm1aMnB4VExJRkNhVkhYYzh2TmpoYnlGMHNnR3FBNDBqeUdCVHBDbUFFdXpnekVPeHEzcVA2dGRWVG5SVzV3djZuQlo0MVg4NE5FNnBBRW94bV9neTJKUS5lN1NzOWs2QnRIYjRibGpDZXM4eURRLnhOa21nSE5WQkREWnNvUmQ4bnEweEp4a1RxUGl0Z25MbHdSVjIwR1VCOV9zTjRSUEk5cVktN2lmOS0xeEJ0UlRGQ0RFR01xVUIwVnJibC1oeFB0RlpGa2JIcVZqZnpkSWI1SmJnbXJTVGZDcGhlcG5jY2w2dENsd2ZZSEFRSTNiYXBlYzBOcUdsM1AwR29xSlBEZDRjQmg1SDYzOW1WeEptUU5lSXFZOUFzRjAzLWc3X2pxNDh0YTlfZ0pzejBGSGNGODMxeVhvaWdYTlAyN0RKTVBDT1Z2c05WVHYybnluOW01U2dRMFFZS0ljV096NG1DM1lGYUo1LXVUZHNrcGEwaDl6N1F1Ul95cUVIMUpuQmx0M2ZzTkV0cHJLNW9YbU14c1A5bDByelFQR2xYQXpRLW9vU2tUN3B4bVpnUGpKRG5xT3p0WTFxLU1wRFA2TkFWVEhqNW5iOU9MeVducFBEREZUcU5vUU94UjRYM19zc1JUZlBSRmZ6SVNWOHY1MUJ5bEtramlaQTBzYzNmcDBpZ09rRW9KNWI4NVhUUjktVUR5WHJKYzdPUVJ3dWk1eUtEUHlqaWZXUzZQZ1cxbVFNcnFnbEtJSnB0cUxXajVTVThadFJ1MU1CaS0yM1BFT2lFMkZGa2FwMktnNzI0OUx4QmtYX0V2ZnZ2MnZJLTVUTlRvV09QdmtxVVp1WEZTeEwwR0hIY09mQlNDYUl2OTY3WlRhalRSdFdQaTJMNF8ydmx0cklWbzRsUzA3dzZlRUF3Y1hpcDhSUXNwSC1lbGpNNmpCak5VUHBpdlZTMlNyckZQTlphRnE3eW9nT1pfUXhDXzJ2QzZlZWNHTGEyRlVCb0NBNE1NRU5McmRabTR0QWQ2ZHY4d1lxX0R3OUV6Y2NKS3ZOUDZRSkY5T0xvTGFkMjF6bXM5LXA5NTgwN2tvN0RlWnZxNDhHOFJNdWo3RktVVGtMQXdJYzVRNGlibVA3SXFrSFJ4N1FRRkE1VGlNRTR0S085T2dNSUpBYllwcW5udVBGaTlOLVpCVTR4UWZFN0dCOUhyd2dzclFYUm96QXFiNV9seG9WQXBKTTg4SHQwOGZ6UU5BMFdEY3M5RE5wR0ppYzdXNzBCWEVESzdzS0VNSU5yU2pPMHZuSkpzVnl5TTBLeHkzRGtOU2pNQTNuR281d1BtOFkwcmg5NlR2Y2JQRENzc3RMZXRQU09QUm5MeXlRNVJJWGhoWE9McnFUckI2RF9nNUJqb3pJVjg1Rzc2NTVWR3FVTEQ2S0hyNmpidTJvMElPRXV1NURucmpheG01aE1YZVpyN243cWhEcE80a3N3SVpXM0JTcXNGTUdqdkhKcEdXb19XOVMwYnpRdEdoQXdFQm9GNE1SOVF6R3l4cVhCbmVUc0NLTVZXMXZfTDRHM2NtUDBoWnd3RGg5UmRRbERhOUNpbDhzRm1GTUpCR1ZVckdwdTBYT2dfMjM3SU5Bd1Z5SnRyWXhuWVJKSDFqb29EUDFMLThib01NanN2U0xQR2FFY2J6a0pnMnB0aGFoYU9Nd2o2elUtQzN1eWJKNFc4YVNqN0hUeXlWY084aXROaUV3V3pWQVJHbFZFWjgxUnBKZl9XNUdLWmxva0FjNDc5dklldTl5c19xTjBUYnVvOTVoTmdndHNzNDIxVTlHc1dFTWpxRGpzUDhqeVQ2VlVscFFsa0FEMW5CNGxnV0FLd2pxM0lxSGVHVENLVDRya2xaNjhfa2FaOWNKQWl1eUNDYUJVX0lNSE9zUjhmeXRsNm9IcmI4SWFUMTVHSGRNdVJubXdSUkZaS0dZc0RZcHBSWW9yLVNhUUJyVFJaTUlwUFZ4bnZST2dkRjctblFhcllFbmhlQUlacDkzVXEwNzhJcmpfOTU4OTdiZG9rME1lOFBwLXJDbDhwV2RzUXFxamlFVlpNdUpMSmpCd2NFckZJZ0thVWE4dGxxNld0NzZqSkxUUE5TTEpGeE9nZ1FBVm1IT0J4NUJtRUFhMnhCQjlDQzlzMkJ2V25xV2ItYlM0Zy0yc2l3Qm1fa1AtTkxhRzZxWnlGcmh1amtiYXdqUzhSS3hWSWVGTjIzU3RDMmtweU9Pc01fRnZjaXdmOUZ0TjFnaVpUSFhMbW5qNk9HY0YxX2Y1VXZRRGRHSlBXWkpEeklUbFZrRnUwQS05cTRyal8xZWFoR0ZDNUVpZFBOQ0VoNXJzNno5WWdMNElwVXlXUDJodmQ4MTI1QWxfeFJadldGTlZ6OVNfVDJuZ0VaRTMzc3BZVFJoZzNFYzNHWXRGWmo1MWY3YkZmUkpFYnphT29MTUI4Nkg4cDF6cUhQYWJUcjU5WGZMOHZRU2tzbXBucUFBOVpoc2lXWFNuU2FzMXpWalZxZlpZSWVLU1BoSnExbl92eURGSEY1c2lMLWV4NTBZVk1lRVJPVDlVa3lCWUlSRXhfQmIzZnJTdm56N3p5Q2xzbkJ1Q2drNnBjaFMyVlVFQldhRkp6WWdTc1M3TUJmb3FaMm1hb1g4WTc5ZXpyYks5Mm00MGVldl80dEo0Z1FBMFc3UUcxcGY4OWdKVnlpVlhfdzZwRnVmQUE5WjFsRWN1MkhfSFI1TmtWazhJa1RjdExNeUhuMHRSV3hqWkpIM1ZrUXhscVQ2WEtvUWZjWWhPQzFnd2lvQTdsbk1EOGhuZWZaSVhJUlRmNzdlRU5pV1J1dXA5VzgxZ3dOaEFxZ2owQ0twMEw3ZlB0eFRHdFVyUFZxNE9nSWctbERHQklTZkJvU3Q1a1MxQVVBb0ZQVExObHNMWjVPMVo2TG9aTmtqbnJic3ZBc3lJWkQ0UnRvRW5xcGFPNHl6MWFoSWZ0LXJHMlFTdGdkN2U3MW1ESGFBYXpOVC05NHNGYUVWUUcxNDBaaHk3TXVTc1VEamlyQlgyV01jMFQ3Zkhabzg0ODJQYi16T21RMlNrT1RvU3pjV0hva0kxZUxFQm1pWlpNdWRkc3FMMGVWejZLRmpndU1oSXpPdnZueXY3RWJRSzRJTVJkN0owQ290X2FXLThfTkg3WHdNcUN5NW1tdzdLVkhzcjNqRGdVRGxPMk83U3FnUl9makxNR0g2Y0RzcjdQSTJQV3AtLVVVcTQyM1BWckNOa1R4R3JhcHNHR2ZQcEk0WHJ1aUVlZjB5NGFlV0ozeGQtel9tN2M4RXItSm1MQ19ZSGF3cXhQM2d0UVpsejFDVDJBc2JTS0o5ZUtHaXJoRTlrWWhfMHVMUWZnazY3djRrNTRRS3JRQ3czRmlCUGEwdHlrdmE0OENGQ0w0SlNDajA2ejdVT0l5b2Y0QXlqQjhGdC1GYTFJb1Y5Y2M1eURpUkQxMlVxWHMzTTg4RnF3TTNDSE9MdGhhM1B2MUpVSE1Xd01kUUo2ZlRjN0R0U3pEdlVaT2ZYLS1GM0ZpZHdUN1RDaFcyaWJqQjlNSjBUMUJOY2p6N3JIdHYyRUlfdWpZd0g2Zkd3RXgtemV4X3Bzak5hS3dzbFNMYlFVclN3Yndxbm5fWmxNTEgtOGJHUTVZbUhMMUd0TE9kX29nRHdkU2F5V0JKQ1ZyT3JqTFFwWkhVNktGZmE2eXR3NXFUV1JYQWtudUt3UFJLeTJpSzg1aVI3UmRTdVB2d01id3NVMlhHOXBMeUw3d1NVVHUzekNoRUZlbTZjdEQwcXl1a3JQWWprN1M1SlFucGV3aHloc0o5X2ctaDh1X2pBWUs5U2FKbUJFUVg2UWhJRzVKaUlFdXVQZTFmUVJ4X19ES1dEU3E5VTRJVDZDRm5tR3FFRDh4dDVTYjhORnhHUi15ZzNNVHZGQmJPdEM2eUtYWkwwaXZQRHVXSmZKdVB1VExMeG1vZGxMdmdIN0RCQ1kwNHNHc01Kb1VzNmszZG94ODZ2V3lvQi03cW5VWUlMaWRweFZaQmt6RHc5NzczYUdSRmVkaFdXRk81V2ZqOGtiS25rUjJUTWN4bDZXYVNISkZJV01Dbks5M1FKdUl2QS01U3VpMTJqblBieTVfNmU4cFJ2Y3RvT000QzhlbWotTWs3NXJNS0t0YU5Da0ViY1VvLVcyWURFZUdYbDBvRFhHXzRUQzl4cll2T0JFakN5d21xRlRHNmNYeGZaUFQxbjhueXN1bW5SdVdrUTcwcTZDTzhLOWVuSkV2M2ZHX1JoRDFlN1VtaXBDU1pwa1prLTM1MDktWTZQWmlaZDVrZ0pHN3JOdHFuZEMxRUZ4VEg3cW93ZGw1b1Rhd2pmdE1PYjVSSGFFRVZvdzhNa3FQTEcwblFreGVVUGpkcUZPVG9uaUxMdVpwbFBneFBwaUc2Nnk0bjhGMmttYlhsTzkyQUxtOVJEaUJTTUpBMTNfQ0tyQ0tRcVRzazVRZVplWTRqdDlHYXcuLVd4YnBYU0Z3dGZoMkxmdFlPX2ZQUQ"}'
+    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLnFYM1dWWVp6OUh4U3YtV0FsVXgzMHpIbGxuZ1JCbWFVU185SlZqaDJsLUFQMHhELVg2c3NMXzZ4ckQ0UDM0ZWVJRm1xZmtwQVBHalZaNEQtQm9XRzk5NERJVmN6U2VuTDJfZldMNjZzNW9pcTVmTGVYM253cm5RMG9tOVBEeUZOZ0dWRWZzb2hJMXhKOXhBTXhXYUFETk8wVHN2ZmlnZWo0UkhxVk1OWFJFeHZBY2dJamF6Y3Z5N0dGcVNYbFNpbEpZYXlzUTI0R05HajNqVHBuV3laU29rakpsd0NBelJVbDBiY21GOWFJdFVkTE9nOTZGbXo3Mzd5a2pfQnlqalVrOGJJZlZ5VHZtMmNQUGt0VnpDMVYtREI1S1h0THlRWHh4Z1Q3ZHhuNUVDTGl4YjZSUV80c0R6VVVGZ0VvOFRBNkJTVHR0SzlUREljZ0ZoZEtlMEc5dy5sOUtPSF9wSXdHcnhOTEY2R1VBYVJRLno2cHIxVFFqUWdhZGVQbzFydkQ1Qy04LVVfWmV1Rmc3Um5ENEtuMVV0YmhtWWJJMk41ZVhWZ3lPQ0N0dHhwa3FJS19OeDZQZTV3a0prVUJhWVE1M1lyVUdIX3VIS1lJakZOX1pHeXhXRWh3OV9IWU1NUlVxY0JTejVlMW5Eb3hua3dSb2hfNnFFSWRGMXh1OTB6dTJDSXpIc0JjZVAtNVJFcWhmanJtSmZPNE5WMjdHdjd6YTFJVW9oQmJYbDlQd0pkUnFRZnRVN0F3Rl9MSDZ0V01NRkZXWEhfMDg2d3ZPN3EtTC1TY1V6NDhQZlRTNkNHXzJTNWFXLTNlTXpyTkR4aFhaZTN3NjlBTXQ3Mmt3RVhpdVdkeEZydnNFaklIU2lRWE8zSUo2OFVEWjdvTkdtOC1ncTdoUU9Xcnc4cWZUVVQ3MGxQUVUtM0xBbDAzSkw1RXIwbTgydTRLRGp2blk0VE9LbnFac3NfaHJPdWo5YnJhNmdacklfdUtod0p6V09XUVZKQjVPZ0pMUndhWEJYVmpvd09WZThrbHl3NUYxWUR6VVo3WE0yWmxnTEZUWjhCd1V6MGlpZlEwdFpYRDYwNE8ybm1makt1YlhqbHVGTWdoY0IySUM1VlB4ZEhrUGFRWm9uWTM2LVFGQzJiMG5sVThnWXVLUlZOS1NjR0ZxVXpSVHpxandxbkdkZld4eEZINlVORWZrNHFlQnJYQ2I0aHY3U3ZWOTlMRXlvb3dfeFktYm5oeXVhSldtTklLUEJXdy1VSV9aTUxKem8zTkEwQjQ4NWlXLUpYUGtYNkRoQnhzU2pVVThZQzAwZFZRLUVDUWlJcU9YOXBPZjBPRlgwNHdlZWNuLTZrejVCWFpRU1dwQjlrTFVhN2tXQnpMamVKbllGcVpOLWotUGF1MTNRTDd3cXphZU9sY0Z1Z3B2Uk4wSkdRbjRLem5ZN3JMV01GUzhuSWRfUHB4TVEyQi0yZks3VjdzM3BYYTRMVzB0OEJMbmhYdHc1UEVWN3M1VlZNOTYzV1dCck02b0lNUjh0T1c5MnlyWGJrTWp4NXZCdXI5aEVlYm4yYUt4Z2d3OWJrWlY0OXpESjNUdk1SdFpBal83QVlOSy1ZX3gyaUlfaEpzWVBYMWNYemJZVDNvV2JwMENWRTFZWDJKeGVNMWFhbGpHajhFb2ZUWVhGa19Wd1V0TUtYaGM3YThrN0QtQVZHWjJMLTNCUU40NUlXbC15Q0g5bnRDblRsWGZOOXpha21wVDl1MjUtdGVIdWVwVF9leW02dWRqVVhlbllYUEpXQ0NHRzAtTjJ3STlSNllfeXlTa0J5V1pqMTdyenBVYXlrRXp2akFKa2xObXhCMlZhN2UwLTEtLV8wV0xPRWNoWUVqUzhaMTF3Mm5LQzM2amZyQ1BxMENZbGN1U3dycmROVmdhMVhPWXNaQTlkTHAzU1ZYUXFmSjhScTFSTUtLVUxzY0NFSzdheW1ua0JUQ0xLaWVxVk55elNERUJDUWM4cU9PbmxHNDJOUk12YlJmMVZ4T24xNnZ1VHhUUmpjaVk0blZVMDhLMW5adU8zRUFJclkwNjJIeXdsV09zWWtfNnRqQ2tHNHpxLUVfNWlWYW9xbENnN181cElDbTlGcEtQdXdJeGI0ZXJ0c1BRLWtsRHlKUDNzYU9sQ2pyS2d3YWJad0t4VEJwVGl3WWhHNkdyZFRIX0tnTVZSZXpSZ0V2dlpnbnktU2hYY3BBZUdqRkNLRVc2b0phd2NBT0JrVmlxZjQybDU0aDR1NDBaMmplVGdqTldjRlRLQkVsM3A4UUtnMWRYZkd0TElXVk1xOXZaMWd5TnRUSFhfUDFIS1JQNFZMOHlNQnd3Q01Ra2oxNm53bEY2SGZieW1xNWdhQzlESXNyTF84aGVtWUkxazc2UHk0dVVHN21ZZkN1ODFFdUc5TTE4dkpJQzJlWVY1M3RYN3E0QWFnLW0xVFVPSmdfOTM5cDViZFJfQ3FNU3ZfUWlsVFJReTEtV0hzTzZsVS02R0Z1VW82NUpwU2lpSHFCTmxrWXRzZURDQThXQXQ0OUFua3QtTjVqWkwzdFh3SDBkNVhXVmlteGoxZkFHTmV3RnhOV3dNLVJLOU4yM1BsbHpWaHFMS0lUeV9pbHkzM2F2YmNhVUNzYTZsVHdhN3FEekxPMDdqaHl5NGtNLUdkeFI3MXZmZEtEd05CQlpvTjAzZWV1Mnh4dDk1anVJbzJzLVlvT3lkblZRYzlLVmtLaHd2a0R3blBkTlU4R1ZSVDdIQV9lOHcwVTNpR29NMWRHblVFS2JtczQ5SjBuZ0tDNHNxeTVudFdTTG05RTJ5aUpsUFRlS1FXWFg0OVNRNXBGRF9yZVRUZnYwbkNETEJHNVdmVUlUc2VkcElvTERobVZ1VXlCcGZpWF9Gem1LTEZUM0xSYWZLU0J6aW5Xa1VkOVlvdUVKM1lxMUcxUHg4c3d6amdxZmg4YXBjRkhKcEd2blR3TXYtMk5lamloQVhfT0tZT1pVeG1BalRVVXA4UXNURDRfTm5zWjZCQlRlVURXdkoySEJYaW0zMnBwbUFObUotODJld3BjWERoeWxjVXFaVG9wNGJBZmlxbG00Z3VNb2xlaWpuNzFHWTFYaG9VWHp1OXRzT19xb3FLLXN3THR2TV8xN0RVcnZ6RFU2SzFGLVZlLXhkM3FlZ0t1YVVCbnBiZUpPbEZOUGxYSjFVd2p1TnVmN0ZRZVhMSTVmbV91ZlJDVWFWZUxqM1EyTUY0ZDBqeGRzeENQZTlydDQ0aXQxUVNlN1lOUlphMkRUc3hpMVlaZVdUc3JmNTZlLTZJN2s5bjJZNFpKQkFMQUFHU0ZKNEFhbFdaX2JYNGJDMnktSDRpenJUV24xaGRTUVlsNzZEa3oyVnBOLUtpaHVWTUE5NnNJQzEwRS1xWWlKNFhzSHJjd2xVRkRlcld3VkdkaFBlMzBBQ3pzQUdWenVWWDdHcTE0Wk1YUHhQOXhVaG1qUklNVzVfRk11YVdlU21QdlVhTFh0UlZYX29nbUk5QkpManpZa2ZBcFpxWjNMZk1jRUZoMkRITnlhSDdraFhhaURVVzJOMHJ2MVRGOTEyVVZBTTFROENaVlBvcFl4b19rdll1UjdwQXFwWWVxeDBPTEhNWHRrUllENndjRkZRdnFyNTdTTGhWLW95TklHcGZOR09pWVhuU0R2NUpxend3QUxndEswMkFjX3dDcHduaUF6Yk02MzJ0Q1YyaW5GRVMyd2lxVlJwaE5OWEdQY3NwamU5cDg1YWZHMDVxUmpUdDJaS3prVTRqWGEzbGpKZk9hTGdLa1UzTlB0cUp0TE9SSU9WbUQxOUw3SXFLQVdqWVh1M2swXzN2NF9fX3o3N2hpZGgxbk9EYWpHLVVWZHV3dlNJWE1Qb0lpcmdPV3pEWmZuTFBzakFNWldjak15YW1qR1loOEZXZmJjUHhFOVl4c1RxUHpVbFBNLVpJTlNHM2E2d0s1bHpaNzNHczJsSVFscTlPcThVU1JMMUtSZ21iakFzTTlGRVJOa1JRcjNYbTlYSE9FbVBBb01tYlRKX0FXOGV2WkhBejVQTUM2dEJjS0E2bWpwaUJRVXp3WmNDMEpOdTJYMzhjd01UWnhlWDVMLUFXTW5GSC1MMS1VVnNkWUpaRXZRMFdNM19oMWRDemphMHhTLWNQUjZEVHpGV2FTNzBOMzVXSE1nZzJURHItR01pR3FQNUpHaTBjckt3bjRoeUVpdTJmT3FxWUVyM3c0U29mMkgzTDhzaE93aWRMbHlDU01Xc0huWXZXZTJweFFQY1ZSaEJ4VlNYUG9vV3NRS2FwM3pydjlZQU1naThhdTVUTHcyVGtPSGFLb08zRGlNNF9xZy05c2Z5S2JwZG5GUXRqUFZQV05iYTVxcXZUNmdNZVdXWTdYeUp0LTZReDhLQmdWcEQzczFNbTA5bXdMRF9ST1lTQTdDak03VUFFUXNXLWpUS0Q4ZlVSWWZtQ3JuTDZtMzVZLTFDUVVZWHNvTmc5ZFBrM0xJal9yWDMxTkdRRDIxdm9vdS1JQm9kQmduQ3Bvb0paTGF3NlFaWjFIUWNRazExMmc5UWhaeGhVTS0yd3dsbDJxcGNIaDV1b2ZOS0JxazZLdTJkLWxaYWRPa1d5UmVJbE02aVBCdU5Dd0ZpQzVpNHZ4dGZCOEJhc1ZYZDNoMlNfR2Q0NUxNMXNJMlM4dU9iZFVfbE5qLXlUUlVfd0tPeEx3amRxWXFjQWRITTdaNnV3X3RVSW1pRlE4MUpjelFwZFpTMUFkeFFQc1FObTFfQzdFVEFPYzRiSnNYWWo0OUh5YkhQQkVPbm5ad3JBd1dxeEFFbjZTN3huUmItY3ZQb3kxV2hTdmtEMTMzMjVhTkYtSjdyQnctS3FwTFhBX3djb1ZLWDdCck1lTms5d1VUblh4NVJVb01WRFF2WHZsaG53Lk1UOERLQ1ZIM3lKVXFVRlJ6UVZ6dGc"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['5123']
+      Content-Length: ['5208']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77f5221e-9414-11e7-9e0e-a0b3ccf7272a]
     method: POST
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/restore?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/restore?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":false,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['279']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:28 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -483,19 +496,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [783cb270-9414-11e7-a5ee-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/versions?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/c90fb8fdaaef4910800ebad7921fe686","attributes":{"enabled":true,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/3383b4cdedc7416485addde0cf45826b","attributes":{"enabled":true,"created":1504884292,"updated":1504884292,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}},{"contentType":"test
+        type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":false,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['547']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -514,19 +527,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [785f2e91-9414-11e7-a0bb-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/b2b6178268b54f9280cb4e49c275cd36","attributes":{"enabled":false,"created":1504820127,"updated":1504820127,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/secret1/57832d5b5be543b29cebce2f9c4f4475","attributes":{"enabled":false,"created":1504884293,"updated":1504884293,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['279']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -544,19 +556,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [78a2a030-9414-11e7-a926-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    body: {string: '{"value":[],"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['28']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -568,27 +579,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
-      "tags": {"file-encoding": "utf-8"}}'
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "attributes": {"enabled":
+      true}, "tags": {"file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [78c8509e-9414-11e7-9333-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-8?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/4f44bad3c50f478691975ee91015616e","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-8/22d93fac4fe043ae9b4a2817d7146562","attributes":{"enabled":true,"created":1504884297,"updated":1504884297,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['299']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -606,19 +616,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [78f0991e-9414-11e7-90a2-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-8/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/4f44bad3c50f478691975ee91015616e","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-8/22d93fac4fe043ae9b4a2817d7146562","attributes":{"enabled":true,"created":1504884297,"updated":1504884297,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['299']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:30 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -630,27 +639,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
-      "tags": {"file-encoding": "utf-16le"}}'
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "attributes": {"enabled":
+      true}, "tags": {"file-encoding": "utf-16le"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79102f0f-9414-11e7-a32d-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16le?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/7cf588a6188947549ceddba8c72a57c9","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16le/3eae64a36ddb461991d566b62b9a191c","attributes":{"enabled":true,"created":1504884298,"updated":1504884298,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:31 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -668,19 +676,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [793b36b0-9414-11e7-8153-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16le/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/7cf588a6188947549ceddba8c72a57c9","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16le/3eae64a36ddb461991d566b62b9a191c","attributes":{"enabled":true,"created":1504884298,"updated":1504884298,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:29 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -692,27 +699,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
-      "tags": {"file-encoding": "utf-16be"}}'
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "attributes": {"enabled":
+      true}, "tags": {"file-encoding": "utf-16be"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [795e4f0f-9414-11e7-94a2-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16be?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/fc24d37e83d14cdebcb4be57899fa773","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16be/fd055b81d34b41fba2a89ce716f00ec3","attributes":{"enabled":true,"created":1504884299,"updated":1504884299,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -730,19 +736,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79a01300-9414-11e7-bdce-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16be/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/fc24d37e83d14cdebcb4be57899fa773","attributes":{"enabled":true,"created":1504820131,"updated":1504820131,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-utf-16be/fd055b81d34b41fba2a89ce716f00ec3","attributes":{"enabled":true,"created":1504884299,"updated":1504884299,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:31 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -754,27 +759,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "TestSecretTestSecretTestSecretTestSecret\n",
-      "tags": {"file-encoding": "ascii"}}'
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "attributes": {"enabled":
+      true}, "tags": {"file-encoding": "ascii"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['124']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79e30f6e-9414-11e7-876a-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-ascii?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/2cd7520c59df406397a0312cf8f36e34","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-ascii/26852e0d25814c6897ecb0d0cb7435d9","attributes":{"enabled":true,"created":1504884297,"updated":1504884297,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['299']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -792,19 +796,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a1cbd0f-9414-11e7-9777-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-ascii/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/2cd7520c59df406397a0312cf8f36e34","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-ascii/26852e0d25814c6897ecb0d0cb7435d9","attributes":{"enabled":true,"created":1504884297,"updated":1504884297,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['299']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -816,27 +819,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n",
-      "tags": {"file-encoding": "base64"}}'
+    body: '{"value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n",
+      "attributes": {"enabled": true}, "tags": {"file-encoding": "base64"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a421f61-9414-11e7-976b-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-base64?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/64402a0bb04a411d8278b72e2d40fcba","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-base64/1fdfe9f9864b4d44ab89e8da6aadb547","attributes":{"enabled":true,"created":1504884300,"updated":1504884300,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['317']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:32 GMT']
+      date: ['Fri, 08 Sep 2017 15:25:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -854,19 +856,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a6fbf11-9414-11e7-b79c-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-base64/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/64402a0bb04a411d8278b72e2d40fcba","attributes":{"enabled":true,"created":1504820132,"updated":1504820132,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-base64/1fdfe9f9864b4d44ab89e8da6aadb547","attributes":{"enabled":true,"created":1504884300,"updated":1504884300,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['317']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -878,27 +879,26 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a",
-      "tags": {"file-encoding": "hex"}}'
+    body: '{"value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a",
+      "attributes": {"enabled": true}, "tags": {"file-encoding": "hex"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['164']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a956f80-9414-11e7-b795-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-hex?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/63fa7a77d557497697a9e8eb9dd97835","attributes":{"enabled":true,"created":1504820133,"updated":1504820133,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-hex/695296e1aad546c3acac115b8bdea877","attributes":{"enabled":true,"created":1504884299,"updated":1504884299,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['337']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      date: ['Fri, 08 Sep 2017 15:24:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -916,19 +916,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7ac02900-9414-11e7-868e-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/?api-version=2016-10-01
+    uri: https://cli-test-kevault-000002.vault.azure.net/secrets/download-hex/?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/63fa7a77d557497697a9e8eb9dd97835","attributes":{"enabled":true,"created":1504820133,"updated":1504820133,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kevault-000002.vault.azure.net/secrets/download-hex/695296e1aad546c3acac115b8bdea877","attributes":{"enabled":true,"created":1504884299,"updated":1504884299,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['337']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:35:33 GMT']
+      date: ['Fri, 08 Sep 2017 15:25:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -939,4 +938,31 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.821]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_secret000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 08 Sep 2017 15:25:01 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGS0VZVkFVTFQ6NUZTRUNSRVQyVUZFTkJRQ0RESVdUQkFDU3wyOUI5REYyN0ZGOTIzRDhBLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_softdelete.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_softdelete.yaml
@@ -6,75 +6,76 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [d31284b4-4fc9-11e7-9e7a-5065f34efe31]
+      x-ms-client-request-id: [30fb0230-9415-11e7-8d2f-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"azkvtest","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":"azkvtest@sschaab.onmicrosoft.com","mailNickname":"azkvtest_sschaab.onmicrosoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["azkvtest@sschaab.onmicrosoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["smtp:azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","SMTP:azkvtest@sschaab.onmicrosoft.com"],"refreshTokensValidFromDateTime":"2017-06-12T23:40:43Z","showInAddressList":false,"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"azkvtest_sschaab.onmicrosoft.com#EXT#@microsoft.onmicrosoft.com","userType":"Guest"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Content-Length: ['1477']
-      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      DataServiceVersion: [3.0;]
-      Date: ['Mon, 12 Jun 2017 23:49:50 GMT']
-      Duration: ['764746']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [auMH3trGGPxUnEra3OEObugLKMuiyORtWJYLQ+Ri0fc=]
-      ocp-aad-session-key: [MbhLiJbXz4kQIoc_IiLHO5BAHk4sD-rcWNyK5lJEEWq1MlbRDZhsuYTt5vR5azhkxIiRZ--F_juVBF0InSRVnAN6fUoa9j8yxBtZJj9EuIqHwYapvN42piz_RWlHVrqJ.pinYxFJCFJh1qEjVPS8jvR0cWdIu6vWfob4oIuHNyok]
-      request-id: [ee960350-e1e2-4c7f-acfa-089df00eccf6]
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      content-length: ['1309']
+      content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      dataserviceversion: [3.0;]
+      date: ['Thu, 07 Sep 2017 21:40:39 GMT']
+      duration: ['1371614']
+      expires: ['-1']
+      ocp-aad-diagnostics-server-name: [nqD28CyTcqD3Biknx4FyJZuYuPTfrh3H9scanSfz64Y=]
+      ocp-aad-session-key: [QnyxkESZbfC8lrQ9UZyJO5GLOzQsfL7mZbZ_TtQs9VFSRGI3LFSLN26p6nJMBXt7fZFHYCa4iV0y-T99tb_iE1GxVG0-qBlBUl9E_PoXloAVA9n9enBuKG6mSWl3ugun.bBKcVt6soxXc0nFT4gYL6N-Bk8RmWoCrzPTyghFNxWI]
+      pragma: [no-cache]
+      request-id: [d818e135-1cf6-4847-9d33-b96dd990d0f6]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-dirapi-data-contract-version: ['1.6']
+      x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "premium"},
+    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
       "enableSoftDelete": true, "accessPolicies": [{"permissions": {"keys": ["get",
       "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
-      "storage": ["get", "list", "delete", "set", "update", "regeneratekey", "setsas",
-      "listsas", "getsas", "deletesas"], "certificates": ["get", "list", "delete",
-      "create", "import", "update", "managecontacts", "getissuers", "listissuers",
-      "setissuers", "deleteissuers", "manageissuers", "recover"], "secrets": ["get",
-      "list", "set", "delete", "backup", "restore", "recover"]}, "objectId": "7541419d-883d-452f-a823-56aa8bf0749f",
-      "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}], "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}}'
+      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
+      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
+      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
+      "recover"], "storage": ["get", "list", "delete", "set", "update", "regeneratekey",
+      "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['771']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d33723ac-4fc9-11e7-adf8-5065f34efe31]
+      x-ms-client-request-id: [3128c8ee-9415-11e7-ac92-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete","name":"cli-kv-test-softdelete","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"secrets":["get","list","set","delete","backup","restore","recover"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete.vault.azure.net"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:49:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['1031']
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      cache-control: [no-cache]
+      content-length: ['1034']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:40:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -83,29 +84,29 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e617b178-4fc9-11e7-a7d3-5065f34efe31]
+      x-ms-client-request-id: [67605500-9415-11e7-a12a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:50:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      WWW-Authenticate: ['Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:42:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      www-authenticate: ['Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
           resource="https://vault.azure.net"']
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 401, message: Unauthorized}
 - request:
     body: null
@@ -114,28 +115,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e617b178-4fc9-11e7-a7d3-5065f34efe31]
+      x-ms-client-request-id: [67605500-9415-11e7-a12a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":null,"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['30']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['30']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -144,24 +145,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e6c1d1fe-4fc9-11e7-8de3-5065f34efe31]
+      x-ms-client-request-id: [67b6d970-9415-11e7-8e90-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azkv-pytest/providers/Microsoft.KeyVault/vaults/pytest-shared-vault","name":"pytest-shared-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert_birq_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-secret_0w5u_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-secret","name":"cli-test-keyvault-secret","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete","name":"cli-kv-test-softdelete","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/cli-vault","name":"cli-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/froyo","name":"froyo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/softserve","name":"softserve","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault2","name":"tempvault2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault3","name":"tempvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault4","name":"tempvault4","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['2296']
+      cache-control: [no-cache]
+      content-length: ['2777']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -170,104 +171,105 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e6d473da-4fc9-11e7-8e5c-5065f34efe31]
+      x-ms-client-request-id: [67d4e8c0-9415-11e7-956c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete","name":"cli-kv-test-softdelete","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"secrets":["get","list","set","delete","backup","restore","recover"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['1032']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      cache-control: [no-cache]
+      content-length: ['1035']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "properties": {"sku": {"family": "A", "name": "premium"},
-      "enableSoftDelete": true, "enabledForDeployment": false, "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "accessPolicies": [{"permissions": {"keys": ["get", "create", "delete", "list",
-      "update", "import", "backup", "restore", "recover", "purge"], "certificates":
-      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"],
-      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover",
-      "purge"]}, "objectId": "7541419d-883d-452f-a823-56aa8bf0749f", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"}],
-      "vaultUri": "https://cli-kv-test-softdelete.vault.azure.net/"}, "tags": {}}'
+    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
+      "family": "A"}, "enableSoftDelete": true, "vaultUri": "https://cli-kv-test-softdelete1.vault.azure.net/",
+      "enabledForDeployment": false, "accessPolicies": [{"permissions": {"keys": ["get",
+      "create", "delete", "list", "update", "import", "backup", "restore", "recover",
+      "purge"], "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover",
+      "purge"], "certificates": ["get", "list", "delete", "create", "import", "update",
+      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
+      "manageissuers", "recover", "purge"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
+      "location": "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['788']
+      Content-Length: ['789']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e717a538-4fc9-11e7-82d3-5065f34efe31]
+      x-ms-client-request-id: [681b679e-9415-11e7-b896-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete","name":"cli-kv-test-softdelete","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7541419d-883d-452f-a823-56aa8bf0749f","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover","purge"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover","purge"],"secrets":["get","list","set","delete","backup","restore","recover","purge"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete.vault.azure.net/"}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover","purge"],"secrets":["get","list","set","delete","backup","restore","recover","purge"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover","purge"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net/"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['951']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      cache-control: [no-cache]
+      content-length: ['954']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"attributes": {"enabled": true}, "value": "ABC123", "tags": {"file-encoding":
-      "utf-8"}}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "ABC123", "tags":
+      {"file-encoding": "utf-8"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e75ee246-4fc9-11e7-b036-5065f34efe31]
+      x-ms-client-request-id: [686df470-9415-11e7-ac13-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1/4b09b6078ad040bc8466ea42352492eb","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['266']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['267']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -277,28 +279,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e7902290-4fc9-11e7-ad04-5065f34efe31]
+      x-ms-client-request-id: [689dde0f-9415-11e7-8006-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1","deletedDate":1497311425,"scheduledPurgeDate":1505087425,"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1/4b09b6078ad040bc8466ea42352492eb","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820532,"scheduledPurgeDate":1512596532,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['391']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -307,28 +309,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e7cb14fe-4fc9-11e7-919e-5065f34efe31]
+      x-ms-client-request-id: [68da23c0-9415-11e7-9414-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -337,28 +339,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [e9b5ec5e-4fc9-11e7-a696-5065f34efe31]
+      x-ms-client-request-id: [6acddd70-9415-11e7-ad4e-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -367,28 +369,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eba64840-4fc9-11e7-af17-5065f34efe31]
+      x-ms-client-request-id: [6cccbab0-9415-11e7-83cd-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -397,28 +399,148 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed958ff6-4fc9-11e7-96b0-5065f34efe31]
+      x-ms-client-request-id: [6ec444f0-9415-11e7-bc88-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1","deletedDate":1497311425,"scheduledPurgeDate":1505087425,"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['386']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [70bdcb00-9415-11e7-9987-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [72b443cf-9415-11e7-821e-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [74aba700-9415-11e7-9a9e-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [76a77700-9415-11e7-8b6e-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820532,"scheduledPurgeDate":1512596532,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['388']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -428,28 +550,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [edc0051a-4fc9-11e7-8b14-5065f34efe31]
+      x-ms-client-request-id: [76d9f8b0-9415-11e7-acb9-a0b3ccf7272a]
     method: POST
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1/4b09b6078ad040bc8466ea42352492eb","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['249']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['250']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -458,28 +580,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [edfe7e62-4fc9-11e7-8103-5065f34efe31]
+      x-ms-client-request-id: [7719e7e1-9415-11e7-90e3-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -488,28 +610,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [eff21136-4fc9-11e7-b547-5065f34efe31]
+      x-ms-client-request-id: [790defb0-9415-11e7-8c71-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:39 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:40 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -518,28 +640,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f1e034ac-4fc9-11e7-b51b-5065f34efe31]
+      x-ms-client-request-id: [7af8a8ae-9415-11e7-991f-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -548,28 +670,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f3cdb5da-4fc9-11e7-94ef-5065f34efe31]
+      x-ms-client-request-id: [7cf27cde-9415-11e7-8937-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -578,58 +700,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f5c07c2c-4fc9-11e7-9549-5065f34efe31]
+      x-ms-client-request-id: [7ee0b84f-9415-11e7-bf87-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['245']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:49 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f7b03b1e-4fc9-11e7-806a-5065f34efe31]
-    method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: '{"value":[{"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['244']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -639,28 +731,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f7d50858-4fc9-11e7-a70d-5065f34efe31]
+      x-ms-client-request-id: [7f0a6061-9415-11e7-b815-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: '{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1","deletedDate":1497311450,"scheduledPurgeDate":1505087450,"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1/4b09b6078ad040bc8466ea42352492eb","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820571,"scheduledPurgeDate":1512596571,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['391']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -669,28 +761,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f8147f6c-4fc9-11e7-82b4-5065f34efe31]
+      x-ms-client-request-id: [7f4e954f-9415-11e7-b3ef-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -699,28 +791,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa037712-4fc9-11e7-95d1-5065f34efe31]
+      x-ms-client-request-id: [813c3480-9415-11e7-b712-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:56 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -729,28 +821,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fbf9887a-4fc9-11e7-8ceb-5065f34efe31]
+      x-ms-client-request-id: [8337b65e-9415-11e7-8416-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:50:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:42:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -759,28 +851,58 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fdee6c6c-4fc9-11e7-8f1b-5065f34efe31]
+      x-ms-client-request-id: [8534bede-9415-11e7-b5fb-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1","deletedDate":1497311450,"scheduledPurgeDate":1505087450,"id":"https://cli-kv-test-softdelete.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1497311424,"updated":1497311424,"recoverylevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['386']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:00 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [872c9740-9415-11e7-9a06-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820571,"scheduledPurgeDate":1512596571,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['388']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:03 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -790,57 +912,57 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ffe971d2-4fc9-11e7-a733-5065f34efe31]
+      x-ms-client-request-id: [875e7cb0-9415-11e7-92c9-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Date: ['Mon, 12 Jun 2017 23:51:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      date: ['Thu, 07 Sep 2017 21:43:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 204, message: No Content}
 - request:
-    body: '{"attributes": {"enabled": true}, "kty": "RSA"}'
+    body: !!python/unicode '{"attributes": {"enabled": true}, "kty": "RSA"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['47']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [002b4640-4fca-11e7-951d-5065f34efe31]
+      x-ms-client-request-id: [87a8cc21-9415-11e7-a8bd-a0b3ccf7272a]
     method: POST
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys/key1/create?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/create?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1/58a0f648b8184b749cf05d5ffaf39937","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tPse6GzqtNMuXqUXyyT4v9XmsgtMNRAKrY9M2XWQUrzuvW1-ia_s29xiRReX5e-h4EexBw_s-VMY3Q2AG4Wka4X8F_unp_moljXybnnVtBnIfDHqDqLts53FRm_-z7wcW9kFyc7JzTI8Y8egpLbCDbw1Sf4CvGtJs2ln3Vyfre-aU_jDSVw53uR6xIyB7deBb7u1AYyyW8BNmBEqjrzCug6iZnlXYGcsiK5GDayrMN4OF6g3OpHU1SCoE_1CaZlk6zY0WREuZOZq6y95ToSbajwfYQqrn6J-SNJIagrYbO0Wd3m-D-NaqM7f6TrJvU5gOuj_z6Jwe6fD4cwmn00O-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['661']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['662']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -850,28 +972,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [00cae3a6-4fca-11e7-9f43-5065f34efe31]
+      x-ms-client-request-id: [87e5fc30-9415-11e7-a1ca-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys/key1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: '{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1","deletedDate":1497311468,"scheduledPurgeDate":1505087468,"key":{"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1/58a0f648b8184b749cf05d5ffaf39937","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tPse6GzqtNMuXqUXyyT4v9XmsgtMNRAKrY9M2XWQUrzuvW1-ia_s29xiRReX5e-h4EexBw_s-VMY3Q2AG4Wka4X8F_unp_moljXybnnVtBnIfDHqDqLts53FRm_-z7wcW9kFyc7JzTI8Y8egpLbCDbw1Sf4CvGtJs2ln3Vyfre-aU_jDSVw53uR6xIyB7deBb7u1AYyyW8BNmBEqjrzCug6iZnlXYGcsiK5GDayrMN4OF6g3OpHU1SCoE_1CaZlk6zY0WREuZOZq6y95ToSbajwfYQqrn6J-SNJIagrYbO0Wd3m-D-NaqM7f6TrJvU5gOuj_z6Jwe6fD4cwmn00O-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}'}
+    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820585,"scheduledPurgeDate":1512596585,"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['797']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['799']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -880,28 +1002,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0118ed48-4fca-11e7-9bfe-5065f34efe31]
+      x-ms-client-request-id: [8829bbf0-9415-11e7-9579-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -910,28 +1032,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0306fe36-4fca-11e7-bde3-5065f34efe31]
+      x-ms-client-request-id: [8a1e6000-9415-11e7-b7a1-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -940,28 +1062,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [04fd54a4-4fca-11e7-9e5f-5065f34efe31]
+      x-ms-client-request-id: [8c1c52e1-9415-11e7-a53e-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -970,28 +1092,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [06ed2558-4fca-11e7-a1e1-5065f34efe31]
+      x-ms-client-request-id: [8e173880-9415-11e7-ab27-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1000,58 +1122,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [08db15b8-4fca-11e7-a857-5065f34efe31]
+      x-ms-client-request-id: [9010224f-9415-11e7-be4e-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820585,"scheduledPurgeDate":1512596585,"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:20 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['344']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0ad22c24-4fca-11e7-b817-5065f34efe31]
-    method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: '{"value":[{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1","deletedDate":1497311468,"scheduledPurgeDate":1505087468,"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['342']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1061,28 +1153,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0b123e10-4fca-11e7-85fc-5065f34efe31]
+      x-ms-client-request-id: [90478600-9415-11e7-9017-a0b3ccf7272a]
     method: POST
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
   response:
-    body: {string: '{"key":{"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1/58a0f648b8184b749cf05d5ffaf39937","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tPse6GzqtNMuXqUXyyT4v9XmsgtMNRAKrY9M2XWQUrzuvW1-ia_s29xiRReX5e-h4EexBw_s-VMY3Q2AG4Wka4X8F_unp_moljXybnnVtBnIfDHqDqLts53FRm_-z7wcW9kFyc7JzTI8Y8egpLbCDbw1Sf4CvGtJs2ln3Vyfre-aU_jDSVw53uR6xIyB7deBb7u1AYyyW8BNmBEqjrzCug6iZnlXYGcsiK5GDayrMN4OF6g3OpHU1SCoE_1CaZlk6zY0WREuZOZq6y95ToSbajwfYQqrn6J-SNJIagrYbO0Wd3m-D-NaqM7f6TrJvU5gOuj_z6Jwe6fD4cwmn00O-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}'}
+    body: {string: !!python/unicode '{"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['661']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['662']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1091,28 +1183,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ba02922-4fca-11e7-91fb-5065f34efe31]
+      x-ms-client-request-id: [9099ebc0-9415-11e7-971c-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:20 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1121,28 +1213,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d91ac12-4fca-11e7-9f33-5065f34efe31]
+      x-ms-client-request-id: [928c1ecf-9415-11e7-8d60-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:22 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1151,28 +1243,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f7e07d0-4fca-11e7-92a8-5065f34efe31]
+      x-ms-client-request-id: [947af680-9415-11e7-993c-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:32 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1181,28 +1273,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [117589a6-4fca-11e7-9484-5065f34efe31]
+      x-ms-client-request-id: [966f9a8f-9415-11e7-8da1-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1211,28 +1303,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [137976dc-4fca-11e7-90fc-5065f34efe31]
+      x-ms-client-request-id: [985c4f61-9415-11e7-99d0-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1241,28 +1333,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [15691a1a-4fca-11e7-8dca-5065f34efe31]
+      x-ms-client-request-id: [9a4b2711-9415-11e7-a5e3-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['206']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['207']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1272,28 +1364,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [158e70cc-4fca-11e7-bbe9-5065f34efe31]
+      x-ms-client-request-id: [9a793bee-9415-11e7-a4b9-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/keys/key1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1?api-version=2016-10-01
   response:
-    body: {string: '{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1","deletedDate":1497311502,"scheduledPurgeDate":1505087502,"key":{"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1/58a0f648b8184b749cf05d5ffaf39937","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"tPse6GzqtNMuXqUXyyT4v9XmsgtMNRAKrY9M2XWQUrzuvW1-ia_s29xiRReX5e-h4EexBw_s-VMY3Q2AG4Wka4X8F_unp_moljXybnnVtBnIfDHqDqLts53FRm_-z7wcW9kFyc7JzTI8Y8egpLbCDbw1Sf4CvGtJs2ln3Vyfre-aU_jDSVw53uR6xIyB7deBb7u1AYyyW8BNmBEqjrzCug6iZnlXYGcsiK5GDayrMN4OF6g3OpHU1SCoE_1CaZlk6zY0WREuZOZq6y95ToSbajwfYQqrn6J-SNJIagrYbO0Wd3m-D-NaqM7f6TrJvU5gOuj_z6Jwe6fD4cwmn00O-Q","e":"AQAB"},"attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}'}
+    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820615,"scheduledPurgeDate":1512596615,"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['797']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['799']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1302,28 +1394,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [15c0ae7e-4fca-11e7-9538-5065f34efe31]
+      x-ms-client-request-id: [9abed070-9415-11e7-bd99-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1332,28 +1424,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [17b6cb94-4fca-11e7-ab66-5065f34efe31]
+      x-ms-client-request-id: [9cb4fb21-9415-11e7-9f94-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1362,28 +1454,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [19ac3480-4fca-11e7-8b47-5065f34efe31]
+      x-ms-client-request-id: [9eae5a1e-9415-11e7-be1d-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1392,28 +1484,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1ba13908-4fca-11e7-a969-5065f34efe31]
+      x-ms-client-request-id: [a0a9dc00-9415-11e7-93ff-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:52 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1422,58 +1514,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1d93631c-4fca-11e7-b63a-5065f34efe31]
+      x-ms-client-request-id: [a2a4c19e-9415-11e7-83a8-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820615,"scheduledPurgeDate":1512596615,"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['344']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1f904ffe-4fca-11e7-9b45-5065f34efe31]
-    method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: '{"value":[{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1","deletedDate":1497311502,"scheduledPurgeDate":1505087502,"kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1497311467,"updated":1497311467,"recoverylevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['342']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1483,30 +1545,30 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [1fe33bb6-4fca-11e7-a912-5065f34efe31]
+      x-ms-client-request-id: [a2d9662e-9415-11e7-920c-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Date: ['Mon, 12 Jun 2017 23:51:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      date: ['Thu, 07 Sep 2017 21:43:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 204, message: No Content}
 - request:
-    body: '{"policy": {"key_props": {"exportable": true, "reuse_key": false, "key_size":
-      2048, "kty": "RSA"}, "secret_props": {"contentType": "application/x-pem-file"},
+    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
+      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
       "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
       "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
       PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
@@ -1517,28 +1579,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['3170']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [203c1dcc-4fca-11e7-bc24-5065f34efe31]
+      x-ms-client-request-id: [a31a8dde-9415-11e7-942e-a0b3ccf7272a]
     method: POST
-    uri: https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1/import?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/import?api-version=2016-10-01
   response:
-    body: {string: '{"id":"https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","sid":"https://cli-kv-test-softdelete.vault.azure.net/secrets/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311519,"updated":1497311519,"recoverylevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311519,"updated":1497311519}}}'}
+    body: {string: !!python/unicode '{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/0fa2ac94d2e543888631b05a14585cfc","kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/cert1/0fa2ac94d2e543888631b05a14585cfc","sid":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/cert1/0fa2ac94d2e543888631b05a14585cfc","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504820632,"updated":1504820632}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2187']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:51:58 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2191']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1548,28 +1610,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [20de0eca-4fca-11e7-a68b-5065f34efe31]
+      x-ms-client-request-id: [a3a51a9e-9415-11e7-8240-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1?api-version=2016-10-01
   response:
-    body: {string: '{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates/cert1","deletedDate":1497311520,"scheduledPurgeDate":1505087520,"id":"https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","kid":"https://cli-kv-test-softdelete.vault.azure.net/keys/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","sid":"https://cli-kv-test-softdelete.vault.azure.net/secrets/cert1/e7b92e0dc86746ada3ec5aa9651cd5aa","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311519,"updated":1497311519,"recoverylevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1497311519,"updated":1497311519}}}'}
+    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1","deletedDate":1504820631,"scheduledPurgeDate":1512596631,"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/0fa2ac94d2e543888631b05a14585cfc","kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/cert1/0fa2ac94d2e543888631b05a14585cfc","sid":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/cert1/0fa2ac94d2e543888631b05a14585cfc","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504820632,"updated":1504820632}}}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['2332']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['2337']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1578,28 +1640,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [211a441a-4fca-11e7-bc17-5065f34efe31]
+      x-ms-client-request-id: [a3dbe20f-9415-11e7-bf51-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1608,28 +1670,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [230c41a4-4fca-11e7-9643-5065f34efe31]
+      x-ms-client-request-id: [a5d47dc0-9415-11e7-97e6-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1638,28 +1700,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [24fbc18a-4fca-11e7-be54-5065f34efe31]
+      x-ms-client-request-id: [a7ce7900-9415-11e7-ab6a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['28']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:43:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1668,28 +1730,58 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [26ea3528-4fca-11e7-abb3-5065f34efe31]
+      x-ms-client-request-id: [a9cbf6b0-9415-11e7-8e96-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
   response:
-    body: {string: '{"value":[{"recoveryId":"https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates/cert1","deletedDate":1497311520,"scheduledPurgeDate":1505087520,"id":"https://cli-kv-test-softdelete.vault.azure.net/certificates/cert1","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1497311519,"updated":1497311519,"recoverylevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
+    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['429']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      content-length: ['28']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [abc44440-9415-11e7-88b0-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
+  response:
+    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1","deletedDate":1504820631,"scheduledPurgeDate":1512596631,"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['431']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1699,26 +1791,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultclient/0.4.0.developer Azure-SDK-For-Python]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [271be836-4fca-11e7-8560-5065f34efe31]
+      x-ms-client-request-id: [abfcb961-9415-11e7-b4ec-a0b3ccf7272a]
     method: DELETE
-    uri: https://cli-kv-test-softdelete.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Date: ['Mon, 12 Jun 2017 23:52:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
+      date: ['Thu, 07 Sep 2017 21:44:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.813]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
     status: {code: 204, message: No Content}
 - request:
     body: null
@@ -1727,24 +1819,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [27555d8a-4fca-11e7-99ad-5065f34efe31]
+      x-ms-client-request-id: [ac4c11e1-9415-11e7-8c7a-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azkv-pytest/providers/Microsoft.KeyVault/vaults/pytest-shared-vault","name":"pytest-shared-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-keyvault-cert_birq_/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-cert1","name":"cli-test-keyvault-cert1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete","name":"cli-kv-test-softdelete","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/cli-vault","name":"cli-vault","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/froyo","name":"froyo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/softserve","name":"softserve","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault2","name":"tempvault2","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault3","name":"tempvault3","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ssrg/providers/Microsoft.KeyVault/vaults/tempvault4","name":"tempvault4","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      content-length: ['2029']
+      cache-control: [no-cache]
+      content-length: ['2777']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:06 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1754,28 +1846,28 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [276c1a30-4fca-11e7-b761-5065f34efe31]
+      x-ms-client-request-id: [ac6677b0-9415-11e7-81cf-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:52:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:44:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1785,30 +1877,30 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [284c1fb6-4fca-11e7-936a-5065f34efe31]
+      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/deletedVaults/cli-kv-test-softdelete/purge?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/deletedVaults/cli-kv-test-softdelete1/purge?api-version=2016-10-01
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Mon, 12 Jun 2017 23:52:14 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/6d8e19c2-3a60-481f-8ebb-118dc3007c5d/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01']
-      Pragma: [no-cache]
-      Retry-After: ['5']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.164]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Thu, 07 Sep 2017 21:44:08 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
+      pragma: [no-cache]
+      retry-after: ['5']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1817,30 +1909,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [284c1fb6-4fca-11e7-936a-5065f34efe31]
+      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
   response:
-    body: {string: '{"createdDateTime":"2017-06-12 23:52:13Z","status":"NotStarted"}'}
+    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","status":"NotStarted"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['64']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:18 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/6d8e19c2-3a60-481f-8ebb-118dc3007c5d/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01']
-      Pragma: [no-cache]
-      Retry-After: ['5']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.164]
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:13 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
+      pragma: [no-cache]
+      retry-after: ['5']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1849,30 +1941,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [284c1fb6-4fca-11e7-936a-5065f34efe31]
+      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
   response:
-    body: {string: '{"createdDateTime":"2017-06-12 23:52:13Z","status":"NotStarted"}'}
+    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","status":"NotStarted"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['64']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:24 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/6d8e19c2-3a60-481f-8ebb-118dc3007c5d/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01']
-      Pragma: [no-cache]
-      Retry-After: ['5']
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-keyvault-service-version: [1.0.0.164]
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:19 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
+      pragma: [no-cache]
+      retry-after: ['5']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1881,30 +1973,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.8
-          msrest_azure/0.4.7 keyvaultmanagementclient/0.40.0.developer Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.7+dev]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
+          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/TEST/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [284c1fb6-4fca-11e7-936a-5065f34efe31]
+      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjMyOTA4MzM1OTE2OTI3OXwyRTlFNjdGQzVFNTM0MkVEOTBBODJDRTVEM0JGMTQ1Qw?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
   response:
-    body: {string: '{"createdDateTime":"2017-06-12 23:52:13Z","lastActionDateTime":"2017-06-12
-        23:52:28Z","status":"Succeeded"}'}
+    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","lastActionDateTime":"2017-09-07
+        21:44:22Z","status":"Succeeded"}'}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 12 Jun 2017 23:52:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      cache-control: [no-cache]
       content-length: ['107']
-      x-ms-keyvault-service-version: [1.0.0.164]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Sep 2017 21:44:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_softdelete.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/latest/test_keyvault_softdelete.yaml
@@ -1,32 +1,58 @@
 interactions:
 - request:
+    body: '{"tags": {"use": "az-test"}, "location": "westus"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group create]
+      Connection: [keep-alive]
+      Content-Length: ['50']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_sd000001?api-version=2017-05-10
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001","name":"cli_test_keyvault_sd000001","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['328']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:00 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 graphrbacmanagementclient/0.31.0 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [30fb0230-9415-11e7-8d2f-a0b3ccf7272a]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/Microsoft.DirectoryServices.User/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","deletionTimestamp":null,"accountEnabled":true,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"Admin2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Admin2","immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"admin2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["destanko@microsoft.com"],"passwordPolicies":"None","passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":"en-US","provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2017-09-06T17:11:13Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":"Admin2","telephoneNumber":null,"usageLocation":null,"userIdentities":[],"userPrincipalName":"admin2@AzureSDKTeam.onmicrosoft.com","userType":"Member"}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: [no-cache]
       content-length: ['1309']
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       dataserviceversion: [3.0;]
-      date: ['Thu, 07 Sep 2017 21:40:39 GMT']
-      duration: ['1371614']
+      date: ['Fri, 08 Sep 2017 19:05:01 GMT']
+      duration: ['1146640']
       expires: ['-1']
-      ocp-aad-diagnostics-server-name: [nqD28CyTcqD3Biknx4FyJZuYuPTfrh3H9scanSfz64Y=]
-      ocp-aad-session-key: [QnyxkESZbfC8lrQ9UZyJO5GLOzQsfL7mZbZ_TtQs9VFSRGI3LFSLN26p6nJMBXt7fZFHYCa4iV0y-T99tb_iE1GxVG0-qBlBUl9E_PoXloAVA9n9enBuKG6mSWl3ugun.bBKcVt6soxXc0nFT4gYL6N-Bk8RmWoCrzPTyghFNxWI]
+      ocp-aad-diagnostics-server-name: [mXAYcbEGDXPGTLgRCKl3Y9JNd8ph+Zl34K70uZzuBPw=]
+      ocp-aad-session-key: [Y9I5dRAUNwYrMCm19pMTFZeGYWw-KxPx4G1brfkzVDrm-i-GpmKhCYXU0zeP4mWLUaPHDXItSctzrwnZmt2DglVW9ayuKyLXgL64dNHzTG4606DBO2uBijTVpd_8-2rc.7RG_Yi_HCwBKAs2QY5vilUJZi_6GGpntmvUvPd_znEs]
       pragma: [no-cache]
-      request-id: [d818e135-1cf6-4847-9d33-b96dd990d0f6]
+      request-id: [f9c70d4a-01f1-4035-b539-9ca8e026f532]
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -35,36 +61,36 @@ interactions:
       x-powered-by: [ASP.NET, ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"sku": {"name": "premium", "family": "A"},
-      "enableSoftDelete": true, "accessPolicies": [{"permissions": {"keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover"],
-      "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
-      "certificates": ["get", "list", "delete", "create", "import", "update", "managecontacts",
-      "getissuers", "listissuers", "setissuers", "deleteissuers", "manageissuers",
-      "recover"], "storage": ["get", "list", "delete", "set", "update", "regeneratekey",
-      "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
+    body: '{"properties": {"enableSoftDelete": true, "accessPolicies": [{"permissions":
+      {"secrets": ["get", "list", "set", "delete", "backup", "restore", "recover"],
+      "keys": ["get", "create", "delete", "list", "update", "import", "backup", "restore",
+      "recover"], "certificates": ["get", "list", "delete", "create", "import", "update",
+      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
+      "manageissuers", "recover"], "storage": ["get", "list", "delete", "set", "update",
+      "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
+      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "sku": {"family": "A",
+      "name": "premium"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}, "location":
+      "westus"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault create]
       Connection: [keep-alive]
       Content-Length: ['771']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3128c8ee-9415-11e7-ac92-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-test-keyvault-000002.vault.azure.net"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1034']
+      content-length: ['1092']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:40:40 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -84,18 +110,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [67605500-9415-11e7-a12a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:42:10 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -115,19 +140,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [67605500-9415-11e7-a12a-a0b3ccf7272a]
     method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":null,"nextLink":null}'}
+    body: {string: '{"value":null,"nextLink":null}'}
     headers:
       cache-control: [no-cache]
       content-length: ['30']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:11 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -143,22 +167,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault set-policy]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [67b6d970-9415-11e7-8e90-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sdsfc2fkseod2tkh2uclvg76eiiqyl2gbxeheunmyug5ifeipqe4764lw/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-gvgzqo","name":"cli-test-keyvault-gvgzqo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjptestkv1","name":"tjptestkv1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['2777']
+      content-length: ['3054']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:10 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -169,64 +193,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault set-policy]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [67d4e8c0-9415-11e7-956c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net/"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"secrets":["get","list","set","delete","backup","restore","recover"],"keys":["get","create","delete","list","update","import","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-test-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['1035']
+      content-length: ['1093']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-service-version: [1.0.0.179]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"tags": {}, "properties": {"sku": {"name": "premium",
-      "family": "A"}, "enableSoftDelete": true, "vaultUri": "https://cli-kv-test-softdelete1.vault.azure.net/",
-      "enabledForDeployment": false, "accessPolicies": [{"permissions": {"keys": ["get",
-      "create", "delete", "list", "update", "import", "backup", "restore", "recover",
-      "purge"], "secrets": ["get", "list", "set", "delete", "backup", "restore", "recover",
-      "purge"], "certificates": ["get", "list", "delete", "create", "import", "update",
-      "managecontacts", "getissuers", "listissuers", "setissuers", "deleteissuers",
-      "manageissuers", "recover", "purge"]}, "objectId": "5963f50c-7c43-405c-af7e-53294de76abd",
-      "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}], "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},
-      "location": "westus"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['789']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [681b679e-9415-11e7-b896-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover","purge"],"secrets":["get","list","set","delete","backup","restore","recover","purge"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover","purge"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-kv-test-softdelete1.vault.azure.net/"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['954']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -236,1629 +218,39 @@ interactions:
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "value": "ABC123", "tags":
-      {"file-encoding": "utf-8"}}'
+    body: 'b''{"tags": {}, "properties": {"enableSoftDelete": true, "enabledForDeployment":
+      false, "vaultUri": "https://cli-test-keyvault-000002.vault.azure.net/", "sku":
+      {"family": "A", "name": "premium"}, "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "accessPolicies": [{"permissions": {"secrets": ["get", "list", "set", "delete",
+      "backup", "restore", "recover", "purge"], "keys": ["get", "create", "delete",
+      "list", "update", "import", "backup", "restore", "recover", "purge"], "certificates":
+      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"]},
+      "objectId": "5963f50c-7c43-405c-af7e-53294de76abd", "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}]},
+      "location": "westus"}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault set-policy]
       Connection: [keep-alive]
-      Content-Length: ['88']
+      Content-Length: ['790']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [686df470-9415-11e7-ac13-a0b3ccf7272a]
     method: PUT
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"value":"ABC123","id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"5963f50c-7c43-405c-af7e-53294de76abd","permissions":{"secrets":["get","list","set","delete","backup","restore","recover","purge"],"keys":["get","create","delete","list","update","import","backup","restore","recover","purge"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover","purge"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"vaultUri":"https://cli-test-keyvault-000002.vault.azure.net/"}}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['267']
+      content-length: ['1012']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [689dde0f-9415-11e7-8006-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820532,"scheduledPurgeDate":1512596532,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['393']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68da23c0-9415-11e7-9414-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6acddd70-9415-11e7-ad4e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6cccbab0-9415-11e7-83cd-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6ec444f0-9415-11e7-bc88-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [70bdcb00-9415-11e7-9987-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [72b443cf-9415-11e7-821e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [74aba700-9415-11e7-9a9e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [76a77700-9415-11e7-8b6e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820532,"scheduledPurgeDate":1512596532,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['388']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [76d9f8b0-9415-11e7-acb9-a0b3ccf7272a]
-    method: POST
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['250']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7719e7e1-9415-11e7-90e3-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:37 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [790defb0-9415-11e7-8c71-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7af8a8ae-9415-11e7-991f-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7cf27cde-9415-11e7-8937-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7ee0b84f-9415-11e7-bf87-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['245']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7f0a6061-9415-11e7-b815-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820571,"scheduledPurgeDate":1512596571,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1/bf6b1cffffbc405eb90a46ad6373689e","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['393']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7f4e954f-9415-11e7-b3ef-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [813c3480-9415-11e7-b712-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8337b65e-9415-11e7-8416-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:42:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8534bede-9415-11e7-b5fb-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [872c9740-9415-11e7-9a06-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1","deletedDate":1504820571,"scheduledPurgeDate":1512596571,"id":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1504820532,"updated":1504820532,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['388']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [875e7cb0-9415-11e7-92c9-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      cache-control: [no-cache]
-      date: ['Thu, 07 Sep 2017 21:43:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 204, message: No Content}
-- request:
-    body: !!python/unicode '{"attributes": {"enabled": true}, "kty": "RSA"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['47']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [87a8cc21-9415-11e7-a8bd-a0b3ccf7272a]
-    method: POST
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/create?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['662']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [87e5fc30-9415-11e7-a1ca-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820585,"scheduledPurgeDate":1512596585,"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['799']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8829bbf0-9415-11e7-9579-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8a1e6000-9415-11e7-b7a1-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8c1c52e1-9415-11e7-a53e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8e173880-9415-11e7-ab27-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9010224f-9415-11e7-be4e-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820585,"scheduledPurgeDate":1512596585,"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['344']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [90478600-9415-11e7-9017-a0b3ccf7272a]
-    method: POST
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['662']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9099ebc0-9415-11e7-971c-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [928c1ecf-9415-11e7-8d60-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [947af680-9415-11e7-993c-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [966f9a8f-9415-11e7-8da1-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [985c4f61-9415-11e7-99d0-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9a4b2711-9415-11e7-a5e3-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['207']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9a793bee-9415-11e7-a4b9-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/keys/key1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820615,"scheduledPurgeDate":1512596615,"key":{"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1/5bec7ee825994317af03734736edba99","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"wllSlTTNgN5LIB-dF7vgf69URwbTgPae68DkM6BxJWexIaOaCqNWhZQKawhjchcBGihkKVv2ba3t2u_sR_MvZVX0pBUlwoP7oMtxt2NhzRSPyb8mrnmM2wZ6EViyl7fwXtPjtgQDvgjDXLvTxM-IhulCVurIDsurCt8OYVjIFIDw-lJ_7vBD6TJ-4gBfmhen82sWETi7dozimlUFXVm8eis0hyP4No3yB4iaHt4J4Nx5_9d1afGMn70pveYNXuU9YY7tNO-JvH_m-rEfiF4ICVmiwASVd7pG4PuWS3NyhlsI5yriN4rxj00mS9RnixLBx55Z68gRB8b2gRYIndeh5Q","e":"AQAB"},"attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['799']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9abed070-9415-11e7-bd99-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:36 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9cb4fb21-9415-11e7-9f94-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9eae5a1e-9415-11e7-be1d-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a0a9dc00-9415-11e7-93ff-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a2a4c19e-9415-11e7-83a8-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1","deletedDate":1504820615,"scheduledPurgeDate":1512596615,"kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/key1","attributes":{"enabled":true,"created":1504820585,"updated":1504820585,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['344']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a2d9662e-9415-11e7-920c-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      cache-control: [no-cache]
-      date: ['Thu, 07 Sep 2017 21:43:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 204, message: No Content}
-- request:
-    body: !!python/unicode '{"policy": {"key_props": {"key_size": 2048, "exportable":
-      true, "kty": "RSA", "reuse_key": false}, "secret_props": {"contentType": "application/x-pem-file"},
-      "issuer": {"name": "Self"}}, "attributes": {"enabled": true, "nbf": 1477593836,
-      "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
-      PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
-      CERTIFICATE-----"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3170']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a31a8dde-9415-11e7-942e-a0b3ccf7272a]
-    method: POST
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/import?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/0fa2ac94d2e543888631b05a14585cfc","kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/cert1/0fa2ac94d2e543888631b05a14585cfc","sid":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/cert1/0fa2ac94d2e543888631b05a14585cfc","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504820632,"updated":1504820632}}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['2191']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a3a51a9e-9415-11e7-8240-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1","deletedDate":1504820631,"scheduledPurgeDate":1512596631,"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/0fa2ac94d2e543888631b05a14585cfc","kid":"https://cli-kv-test-softdelete1.vault.azure.net/keys/cert1/0fa2ac94d2e543888631b05a14585cfc","sid":"https://cli-kv-test-softdelete1.vault.azure.net/secrets/cert1/0fa2ac94d2e543888631b05a14585cfc","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504820632,"updated":1504820632}}}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['2337']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a3dbe20f-9415-11e7-bf51-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a5d47dc0-9415-11e7-97e6-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a7ce7900-9415-11e7-ab6a-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:43:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a9cbf6b0-9415-11e7-8e96-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['28']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [abc44440-9415-11e7-88b0-a0b3ccf7272a]
-    method: GET
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode '{"value":[{"recoveryId":"https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1","deletedDate":1504820631,"scheduledPurgeDate":1512596631,"id":"https://cli-kv-test-softdelete1.vault.azure.net/certificates/cert1","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504820632,"updated":1504820632,"recoveryLevel":"Recoverable+Purgeable"}}],"nextLink":null}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['431']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultclient/0.3.4 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [abfcb961-9415-11e7-b4ec-a0b3ccf7272a]
-    method: DELETE
-    uri: https://cli-kv-test-softdelete1.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      cache-control: [no-cache]
-      date: ['Thu, 07 Sep 2017 21:44:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000;includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.821]
-      x-powered-by: [ASP.NET]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ac4c11e1-9415-11e7-8c7a-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
-  response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1","name":"cli-kv-test-softdelete1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgoh2h7jpn7vzu53hinsy6qhvevy2cv5r34hho7bwh4qnayn5f6olkoaxb2tmdcakpj/providers/Microsoft.KeyVault/vaults/clibatchtestkeyvault1","name":"clibatchtestkeyvault1","type":"Microsoft.KeyVault/vaults","location":"uksouth","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['2777']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ac6677b0-9415-11e7-81cf-a0b3ccf7272a]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-kv-sd/providers/Microsoft.KeyVault/vaults/cli-kv-test-softdelete1?api-version=2016-10-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:44:07 GMT']
+      date: ['Fri, 08 Sep 2017 19:05:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1870,6 +262,37 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
+    body: '{"tags": {"file-encoding": "utf-8"}, "value": "ABC123", "attributes": {"enabled":
+      true}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['88']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/9801276346384a859940b94151b93a96","attributes":{"enabled":true,"created":1504897538,"updated":1504897538,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['268']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
     body: null
     headers:
       Accept: [application/json]
@@ -1877,29 +300,1691 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/deletedVaults/cli-kv-test-softdelete1/purge?api-version=2016-10-01
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: '{"recoveryId":"https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1504897537,"scheduledPurgeDate":1512673537,"id":"https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/9801276346384a859940b94151b93a96","attributes":{"enabled":true,"created":1504897538,"updated":1504897538,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['395']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:38 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:37 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret secret1 is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['129']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:54 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/9801276346384a859940b94151b93a96","attributes":{"enabled":true,"created":1504897538,"updated":1504897538,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['251']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:05:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:01 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:07 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/9801276346384a859940b94151b93a96","attributes":{"enabled":true,"created":1504897538,"updated":1504897538,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['268']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"recoveryId":"https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1","deletedDate":1504897571,"scheduledPurgeDate":1512673571,"id":"https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/9801276346384a859940b94151b93a96","attributes":{"enabled":true,"created":1504897538,"updated":1504897538,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['395']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:23 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Secret is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['121']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedsecrets/secret1?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      date: ['Fri, 08 Sep 2017 19:06:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/secrets/secret1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"SecretNotFound","message":"Secret not found:
+        secret1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['73']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"attributes": {"enabled": true}, "kty": "RSA"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['47']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/create?api-version=2016-10-01
+  response:
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/1b6ac08c757348cea8f74561d640c5bd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zGYPoZDOL-_WXZZLV8n02pQ0xDP71WKBDLkcg3zXRi1wL7LL6s2C8yl0CQiICgEvwGzieJPy6f5ymXtieWAICmkzK7b5Njf7KUbHn3U3m28r2glugz8yrvdbYEyqswMou6YJfHqlIQsBqrx6rguEfPy9h55pIanGSbiwGbjs8jVAuJkPkDecBjbkdvGeWM_4nXBxbSoHBOFEYP6tOejple68a3QJcatsGK4Tt7JUIn1PqI0PgysCN0Ts-7_3tMXpWIGhDr8f4EE1_CxRH9DBDPvTC903UqKaQyRRCSCOnknM4aqAb-kVJCqeJYxbHHCJ5XfikloH42bua_QfC-Xhkw","e":"AQAB"},"attributes":{"enabled":true,"created":1504897589,"updated":1504897589,"recoveryLevel":"Recoverable+Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['663']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"recoveryId":"https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1","deletedDate":1504897589,"scheduledPurgeDate":1512673589,"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/1b6ac08c757348cea8f74561d640c5bd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zGYPoZDOL-_WXZZLV8n02pQ0xDP71WKBDLkcg3zXRi1wL7LL6s2C8yl0CQiICgEvwGzieJPy6f5ymXtieWAICmkzK7b5Njf7KUbHn3U3m28r2glugz8yrvdbYEyqswMou6YJfHqlIQsBqrx6rguEfPy9h55pIanGSbiwGbjs8jVAuJkPkDecBjbkdvGeWM_4nXBxbSoHBOFEYP6tOejple68a3QJcatsGK4Tt7JUIn1PqI0PgysCN0Ts-7_3tMXpWIGhDr8f4EE1_CxRH9DBDPvTC903UqKaQyRRCSCOnknM4aqAb-kVJCqeJYxbHHCJ5XfikloH42bua_QfC-Xhkw","e":"AQAB"},"attributes":{"enabled":true,"created":1504897589,"updated":1504897589,"recoveryLevel":"Recoverable+Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['801']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"KeyNotFound","message":"Key not found: key1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key key1 is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['123']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key key1 is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['123']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1/recover?api-version=2016-10-01
+  response:
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/1b6ac08c757348cea8f74561d640c5bd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zGYPoZDOL-_WXZZLV8n02pQ0xDP71WKBDLkcg3zXRi1wL7LL6s2C8yl0CQiICgEvwGzieJPy6f5ymXtieWAICmkzK7b5Njf7KUbHn3U3m28r2glugz8yrvdbYEyqswMou6YJfHqlIQsBqrx6rguEfPy9h55pIanGSbiwGbjs8jVAuJkPkDecBjbkdvGeWM_4nXBxbSoHBOFEYP6tOejple68a3QJcatsGK4Tt7JUIn1PqI0PgysCN0Ts-7_3tMXpWIGhDr8f4EE1_CxRH9DBDPvTC903UqKaQyRRCSCOnknM4aqAb-kVJCqeJYxbHHCJ5XfikloH42bua_QfC-Xhkw","e":"AQAB"},"attributes":{"enabled":true,"created":1504897589,"updated":1504897589,"recoveryLevel":"Recoverable+Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['663']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"KeyNotFound","message":"Key not found: key1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:06:57 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"KeyNotFound","message":"Key not found: key1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:00 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/1b6ac08c757348cea8f74561d640c5bd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zGYPoZDOL-_WXZZLV8n02pQ0xDP71WKBDLkcg3zXRi1wL7LL6s2C8yl0CQiICgEvwGzieJPy6f5ymXtieWAICmkzK7b5Njf7KUbHn3U3m28r2glugz8yrvdbYEyqswMou6YJfHqlIQsBqrx6rguEfPy9h55pIanGSbiwGbjs8jVAuJkPkDecBjbkdvGeWM_4nXBxbSoHBOFEYP6tOejple68a3QJcatsGK4Tt7JUIn1PqI0PgysCN0Ts-7_3tMXpWIGhDr8f4EE1_CxRH9DBDPvTC903UqKaQyRRCSCOnknM4aqAb-kVJCqeJYxbHHCJ5XfikloH42bua_QfC-Xhkw","e":"AQAB"},"attributes":{"enabled":true,"created":1504897589,"updated":1504897589,"recoveryLevel":"Recoverable+Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['663']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"recoveryId":"https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1","deletedDate":1504897650,"scheduledPurgeDate":1512673650,"key":{"kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/key1/1b6ac08c757348cea8f74561d640c5bd","kty":"RSA","key_ops":["encrypt","decrypt","sign","verify","wrapKey","unwrapKey"],"n":"zGYPoZDOL-_WXZZLV8n02pQ0xDP71WKBDLkcg3zXRi1wL7LL6s2C8yl0CQiICgEvwGzieJPy6f5ymXtieWAICmkzK7b5Njf7KUbHn3U3m28r2glugz8yrvdbYEyqswMou6YJfHqlIQsBqrx6rguEfPy9h55pIanGSbiwGbjs8jVAuJkPkDecBjbkdvGeWM_4nXBxbSoHBOFEYP6tOejple68a3QJcatsGK4Tt7JUIn1PqI0PgysCN0Ts-7_3tMXpWIGhDr8f4EE1_CxRH9DBDPvTC903UqKaQyRRCSCOnknM4aqAb-kVJCqeJYxbHHCJ5XfikloH42bua_QfC-Xhkw","e":"AQAB"},"attributes":{"enabled":true,"created":1504897589,"updated":1504897589,"recoveryLevel":"Recoverable+Purgeable"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['801']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"KeyNotFound","message":"Key not found: key1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:34 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:39 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:50 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Key is currently being
+        deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['118']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:52 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedkeys/key1?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      date: ['Fri, 08 Sep 2017 19:07:56 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/keys/key1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"KeyNotFound","message":"Key not found: key1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['64']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"policy": {"secret_props": {"contentType": "application/x-pem-file"},
+      "key_props": {"key_size": 2048, "exportable": true, "reuse_key": false, "kty":
+      "RSA"}, "issuer": {"name": "Self"}}, "attributes": {"nbf": 1477593836, "enabled":
+      true, "exp": 1509130436}, "value": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCRUPFgOvovNJ0e\nXSHlcm2V9w/ECwzMc31BaN2xBmWjegmqixv9GN3GWMgUQ9zC9k9bxd491Awa55Sq\nht86TL8Q3Fcn8fXuhWbX/gNAO8h5tfuQVA1zB5bVxEQsCNmmLrpgNhLYO+excyCJ\nocqidQostSQfcXU7qJtifpgmRt5oW3WhmpVsnAugS8y8vbCGJXdKqLCZXjL/H0aa\n+r/Z3BzQ+BglULKYshSBinxbYe+1GJ/028/50y/MPf9iFiiS9xtspOtSzd1e+NA5\nG+pCMppJHars9D/FavTewI1zJa9jPxtrwr8L3nEmy9gv6v1474XNYaagtQNjdU0b\nAV3EDfn9AgMBAAECggEADJtGjXAgYzb/yHIQ7jxamG96DSpePmBoheOok+J3r9J3\nAzYVRARDvSDXnrZycPF4WgBU8u0x7aWYhqCzvfWJf9d1si/yA3LMRMGzG3/0OOba\nP5+jGQ8X/UyNE3rjEuEr5wvZ36t2wrS3pmkEUMqxisZeL2Ii5v2OGWHdJjjws4HW\nP9pBGjcgxUP7UKPLQExHb9oUswh66Z+K9o10ZwArPYhnhc546vPlbHqO5bTS/Rza\nPd+c/h7PrrqwSBavm5mdjcHwqr5JjhE4OzbS4HkiYVnpx4OPRcgR0vWE6cG+0zg5\n4AROSM9kvrGflIqn2EAojRAz5S6wHMk7pImk4kAdSwKBgQC/wVsEruzUj3p7DvXc\nXRo8juRrWztrmOvp0GwhsVIVaF0Fr2lqCEGgOqqj5IEfue0UaCNCW3I73rRSYaNe\nnJ7PGZMYmLkzwcvGTEeV9CRqOgvKvbf3RiCpkKeLz3dil8AGdyVlwAJmq8Fn+IMT\nrwGaw3/UHTRMnse6JPoQ+k4KMwKBgQDCAI4Mlq5K7WSH1zNKSLgII9KnfHHkusNU\n88hpaVReXmxU7uQIC02nbtYl2oM3I/Lz9Otk/nPIbh4g9LKmju5Gi1S2wchInDfP\nKwgPoClM6/VM4e6CS9qq/FvJdLu2228AxcdSoIwGmrkbiTtGNedO4CdBa3/vacac\nuD0iD/gbDwKBgQC+mXzVHOJ/LdZ6txYe4dQQWaAmLdrUSn5EPE0e+Fg0uzWrTv4i\nzO4eS/INUjYeyPokjJZvgOH9LJJkSHTQuDEKfcs+aZ+9GGZqRqvpG3GOvP+3l/hi\nKyyQHx7K039BWsEeLBPaHY7FavelVtlDGXMo2CYZOqYfervgBJ0jfwlPDQKBgCuC\nSFlWadxwBT3Z66zbRjq9Hf9mD30Gzcv9qJLLhpprfsxFj2qmblIAr5JpwUfajiBc\na3aJApqO577oYjCsmY/Eq8kZCLwQHQwfUH2ApAKWYLtPaFhcfrweQM+bmIXYDLsV\noDBNxVmt1ZnxWxPR/wBXkTZAz7538I0xXLSI9FHNAoGBAJ/2ck5G+pKVHJA9sFoO\nwpB1jimZNmZjw2Fiu7u33IQSq1oMijD/M8qLFlnquetBrjniW55ViR89HMe+5Bwt\nnZ+Pq6xDKnzxRyyFWGM8lp+JDMMj1xOHIYil+aFgZyWm6/VzN24vdp2eYRYWBdMT\nP8mukpnNhytmI1/4ozaU+wai\n-----END
+      PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAP\nMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1Nlow\nDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\nAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2\nT1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYu\numA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYl\nd0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3\nG2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjv\nhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1Ud\nEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaA\nFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m\n2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX\n+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnsc\njSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGX\nHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LY\nWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZx\niAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==\n-----END
+      CERTIFICATE-----"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3170']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/import?api-version=2016-10-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504897678,"updated":1504897678,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504897678,"updated":1504897678}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2195']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: '{"recoveryId":"https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1","deletedDate":1504897678,"scheduledPurgeDate":1512673678,"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","kid":"https://cli-test-keyvault-000002.vault.azure.net/keys/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","sid":"https://cli-test-keyvault-000002.vault.azure.net/secrets/cert1/4a4dc890893b426e9bda0edf2d9ca7ae","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1504897678,"updated":1504897678,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1504897678,"updated":1504897678}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['2342']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"CertificateNotFound","message":"Certificate
+        not found: cert1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['81']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:58 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Certificate is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:07:59 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Certificate is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:08:02 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Certificate is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:08:05 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"Conflict","message":"Certificate is currently
+        being deleted.","innererror":{"code":"ObjectIsBeingDeleted"}}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['126']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:08:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 409, message: Conflict}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://cli-test-keyvault-000002.vault.azure.net/deletedcertificates/cert1?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      date: ['Fri, 08 Sep 2017 19:08:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultclient/0.3.4 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://cli-test-keyvault-000002.vault.azure.net/certificates/cert1/?api-version=2016-10-01
+  response:
+    body: {string: '{"error":{"code":"CertificateNotFound","message":"Certificate
+        not found: cert1"}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['81']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:08:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000;includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.821]
+      x-powered-by: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sdsfc2fkseod2tkh2uclvg76eiiqyl2gbxeheunmyug5ifeipqe4764lw/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-gvgzqo","name":"cli-test-keyvault-gvgzqo","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002","name":"cli-test-keyvault-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_existing_certkvg22v5fsol3lqdivew2w3dkv7qe2tcbcp7wmjxb53/providers/Microsoft.KeyVault/vaults/clitestemcd3ylngb6xyfjjh","name":"clitestemcd3ylngb6xyfjjh","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_sp_with_kv_new_certxgwr3fn6lyna6zrxeastkyrtqvlylxcx4eylctfborrrthj/providers/Microsoft.KeyVault/vaults/clitestuznjfpcwnzpbea5ff","name":"clitestuznjfpcwnzpbea5ff","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation/providers/Microsoft.KeyVault/vaults/cliautomationlab786","name":"cliautomationlab786","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"9f45d4bf-7e01-4684-9438-37c712728db1","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliautomation01/providers/Microsoft.KeyVault/vaults/cliautomationlab6073","name":"cliautomationlab6073","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{"hidden-DevTestLabs-LabUId":"72f1b266-2a21-4f0a-af01-934c93c72e6e","CreatedBy":"DevTestLabs"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg4mlozagf3pwtonk2fy32dz2fektoa5zcrvjis2bthl5uq7euxewj7saj52y5z5ydw/providers/Microsoft.KeyVault/vaults/vmkeyvault5sf56op5ih","name":"vmkeyvault5sf56op5ih","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgf3taitsxo7e7papbgdn77qjvbmonegm72h4xxj4ejfnnr3zs5v37lu2v4yuhngcgt/providers/Microsoft.KeyVault/vaults/vmkeyvaultwga4pgpqfg","name":"vmkeyvaultwga4pgpqfg","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rguewohnkhvsl75xdfx66o4y3evlji7jv3n6f7bqhjowvumyyqknlgyouo3hatlnzsj/providers/Microsoft.KeyVault/vaults/vmlinuxkvhfrbfprtn5q","name":"vmlinuxkvhfrbfprtn5q","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-kv/providers/Microsoft.KeyVault/vaults/tjptestkv1","name":"tjptestkv1","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}}]}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['3054']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 19:08:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_sd000001/providers/Microsoft.KeyVault/vaults/cli-test-keyvault-000002?api-version=2016-10-01
+  response:
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 07 Sep 2017 21:44:08 GMT']
+      date: ['Fri, 08 Sep 2017 19:08:14 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
       pragma: [no-cache]
-      retry-after: ['5']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
       x-ms-keyvault-service-version: [1.0.0.179]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault purge]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/deletedVaults/cli-test-keyvault-000002/purge?api-version=2016-10-01
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 08 Sep 2017 19:08:14 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01']
+      pragma: [no-cache]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-keyvault-service-version: [1.0.0.179]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
       x-powered-by: [ASP.NET]
     status: {code: 202, message: Accepted}
 - request:
@@ -1907,26 +1992,25 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault purge]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","status":"NotStarted"}'}
+    body: {string: '{"createdDateTime":"2017-09-08 19:08:16Z","status":"NotStarted"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['64']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:13 GMT']
+      date: ['Fri, 08 Sep 2017 19:08:20 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01']
       pragma: [no-cache]
-      retry-after: ['5']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -1939,26 +2023,25 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault purge]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","status":"NotStarted"}'}
+    body: {string: '{"createdDateTime":"2017-09-08 19:08:16Z","status":"NotStarted"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['64']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:19 GMT']
+      date: ['Fri, 08 Sep 2017 19:08:25 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01']
       pragma: [no-cache]
-      retry-after: ['5']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
@@ -1971,23 +2054,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
+      CommandName: [keyvault purge]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.15063) requests/2.9.1 msrest/0.4.11
-          msrest_azure/0.4.11 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
-          AZURECLI/TEST/2.0.15+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad6d394f-9415-11e7-a83e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDE3NDUwNzAwMjI4NnwwM0Q5OTRBQkM1ODg0RENDOUJGQTc3ODQzREQzM0Q1Qg?api-version=2016-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/locations/westus/operationResults/VVR8MDYzNjQwNDk0NDk3NDQ1Nzk1M3xCQTJBQTI4OEM4Q0Y0QTFBQjlBNUZENUM1N0I4NjI3RQ?api-version=2016-10-01
   response:
-    body: {string: !!python/unicode '{"createdDateTime":"2017-09-07 21:44:09Z","lastActionDateTime":"2017-09-07
-        21:44:22Z","status":"Succeeded"}'}
+    body: {string: '{"createdDateTime":"2017-09-08 19:08:16Z","lastActionDateTime":"2017-09-08
+        19:08:28Z","status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['107']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 07 Sep 2017 21:44:25 GMT']
+      date: ['Fri, 08 Sep 2017 19:08:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-IIS/8.5]
@@ -1999,4 +2082,31 @@ interactions:
       x-ms-keyvault-service-version: [1.0.0.179]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [group delete]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_keyvault_sd000001?api-version=2017-05-10
+  response:
+    body: {string: ''}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 08 Sep 2017 19:08:32 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTEk6NUZURVNUOjVGS0VZVkFVTFQ6NUZTRFo1U0k1VkkyNEVTRTZZS0taSFI0M3wzQUVCNzA1MEZDN0I3NEVDLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
@@ -601,7 +601,7 @@ class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
         super(KeyVaultSoftDeleteScenarioTest, self).__init__(__file__, test_method,
                                                              resource_group='cli-test-kv-sd')
-        self.keyvault_name = 'cli-kv-test-softdelete'
+        self.keyvault_name = 'cli-kv-test-softdelete1'
         self.location = 'westus'
 
     def test_keyvault_softdelete(self):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
@@ -14,16 +14,14 @@ from dateutil import tz
 from azure.cli.command_modules.keyvault.custom import _asn1_to_iso8601
 
 from azure.cli.core.util import CLIError
-from azure.cli.testsdk.vcr_test_base import (ResourceGroupVCRTestBase, JMESPathCheck,
-                                             NoneCheck)
+from azure.cli.testsdk import ScenarioTest, JMESPathCheck, NoneCheck, ResourceGroupPreparer
 
 from azure.cli.command_modules.keyvault._params import secret_encoding_values
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 
-def _create_keyvault(test,
-                     vault_name, resource_group, location, retry_wait=30, max_retries=10, additional_args=None):
+def _create_keyvault(test, vault_name, resource_group, location, retry_wait=30, max_retries=10, additional_args=None):
 
     # need premium KeyVault to store keys in HSM
     vault = test.cmd('keyvault create -g {} -n {} -l {} --sku premium {}'.format(resource_group, vault_name,
@@ -64,23 +62,22 @@ class DateTimeParseTest(unittest.TestCase):
         self.assertEqual(_asn1_to_iso8601("20170424163720Z"), expected)
 
 
-class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):
-    def __init__(self, test_method):
-        super(KeyVaultMgmtScenarioTest, self).__init__(__file__, test_method,
-                                                       resource_group='cli-test-keyvault-mgmt')
-        self.keyvault_names = ['cli-keyvault-12345-0',
-                               'cli-keyvault-12345-1',
-                               'cli-keyvault-12345-2',
-                               'cli-keyvault-12345-3']
-        self.location = 'westus'
+class KeyVaultMgmtScenarioTest(ScenarioTest):
 
-    def test_keyvault_mgmt(self):
-        self.execute()
+    @ResourceGroupPreparer(name_prefix='cli_test_keyvault_mgmt')
+    def test_keyvault_mgmt(self, resource_group):
 
-    def body(self):
-        rg = self.resource_group
+        self.keyvault_names = [
+            self.create_random_name('cli-keyvault-', 24),
+            self.create_random_name('cli-keyvault-', 24),
+            self.create_random_name('cli-keyvault-', 24),
+            self.create_random_name('cli-keyvault-', 24)
+        ]
+
+        rg = resource_group
         kv = self.keyvault_names[0]
-        loc = self.location
+        loc = 'westus'
+
         # test create keyvault with default access policy set
         keyvault = self.cmd('keyvault create -g {} -n {} -l {}'.format(rg, kv, loc), checks=[
             JMESPathCheck('name', kv),
@@ -89,7 +86,7 @@ class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('type(properties.accessPolicies)', 'array'),
             JMESPathCheck('length(properties.accessPolicies)', 1),
             JMESPathCheck('properties.sku.name', 'standard')
-        ])
+        ]).get_output_in_json()
         policy_id = keyvault['properties']['accessPolicies'][0]['objectId']
         self.cmd('keyvault show -n {}'.format(kv), checks=[
             JMESPathCheck('name', kv),
@@ -106,63 +103,51 @@ class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('[0].resourceGroup', rg),
         ])
         # test updating keyvault sku name
-        self.cmd('keyvault update -g {} -n {} --set properties.sku.name=premium'.format(rg, kv),
-                 checks=[
-                     JMESPathCheck('name', kv),
-                     JMESPathCheck('properties.sku.name', 'premium'),
-                 ])
+        self.cmd('keyvault update -g {} -n {} --set properties.sku.name=premium'.format(rg, kv), checks=[
+            JMESPathCheck('name', kv),
+            JMESPathCheck('properties.sku.name', 'premium'),
+        ])
         # test policy set/delete
-        self.cmd(
-            'keyvault set-policy -g {} -n {} --object-id {} --certificate-permissions get list'.format(
-                rg, kv, policy_id),
-            checks=JMESPathCheck('length(properties.accessPolicies[0].permissions.certificates)',
-                                 2))
-        self.cmd('keyvault delete-policy -g {} -n {} --object-id {}'.format(rg, kv, policy_id),
-                 checks=[
-                     JMESPathCheck('type(properties.accessPolicies)', 'array'),
-                     JMESPathCheck('length(properties.accessPolicies)', 0)
-                 ])
+        self.cmd('keyvault set-policy -g {} -n {} --object-id {} --certificate-permissions get list'.format(rg, kv, policy_id),
+                 checks=JMESPathCheck('length(properties.accessPolicies[0].permissions.certificates)', 2))
+        self.cmd('keyvault delete-policy -g {} -n {} --object-id {}'.format(rg, kv, policy_id), checks=[
+            JMESPathCheck('type(properties.accessPolicies)', 'array'),
+            JMESPathCheck('length(properties.accessPolicies)', 0)
+        ])
 
         # test keyvault delete
         self.cmd('keyvault delete -n {}'.format(kv))
         self.cmd('keyvault list -g {}'.format(rg), checks=NoneCheck())
 
         # test create keyvault further
-        self.cmd(
-            'keyvault create -g {} -n {} -l {} --no-self-perms'.format(rg, self.keyvault_names[1],
-                                                                       loc), checks=[
-                JMESPathCheck('type(properties.accessPolicies)', 'array'),
-                JMESPathCheck('length(properties.accessPolicies)', 0)
-            ])
-        self.cmd('keyvault create -g {} -n {} -l {} --enabled-for-deployment true '
-                 '--enabled-for-disk-encryption true --enabled-for-template-deployment true'
-                 .format(rg, self.keyvault_names[2], loc),
-                 checks=[JMESPathCheck('properties.enabledForDeployment', True),
-                         JMESPathCheck('properties.enabledForDiskEncryption', True),
-                         JMESPathCheck('properties.enabledForTemplateDeployment', True)])
-        self.cmd(
-            'keyvault create -g {} -n {} -l {} --sku premium'.format(rg, self.keyvault_names[3],
-                                                                     loc), checks=[
-                JMESPathCheck('properties.sku.name', 'premium')
-            ])
+        self.cmd('keyvault create -g {} -n {} -l {} --no-self-perms'.format(rg, self.keyvault_names[1], loc), checks=[
+            JMESPathCheck('type(properties.accessPolicies)', 'array'),
+            JMESPathCheck('length(properties.accessPolicies)', 0)
+        ])
+        self.cmd('keyvault create -g {} -n {} -l {} --enabled-for-deployment true --enabled-for-disk-encryption true --enabled-for-template-deployment true'.format(rg, self.keyvault_names[2], loc), checks=[
+            JMESPathCheck('properties.enabledForDeployment', True),
+            JMESPathCheck('properties.enabledForDiskEncryption', True),
+            JMESPathCheck('properties.enabledForTemplateDeployment', True)
+        ])
+        self.cmd('keyvault create -g {} -n {} -l {} --sku premium'.format(rg, self.keyvault_names[3], loc), checks=[
+            JMESPathCheck('properties.sku.name', 'premium')
+        ])
 
 
-class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
-    def __init__(self, test_method):
-        super(KeyVaultKeyScenarioTest, self).__init__(__file__, test_method,
-                                                      resource_group='cli-test-keyvault-key')
-        self.keyvault_name = 'cli-keyvault-test-key'
+class KeyVaultKeyScenarioTest(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_keyvault_key')
+    def test_keyvault_key(self, resource_group):
+
+        self.resource_group = resource_group
+        kv = self.create_random_name('cli-test-keyvault-', 24)
         self.location = 'westus'
 
-    def test_keyvault_key(self):
-        self.execute()
+        _create_keyvault(self, kv, self.resource_group, self.location)
 
-    def body(self):
-        _create_keyvault(self, self.keyvault_name, self.resource_group, self.location)
-        kv = self.keyvault_name
         # create a key
         key = self.cmd('keyvault key create --vault-name {} -n key1 -p software'.format(kv),
-                       checks=JMESPathCheck('attributes.enabled', True))
+                       checks=JMESPathCheck('attributes.enabled', True)).get_output_in_json()
         first_kid = key['key']['kid']
         first_version = first_kid.rsplit('/', 1)[1]
 
@@ -171,13 +156,11 @@ class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
                  checks=JMESPathCheck('length(@)', 1))
 
         # create a new key version
-        key = self.cmd(
-            'keyvault key create --vault-name {} -n key1 -p software --disabled --ops encrypt decrypt --tags test=foo'.format(
-                kv), checks=[
-                JMESPathCheck('attributes.enabled', False),
-                JMESPathCheck('length(key.keyOps)', 2),
-                JMESPathCheck('tags', {'test': 'foo'})
-            ])
+        key = self.cmd('keyvault key create --vault-name {} -n key1 -p software --disabled --ops encrypt decrypt --tags test=foo'.format(kv), checks=[
+            JMESPathCheck('attributes.enabled', False),
+            JMESPathCheck('length(key.keyOps)', 2),
+            JMESPathCheck('tags', {'test': 'foo'})
+        ]).get_output_in_json()
         second_kid = key['key']['kid']
         # list key versions
         self.cmd('keyvault key list-versions --vault-name {} -n key1'.format(kv),
@@ -192,11 +175,10 @@ class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
                  checks=JMESPathCheck('key.kid', first_kid))
 
         # set key attributes
-        self.cmd('keyvault key set-attributes --vault-name {} -n key1 --enabled true'.format(kv),
-                 checks=[
-                     JMESPathCheck('key.kid', second_kid),
-                     JMESPathCheck('attributes.enabled', True)
-                 ])
+        self.cmd('keyvault key set-attributes --vault-name {} -n key1 --enabled true'.format(kv), checks=[
+            JMESPathCheck('key.kid', second_kid),
+            JMESPathCheck('attributes.enabled', True)
+        ])
 
         # backup and then delete key
         key_file = 'backup.key'
@@ -216,23 +198,11 @@ class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
         key_enc_file = os.path.join(TEST_DIR, 'mydomain.test.encrypted.pem')
         key_enc_password = 'password'
         key_plain_file = os.path.join(TEST_DIR, 'mydomain.test.pem')
-        self.cmd(
-            'keyvault key import --vault-name {} -n import-key-plain --pem-file "{}" -p software'.format(
-                kv, key_plain_file))
-        self.cmd(
-            'keyvault key import --vault-name {} -n import-key-encrypted --pem-file "{}" --pem-password {} -p hsm'.format(
-                kv, key_enc_file, key_enc_password))
+        self.cmd('keyvault key import --vault-name {} -n import-key-plain --pem-file "{}" -p software'.format(kv, key_plain_file))
+        self.cmd('keyvault key import --vault-name {} -n import-key-encrypted --pem-file "{}" --pem-password {} -p hsm'.format(kv, key_enc_file, key_enc_password))
 
 
-class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
-    def __init__(self, test_method):
-        super(KeyVaultSecretScenarioTest, self).__init__(__file__, test_method,
-                                                         resource_group='cli-test-keyvault-secret')
-        self.keyvault_name = 'cli-test-keyvault-secret'
-        self.location = 'westus'
-
-    def test_keyvault_secret(self):
-        self.execute()
+class KeyVaultSecretScenarioTest(ScenarioTest):
 
     def _test_download_secret(self):
         kv = self.keyvault_name
@@ -241,14 +211,9 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
             expected = f.read().replace('\r\n', '\n')
 
         def _test_set_and_download(encoding):
-            self.cmd(
-                'keyvault secret set --vault-name {} -n download-{} --file "{}" --encoding {}'.format(
-                    kv, encoding, secret_path, encoding))
+            self.cmd('keyvault secret set --vault-name {} -n download-{} --file "{}" --encoding {}'.format(kv, encoding, secret_path, encoding))
             dest_path = os.path.join(TEST_DIR, 'recover-{}'.format(encoding))
-            self.cmd(
-                'keyvault secret download --vault-name {} -n download-{} --file "{}"'.format(kv,
-                                                                                             encoding,
-                                                                                             dest_path))
+            self.cmd('keyvault secret download --vault-name {} -n download-{} --file "{}"'.format(kv, encoding, dest_path))
             with open(dest_path, 'r') as f:
                 actual = f.read().replace('\r\n', '\n')
             self.assertEqual(actual, expected)
@@ -257,28 +222,30 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
         for encoding in secret_encoding_values:
             _test_set_and_download(encoding)
 
-    def body(self):
+    @ResourceGroupPreparer(name_prefix='cli_test_keyvault_secret')
+    def test_keyvault_secret(self, resource_group):
+
+        self.resource_group = resource_group
+        self.keyvault_name = self.create_random_name('cli-test-kevault-', 24)
+        self.location = 'westus'
+
         _create_keyvault(self, self.keyvault_name, self.resource_group, self.location)
         kv = self.keyvault_name
         # create a secret
-        secret = self.cmd(
-            'keyvault secret set --vault-name {} -n secret1 --value ABC123'.format(kv),
-            checks=JMESPathCheck('value', 'ABC123'))
+        secret = self.cmd('keyvault secret set --vault-name {} -n secret1 --value ABC123'.format(kv),
+                          checks=JMESPathCheck('value', 'ABC123')).get_output_in_json()
         first_kid = secret['id']
         first_version = first_kid.rsplit('/', 1)[1]
 
         # list secrets
-        self.cmd('keyvault secret list --vault-name {}'.format(kv),
-                 checks=JMESPathCheck('length(@)', 1))
+        self.cmd('keyvault secret list --vault-name {}'.format(kv), checks=JMESPathCheck('length(@)', 1))
 
         # create a new secret version
-        secret = self.cmd(
-            'keyvault secret set --vault-name {} -n secret1 --value DEF456 --tags test=foo --description "test type"'.format(
-                kv), checks=[
-                JMESPathCheck('value', 'DEF456'),
-                JMESPathCheck('tags', {'file-encoding': 'utf-8', 'test': 'foo'}),
-                JMESPathCheck('contentType', 'test type')
-            ])
+        secret = self.cmd('keyvault secret set --vault-name {} -n secret1 --value DEF456 --tags test=foo --description "test type"'.format(kv), checks=[
+            JMESPathCheck('value', 'DEF456'),
+            JMESPathCheck('tags', {'file-encoding': 'utf-8', 'test': 'foo'}),
+            JMESPathCheck('contentType', 'test type')
+        ]).get_output_in_json()
         second_kid = secret['id']
 
         # list secret versions
@@ -294,19 +261,16 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
                  checks=JMESPathCheck('id', first_kid))
 
         # set secret attributes
-        self.cmd(
-            'keyvault secret set-attributes --vault-name {} -n secret1 --enabled false'.format(kv),
-            checks=[
-                JMESPathCheck('id', second_kid),
-                JMESPathCheck('attributes.enabled', False)
-            ])
+        self.cmd('keyvault secret set-attributes --vault-name {} -n secret1 --enabled false'.format(kv), checks=[
+            JMESPathCheck('id', second_kid),
+            JMESPathCheck('attributes.enabled', False)
+        ])
 
         # backup and then delete secret
         bak_file = 'backup.secret'
         self.cmd('keyvault secret backup --vault-name {} -n secret1 --file {}'.format(kv, bak_file))
         self.cmd('keyvault secret delete --vault-name {} -n secret1'.format(kv))
-        self.cmd('keyvault secret list --vault-name {}'.format(kv),
-                 checks=NoneCheck())
+        self.cmd('keyvault secret list --vault-name {}'.format(kv), checks=NoneCheck())
 
         # restore key from backup
         self.cmd('keyvault secret restore --vault-name {} --file {}'.format(kv, bak_file))
@@ -323,29 +287,15 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
         self._test_download_secret()
 
 
-class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
-    def __init__(self, test_method):
-        super(KeyVaultCertificateScenarioTest, self).__init__(__file__, test_method,
-                                                              resource_group='cli-test-keyvault-cert')
-        self.keyvault_name = 'cli-test-keyvault-cert1'
-        self.location = 'westus'
-
-    def test_keyvault_certificate(self):
-        self.execute()
+class KeyVaultCertificateScenarioTest(ScenarioTest):
 
     def _test_keyvault_certificate_contacts(self):
         kv = self.keyvault_name
-        self.cmd(
-            'keyvault certificate contact add --vault-name {} --email admin@contoso.com --name "John Doe" --phone 123-456-7890'.format(
-                kv))
-        self.cmd(
-            'keyvault certificate contact add --vault-name {} --email other@contoso.com '.format(
-                kv))
+        self.cmd('keyvault certificate contact add --vault-name {} --email admin@contoso.com --name "John Doe" --phone 123-456-7890'.format(kv))
+        self.cmd('keyvault certificate contact add --vault-name {} --email other@contoso.com '.format(kv))
         self.cmd('keyvault certificate contact list --vault-name {}'.format(kv),
                  checks=JMESPathCheck('length(contactList)', 2))
-        self.cmd(
-            'keyvault certificate contact delete --vault-name {} --email admin@contoso.com'.format(
-                kv))
+        self.cmd('keyvault certificate contact delete --vault-name {} --email admin@contoso.com'.format(kv))
         self.cmd('keyvault certificate contact list --vault-name {}'.format(kv), checks=[
             JMESPathCheck('length(contactList)', 1),
             JMESPathCheck('contactList[0].emailAddress', 'other@contoso.com')
@@ -353,106 +303,75 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
 
     def _test_keyvault_certificate_issuers(self):
         kv = self.keyvault_name
-        self.cmd(
-            'keyvault certificate issuer create --vault-name {} --issuer-name issuer1 --provider Test'.format(
-                kv), checks=[
-                JMESPathCheck('provider', 'Test'),
-                JMESPathCheck('attributes.enabled', True)
-            ])
-        self.cmd(
-            'keyvault certificate issuer show --vault-name {} --issuer-name issuer1'.format(kv),
-            checks=[
-                JMESPathCheck('provider', 'Test'),
-                JMESPathCheck('attributes.enabled', True)
-            ])
-        self.cmd(
-            'keyvault certificate issuer update --vault-name {} --issuer-name issuer1 --organization-id TestOrg --account-id test_account'.format(
-                kv), checks=[
-                JMESPathCheck('provider', 'Test'),
-                JMESPathCheck('attributes.enabled', True),
-                JMESPathCheck('organizationDetails.id', 'TestOrg'),
-                JMESPathCheck('credentials.accountId', 'test_account')
-            ])
+        self.cmd('keyvault certificate issuer create --vault-name {} --issuer-name issuer1 --provider Test'.format(kv), checks=[
+            JMESPathCheck('provider', 'Test'),
+            JMESPathCheck('attributes.enabled', True)
+        ])
+        self.cmd('keyvault certificate issuer show --vault-name {} --issuer-name issuer1'.format(kv), checks=[
+            JMESPathCheck('provider', 'Test'),
+            JMESPathCheck('attributes.enabled', True)
+        ])
+        self.cmd('keyvault certificate issuer update --vault-name {} --issuer-name issuer1 --organization-id TestOrg --account-id test_account'.format(kv), checks=[
+            JMESPathCheck('provider', 'Test'),
+            JMESPathCheck('attributes.enabled', True),
+            JMESPathCheck('organizationDetails.id', 'TestOrg'),
+            JMESPathCheck('credentials.accountId', 'test_account')
+        ])
         with self.assertRaises(CLIError):
-            self.cmd(
-                'keyvault certificate issuer update --vault-name {} --issuer-name notexist --organization-id TestOrg --account-id test_account'.format(
-                    kv))
-        self.cmd(
-            'keyvault certificate issuer update --vault-name {} --issuer-name issuer1 --account-id ""'.format(
-                kv), checks=[
-                JMESPathCheck('provider', 'Test'),
-                JMESPathCheck('attributes.enabled', True),
-                JMESPathCheck('organizationDetails.id', 'TestOrg'),
-                JMESPathCheck('credentials.accountId', None)
-            ])
+            self.cmd('keyvault certificate issuer update --vault-name {} --issuer-name notexist --organization-id TestOrg --account-id test_account'.format(kv))
+        self.cmd('keyvault certificate issuer update --vault-name {} --issuer-name issuer1 --account-id ""'.format(kv), checks=[
+            JMESPathCheck('provider', 'Test'),
+            JMESPathCheck('attributes.enabled', True),
+            JMESPathCheck('organizationDetails.id', 'TestOrg'),
+            JMESPathCheck('credentials.accountId', None)
+        ])
         self.cmd('keyvault certificate issuer list --vault-name {}'.format(kv),
                  checks=JMESPathCheck('length(@)', 1))
 
         # test admin commands
-        self.cmd(
-            'keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test@test.com --first-name Test --last-name Admin --phone 123-456-7890'.format(
-                kv), checks=[
-                JMESPathCheck('emailAddress', 'test@test.com'),
-                JMESPathCheck('firstName', 'Test'),
-                JMESPathCheck('lastName', 'Admin'),
-                JMESPathCheck('phone', '123-456-7890'),
-            ])
+        self.cmd('keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test@test.com --first-name Test --last-name Admin --phone 123-456-7890'.format(kv), checks=[
+            JMESPathCheck('emailAddress', 'test@test.com'),
+            JMESPathCheck('firstName', 'Test'),
+            JMESPathCheck('lastName', 'Admin'),
+            JMESPathCheck('phone', '123-456-7890'),
+        ])
         with self.assertRaises(CLIError):
             self.cmd(
-                'keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test@test.com'.format(
-                    kv))
-        self.cmd(
-            'keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test2@test.com'.format(
-                kv), checks=[
-                JMESPathCheck('emailAddress', 'test2@test.com'),
-                JMESPathCheck('firstName', None),
-                JMESPathCheck('lastName', None),
-                JMESPathCheck('phone', None),
-            ])
-        self.cmd(
-            'keyvault certificate issuer admin list --vault-name {} --issuer-name issuer1'.format(
-                kv),
-            checks=JMESPathCheck('length(@)', 2))
-        self.cmd(
-            'keyvault certificate issuer admin delete --vault-name {} --issuer-name issuer1 --email test@test.com'.format(
-                kv))
-        self.cmd(
-            'keyvault certificate issuer admin list --vault-name {} --issuer-name issuer1'.format(
-                kv),
-            checks=JMESPathCheck('length(@)', 1))
+                'keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test@test.com'.format(kv))
+        self.cmd('keyvault certificate issuer admin add --vault-name {} --issuer-name issuer1 --email test2@test.com'.format(kv), checks=[
+            JMESPathCheck('emailAddress', 'test2@test.com'),
+            JMESPathCheck('firstName', None),
+            JMESPathCheck('lastName', None),
+            JMESPathCheck('phone', None),
+        ])
+        self.cmd('keyvault certificate issuer admin list --vault-name {} --issuer-name issuer1'.format(kv),
+                 checks=JMESPathCheck('length(@)', 2))
+        self.cmd('keyvault certificate issuer admin delete --vault-name {} --issuer-name issuer1 --email test@test.com'.format(kv))
+        self.cmd('keyvault certificate issuer admin list --vault-name {} --issuer-name issuer1'.format(kv),
+                 checks=JMESPathCheck('length(@)', 1))
 
-        self.cmd(
-            'keyvault certificate issuer delete --vault-name {} --issuer-name issuer1'.format(kv))
+        self.cmd('keyvault certificate issuer delete --vault-name {} --issuer-name issuer1'.format(kv))
         self.cmd('keyvault certificate issuer list --vault-name {}'.format(kv), checks=NoneCheck())
 
     def _test_keyvault_pending_certificate(self):
         kv = self.keyvault_name
         policy_path = os.path.join(TEST_DIR, 'policy_pending.json')
         fake_cert_path = os.path.join(TEST_DIR, 'import_pem_plain.pem')
-        self.cmd('keyvault certificate create --vault-name {} -n pending-cert -p @"{}"'.format(kv,
-                                                                                               policy_path),
-                 checks=[
-                     JMESPathCheck('statusDetails',
-                                   'Pending certificate created. Please Perform Merge to complete the request.'),
-                     JMESPathCheck('cancellationRequested', False),
-                     JMESPathCheck('status', 'inProgress')
-                 ])
-        self.cmd('keyvault certificate pending show --vault-name {} -n pending-cert'.format(kv),
-                 checks=[
-                     JMESPathCheck('statusDetails',
-                                   'Pending certificate created. Please Perform Merge to complete the request.'),
-                     JMESPathCheck('cancellationRequested', False),
-                     JMESPathCheck('status', 'inProgress')
-                 ])
+        self.cmd('keyvault certificate create --vault-name {} -n pending-cert -p @"{}"'.format(kv, policy_path), checks=[
+            JMESPathCheck('statusDetails', 'Pending certificate created. Please Perform Merge to complete the request.'),
+            JMESPathCheck('cancellationRequested', False),
+            JMESPathCheck('status', 'inProgress')
+        ])
+        self.cmd('keyvault certificate pending show --vault-name {} -n pending-cert'.format(kv), checks=[
+            JMESPathCheck('statusDetails', 'Pending certificate created. Please Perform Merge to complete the request.'),
+            JMESPathCheck('cancellationRequested', False),
+            JMESPathCheck('status', 'inProgress')
+        ])
         # we do not have a way of actually getting a certificate that would pass this test so
         # we simply ensure that the payload successfully serializes and is received by the server
-        self.cmd(
-            'keyvault certificate pending merge --vault-name {} -n pending-cert --file "{}"'.format(
-                kv, fake_cert_path),
-            allowed_exceptions="Public key from x509 certificate and key of this instance doesn't match")
+        self.cmd('keyvault certificate pending merge --vault-name {} -n pending-cert --file "{}"'.format(kv, fake_cert_path), expect_failure=True)
         self.cmd('keyvault certificate pending delete --vault-name {} -n pending-cert'.format(kv))
-        self.cmd('keyvault certificate pending show --vault-name {} -n pending-cert'.format(kv),
-                 allowed_exceptions='Pending certificate not found')
+        self.cmd('keyvault certificate pending show --vault-name {} -n pending-cert'.format(kv), expect_failure=True)
 
     def _test_certificate_download(self):
         import OpenSSL.crypto
@@ -460,9 +379,7 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         kv = self.keyvault_name
         pem_file = os.path.join(TEST_DIR, 'import_pem_plain.pem')
         pem_policy_path = os.path.join(TEST_DIR, 'policy_import_pem.json')
-        pem_cert = self.cmd(
-            'keyvault certificate import --vault-name {} -n pem-cert1 --file "{}" -p @"{}"'.format(
-                kv, pem_file, pem_policy_path))
+        pem_cert = self.cmd('keyvault certificate import --vault-name {} -n pem-cert1 --file "{}" -p @"{}"'.format(kv, pem_file, pem_policy_path)).get_output_in_json()
         cert_data = pem_cert['cer']
 
         dest_binary = os.path.join(TEST_DIR, 'download-binary')
@@ -474,12 +391,8 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         expected_pem = expected_pem.replace('\n', '')
 
         try:
-            self.cmd(
-                'keyvault certificate download --vault-name {} -n pem-cert1 --file "{}" -e DER'.format(
-                    kv, dest_binary))
-            self.cmd(
-                'keyvault certificate download --vault-name {} -n pem-cert1 --file "{}" -e PEM'.format(
-                    kv, dest_string))
+            self.cmd('keyvault certificate download --vault-name {} -n pem-cert1 --file "{}" -e DER'.format(kv, dest_binary))
+            self.cmd('keyvault certificate download --vault-name {} -n pem-cert1 --file "{}" -e PEM'.format(kv, dest_string))
             self.cmd('keyvault certificate delete --vault-name {} -n pem-cert1'.format(kv))
 
             def verify(path, file_type):
@@ -499,20 +412,25 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
                 os.remove(dest_string)
 
     def _test_keyvault_certificate_get_default_policy(self):
-        result = self.cmd('keyvault certificate get-default-policy')
+        result = self.cmd('keyvault certificate get-default-policy').get_output_in_json()
         self.assertEqual(result['keyProperties']['keyType'], 'RSA')
         self.assertEqual(result['issuerParameters']['name'], 'Self')
         self.assertEqual(result['secretProperties']['contentType'], 'application/x-pkcs12')
         subject = 'CN=CLIGetDefaultPolicy'
         self.assertEqual(result['x509CertificateProperties']['subject'], subject)
 
-        result = self.cmd('keyvault certificate get-default-policy --scaffold')
+        result = self.cmd('keyvault certificate get-default-policy --scaffold').get_output_in_json()
         self.assertIn('RSA or RSA-HSM', result['keyProperties']['keyType'])
         self.assertIn('Self', result['issuerParameters']['name'])
         self.assertIn('application/x-pkcs12', result['secretProperties']['contentType'])
         self.assertIn('Contoso', result['x509CertificateProperties']['subject'])
 
-    def body(self):
+    @ResourceGroupPreparer(name_prefix='cli_test_keyvault_cert')
+    def test_keyvault_certificate(self, resource_group):
+
+        self.resource_group = resource_group
+        self.keyvault_name = self.create_random_name('cli-test-keyvault-', 24)
+        self.location = 'westus'
 
         self._test_keyvault_certificate_get_default_policy()
 
@@ -525,25 +443,21 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         policy2_path = os.path.join(TEST_DIR, 'policy2.json')
 
         # create a certificate
-        self.cmd(
-            'keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(kv, policy_path),
-            checks=JMESPathCheck('status', 'completed'))
+        self.cmd('keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(kv, policy_path),
+                 checks=JMESPathCheck('status', 'completed'))
 
         # list certificates
         self.cmd('keyvault certificate list --vault-name {}'.format(kv),
                  checks=JMESPathCheck('length(@)', 1))
 
         # create a new certificate version
-        self.cmd('keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(kv,
-                                                                                        policy2_path),
-                 checks=[
-                     JMESPathCheck('status', 'completed'),
-                 ])
+        self.cmd('keyvault certificate create --vault-name {} -n cert1 -p @"{}"'.format(kv, policy2_path), checks=[
+            JMESPathCheck('status', 'completed'),
+        ])
 
         # list certificate versions
-        ver_list = self.cmd(
-            'keyvault certificate list-versions --vault-name {} -n cert1'.format(kv),
-            checks=JMESPathCheck('length(@)', 2))
+        ver_list = self.cmd('keyvault certificate list-versions --vault-name {} -n cert1'.format(kv),
+                            checks=JMESPathCheck('length(@)', 2)).get_output_in_json()
 
         ver_list = sorted(ver_list, key=lambda x: x['attributes']['created'])
         versions = [x['id'] for x in ver_list]
@@ -556,18 +470,15 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
 
         # show certificate (specific version)
         cert_version = versions[0].rsplit('/', 1)[1]
-        self.cmd(
-            'keyvault certificate show --vault-name {} -n cert1 -v {}'.format(kv, cert_version),
-            checks=JMESPathCheck('id', versions[0]))
+        self.cmd('keyvault certificate show --vault-name {} -n cert1 -v {}'.format(kv, cert_version),
+                 checks=JMESPathCheck('id', versions[0]))
 
         # update certificate attributes
-        self.cmd(
-            'keyvault certificate set-attributes --vault-name {} -n cert1 --enabled false -p @"{}"'.format(
-                kv, policy_path), checks=[
-                JMESPathCheck('id', versions[1]),
-                JMESPathCheck('attributes.enabled', False),
-                JMESPathCheck('policy.x509CertificateProperties.validityInMonths', 60)
-            ])
+        self.cmd('keyvault certificate set-attributes --vault-name {} -n cert1 --enabled false -p @"{}"'.format(kv, policy_path), checks=[
+            JMESPathCheck('id', versions[1]),
+            JMESPathCheck('attributes.enabled', False),
+            JMESPathCheck('policy.x509CertificateProperties.validityInMonths', 60)
+        ])
 
         self._test_keyvault_certificate_contacts()
         self._test_keyvault_certificate_issuers()
@@ -583,33 +494,24 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         pem_encrypted_password = '1234'
         pem_plain_file = os.path.join(TEST_DIR, 'import_pem_plain.pem')
         pem_policy_path = os.path.join(TEST_DIR, 'policy_import_pem.json')
-        self.cmd(
-            'keyvault certificate import --vault-name {} -n pem-cert1 --file "{}" -p @"{}"'.format(
-                kv, pem_plain_file, pem_policy_path))
-        self.cmd(
-            'keyvault certificate import --vault-name {} -n pem-cert2 --file "{}" --password {} -p @"{}"'.format(
-                kv, pem_encrypted_file, pem_encrypted_password, pem_policy_path))
+        self.cmd('keyvault certificate import --vault-name {} -n pem-cert1 --file "{}" -p @"{}"'.format(kv, pem_plain_file, pem_policy_path))
+        self.cmd('keyvault certificate import --vault-name {} -n pem-cert2 --file "{}" --password {} -p @"{}"'.format(kv, pem_encrypted_file, pem_encrypted_password, pem_policy_path))
 
         pfx_plain_file = os.path.join(TEST_DIR, 'import_pfx.pfx')
         pfx_policy_path = os.path.join(TEST_DIR, 'policy_import_pfx.json')
-        self.cmd(
-            'keyvault certificate import --vault-name {} -n pfx-cert --file "{}" -p @"{}"'.format(
-                kv, pfx_plain_file, pfx_policy_path))
+        self.cmd('keyvault certificate import --vault-name {} -n pfx-cert --file "{}" -p @"{}"'.format(kv, pfx_plain_file, pfx_policy_path))
 
 
-class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
-    def __init__(self, test_method):
-        super(KeyVaultSoftDeleteScenarioTest, self).__init__(__file__, test_method,
-                                                             resource_group='cli-test-kv-sd')
-        self.keyvault_name = 'cli-kv-test-softdelete1'
+class KeyVaultSoftDeleteScenarioTest(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_keyvault_sd')
+    def test_keyvault_softdelete(self, resource_group):
+
+        self.resource_group = resource_group
+        self.keyvault_name = self.create_random_name('cli-test-keyvault-', 24)
         self.location = 'westus'
-
-    def test_keyvault_softdelete(self):
-        self.execute()
-
-    def body(self):
         vault = _create_keyvault(self, self.keyvault_name, self.resource_group, self.location,
-                                 additional_args='--enable-soft-delete true')
+                                 additional_args='--enable-soft-delete true').get_output_in_json()
         kv = self.keyvault_name
 
         # add all purge permissions to default the access policy
@@ -623,8 +525,6 @@ class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
 
         cmdstr = 'keyvault set-policy -n {} --object-id {} --key-permissions {} --secret-permissions {} --certificate-permissions {}'.format(
             kv, default_policy['objectId'], ' '.join(keyPerms), ' '.join(secretPerms), ' '.join(certPerms))
-        print(cmdstr)
-
         self.cmd(cmdstr)
 
         # create, delete, restore, and purge a secret
@@ -633,7 +533,7 @@ class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
         self._delete_entity('secret', 'secret1')
         self._recover_entity('secret', 'secret1')
         self._delete_entity('secret', 'secret1')
-        self.cmd('keyvault secret purge --vault-name {} -n secret1'.format(kv))
+        self._purge_entity('secret', 'secret1')
 
         # create, delete, restore, and purge a key
         self.cmd('keyvault key create --vault-name {} -n key1 -p software'.format(kv),
@@ -641,16 +541,14 @@ class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
         self._delete_entity('key', 'key1')
         self._recover_entity('key', 'key1')
         self._delete_entity('key', 'key1')
-        self.cmd('keyvault key purge --vault-name {} -n key1'.format(kv))
+        self._purge_entity('key', 'key1')
 
         # create, delete, restore, and purge a certificate
         pem_plain_file = os.path.join(TEST_DIR, 'import_pem_plain.pem')
         pem_policy_path = os.path.join(TEST_DIR, 'policy_import_pem.json')
-        self.cmd('keyvault certificate import --vault-name {} -n cert1 --file "{}" -p @"{}"'.format(kv,
-                                                                                                    pem_plain_file,
-                                                                                                    pem_policy_path))
+        self.cmd('keyvault certificate import --vault-name {} -n cert1 --file "{}" -p @"{}"'.format(kv, pem_plain_file, pem_policy_path))
         self._delete_entity('certificate', 'cert1')
-        self.cmd('keyvault certificate purge --vault-name {} -n cert1'.format(kv))
+        self._purge_entity('certificate', 'cert1')
 
         self.cmd('keyvault delete -n {}'.format(kv))
         self.cmd('keyvault purge -n {} -l {}'.format(kv, self.location))
@@ -659,29 +557,57 @@ class KeyVaultSoftDeleteScenarioTest(ResourceGroupVCRTestBase):
         # delete the specified entity
         self.cmd('keyvault {} delete --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
 
-        retry_count = 0
         # while getting the deleted entities returns a zero entities
-        while not self.cmd('keyvault {} list-deleted --vault-name {}'.format(entity_type, self.keyvault_name)) \
-                and retry_count < max_retries:
-            retry_count += 1
-            time.sleep(retry_wait)
-
-        if retry_count >= max_retries:
-            self.assertFail('{} {} not deleted'.format(entity_type, entity_name))
+        for _ in range(max_retries):
+            try:
+                self.cmd('keyvault {} show --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
+                time.sleep(retry_wait)
+            except Exception as ex:
+                if 'not found' in str(ex):
+                    return
+        self.fail('{} {} not deleted'.format(entity_type, entity_name))
 
     def _recover_entity(self, entity_type, entity_name, retry_wait=3, max_retries=10):
-        # delete the specified entity
-        self.cmd('keyvault {} recover --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
 
-        retry_count = 0
         # while getting the deleted entities returns a zero entities
-        while not self.cmd('keyvault {} list --vault-name {}'.format(entity_type, self.keyvault_name)) \
-                and retry_count < max_retries:
-            retry_count += 1
-            time.sleep(retry_wait)
+        for _ in range(max_retries):
+            try:
+                self.cmd('keyvault {} recover --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
+                break
+            except Exception as ex:
+                if 'currently being deleted' in str(ex):
+                    time.sleep(retry_wait)
 
-        if retry_count >= max_retries:
-            self.assertFail('{} {} not restored'.format(entity_type, entity_name))
+        for _ in range(max_retries):
+            try:
+                self.cmd('keyvault {} show --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
+                return
+            except Exception as ex:
+                if 'not found' in str(ex) or 'currently being deleted' in str(ex):
+                    time.sleep(retry_wait)
+
+        self.fail('{} {} not restored'.format(entity_type, entity_name))
+
+    def _purge_entity(self, entity_type, entity_name, retry_wait=3, max_retries=10):
+
+        # while getting the deleted entities returns a zero entities
+        for _ in range(max_retries):
+            try:
+                self.cmd('keyvault {} purge --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
+                break
+            except Exception as ex:
+                if 'currently being deleted' in str(ex):
+                    time.sleep(retry_wait)
+
+        for _ in range(max_retries):
+            try:
+                self.cmd('keyvault {} show --vault-name {} -n {}'.format(entity_type, self.keyvault_name, entity_name))
+                time.sleep(retry_wait)
+            except Exception as ex:
+                if 'not found' in str(ex):
+                    return
+
+        self.fail('{} {} not purged'.format(entity_type, entity_name))
 
 
 if __name__ == '__main__':

--- a/src/command_modules/azure-cli-vm/HISTORY.rst
+++ b/src/command_modules/azure-cli-vm/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 * msi: use the same extension naming as portal does
 * msi: remove the useless `subscription` from the `vm/vmss create` commands output
 * `vm/vmss create`: fix a bug that the storage sku is not applied on data disks coming with an image
+* `vm format-secret`: Fix issue where `--secrets` would not accept newline separated IDs.
 
 2.0.13 (2017-08-28)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -2064,8 +2064,12 @@ def get_vm_format_secret(secrets, certificate_store=None):
     client = get_mgmt_service_client(KeyVaultManagementClient).vaults
     grouped_secrets = {}
 
+    merged_secrets = []
+    for s in secrets:
+        merged_secrets += s.splitlines()
+
     # group secrets by source vault
-    for secret in secrets:
+    for secret in merged_secrets:
         parsed = KeyVaultId.parse_secret_id(secret)
         match = re.search('://(.+?)\\.', parsed.vault)
         vault_name = match.group(1)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_with_ilb.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/latest/test_vmss_with_ilb.yaml
@@ -8,9 +8,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['50']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -20,11 +20,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:06:54 GMT']
+      date: ['Fri, 08 Sep 2017 23:26:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1157']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -34,9 +34,9 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -46,7 +46,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['328']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:06:55 GMT']
+      date: ['Fri, 08 Sep 2017 23:26:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -104,22 +104,22 @@ interactions:
       content-length: ['2235']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:06:55 GMT']
+      date: ['Fri, 08 Sep 2017 23:26:43 GMT']
       etag: ['"d6824855d13e27c5258a680eb60f635d088fd05e"']
-      expires: ['Wed, 23 Aug 2017 21:11:55 GMT']
-      source-age: ['91']
+      expires: ['Fri, 08 Sep 2017 23:31:43 GMT']
+      source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
+      x-cache: [MISS]
+      x-cache-hits: ['0']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [4b3ee57d797344d1058e493aad591f34db585ae9]
+      x-fastly-request-id: [e966dddb9234c601d57430ed1e820752562673d7]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['DBE0:100D0:29031:2B734:599DEE14']
-      x-served-by: [cache-dfw1845-DFW]
-      x-timer: ['S1503522416.767042,VS0,VE0']
+      x-github-request-id: ['C272:2F965:1B5BEA3:1D7375A:59B32733']
+      x-served-by: [cache-sea1039-SEA]
+      x-timer: ['S1504913203.233909,VS0,VE25']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -130,8 +130,8 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2017-08-01
@@ -141,69 +141,71 @@ interactions:
       cache-control: [no-cache]
       content-length: ['12']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:06:55 GMT']
+      date: ['Fri, 08 Sep 2017 23:26:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: 'b''{"properties": {"parameters": {}, "mode": "Incremental", "template":
-      {"contentVersion": "1.0.0.0", "variables": {}, "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "parameters": {}, "outputs": {"VMSS": {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
+    body: 'b''{"properties": {"mode": "Incremental", "template": {"outputs": {"VMSS":
+      {"type": "object", "value": "[reference(resourceId(\''Microsoft.Compute/virtualMachineScaleSets\'',
       \''vmss1\''),providers(\''Microsoft.Compute\'', \''virtualMachineScaleSets\'').apiVersions[0])]"}},
-      "resources": [{"properties": {"subnets": [{"properties": {"addressPrefix": "10.0.0.0/24"},
-      "name": "vmss1Subnet"}], "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}},
-      "dependsOn": [], "tags": {}, "name": "vmss1VNET", "location": "westus", "type":
-      "Microsoft.Network/virtualNetworks", "apiVersion": "2015-06-15"}, {"properties":
-      {"frontendIPConfigurations": [{"properties": {"subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
-      "privateIPAllocationMethod": "Dynamic", "privateIPAddress": ""}, "name": "loadBalancerFrontEnd"}],
-      "inboundNatPools": [{"properties": {"frontendIPConfiguration": {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'',
-      \''vmss1LB\''), \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"},
-      "frontendPortRangeEnd": "50119", "protocol": "tcp", "backendPort": 22, "frontendPortRangeStart":
-      "50000"}, "name": "vmss1LBNatPool"}], "backendAddressPools": [{"name": "vmss1LBBEPool"}]},
-      "dependsOn": [], "tags": {}, "name": "vmss1LB", "location": "westus", "type":
-      "Microsoft.Network/loadBalancers", "apiVersion": "2015-06-15"}, {"properties":
-      {"overprovision": true, "singlePlacementGroup": true, "upgradePolicy": {"mode":
-      "Manual"}, "virtualMachineProfile": {"storageProfile": {"osDisk": {"managedDisk":
-      {"storageAccountType": null}, "caching": "ReadWrite", "createOption": "FromImage"},
-      "imageReference": {"sku": "7.3", "publisher": "OpenLogic", "offer": "CentOS",
-      "version": "latest"}}, "osProfile": {"computerNamePrefix": "vmss1599e", "adminPassword":
-      "PasswordPassword1!", "adminUsername": "admin123"}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"properties": {"ipConfigurations": [{"properties": {"loadBalancerInboundNatPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}],
-      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
-      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"}},
-      "name": "vmss1599eIPConfig"}], "primary": "true"}, "name": "vmss1599eNic"}]}}},
-      "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET", "Microsoft.Network/loadBalancers/vmss1LB"],
-      "tags": {}, "name": "vmss1", "location": "westus", "sku": {"capacity": 1, "name":
-      "Standard_D1_v2", "tier": "Standard"}, "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "apiVersion": "2017-03-30"}]}}}'''
+      "parameters": {}, "contentVersion": "1.0.0.0", "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "resources": [{"tags": {}, "name": "vmss1VNET", "dependsOn": [], "location":
+      "westus", "apiVersion": "2015-06-15", "properties": {"subnets": [{"name": "vmss1Subnet",
+      "properties": {"addressPrefix": "10.0.0.0/24"}}], "addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}}, "type": "Microsoft.Network/virtualNetworks"}, {"tags": {},
+      "name": "vmss1LB", "dependsOn": [], "location": "westus", "sku": {"name": "Basic"},
+      "apiVersion": "2017-08-01", "properties": {"inboundNatPools": [{"name": "vmss1LBNatPool",
+      "properties": {"frontendPortRangeStart": "50000", "protocol": "tcp", "frontendIPConfiguration":
+      {"id": "[concat(resourceId(\''Microsoft.Network/loadBalancers\'', \''vmss1LB\''),
+      \''/frontendIPConfigurations/\'', \''loadBalancerFrontEnd\'')]"}, "backendPort":
+      22, "frontendPortRangeEnd": "50119"}}], "backendAddressPools": [{"name": "vmss1LBBEPool"}],
+      "frontendIPConfigurations": [{"name": "loadBalancerFrontEnd", "properties":
+      {"privateIPAddress": "", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
+      "privateIPAllocationMethod": "Dynamic"}}]}, "type": "Microsoft.Network/loadBalancers"},
+      {"tags": {}, "name": "vmss1", "dependsOn": ["Microsoft.Network/virtualNetworks/vmss1VNET",
+      "Microsoft.Network/loadBalancers/vmss1LB"], "location": "westus", "sku": {"name":
+      "Standard_D1_v2", "capacity": 1, "tier": "Standard"}, "apiVersion": "2017-03-30",
+      "properties": {"upgradePolicy": {"mode": "Manual"}, "virtualMachineProfile":
+      {"storageProfile": {"imageReference": {"publisher": "OpenLogic", "sku": "7.3",
+      "version": "latest", "offer": "CentOS"}, "osDisk": {"managedDisk": {"storageAccountType":
+      null}, "createOption": "FromImage", "caching": "ReadWrite"}}, "networkProfile":
+      {"networkInterfaceConfigurations": [{"name": "vmss15349Nic", "properties": {"primary":
+      "true", "ipConfigurations": [{"name": "vmss15349IPConfig", "properties": {"subnet":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},
+      "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],
+      "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]},
+      "osProfile": {"adminPassword": "PasswordPassword1!", "computerNamePrefix": "vmss15349",
+      "adminUsername": "admin123"}}, "singlePlacementGroup": true, "overprovision":
+      true}, "type": "Microsoft.Compute/virtualMachineScaleSets"}], "variables": {}},
+      "parameters": {}}}'''
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [vmss create]
       Connection: [keep-alive]
-      Content-Length: ['3431']
+      Content-Length: ['3457']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_WfAzTrB6dJBh6prWadJG5HoZLfaaTDak","name":"vmss_deploy_WfAzTrB6dJBh6prWadJG5HoZLfaaTDak","properties":{"templateHash":"2825916104341497561","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-08-23T21:06:58.4102656Z","duration":"PT0.4332251S","correlationId":"f64a94eb-a3ee-49ef-9e64-805dde421c60","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_PiPrS5tiJpHlsPlVRILsIWZAshBSm5s6","name":"vmss_deploy_PiPrS5tiJpHlsPlVRILsIWZAshBSm5s6","properties":{"templateHash":"6968232314983525423","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-09-08T23:26:45.25498Z","duration":"PT0.6527151S","correlationId":"266c3e24-e243-44ac-bd2c-efe3ae4f4032","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_WfAzTrB6dJBh6prWadJG5HoZLfaaTDak/operationStatuses/08586980844675005801?api-version=2017-05-10']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_PiPrS5tiJpHlsPlVRILsIWZAshBSm5s6/operationStatuses/08586966936808753600?api-version=2017-05-10']
       cache-control: [no-cache]
-      content-length: ['1717']
+      content-length: ['1715']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:06:58 GMT']
+      date: ['Fri, 08 Sep 2017 23:26:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1184']
+      x-ms-ratelimit-remaining-subscription-writes: ['1185']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -213,19 +215,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980844675005801?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:07:28 GMT']
+      date: ['Fri, 08 Sep 2017 23:27:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -239,19 +241,44 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980844675005801?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:07:59 GMT']
+      date: ['Fri, 08 Sep 2017 23:27:46 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 23:28:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -265,19 +292,19 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980844675005801?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['20']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:08:29 GMT']
+      date: ['Fri, 08 Sep 2017 23:28:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -291,23 +318,72 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586980844675005801?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 23:29:17 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['20']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Sep 2017 23:29:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      CommandName: [vmss create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586966936808753600?api-version=2017-05-10
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
       content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:09:00 GMT']
+      date: ['Fri, 08 Sep 2017 23:30:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -317,23 +393,22 @@ interactions:
       CommandName: [vmss create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2017-05-10
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_WfAzTrB6dJBh6prWadJG5HoZLfaaTDak","name":"vmss_deploy_WfAzTrB6dJBh6prWadJG5HoZLfaaTDak","properties":{"templateHash":"2825916104341497561","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-08-23T21:08:52.2584754Z","duration":"PT1M54.2814349S","correlationId":"f64a94eb-a3ee-49ef-9e64-805dde421c60","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss1599e","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.3","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss1599eNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss1599eIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"3e3386c6-644e-4383-a0b6-6458a1aa3ed2"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vmss_deploy_PiPrS5tiJpHlsPlVRILsIWZAshBSm5s6","name":"vmss_deploy_PiPrS5tiJpHlsPlVRILsIWZAshBSm5s6","properties":{"templateHash":"6968232314983525423","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-09-08T23:30:04.7980921Z","duration":"PT3M20.1958272S","correlationId":"266c3e24-e243-44ac-bd2c-efe3ae4f4032","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmss1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmss1LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmss1"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"upgradePolicy":{"mode":"Manual"},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmss15349","adminUsername":"admin123","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"storageProfile":{"osDisk":{"createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS"}},"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.3","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"vmss15349Nic","properties":{"primary":true,"enableAcceleratedNetworking":false,"dnsSettings":{"dnsServers":[]},"ipConfigurations":[{"name":"vmss15349IPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool"}]}}]}}]}},"provisioningState":"Succeeded","overprovision":true,"uniqueId":"0d988c27-0c7c-4b69-aee5-7b7690db8bf2"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET"}]}}'}
     headers:
       cache-control: [no-cache]
       content-length: ['4013']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:09:00 GMT']
+      date: ['Fri, 08 Sep 2017 23:30:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -343,8 +418,8 @@ interactions:
       CommandName: [vmss list-instance-connection-info]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 computemanagementclient/2.0.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2017-03-30
@@ -353,7 +428,7 @@ interactions:
         \ \"tier\": \"Standard\",\r\n    \"capacity\": 1\r\n  },\r\n  \"properties\"\
         : {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n\
         \      \"mode\": \"Manual\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\
-        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss1599e\"\
+        \n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss15349\"\
         ,\r\n        \"adminUsername\": \"admin123\",\r\n        \"linuxConfiguration\"\
         : {\r\n          \"disablePasswordAuthentication\": false\r\n        },\r\n\
         \        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n  \
@@ -363,15 +438,15 @@ interactions:
         \     },\r\n        \"imageReference\": {\r\n          \"publisher\": \"OpenLogic\"\
         ,\r\n          \"offer\": \"CentOS\",\r\n          \"sku\": \"7.3\",\r\n \
         \         \"version\": \"latest\"\r\n        }\r\n      },\r\n      \"networkProfile\"\
-        : {\"networkInterfaceConfigurations\":[{\"name\":\"vmss1599eNic\",\"properties\"\
+        : {\"networkInterfaceConfigurations\":[{\"name\":\"vmss15349Nic\",\"properties\"\
         :{\"primary\":true,\"enableAcceleratedNetworking\":false,\"dnsSettings\":{\"\
-        dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"vmss1599eIPConfig\",\"\
+        dnsServers\":[]},\"ipConfigurations\":[{\"name\":\"vmss15349IPConfig\",\"\
         properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         },\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\"\
         :[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
         }],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         }]}}]}}]}\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        overprovision\": true,\r\n    \"uniqueId\": \"3e3386c6-644e-4383-a0b6-6458a1aa3ed2\"\
+        overprovision\": true,\r\n    \"uniqueId\": \"0d988c27-0c7c-4b69-aee5-7b7690db8bf2\"\
         \r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n\
         \  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\
         ,\r\n  \"name\": \"vmss1\"\r\n}"}
@@ -379,13 +454,11 @@ interactions:
       cache-control: [no-cache]
       content-length: ['2389']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:09:01 GMT']
+      date: ['Fri, 08 Sep 2017 23:30:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -395,49 +468,60 @@ interactions:
       CommandName: [vmss list-instance-connection-info]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 networkmanagementclient/1.4.0 Azure-SDK-For-Python AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB?api-version=2017-08-01
   response:
     body: {string: "{\r\n  \"name\": \"vmss1LB\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB\"\
-        ,\r\n  \"etag\": \"W/\\\"24031352-bd11-4f1d-88fc-3d812fd3b7b3\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"19647d54-7f32-4f6e-b611-f137d12baaa6\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"2b97ab54-e636-4d55-a45e-f8f574b08a68\"\
         ,\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"\
         loadBalancerFrontEnd\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
-        ,\r\n        \"etag\": \"W/\\\"24031352-bd11-4f1d-88fc-3d812fd3b7b3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
         : \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vmss1VNET/subnets/vmss1Subnet\"\
         \r\n          },\r\n          \"inboundNatRules\": [\r\n            {\r\n\
-        \              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
+        \              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.0\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
         \r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n\
         \            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"vmss1LBBEPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/backendAddressPools/vmss1LBBEPool\"\
-        ,\r\n        \"etag\": \"W/\\\"24031352-bd11-4f1d-88fc-3d812fd3b7b3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"backendIPConfigurations\": [\r\n            {\r\n       \
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1599eNic/ipConfigurations/vmss1599eIPConfig\"\
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss15349Nic/ipConfigurations/vmss15349IPConfig\"\
+        \r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss15349Nic/ipConfigurations/vmss15349IPConfig\"\
         \r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n   \
         \ \"loadBalancingRules\": [],\r\n    \"probes\": [],\r\n    \"inboundNatRules\"\
-        : [\r\n      {\r\n        \"name\": \"vmss1LBNatPool.1\",\r\n        \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
-        ,\r\n        \"etag\": \"W/\\\"24031352-bd11-4f1d-88fc-3d812fd3b7b3\\\"\"\
+        : [\r\n      {\r\n        \"name\": \"vmss1LBNatPool.0\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.0\"\
+        ,\r\n        \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
+        \r\n          },\r\n          \"frontendPort\": 50000,\r\n          \"backendPort\"\
+        : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
+        : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss15349Nic/ipConfigurations/vmss15349IPConfig\"\
+        \r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        vmss1LBNatPool.1\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatRules/vmss1LBNatPool.1\"\
+        ,\r\n        \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/frontendIPConfigurations/loadBalancerFrontEnd\"\
         \r\n          },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\"\
         : 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\"\
         : 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\"\
-        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1599eNic/ipConfigurations/vmss1599eIPConfig\"\
+        : {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss15349Nic/ipConfigurations/vmss15349IPConfig\"\
         \r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\"\
         : [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"vmss1LBNatPool\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/vmss1LB/inboundNatPools/vmss1LBNatPool\"\
-        ,\r\n        \"etag\": \"W/\\\"24031352-bd11-4f1d-88fc-3d812fd3b7b3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"1e41ec82-e587-41f9-8b8d-317f953eb387\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
         ,\r\n          \"frontendPortRangeStart\": 50000,\r\n          \"frontendPortRangeEnd\"\
         : 50119,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\"\
@@ -446,10 +530,10 @@ interactions:
         \n    \"name\": \"Basic\"\r\n  }\r\n}"}
     headers:
       cache-control: [no-cache]
-      content-length: ['5255']
+      content-length: ['7160']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 23 Aug 2017 21:09:02 GMT']
-      etag: [W/"24031352-bd11-4f1d-88fc-3d812fd3b7b3"]
+      date: ['Fri, 08 Sep 2017 23:30:26 GMT']
+      etag: [W/"1e41ec82-e587-41f9-8b8d-317f953eb387"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -466,9 +550,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.13
-          msrest_azure/0.4.11 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
-          AZURECLI/2.0.13+dev]
+      User-Agent: [python/3.5.3 (Windows-10-10.0.15063-SP0) requests/2.9.1 msrest/0.4.14
+          msrest_azure/0.4.13 resourcemanagementclient/1.1.0 Azure-SDK-For-Python
+          AZURECLI/2.0.15+dev]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2017-05-10
@@ -477,11 +561,11 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 23 Aug 2017 21:09:03 GMT']
+      date: ['Fri, 08 Sep 2017 23:30:26 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkdNNVZNTEZaUlFUVURUTUpGMks0NlpONlk1R01XWlVSNktSR3w0OEI2NENDMjU2Q0UzODFELVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
+      location: ['https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1DTElURVNUOjJFUkcyM05GRjdBVFRXVjRGN1pYWUxRUVVIVFpUSklSNEU1S1JTUHw5QTExNDUxMTQ5MkYxQUExLVdFU1RVUyIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2017-05-10']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1926,7 +1926,7 @@ class VMSSILBSceanrioTest(ScenarioTest):
         self.cmd('vmss create -g {} -n {} --admin-username admin123 --admin-password PasswordPassword1! --image centos --instance-count 1 --public-ip-address ""'.format(resource_group, vmss_name))
         # list connection information should fail
         with self.assertRaises(CLIError) as err:
-            self.cmd('vmss list-instance-connection-info -g {} -n {}'.format(resource_group, vmss_name), expect_failure=True)
+            self.cmd('vmss list-instance-connection-info -g {} -n {}'.format(resource_group, vmss_name))
         self.assertTrue('internal load balancer' in str(err.exception))
 
 


### PR DESCRIPTION
Fixes #4384. Intended to fix #4379.

1. Uses enum_choice_list to ensure that KeyVault permissions are case insensitive and simplify manually checking for membership in the valid set.
2. Ensures that the `--secret` parameter of `vm format-secret` works with the TSV output from a `secret list-versions` command.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [X] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
