### PR TITLE
Print message during -h verification

### DIFF
--- a/tools/automation/tests/verify_packages.py
+++ b/tools/automation/tests/verify_packages.py
@@ -118,7 +118,8 @@ def verify_packages(built_packages_dir):
     command_results = []
     p = multiprocessing.Pool(multiprocessing.cpu_count())
     for i, res in enumerate(p.imap_unordered(run_help_on_command_without_err, all_commands, 10), 1):
-        sys.stderr.write('{}/{}'.format(i, len(all_commands)))
+        sys.stderr.write('{}/{} \t'.format(i, len(all_commands)))
+        sys.stderr.flush()
         command_results.append(res)
 
     p.close()


### PR DESCRIPTION
Solving the timeout issue in the integration test. @yugangw-msft 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
