### PR TITLE
[Backup] Fix 'restore-files' group name

### DIFF
--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_help.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_help.py
@@ -160,22 +160,22 @@ helps['backup restore'] = """
             short-summary: Restore the backed up items from recovery points in the Recovery Services vault.
             """
 
-helps['backup restore-disks'] = """
+helps['backup restore restore-disks'] = """
             type: command
             short-summary: Restore the disks of the backed VM from the specified recovery point.
             """
 
-helps['backup restore-files'] = """
+helps['backup restore files'] = """
             type: group
             short-summary: Gives access to all the files of the recovery point.
             """
 
-helps['backup restore-files mount-rp'] = """
+helps['backup restore files mount-rp'] = """
             type: command
             short-summary: Downloads a script which mounts the files of a recovery point.
             """
 
-helps['backup restore-files unmount-rp'] = """
+helps['backup restore files unmount-rp'] = """
             type: command
             short-summary: Closes the access to the recovery point.
             """

--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/commands.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/commands.py
@@ -104,6 +104,6 @@ cli_command(__name__, 'backup job wait', 'azure.cli.command_modules.backup.custo
 cli_command(__name__, 'backup recoverypoint show', 'azure.cli.command_modules.backup.custom#show_recovery_point', recovery_points_cf)
 cli_command(__name__, 'backup recoverypoint list', 'azure.cli.command_modules.backup.custom#list_recovery_points', recovery_points_cf, table_transformer=transform_recovery_point_list)
 
-cli_command(__name__, 'backup restore-disks', 'azure.cli.command_modules.backup.custom#restore_disks', restores_cf)
-cli_command(__name__, 'backup restore-files mount-rp', 'azure.cli.command_modules.backup.custom#restore_files_mount_rp', item_level_recovery_connections_cf)
-cli_command(__name__, 'backup restore-files unmount-rp', 'azure.cli.command_modules.backup.custom#restore_files_unmount_rp', item_level_recovery_connections_cf)
+cli_command(__name__, 'backup restore restore-disks', 'azure.cli.command_modules.backup.custom#restore_disks', restores_cf)
+cli_command(__name__, 'backup restore files mount-rp', 'azure.cli.command_modules.backup.custom#restore_files_mount_rp', item_level_recovery_connections_cf)
+cli_command(__name__, 'backup restore files unmount-rp', 'azure.cli.command_modules.backup.custom#restore_files_unmount_rp', item_level_recovery_connections_cf)


### PR DESCRIPTION
Changes the following:
```
az backup restore-files mount-rp
az backup restore-files unmount-rp
az backup restore-disks
```
to the following:
```
az backup restore files mount-rp
az backup restore files unmount-rp
az backup restore restore-disks
```

This ensures the commands (restore-disks, mount-rp and unmount-rp).  "restore-files" as a group contains a verb and could be confused for a command, so the change keeps it a noun.

cc/ @dragonfly91 