### PR TITLE
[Backup] Fix restore group names.

### DIFF
--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_help.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_help.py
@@ -160,22 +160,22 @@ helps['backup restore'] = """
             short-summary: Restore the backed up items from recovery points in the Recovery Services vault.
             """
 
-helps['backup restore-disks'] = """
+helps['backup restore restore-disks'] = """
             type: command
             short-summary: Restore the disks of the backed VM from the specified recovery point.
             """
 
-helps['backup restore-files'] = """
+helps['backup restore files'] = """
             type: group
             short-summary: Gives access to all the files of the recovery point.
             """
 
-helps['backup restore-files mount-rp'] = """
+helps['backup restore files mount-rp'] = """
             type: command
             short-summary: Downloads a script which mounts the files of a recovery point.
             """
 
-helps['backup restore-files unmount-rp'] = """
+helps['backup restore files unmount-rp'] = """
             type: command
             short-summary: Closes the access to the recovery point.
             """

--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_params.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/_params.py
@@ -82,13 +82,13 @@ register_cli_argument('backup protection backup-now', 'retain_until', type=datet
 register_cli_argument('backup protection disable', 'delete_backup_data', help='Option to delete the existing backed up data in the recovery services vault.', **three_state_flag())
 
 # Restore
-for command in ['disks', 'files']:
-    register_cli_argument('backup restore-{}'.format(command), 'vault_name', vault_name_type)
-    register_cli_argument('backup restore-{}'.format(command), 'container_name', container_name_type)
-    register_cli_argument('backup restore-{}'.format(command), 'item_name', item_name_type)
-    register_cli_argument('backup restore-{}'.format(command), 'rp_name', rp_name_type)
+for command in ['restore-disks', 'files']:
+    register_cli_argument('backup restore {}'.format(command), 'vault_name', vault_name_type)
+    register_cli_argument('backup restore {}'.format(command), 'container_name', container_name_type)
+    register_cli_argument('backup restore {}'.format(command), 'item_name', item_name_type)
+    register_cli_argument('backup restore {}'.format(command), 'rp_name', rp_name_type)
 
-register_cli_argument('backup restore-disks', 'storage_account', help='Name or ID of the storge accout to which the disks are restored.')
+register_cli_argument('backup restore restore-disks', 'storage_account', help='Name or ID of the storge accout to which the disks are restored.')
 
 # Job
 register_cli_argument('backup job', 'vault_name', vault_name_type)

--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/commands.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/commands.py
@@ -104,6 +104,6 @@ cli_command(__name__, 'backup job wait', 'azure.cli.command_modules.backup.custo
 cli_command(__name__, 'backup recoverypoint show', 'azure.cli.command_modules.backup.custom#show_recovery_point', recovery_points_cf)
 cli_command(__name__, 'backup recoverypoint list', 'azure.cli.command_modules.backup.custom#list_recovery_points', recovery_points_cf, table_transformer=transform_recovery_point_list)
 
-cli_command(__name__, 'backup restore-disks', 'azure.cli.command_modules.backup.custom#restore_disks', restores_cf)
-cli_command(__name__, 'backup restore-files mount-rp', 'azure.cli.command_modules.backup.custom#restore_files_mount_rp', item_level_recovery_connections_cf)
-cli_command(__name__, 'backup restore-files unmount-rp', 'azure.cli.command_modules.backup.custom#restore_files_unmount_rp', item_level_recovery_connections_cf)
+cli_command(__name__, 'backup restore restore-disks', 'azure.cli.command_modules.backup.custom#restore_disks', restores_cf)
+cli_command(__name__, 'backup restore files mount-rp', 'azure.cli.command_modules.backup.custom#restore_files_mount_rp', item_level_recovery_connections_cf)
+cli_command(__name__, 'backup restore files unmount-rp', 'azure.cli.command_modules.backup.custom#restore_files_unmount_rp', item_level_recovery_connections_cf)


### PR DESCRIPTION
Changes `backup restore-files ...` to `backup restore files` since "restore-files" sounds like a command.
Changes `backup restore-disks` to `backup restore restore-disks` so the restore-disks commands is in the same subgroup as the restore-files subgroup.

This maintains the CLI's subgroup/command naming consistency.