### PR TITLE
Fixing bug: restore files mount-rp command failure

### DIFF
--- a/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/custom.py
+++ b/src/command_modules/azure-cli-backup/azure/cli/command_modules/backup/custom.py
@@ -546,7 +546,7 @@ def _run_client_script_for_linux(client_scripts):
         with open(file_name, 'w', newline='\n') as out_file:
             out_file.write(script_content)
     elif _get_host_os() == os_linux:
-        with open(file_name, 'wb') as out_file:
+        with open(file_name, 'w') as out_file:
             out_file.write(script_content)
 
     logger.warning('File downloaded: {}. Use password {}'.format(file_name, password))


### PR DESCRIPTION
Restore files mount-rp fails during script download when run on a linux machine with Python 3. Fix is tested on Linux machines with Python 2 and Python 3.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [x] Each command and parameter has a meaningful description.
- [x] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
