### PR TITLE
'pem_output_folder' not defined when -certificate-output-folder not

### DIFF
--- a/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/command_modules/azure-cli-servicefabric/azure/cli/command_modules/servicefabric/custom.py
@@ -1532,6 +1532,7 @@ def _create_self_signed_key_vault_certificate(vault_base_url, certificate_name, 
 
             raise CLIError('{}'.format(message))
 
+    pem_output_folder = None
     if certificate_output_folder is not None:
         pem_output_folder = os.path.join(
             certificate_output_folder, certificate_name + '.pem')


### PR DESCRIPTION
given

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
