### PR TITLE
login SP graph permission required

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -9,6 +9,7 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 helps['ad sp create-for-rbac'] = """
     type: command
     short-summary: Create a service principal and configure its access to Azure resources.
+    Note: if cli login is using service principal, the service principal should have read and write access to Microsoft Graph appliation in the AAD tenant.
     parameters:
         - name: --name -n
           short-summary: Name or app URI to associate the RBAC with. If not present, a name will be generated.

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -9,7 +9,10 @@ from azure.cli.core.help_files import helps  # pylint: disable=unused-import
 helps['ad sp create-for-rbac'] = """
     type: command
     short-summary: Create a service principal and configure its access to Azure resources.
-    Note: if cli login is using service principal, the service principal should have read and write access to Microsoft Graph appliation in the AAD tenant.
+    Note: if cli login is using service principal, ensure the service principal have read and write access
+    to following applications in the tenant to be able to create role assigment.
+     1. Microsoft Graph 
+     2. Windows Azure Active Directory
     parameters:
         - name: --name -n
           short-summary: Name or app URI to associate the RBAC with. If not present, a name will be generated.


### PR DESCRIPTION
if login sp does not have access to graph permission, the command will result in error like:

Operation failed with status: 'Forbidden'. Details: 403 Client Error: Forbidden for url: https://graph.windows.net/xxxxxxxx-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6

the login SP need to be configured to give permission on Microsoft Graph .

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
