### PR TITLE
[KeyVault] upgrade azure-keyvault to 0.3.7

### DIFF
--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 unreleased
 ++++++++++
-* Update azure-keyvault SDK to 0.3.7
+* Fixed Key Vault authentication issue when using ADFS on Azure Stack. https://github.com/Azure/azure-cli/issues/4448
 
 2.0.11 (2017-09-22)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-keyvault/HISTORY.rst
+++ b/src/command_modules/azure-cli-keyvault/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+unreleased
+++++++++++
+* Update azure-keyvault SDK to 0.3.7
 
 2.0.11 (2017-09-22)
 +++++++++++++++++++

--- a/src/command_modules/azure-cli-keyvault/setup.py
+++ b/src/command_modules/azure-cli-keyvault/setup.py
@@ -35,7 +35,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-mgmt-keyvault==0.40.0',
-    'azure-keyvault==0.3.6',
+    'azure-keyvault==0.3.7',
     'azure-cli-core',
     'pyOpenSSL'
 ]

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -33,7 +33,7 @@ DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-authorization==0.30.0',
     'azure-graphrbac==0.31.0',
-    'azure-keyvault==0.3.6',
+    'azure-keyvault==0.3.7',
     'pytz'
 ]
 

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -34,7 +34,7 @@ DEPENDENCIES = [
     'azure-mgmt-authorization==0.30.0',
     'azure-mgmt-compute==3.0.0rc1',
     'azure-mgmt-keyvault==0.40.0',
-    'azure-keyvault==0.3.6',
+    'azure-keyvault==0.3.7',
     'azure-mgmt-network==1.5.0rc3',
     'azure-mgmt-resource==1.2.0rc2',
     'azure-multiapi-storage==0.1.4',


### PR DESCRIPTION
Updating references to azure-keyvault to 0.3.7 as this has a workaround fix for **Azure Stack: ADFS: Keyvault Secret cmds don't work #4448**

See change: https://github.com/Azure/azure-sdk-for-python/pull/1466  for details

---
This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [ ] Each command and parameter has a meaningful description.
- [ ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
