### PR TITLE
Include only python sources in Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Exclude everything by default
+*
+# Make an exception for azure-cli source code
+!src/*
+# Make an exception for the license file
+!LICENSE.txt
+# Exclude build droppings, as mentioned in .gitignore
+src/build*
+**/*.pyc
+**/__pycache__


### PR DESCRIPTION
Adds a [`.dockerignore`](https://docs.docker.com/engine/reference/builder/#dockerignore-file) file to ensure that extraneous content is not built into `azure-cli` Docker images.

YMMV, but for me when building locally this makes a smaller development image and slightly faster build. 

```console
$ git checkout master && docker build --tag azure-cli:before .
$ git checkout add-dockerfile && docker build --tag azure-cli:after .
$ docker images
REPOSITORY        TAG       IMAGE ID            CREATED             SIZE
azure-cli         before    5a0c7ed1f850        3 days ago          500MB
azure-cli         after     fabdd3da2c7e        3 days ago          362MB
$ docker run --tty azure-cli:before ls -p /azure-cli
CONTRIBUTING.rst       azure-cli.pyproj       nose.cfg
Dockerfile             azure-cli.sln          packaged_releases/
Jenkinsfile            azure-cli2017.pyproj   pylintrc
LICENSE.txt            azure-cli2017.sln      requirements.txt
MANIFEST.in            bin/                   scripts/
README.md              cli_license_terms.md   src/
appveyor-mooncake.yml  doc/                   tools/
appveyor.yml           env/
$ # ^^ Even included my python virtualenv! :-(
$ docker run --tty azure-cli:after ls -p /azure-cli
LICENSE.txt  src/
```