### PR TITLE
Don't build caches into Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR azure-cli
 COPY . /azure-cli
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
-RUN pip install --upgrade pip wheel jmespath-terminal
+RUN pip install --no-cache-dir --upgrade pip wheel jmespath-terminal
 # bash gcc make openssl-dev libffi-dev musl-dev - dependencies required for CLI
 # jq - we include jq as a useful tool
 # openssh - included for ssh-keygen
@@ -35,8 +35,8 @@ RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \
     for f in $TMP_PKG_DIR/*; \
     do MODULE_NAMES="$MODULE_NAMES $f"; \
     done; \
-    pip install $MODULE_NAMES; \
-    pip install --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg;'
+    pip install --no-cache-dir $MODULE_NAMES; \
+    pip install --no-cache-dir --force-reinstall --upgrade azure-nspkg azure-mgmt-nspkg;'
 
 # Tab completion
 RUN echo -e "\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip wheel jmespath-terminal
 # openssh - included for ssh-keygen
 # ca-certificates
 # wget - required for installing jp
-RUN apk update && apk add bash gcc make openssl-dev libffi-dev musl-dev jq openssh \
+RUN apk add --no-cache bash gcc make openssl-dev libffi-dev musl-dev jq openssh \
     ca-certificates wget openssl git && update-ca-certificates
 # We also, install jp
 RUN wget https://github.com/jmespath/jp/releases/download/0.1.2/jp-linux-amd64 -qO /usr/local/bin/jp && chmod +x /usr/local/bin/jp

--- a/packaged_releases/docker/Dockerfile
+++ b/packaged_releases/docker/Dockerfile
@@ -31,8 +31,7 @@ RUN pip install --no-cache-dir --upgrade pip wheel jmespath-terminal
 # openssh - included for ssh-keygen
 # ca-certificates
 # wget - required for installing jp
-RUN apk update \
-        && apk add bash gcc make openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git \
+RUN apk add --no-cache bash gcc make openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git \
         && update-ca-certificates
 # We also, install jp
 RUN wget https://github.com/jmespath/jp/releases/download/0.1.2/jp-linux-amd64 -qO /usr/local/bin/jp \

--- a/packaged_releases/docker/Dockerfile
+++ b/packaged_releases/docker/Dockerfile
@@ -25,11 +25,11 @@ LABEL org.label-schema.schema-version="1.0" \
 # INSTALL DEPENDENCIES
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
-RUN pip install --upgrade pip wheel jmespath-terminal
+RUN pip install --no-cache-dir --upgrade pip wheel jmespath-terminal
 # bash gcc openssl-dev libffi-dev musl-dev - dependencies required for CLI
 # jq - we include jq as a useful tool
 # openssh - included for ssh-keygen
-# ca-certificates 
+# ca-certificates
 # wget - required for installing jp
 RUN apk update \
         && apk add bash gcc make openssl-dev libffi-dev musl-dev jq openssh ca-certificates wget openssl git \

--- a/scripts/github_bot/api/Dockerfile
+++ b/scripts/github_bot/api/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM python:3.5.2-alpine
 
-RUN apk update && apk upgrade && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache bash git openssh
 
 RUN pip install --no-cache-dir --upgrade pip gunicorn Flask wheel twine requests uritemplate.py

--- a/scripts/github_bot/api/Dockerfile
+++ b/scripts/github_bot/api/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.5.2-alpine
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
-RUN pip install --upgrade pip gunicorn Flask wheel twine requests uritemplate.py
+RUN pip install --no-cache-dir --upgrade pip gunicorn Flask wheel twine requests uritemplate.py
 
 ADD app.py /
 

--- a/scripts/releaser/Dockerfile
+++ b/scripts/releaser/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc make \
     openssl-dev libffi-dev musl-dev ca-certificates openssl && update-ca-certificates
 
-RUN pip install --upgrade pip wheel twine requests virtualenv uritemplate.py azure-cli sh
+RUN pip install --no-cache-dir --upgrade pip wheel twine requests virtualenv uritemplate.py azure-cli sh
 
 ADD . /
 

--- a/scripts/releaser/Dockerfile
+++ b/scripts/releaser/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM python:3.5.2-alpine
 
-RUN apk update && apk upgrade && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache bash git openssh gcc make \
-    openssl-dev libffi-dev musl-dev ca-certificates openssl && update-ca-certificates
+      openssl-dev libffi-dev musl-dev ca-certificates openssl && update-ca-certificates
 
 RUN pip install --no-cache-dir --upgrade pip wheel twine requests virtualenv uritemplate.py azure-cli sh
 


### PR DESCRIPTION
Adds flags to `pip` and `apk` commands in the Dockerfiles to prevent those tools from creating cache data which gets built into the Docker images.

YMMV in terms of space savings, but not caching these items is generally considered a best practice for containers.

```console
$ git checkout master && docker build -t azure-cli:before .
$ git checkout dont-cache-inside-docker-image && docker build -t azure-cli:after .
$ docker images
REPOSITORY         TAG       IMAGE ID            CREATED             SIZE
azure-cli          before    408d8e5affc2        3 days ago          500MB
azure-cli          after     285a1d5f2499        3 days ago          482MB
```