### PR TITLE
[Network] Make `--servers` optional for AppGateway backend address pool create.

### DIFF
--- a/src/command_modules/azure-cli-network/HISTORY.rst
+++ b/src/command_modules/azure-cli-network/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+unreleased
++++++++++++++++++++
+* `application-gateway address-pool create`: `--server` argument is not optional to allow creation of empty address pools.
+
+
 2.0.15 (2017-09-22)
 +++++++++++++++++++
 * `lb/public-ip`: Add availability zone support.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -262,7 +262,7 @@ def update_ag_authentication_certificate(instance, parent, item_name, cert_data)
 
 
 def create_ag_backend_address_pool(resource_group_name, application_gateway_name, item_name,
-                                   servers, no_wait=False):
+                                   servers=None, no_wait=False):
     ApplicationGatewayBackendAddressPool = get_sdk(
         ResourceType.MGMT_NETWORK,
         'ApplicationGatewayBackendAddressPool',


### PR DESCRIPTION
Closes #4533.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [N/A] Each command and parameter has a meaningful description.
- [N/A] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
