### PR TITLE
Allowed arbitrary number of resource levels for `--ids` parameter

### DIFF
--- a/doc/authoring_command_modules/authoring_commands.md
+++ b/doc/authoring_command_modules/authoring_commands.md
@@ -131,7 +131,7 @@ def show_nic_ip_config(resource_group_name, nic_name, ip_config_name):
 register_cli_command('network nic ip-config show', ...#show_nic_ip_config, ...)
 
 register_cli_argument('network nic ip-config', 'nic_name', id_part='name', help='The NIC name.')
-register_cli_argument('network nic ip-config', 'ip_config_name', id_part='child_name', options_list=('--name', '-n'), help='The IP config name.')
+register_cli_argument('network nic ip-config', 'ip_config_name', id_part='child_name_1', options_list=('--name', '-n'), help='The IP config name.')
 ```
 The help output becomes:
 ```
@@ -148,7 +148,7 @@ Now the user may identify the target IP config by specifying either the resource
 
 A couple things to note:
 - Currently, `--ids` is not exposed for any command that is called 'create', even if it is configured properly.
-- The supported values for `id_part` are: `name`, `child_name`, and `grandchild_name`.
+- The supported values for `id_part` are: `name` and `child_name_{level}`; for example, `child_name_2` is the name of the child two levels under the resource correspond to `name`.
 
 
 Generic Update Commands

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -118,12 +118,12 @@ def _populate_alternate_kwargs(kwargs):
     """ Translates the parsed arguments into a format used by generic ARM commands
     such as the resource and lock commands. """
     print("_________________")
-    kwargs['child_namespace'] = kwargs.get('child_namespace_1')
-    kwargs['child_type'] = kwargs.get('child_type_1')
-    kwargs['child_name'] = kwargs.get('child_name_1')
-    kwargs['grandchild_namespace'] = kwargs.get('child_namespace_2')
-    kwargs['grandchild_type'] = kwargs.get('child_type_2')
-    kwargs['grandchild_name'] = kwargs.get('child_name_2')
+    # kwargs['child_namespace'] = kwargs.get('child_namespace_1')
+    # kwargs['child_type'] = kwargs.get('child_type_1')
+    # kwargs['child_name'] = kwargs.get('child_name_1')
+    # kwargs['grandchild_namespace'] = kwargs.get('child_namespace_2')
+    # kwargs['grandchild_type'] = kwargs.get('child_type_2')
+    # kwargs['grandchild_name'] = kwargs.get('child_name_2')
 
     resource_namespace = kwargs['namespace']
     resource_type = kwargs.get('child_type_{}'.format(kwargs['last_child_num'])) or kwargs['type']

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -25,7 +25,7 @@ logger = azlogging.get_az_logger(__name__)
 
 regex = re.compile(
     '/subscriptions/(?P<subscription>[^/]*)(/resource[gG]roups/(?P<resource_group>[^/]*))?'
-    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)(?P<children>.+)')
+    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)(?P<children>.*)')
     # '((/providers/(?P<child_namespace>[^/]*))?/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
     # '((/providers/(?P<grandchild_namespace>[^/]*))?/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
 
@@ -134,7 +134,7 @@ def _populate_alternate_kwargs(kwargs):
     kwargs['resource_type'] = resource_type
     kwargs['resource_name'] = resource_name
     print(kwargs)
-    print(resource_id(**kwargs))
+    print(resource_id(**{key: value for key, value in kwargs.items() if value is not None}))
     return kwargs
 
 
@@ -201,7 +201,7 @@ def parse_resource_id(rid):
         count = None
         for count, child in enumerate(children):
             result.update({key + '_%d' % (count + 1):group for key, group in child.groupdict().items()})
-        result["last_child_num"] = count + 1
+        result["last_child_num"] = count + 1 if isinstance(count, int) else None
         print("result", result)
         result = _populate_alternate_kwargs(result)
     else:
@@ -213,7 +213,6 @@ def parse_resource_id(rid):
 def is_valid_resource_id(rid, exception_type=None):
     is_valid = False
     try:
-        print("here")
         is_valid = rid and resource_id(**parse_resource_id(rid)).lower() == rid.lower()
     except KeyError:
         pass

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -25,9 +25,11 @@ logger = azlogging.get_az_logger(__name__)
 
 regex = re.compile(
     '/subscriptions/(?P<subscription>[^/]*)(/resource[gG]roups/(?P<resource_group>[^/]*))?'
-    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)'
-    '((/providers/(?P<child_namespace>[^/]*))?/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
-    '((/providers/(?P<grandchild_namespace>[^/]*))?/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
+    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)(?P<id_end>.+)')
+    # '((/providers/(?P<child_namespace>[^/]*))?/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
+    # '((/providers/(?P<grandchild_namespace>[^/]*))?/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
+
+children_regex = re.compile('((/providers/(?P<child_namespace>[^/]*))?/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?')
 
 
 def handle_long_running_operation_exception(ex):
@@ -92,6 +94,7 @@ def deployment_validate_table_format(result):
 def _populate_alternate_kwargs(kwargs):
     """ Translates the parsed arguments into a format used by generic ARM commands
     such as the resource and lock commands. """
+
     parent = ''
     has_child = all(kwargs[x] is not None for x in ['child_name', 'child_type'])
     has_grandchild = all(kwargs[x] is not None for x in ['grandchild_name', 'grandchild_type'])

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -133,6 +133,7 @@ def resource_id(**kwargs):
         - child_type_{level}        Type of the child resource of that level
         - child_name_{level}        Name of the child resource of that level
     '''
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
     rid_builder = ['/subscriptions/{subscription}'.format(**kwargs)]
     try:
         try:

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -135,7 +135,10 @@ def resource_id(**kwargs):
     '''
     rid_builder = ['/subscriptions/{subscription}'.format(**kwargs)]
     try:
-        rid_builder.append('resourceGroups/{resource_group}'.format(**kwargs))
+        try:
+            rid_builder.append('resourceGroups/{resource_group}'.format(**kwargs))
+        except KeyError:
+            pass
         rid_builder.append('providers/{namespace}'.format(**kwargs))
         rid_builder.append('{type}/{name}'.format(**kwargs))
         count = 1

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -191,28 +191,29 @@ def parse_resource_id(rid):
     '''
     if not rid:
         return {}
-
+    print("rid", rid)
     m = regex.match(rid)
     if m:
         result = m.groupdict()
-        print("result1:", result)
         children = children_regex.finditer(result["children"])
-        print("children:")
         count = None
         for count, child in enumerate(children):
+            print("child", child.groupdict())
             result.update({key + '_%d' % (count + 1):group for key, group in child.groupdict().items()})
         result["last_child_num"] = count + 1 if isinstance(count, int) else None
         print("result", result)
         result = _populate_alternate_kwargs(result)
+        print("result after populate", result)
     else:
         result = dict(name=rid)
-    print("after")
     return {key: value for key, value in result.items() if value is not None}
 
 
 def is_valid_resource_id(rid, exception_type=None):
     is_valid = False
     try:
+        print("parsed:", resource_id(**parse_resource_id(rid)).lower())
+        print("unparsed:", rid.lower())
         is_valid = rid and resource_id(**parse_resource_id(rid)).lower() == rid.lower()
     except KeyError:
         pass

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -61,8 +61,8 @@ def _validate_name_or_id(
             namespace=parent_type.split('/')[0],
             type=parent_type.split('/')[1],
             subscription=get_subscription_id(),
-            child_name=property_value,
-            child_type=property_type)
+            child_name_1=property_value,
+            child_type_1=property_type)
         value_supplied_was_id = False
     else:
         resource_id_parts = dict(

--- a/src/azure-cli-core/azure/cli/core/tests/test_arm.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_arm.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from azure.cli.core.commands.arm import parse_resource_id
+from azure.cli.core.commands.arm import parse_resource_id, is_valid_resource_id
 
 
 class TestARM(unittest.TestCase):
@@ -20,9 +20,9 @@ class TestARM(unittest.TestCase):
                     'name': 'foo',
                     'type': 'storageAccounts',
                     'namespace': 'Microsoft.Storage',
-                    'child_name': 'bar',
-                    'child_namespace': 'Microsoft.Authorization',
-                    'child_type': 'locks',
+                    'child_name_1': 'bar',
+                    'child_namespace_1': 'Microsoft.Authorization',
+                    'child_type_1': 'locks',
                     'resource_group': 'testgroup',
                     'subscription': 'fakesub',
                 }
@@ -35,8 +35,8 @@ class TestARM(unittest.TestCase):
                     'name': 'foo',
                     'type': 'storageAccounts',
                     'namespace': 'Microsoft.Storage',
-                    'child_name': 'bar',
-                    'child_type': 'locks',
+                    'child_name_1': 'bar',
+                    'child_type_1': 'locks',
                     'resource_group': 'testgroup',
                     'subscription': 'fakesub',
                 }
@@ -53,28 +53,19 @@ class TestARM(unittest.TestCase):
                 }
             },
             {
-                'resource_id': '/subscriptions/fakesub/providers/Microsoft.Authorization'
-                               '/locks/foo',
-                'expected': {
-                    'name': 'foo',
-                    'type': 'locks',
-                    'namespace': 'Microsoft.Authorization',
-                    'subscription': 'fakesub',
-                }
-            },
-            {
                 'resource_id': '/subscriptions/fakesub/resourcegroups/testgroup/providers'
                                '/Microsoft.Storage/storageAccounts/foo/providers'
-                               '/Microsoft.Authorization/locks/bar/nets/gc',
+                               '/Microsoft.Authorization/locks/bar/providers/Microsoft.Network/nets/gc',
                 'expected': {
                     'name': 'foo',
                     'type': 'storageAccounts',
                     'namespace': 'Microsoft.Storage',
-                    'child_name': 'bar',
-                    'child_namespace': 'Microsoft.Authorization',
-                    'child_type': 'locks',
-                    'grandchild_name': 'gc',
-                    'grandchild_type': 'nets',
+                    'child_name_1': 'bar',
+                    'child_namespace_1': 'Microsoft.Authorization',
+                    'child_type_1': 'locks',
+                    'child_name_2': 'gc',
+                    'child_namespace_2': 'Microsoft.Network',
+                    'child_type_2': 'nets',
                     'resource_group': 'testgroup',
                     'subscription': 'fakesub',
                 }
@@ -87,10 +78,10 @@ class TestARM(unittest.TestCase):
                     'name': 'foo',
                     'type': 'storageAccounts',
                     'namespace': 'Microsoft.Storage',
-                    'child_name': 'bar',
-                    'child_type': 'locks',
-                    'grandchild_name': 'gc',
-                    'grandchild_type': 'nets',
+                    'child_name_1': 'bar',
+                    'child_type_1': 'locks',
+                    'child_name_2': 'gc',
+                    'child_type_2': 'nets',
                     'resource_group': 'testgroup',
                     'subscription': 'fakesub',
                 }
@@ -119,9 +110,9 @@ class TestARM(unittest.TestCase):
                     'namespace': 'Microsoft.Provider1',
                     'type': 'resourceType1',
                     'name': 'name1',
-                    'child_namespace': None,
-                    'child_type': 'resourceType2',
-                    'child_name': 'name2',
+                    'child_namespace_1': None,
+                    'child_type_1': 'resourceType2',
+                    'child_name_1': 'name2',
                     'resource_parent': 'resourceType1/name1/',
                     'resource_namespace': 'Microsoft.Provider1',
                     'resource_type': 'resourceType2',
@@ -138,23 +129,80 @@ class TestARM(unittest.TestCase):
                     'namespace': 'Microsoft.Provider1',
                     'type': 'resourceType1',
                     'name': 'name1',
-                    'child_namespace': 'Microsoft.Provider2',
-                    'child_type': 'resourceType2',
-                    'child_name': 'name2',
+                    'child_namespace_1': 'Microsoft.Provider2',
+                    'child_type_1': 'resourceType2',
+                    'child_name_1': 'name2',
                     'resource_parent': 'resourceType1/name1/providers/Microsoft.Provider2/',
                     'resource_namespace': 'Microsoft.Provider1',
                     'resource_type': 'resourceType2',
                     'resource_name': 'name2'
                 }
+            },
+            {
+                'resource_id': '/subscriptions/00000/resourceGroups/myRg/providers/Microsoft.RecoveryServices/'
+                               'vaults/vault_name/backupFabrics/fabric_name/protectionContainers/container_name/'
+                               'protectedItems/item_name/recoveryPoint/recovery_point_guid',
+                'expected': {
+                    'subscription': '00000',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.RecoveryServices',
+                    'type': 'vaults',
+                    'name': 'vault_name',
+                    'child_type_1': 'backupFabrics',
+                    'child_name_1': 'fabric_name',
+                    'child_type_2': 'protectionContainers',
+                    'child_name_2': 'container_name',
+                    'child_type_3': 'protectedItems',
+                    'child_name_3': 'item_name',
+                    'child_type_4': 'recoveryPoint',
+                    'child_name_4': 'recovery_point_guid',
+                    'resource_parent': 'vaults/vault_name/backupFabrics/fabric_name/'
+                                       'protectionContainers/container_name/protectedItems/item_name/',
+                    'resource_namespace': 'Microsoft.RecoveryServices',
+                    'resource_type': 'recoveryPoint',
+                    'resource_name': 'recovery_point_guid'
+                }
+            },
+            {
+                'resource_id': '/subscriptions/mySub/resourceGroups/myRg/providers/'
+                               'Microsoft.Provider1/resourceType1/name1/resourceType2/name2/providers/'
+                               'Microsoft.Provider3/resourceType3/name3',
+                'expected': {
+                    'subscription': 'mySub',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.Provider1',
+                    'type': 'resourceType1',
+                    'name': 'name1',
+                    'child_namespace_1': None,
+                    'child_type_1': 'resourceType2',
+                    'child_name_1': 'name2',
+                    'child_namespace_2': 'Microsoft.Provider3',
+                    'child_type_2': 'resourceType3',
+                    'child_name_2': 'name3',
+                    'resource_parent': 'resourceType1/name1/resourceType2/name2/providers/Microsoft.Provider3/',
+                    'resource_namespace': 'Microsoft.Provider1',
+                    'resource_type': 'resourceType3',
+                    'resource_name': 'name3'
+                }
             }
         ]
         for test in tests:
+            self.assertTrue(is_valid_resource_id(test['resource_id']))
             kwargs = parse_resource_id(test['resource_id'])
             for key in test['expected']:
                 try:
                     self.assertEqual(kwargs[key], test['expected'][key])
                 except KeyError:
                     self.assertTrue(key not in kwargs and test['expected'][key] is None)
+
+        invalid_ids = [
+            '/subscriptions/fakesub/providers/Microsoft.Authorization/locks/foo',
+            '/subscriptions/fakesub/resourceGroups/myRg/type1/name1',
+            '/subscriptions/fakesub/resourceGroups/myRg/providers/Microsoft.Provider/foo',
+            '/subscriptions/fakesub/resourceGroups/myRg/providers/Microsoft.Provider/type/name/type1'
+        ]
+        for invalid_id in invalid_ids:
+            self.assertFalse(is_valid_resource_id(invalid_id))
 
 
 if __name__ == "__main__":

--- a/src/azure-cli-core/azure/cli/core/tests/test_arm.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_arm.py
@@ -288,6 +288,20 @@ class TestARM(unittest.TestCase):
                     'child_name_1': 'name2',
                     'child_namespace_2': 'Microsoft.Provider3'
                 }
+            },
+            {
+                'resource_id': '/subscriptions/mySub/resourceGroups/myRg/providers/Microsoft.Provider1'
+                               '/resourceType1/name1',
+                'id_args': {
+                    'subscription': 'mySub',
+                    'resource_group': 'myRg',
+                    'namespace': 'Microsoft.Provider1',
+                    'type': 'resourceType1',
+                    'name': 'name1',
+                    'child_type_1': None,
+                    'child_name_1': 'name2',
+                    'child_namespace_2': 'Microsoft.Provider3'
+                }
             }
         ]
         for test in tests:

--- a/src/azure-cli-core/azure/cli/core/tests/test_resource_id.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_resource_id.py
@@ -39,7 +39,7 @@ class TestApplication(unittest.TestCase):
         bep_type = 'backendAddressPools'
         sub = '00000000-0000-0000-0000-000000000000'
         result = resource_id(name=lb, resource_group=rg, namespace=namespace,
-                             type=rtype, subscription=sub, child_type=bep_type, child_name=bep)
+                             type=rtype, subscription=sub, child_type_1=bep_type, child_name_1=bep)
         expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))
@@ -56,7 +56,7 @@ class TestApplication(unittest.TestCase):
         gc_type = 'grandchildType'
         sub = '00000000-0000-0000-0000-000000000000'
         result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub,
-                             child_type=bep_type, child_name=bep, grandchild_name=grandchild, grandchild_type=gc_type)
+                             child_type_1=bep_type, child_name_1=bep, child_name_2=grandchild, child_type_2=gc_type)
         expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep/grandchildType/grandchild'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -109,7 +109,7 @@ for scope in ['webapp', 'functionapp']:
     register_cli_argument(scope + ' config ssl', 'certificate_thumbprint', help='The ssl cert thumbprint')
     register_cli_argument(scope + ' config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
     register_cli_argument(scope + ' config appsettings', 'setting_names', nargs='+', help="space separated app setting names")
-    register_cli_argument(scope + ' config hostname', 'hostname', completer=get_hostname_completion_list, help="hostname assigned to the site, such as custom domains", id_part='child_name')
+    register_cli_argument(scope + ' config hostname', 'hostname', completer=get_hostname_completion_list, help="hostname assigned to the site, such as custom domains", id_part='child_name_1')
     register_cli_argument(scope + ' deployment user', 'user_name', help='user name')
     register_cli_argument(scope + ' deployment user', 'password', help='password, will prompt if not specified')
     register_cli_argument(scope + ' deployment source', 'manual_integration', action='store_true', help='disable automatic sync between source control and web')

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -36,13 +36,13 @@ register_cli_argument('iot', 'device_id', options_list=('--device-id', '-d'), he
 # Arguments for 'iot hub consumer-group' group
 register_cli_argument('iot hub consumer-group', 'consumer_group_name',
                       options_list=('--name', '-n'),
-                      id_part='grandchild_name', help='Event hub consumer group name.')
-register_cli_argument('iot hub consumer-group', 'event_hub_name', id_part='child_name',
+                      id_part='child_name_2', help='Event hub consumer group name.')
+register_cli_argument('iot hub consumer-group', 'event_hub_name', id_part='child_name_1',
                       help='Event hub endpoint name.')
 
 # Arguments for 'iot hub policy' group
 register_cli_argument('iot hub policy', 'policy_name', options_list=('--name', '-n'),
-                      id_part='child_name',
+                      id_part='child_name_1',
                       help='Shared access policy name.')
 
 permission_values = ', '.join([x.value for x in SimpleAccessRights])
@@ -52,7 +52,7 @@ register_cli_argument('iot hub policy', 'permissions', nargs='*',
                            'multiple permissions. Possible values: {}'.format(permission_values))
 
 # Arguments for 'iot hub job' group
-register_cli_argument('iot hub job', 'job_id', id_part='child_name', help='Job Id.')
+register_cli_argument('iot hub job', 'job_id', id_part='child_name_1', help='Job Id.')
 
 # Arguments for 'iot hub create'
 register_cli_argument('iot hub create', 'hub_name', completer=None)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -166,13 +166,13 @@ register_cli_argument('keyvault set-policy', 'certificate_permissions', metavar=
 for item in ['key', 'secret', 'certificate']:
     register_cli_argument('keyvault {}'.format(item), '{}_name'.format(item),
                           options_list=('--name', '-n'), help='Name of the {}.'.format(item),
-                          id_part='child_name', completer=get_keyvault_name_completion_list(item))
+                          id_part='child_name_1', completer=get_keyvault_name_completion_list(item))
     register_cli_argument('keyvault {}'.format(item), 'vault_base_url', vault_name_type,
                           type=vault_base_url_type, id_part=None)
 # TODO: Fix once service side issue is fixed that there is no way to list pending certificates
 register_cli_argument('keyvault certificate pending', 'certificate_name',
                       options_list=('--name', '-n'), help='Name of the pending certificate.',
-                      id_part='child_name', completer=None)
+                      id_part='child_name_1', completer=None)
 
 register_cli_argument('keyvault key', 'key_ops', options_list=('--ops'), nargs='*',
                       help='Space separated list of permitted JSON web key operations.',

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/params.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/params.py
@@ -74,7 +74,7 @@ with ParametersContext(command='lab vm list') as c:
 
 with ParametersContext(command='lab vm claim') as c:
     c.register_alias('resource_group', ('--resource-group', '-g'), validator=validate_claim_vm)
-    c.register_alias('name', ('--name', '-n'), id_part='child_name')
+    c.register_alias('name', ('--name', '-n'), id_part='child_name_1')
     c.argument('lab_name', id_part='name')
 
 

--- a/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
+++ b/src/command_modules/azure-cli-lab/azure/cli/command_modules/lab/validators.py
@@ -80,10 +80,10 @@ def validate_lab_vm_list(namespace):
                                                 namespace='Microsoft.DevTestLab',
                                                 type='labs',
                                                 name=namespace.lab_name,
-                                                child_type='users',
-                                                child_name=_get_owner_object_id(),
-                                                grandchild_type='environments',
-                                                grandchild_name=namespace.environment)
+                                                child_type_1='users',
+                                                child_name_1=_get_owner_object_id(),
+                                                child_type_2='environments',
+                                                child_name_2=namespace.environment)
         if namespace.filters is None:
             namespace.filters = "Properties/environmentId eq '{}'".format(namespace.environment)
         else:
@@ -107,10 +107,10 @@ def validate_template_id(namespace):
                                              namespace='Microsoft.DevTestLab',
                                              type='labs',
                                              name=namespace.lab_name,
-                                             child_type='artifactSources',
-                                             child_name=namespace.artifact_source_name,
-                                             grandchild_type='armTemplates',
-                                             grandchild_name=namespace.arm_template)
+                                             child_type_1='artifactSources',
+                                             child_name_1=namespace.artifact_source_name,
+                                             child_type_2='armTemplates',
+                                             child_name_2=namespace.arm_template)
 
 
 def validate_claim_vm(namespace):

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -70,7 +70,7 @@ register_resource_parameter('monitor alert update', 'target', 'Target Resource',
 
 for item in ['show-incident', 'list-incidents']:
     register_cli_argument('monitor alert {}'.format(item), 'rule_name', options_list=['--rule-name'], id_part='name')
-    register_cli_argument('monitor alert {}'.format(item), 'incident_name', name_arg_type, id_part='child_name')
+    register_cli_argument('monitor alert {}'.format(item), 'incident_name', name_arg_type, id_part='child_name_1')
 
 register_cli_argument('monitor alert list-incidents', 'rule_name', options_list=['--rule-name'], id_part=None)
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/validators.py
@@ -61,8 +61,8 @@ def validate_diagnostic_settings(namespace):
                                                         namespace='microsoft.ServiceBus',
                                                         type='namespaces',
                                                         name=namespace.namespace,
-                                                        child_type='AuthorizationRules',
-                                                        child_name=namespace.rule_name)
+                                                        child_type_1='AuthorizationRules',
+                                                        child_name_1=namespace.rule_name)
         else:
             resource_dict = parse_resource_id(namespace.namespace)
             namespace.service_bus_rule_id = resource_id(subscription=resource_dict['subscription'],
@@ -70,8 +70,8 @@ def validate_diagnostic_settings(namespace):
                                                         namespace=resource_dict['namespace'],
                                                         type=resource_dict['type'],
                                                         name=resource_dict['name'],
-                                                        child_type='AuthorizationRules',
-                                                        child_name=namespace.rule_name)
+                                                        child_type_1='AuthorizationRules',
+                                                        child_name_1=namespace.rule_name)
 
     if namespace.storage_account and not is_valid_resource_id(namespace.storage_account):
         if namespace.resource_group is None:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -214,7 +214,7 @@ ag_subresources = [
 ]
 
 for item in ag_subresources:
-    register_cli_argument('network application-gateway {}'.format(item['name']), 'item_name', options_list=('--name', '-n'), help='The name of the {}.'.format(item['display']), completer=get_ag_subresource_completion_list(item['ref']), id_part='child_name')
+    register_cli_argument('network application-gateway {}'.format(item['name']), 'item_name', options_list=('--name', '-n'), help='The name of the {}.'.format(item['display']), completer=get_ag_subresource_completion_list(item['ref']), id_part='child_name_1')
     register_cli_argument('network application-gateway {} create'.format(item['name']), 'item_name', options_list=('--name', '-n'), help='The name of the {}.'.format(item['display']), completer=None)
     register_cli_argument('network application-gateway {}'.format(item['name']), 'resource_name', options_list=('--gateway-name',), help='The name of the application gateway.')
     register_cli_argument('network application-gateway {}'.format(item['name']), 'application_gateway_name', options_list=('--gateway-name',), help='The name of the application gateway.')
@@ -285,9 +285,9 @@ register_cli_argument('network application-gateway url-path-map', 'paths', nargs
 register_cli_argument('network application-gateway url-path-map', 'address_pool', help='The name or ID of the backend address pool to use with the created rule.', completer=get_ag_subresource_completion_list('backend_address_pools'), arg_group='First Rule')
 register_cli_argument('network application-gateway url-path-map', 'http_settings', help='The name or ID of the HTTP settings to use with the created rule.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'), arg_group='First Rule')
 
-register_cli_argument('network application-gateway url-path-map rule', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=get_ag_url_map_rule_completion_list(), id_part='grandchild_name')
+register_cli_argument('network application-gateway url-path-map rule', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=get_ag_url_map_rule_completion_list(), id_part='child_name_2')
 register_cli_argument('network application-gateway url-path-map rule create', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=None, validator=process_ag_url_path_map_rule_create_namespace)
-register_cli_argument('network application-gateway url-path-map rule', 'url_path_map_name', options_list=('--path-map-name',), help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'), id_part='child_name')
+register_cli_argument('network application-gateway url-path-map rule', 'url_path_map_name', options_list=('--path-map-name',), help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'), id_part='child_name_1')
 register_cli_argument('network application-gateway url-path-map rule', 'address_pool', help='The name or ID of the backend address pool. If not specified, the default for the map will be used.', completer=get_ag_subresource_completion_list('backend_address_pools'))
 register_cli_argument('network application-gateway url-path-map rule', 'http_settings', help='The name or ID of the HTTP settings. If not specified, the default for the map will be used.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
 
@@ -355,12 +355,12 @@ register_cli_argument('network express-route', 'vlan_id', type=int)
 register_cli_argument('network express-route', 'location', location_type, validator=get_default_location_from_resource_group)
 
 register_cli_argument('network express-route auth', 'circuit_name', circuit_name_type)
-register_cli_argument('network express-route auth', 'authorization_name', name_arg_type, id_part='child_name', help='Authorization name')
+register_cli_argument('network express-route auth', 'authorization_name', name_arg_type, id_part='child_name_1', help='Authorization name')
 
 register_cli_argument('network express-route auth create', 'authorization_parameters', ignore_type, validator=process_auth_create_namespace)
 
 register_cli_argument('network express-route peering', 'circuit_name', circuit_name_type)
-register_cli_argument('network express-route peering', 'peering_name', name_arg_type, id_part='child_name')
+register_cli_argument('network express-route peering', 'peering_name', name_arg_type, id_part='child_name_1')
 register_cli_argument('network express-route peering', 'peering_type', validator=validate_peering_type, **enum_choice_list(ExpressRouteCircuitPeeringType))
 register_cli_argument('network express-route peering', 'sku_family', **enum_choice_list(ExpressRouteCircuitSkuFamily))
 register_cli_argument('network express-route peering', 'sku_tier', **enum_choice_list(ExpressRouteCircuitSkuTier))
@@ -425,9 +425,9 @@ for item in ['create', 'ip-config update', 'ip-config create']:
 
 
 register_cli_argument('network nic ip-config', 'network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
-register_cli_argument('network nic ip-config', 'ip_config_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name')
+register_cli_argument('network nic ip-config', 'ip_config_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
 register_cli_argument('network nic ip-config', 'resource_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
-register_cli_argument('network nic ip-config', 'item_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name')
+register_cli_argument('network nic ip-config', 'item_name', options_list=('--name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
 register_cli_argument('network nic ip-config', 'subnet', validator=get_subnet_validator(), help='Name or ID of an existing subnet. If name is specified, also specify --vnet-name.')
 register_cli_argument('network nic ip-config', 'virtual_network_name', help='The virtual network (VNet) associated with the subnet (Omit if supplying a subnet id).', id_part=None, metavar='')
 register_cli_argument('network nic ip-config', 'public_ip_address', help='Name or ID of the public IP to use.', validator=get_public_ip_validator())
@@ -435,7 +435,7 @@ register_cli_argument('network nic ip-config', 'private_ip_address_allocation', 
 register_cli_argument('network nic ip-config', 'make_primary', action='store_true', help='Set to make this configuration the primary one for the NIC.')
 
 for item in ['address-pool', 'inbound-nat-rule']:
-    register_cli_argument('network nic ip-config {}'.format(item), 'ip_config_name', options_list=('--ip-config-name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name')
+    register_cli_argument('network nic ip-config {}'.format(item), 'ip_config_name', options_list=('--ip-config-name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name_1')
     register_cli_argument('network nic ip-config {}'.format(item), 'network_interface_name', nic_type)
 
 register_cli_argument('network nic ip-config address-pool remove', 'network_interface_name', nic_type, id_part=None)
@@ -453,7 +453,7 @@ register_cli_argument('network nsg create', 'name', name_arg_type)
 register_cli_argument('network nsg create', 'location', location_type, validator=get_default_location_from_resource_group)
 
 # NSG Rule
-register_cli_argument('network nsg rule', 'security_rule_name', name_arg_type, id_part='child_name', help='Name of the network security group rule')
+register_cli_argument('network nsg rule', 'security_rule_name', name_arg_type, id_part='child_name_1', help='Name of the network security group rule')
 register_cli_argument('network nsg rule', 'network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part='name')
 
 for item in ['create', 'update']:
@@ -515,7 +515,7 @@ register_cli_argument('network route-table create', 'location', location_type, v
 register_cli_argument('network route-table create', 'parameters', ignore_type)
 
 # Route Operation
-register_cli_argument('network route-table route', 'route_name', name_arg_type, id_part='child_name', help='Route name')
+register_cli_argument('network route-table route', 'route_name', name_arg_type, id_part='child_name_1', help='Route name')
 register_cli_argument('network route-table route', 'route_table_name', options_list=('--route-table-name',), help='Route table name')
 register_cli_argument('network route-table route', 'next_hop_type', help='The type of Azure hop the packet should be sent to.', **enum_choice_list(RouteNextHopType))
 register_cli_argument('network route-table route', 'next_hop_ip_address', help='The IP address packets should be forwarded to when using the VirtualAppliance hop type.')
@@ -528,7 +528,7 @@ register_cli_argument('network route-filter', 'expand', **enum_choice_list(['pee
 register_cli_argument('network route-filter create', 'location', location_type, validator=get_default_location_from_resource_group)
 
 register_cli_argument('network route-filter rule', 'route_filter_name', options_list=['--filter-name'], help='Name of the route filter.', id_part='name')
-register_cli_argument('network route-filter rule', 'rule_name', name_arg_type, help='Name of the route filter rule.', id_part='child_name')
+register_cli_argument('network route-filter rule', 'rule_name', name_arg_type, help='Name of the route filter rule.', id_part='child_name_1')
 register_cli_argument('network route-filter rule', 'access', help='The access type of the rule.', **model_choice_list(ResourceType.MGMT_NETWORK, 'Access'))
 register_cli_argument('network route-filter rule', 'communities', nargs='+')
 
@@ -551,7 +551,7 @@ register_cli_argument('network vnet create', 'vnet_name', virtual_network_name_t
 register_cli_argument('network vnet update', 'address_prefixes', nargs='+')
 
 register_cli_argument('network vnet peering', 'virtual_network_name', virtual_network_name_type)
-register_cli_argument('network vnet peering', 'virtual_network_peering_name', options_list=('--name', '-n'), help='The name of the VNet peering.', id_part='child_name')
+register_cli_argument('network vnet peering', 'virtual_network_peering_name', options_list=('--name', '-n'), help='The name of the VNet peering.', id_part='child_name_1')
 register_cli_argument('network vnet peering', 'remote_virtual_network', options_list=('--remote-vnet-id',), help='ID of the remote VNet.')
 
 register_cli_argument('network vnet peering create', 'allow_virtual_network_access', options_list=('--allow-vnet-access',), action='store_true', help='Allows VMs in the remote VNet to access all VMs in the local VNet.')
@@ -559,7 +559,7 @@ register_cli_argument('network vnet peering create', 'allow_gateway_transit', ac
 register_cli_argument('network vnet peering create', 'allow_forwarded_traffic', action='store_true', help='Allows forwarded traffic from the VMs in the remote VNet.')
 register_cli_argument('network vnet peering create', 'use_remote_gateways', action='store_true', help='Allows VNet to use the remote VNet\'s gateway. Remote VNet gateway must have --allow-gateway-transit enabled for remote peering. Only 1 peering can have this flag enabled. Cannot be set if the VNet already has a gateway.')
 
-register_cli_argument('network vnet subnet', 'subnet_name', arg_type=subnet_name_type, options_list=('--name', '-n'), id_part='child_name')
+register_cli_argument('network vnet subnet', 'subnet_name', arg_type=subnet_name_type, options_list=('--name', '-n'), id_part='child_name_1')
 register_cli_argument('network vnet subnet', 'address_prefix', metavar='PREFIX', help='the address prefix in CIDR format.')
 register_cli_argument('network vnet subnet', 'virtual_network_name', virtual_network_name_type)
 register_cli_argument('network vnet subnet', 'network_security_group', validator=get_nsg_validator())
@@ -577,7 +577,7 @@ lb_subresources = [
     {'name': 'probe', 'display': 'probe', 'ref': 'probes'},
 ]
 for item in lb_subresources:
-    register_cli_argument('network lb {}'.format(item['name']), 'item_name', options_list=('--name', '-n'), help='The name of the {}'.format(item['display']), completer=get_lb_subresource_completion_list(item['ref']), id_part='child_name')
+    register_cli_argument('network lb {}'.format(item['name']), 'item_name', options_list=('--name', '-n'), help='The name of the {}'.format(item['display']), completer=get_lb_subresource_completion_list(item['ref']), id_part='child_name_1')
     register_cli_argument('network lb {}'.format(item['name']), 'resource_name', options_list=('--lb-name',), help='The name of the load balancer.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'))
     register_cli_argument('network lb {}'.format(item['name']), 'load_balancer_name', load_balancer_name_type)
 
@@ -724,8 +724,8 @@ register_cli_argument('network traffic-manager profile check-dns', 'type', ignor
 
 # Traffic manager endpoints
 endpoint_types = ['azureEndpoints', 'externalEndpoints', 'nestedEndpoints']
-register_cli_argument('network traffic-manager endpoint', 'endpoint_name', name_arg_type, id_part='child_name', help='Endpoint name.', completer=get_tm_endpoint_completion_list())
-register_cli_argument('network traffic-manager endpoint', 'endpoint_type', options_list=['--type', '-t'], help='Endpoint type.', id_part='child_name', **enum_choice_list(endpoint_types))
+register_cli_argument('network traffic-manager endpoint', 'endpoint_name', name_arg_type, id_part='child_name_1', help='Endpoint name.', completer=get_tm_endpoint_completion_list())
+register_cli_argument('network traffic-manager endpoint', 'endpoint_type', options_list=['--type', '-t'], help='Endpoint type.', id_part='child_name_1', **enum_choice_list(endpoint_types))
 register_cli_argument('network traffic-manager endpoint', 'profile_name', help='Name of parent profile.', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'), id_part='name')
 register_cli_argument('network traffic-manager endpoint', 'endpoint_location', help="Location of the external or nested endpoints when using the 'Performance' routing method.")
 register_cli_argument('network traffic-manager endpoint', 'endpoint_monitor_status', help='The monitoring status of the endpoint.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -86,8 +86,8 @@ def _generate_ag_subproperty_id(namespace, child_type, child_name, subscription=
         namespace='Microsoft.Network',
         type='applicationGateways',
         name=namespace.application_gateway_name,
-        child_type=child_type,
-        child_name=child_name)
+        child_type_1=child_type,
+        child_name_1=child_name)
 
 
 def _generate_lb_subproperty_id(namespace, child_type, child_name, subscription=None):
@@ -97,8 +97,8 @@ def _generate_lb_subproperty_id(namespace, child_type, child_name, subscription=
         namespace='Microsoft.Network',
         type='loadBalancers',
         name=namespace.load_balancer_name,
-        child_type=child_type,
-        child_name=child_name)
+        child_type_1=child_type,
+        child_name_1=child_name)
 
 
 def _generate_lb_id_list_from_names_or_ids(namespace, prop, child_type):
@@ -307,8 +307,8 @@ def get_subnet_validator(has_type_field=False, allow_none=False, allow_new=False
                 namespace='Microsoft.Network',
                 type='virtualNetworks',
                 name=namespace.virtual_network_name,
-                child_type='subnets',
-                child_name=namespace.subnet)
+                child_type_1='subnets',
+                child_name_1=namespace.subnet)
 
     def complex_validator_with_type(namespace):
 
@@ -362,8 +362,8 @@ def validate_target_listener(namespace):
             name=namespace.application_gateway_name,
             namespace='Microsoft.Network',
             type='applicationGateways',
-            child_type='httpListeners',
-            child_name=namespace.target_listener)
+            child_type_1='httpListeners',
+            child_name_1=namespace.target_listener)
 
 
 def get_virtual_network_validator(has_type_field=False, allow_none=False, allow_new=False,

--- a/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/params.py
+++ b/src/command_modules/azure-cli-rdbms/azure/cli/command_modules/rdbms/params.py
@@ -99,7 +99,7 @@ for command_group_name in ['mysql', 'postgres']:
     register_cli_argument('{0} db'.format(command_group_name), 'database_name', options_list=('--name', '-n'))
 
     register_cli_argument('{0} server firewall-rule'.format(command_group_name), 'server_name', options_list=('--server-name', '-s'))
-    register_cli_argument('{0} server firewall-rule'.format(command_group_name), 'firewall_rule_name', options_list=('--name', '-n'), id_part='child_name',
+    register_cli_argument('{0} server firewall-rule'.format(command_group_name), 'firewall_rule_name', options_list=('--name', '-n'), id_part='child_name_1',
                           help='The name of the firewall rule.')
     register_cli_argument('{0} server firewall-rule'.format(command_group_name), 'start_ip_address', options_list=('--start-ip-address',),
                           help='The start IP address of the firewall rule. Must be IPv4 format.')
@@ -107,4 +107,4 @@ for command_group_name in ['mysql', 'postgres']:
                           help='The end IP address of the firewall rule. Must be IPv4 format.')
 
     register_cli_argument('{0} server configuration'.format(command_group_name), 'server_name', options_list=('--server-name', '-s'))
-    register_cli_argument('{0} server configuration'.format(command_group_name), 'configuration_name', id_part='child_name', options_list=('--name', '-n'))
+    register_cli_argument('{0} server configuration'.format(command_group_name), 'configuration_name', id_part='child_name_1', options_list=('--name', '-n'))

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -883,9 +883,9 @@ def list_policy_assignment(disable_scope_strict_match=None, resource_group_name=
     elif scope:
         # pylint: disable=redefined-builtin
         id = parse_resource_id(scope)
-        parent_resource_path = '' if not id.get('child_name') else (id['type'] + '/' + id['name'])
-        resource_type = id.get('child_type') or id['type']
-        resource_name = id.get('child_name') or id['name']
+        parent_resource_path = '' if not id.get('child_name_1') else (id['type'] + '/' + id['name'])
+        resource_type = id.get('child_type_1') or id['type']
+        resource_name = id.get('child_name_1') or id['name']
         result = policy_client.policy_assignments.list_for_resource(
             id['resource_group'], id['namespace'],
             parent_resource_path, resource_type, resource_name)
@@ -1133,12 +1133,12 @@ def _validate_lock_params_match_lock(
         if resource_provider_namespace != _resource_namespace:
             raise CLIError(
                 'Unexpected --namespace for lock {}, expected {}'.format(name, _resource_namespace))
-        if resource.get('grandchild_type', None) is None:
+        if resource.get('child_type_2', None) is None:
             _resource_type = resource.get('type', None)
             _resource_name = resource.get('name', None)
         else:
-            _resource_type = resource.get('child_type', None)
-            _resource_name = resource.get('child_name', None)
+            _resource_type = resource.get('child_type_1', None)
+            _resource_name = resource.get('child_name_1', None)
             parent = (resource['type'] + '/' + resource['name'])
             if parent != parent_resource_path:
                 raise CLIError(
@@ -1643,19 +1643,19 @@ class _ResourceUtils(object):  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def _resolve_api_version_by_id(rcf, resource_id):
         parts = parse_resource_id(resource_id)
-        namespace = parts.get('child_namespace', parts['namespace'])
-        if parts.get('grandchild_type'):
+        namespace = parts.get('child_namespace_1', parts['namespace'])
+        if parts.get('child_type_2'):
             parent = (parts['type'] + '/' + parts['name'] + '/' +
-                      parts['child_type'] + '/' + parts['child_name'])
-            resource_type = parts['grandchild_type']
-        elif parts.get('child_type'):
+                      parts['child_type_1'] + '/' + parts['child_name_1'])
+            resource_type = parts['child_type_2']
+        elif parts.get('child_type_1'):
             # if the child resource has a provider namespace it is independent of the
             # parent, so set the parent to empty
-            if parts.get('child_namespace') is not None:
+            if parts.get('child_namespace_1') is not None:
                 parent = ''
             else:
                 parent = parts['type'] + '/' + parts['name']
-            resource_type = parts['child_type']
+            resource_type = parts['child_type_1']
         else:
             parent = None
             resource_type = parts['type']

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/custom.py
@@ -1096,8 +1096,8 @@ def validate_subnet(namespace):
             namespace='Microsoft.Network',
             type='virtualNetworks',
             name=vnet,
-            child_type='subnets',
-            child_name=subnet)
+            child_type_1='subnets',
+            child_name_1=subnet)
     else:
         raise CLIError('incorrect usage: [--subnet ID | --subnet NAME --vnet-name NAME]')
     delattr(namespace, 'vnet_name')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -805,8 +805,8 @@ def validate_subnet(namespace):
             namespace='Microsoft.Network',
             type='virtualNetworks',
             name=vnet,
-            child_type='subnets',
-            child_name=subnet)
+            child_type_1='subnets',
+            child_name_1=subnet)
     else:
         raise CLIError('incorrect usage: [--subnet ID | --subnet NAME --vnet-name NAME]')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -122,7 +122,7 @@ register_cli_argument('vm capture', 'overwrite', action='store_true')
 register_cli_argument('vm diagnostics', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
 register_cli_argument('vm diagnostics set', 'storage_account', completer=get_resource_name_completion_list('Microsoft.Storage/storageAccounts'))
 
-register_cli_argument('vm extension', 'vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'), id_part='child_name')
+register_cli_argument('vm extension', 'vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'), id_part='child_name_1')
 register_cli_argument('vm extension', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',), id_part='name')
 
 register_cli_argument('vm extension image', 'image_location', options_list=('--location', '-l'))
@@ -141,7 +141,7 @@ for dest in ['vm_scale_set_name', 'virtual_machine_scale_set_name', 'name']:
     register_cli_argument('vmss show', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
     register_cli_argument('vmss update-instances', dest, vmss_name_type, id_part=None)  # due to instance-ids parameter
 
-register_cli_argument('vmss', 'instance_id', id_part='child_name')
+register_cli_argument('vmss', 'instance_id', id_part='child_name_1')
 register_cli_argument('vmss', 'instance_ids', multi_ids_type, help='Space separated list of IDs (ex: 1 2 3 ...) or * for all instances. If not provided, the action will be applied on the scaleset itself')
 register_cli_argument('vmss', 'tags', tags_type)
 register_cli_argument('vmss', 'caching', help='Disk caching policy', **enum_choice_list(CachingTypes))
@@ -195,8 +195,8 @@ register_cli_argument('vm nic', 'nics', nargs='+', help='Names or IDs of NICs.',
 register_cli_argument('vm nic show', 'nic', help='NIC name or ID.', validator=validate_vm_nic)
 
 register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
-register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',), id_part='child_name')
-register_cli_argument('vmss nic', 'network_interface_name', options_list=('--name', '-n'), metavar='NIC_NAME', help='The network interface (NIC).', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'), id_part='grandchild_name')
+register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',), id_part='child_name_1')
+register_cli_argument('vmss nic', 'network_interface_name', options_list=('--name', '-n'), metavar='NIC_NAME', help='The network interface (NIC).', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'), id_part='child_name_2')
 
 register_cli_argument('network nic scale-set list', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_vm_utils.py
@@ -63,8 +63,8 @@ def check_existence(value, resource_group, provider_namespace, resource_type,
 
     if parent_name and parent_type:
         parent_path = '{}/{}'.format(parent_type, parent_name)
-        resource_name = id_parts.get('child_name', value)
-        resource_type = id_parts.get('child_type', resource_type)
+        resource_name = id_parts.get('child_name_1', value)
+        resource_type = id_parts.get('child_type_1', resource_type)
     else:
         parent_path = ''
         resource_name = id_parts['name']

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1239,7 +1239,7 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
         subnet_id = parse_resource_id(nic.ip_configurations[0].subnet.id)
         subnet = network.subnets.get(resource_group_name,
                                      subnet_id['name'],
-                                     subnet_id['child_name'])
+                                     subnet_id['child_name_1'])
         nsg = subnet.network_security_group
 
     if not nsg:
@@ -1276,7 +1276,7 @@ def vm_open_port(resource_group_name, vm_name, port, priority=900, network_secur
         LongRunningOperation('Updating subnet')(network.subnets.create_or_update(
             resource_group_name=resource_group_name,
             virtual_network_name=subnet_id['name'],
-            subnet_name=subnet_id['child_name'],
+            subnet_name=subnet_id['child_name_1'],
             subnet_parameters=subnet
         ))
 
@@ -1501,7 +1501,7 @@ def list_vmss_instance_connection_info(resource_group_name, vm_scale_set_name):
         # loop around inboundnatrule
         instance_addresses = {}
         for rule in lb.inbound_nat_rules:
-            instance_id = parse_resource_id(rule.backend_ip_configuration.id)['child_name']
+            instance_id = parse_resource_id(rule.backend_ip_configuration.id)['child_name_1']
             instance_addresses['instance ' + instance_id] = '{}:{}'.format(public_ip_address,
                                                                            rule.frontend_port)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1194,7 +1194,7 @@ class VMCreateExistingIdsOptions(ResourceGroupVCRTestBase):
 
         av_set = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Compute', type='availabilitySets', name=self.availset_name)
         pub_ip = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='publicIpAddresses', name=self.pubip_name)
-        subnet = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='virtualNetworks', child_type='subnets', name=self.vnet_name, child_name=self.subnet_name)
+        subnet = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='virtualNetworks', child_type_1='subnets', name=self.vnet_name, child_name_1=self.subnet_name)
         nsg = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='networkSecurityGroups', name=self.nsg_name)
 
         assert is_valid_resource_id(av_set)
@@ -1809,7 +1809,7 @@ class VMSSCreateExistingIdsOptions(ResourceGroupVCRTestBase):
         container_name = 'vrfcontainer'
         sku_name = 'Standard_A3'
 
-        subnet = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='virtualNetworks', child_type='subnets', name=self.vnet_name, child_name=self.subnet_name)
+        subnet = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='virtualNetworks', child_type_1='subnets', name=self.vnet_name, child_name_1=self.subnet_name)
         lb = resource_id(subscription=subscription_id, resource_group=rg, namespace='Microsoft.Network', type='loadBalancers', name=self.lb_name)
 
         assert is_valid_resource_id(subnet)


### PR DESCRIPTION
---
Fixes: https://github.com/Azure/azure-cli/issues/4443

Resource levels after the first can now be referenced by `children_name_{level}`; replacing the older `child_name`, `grandchild_name` structure.

Levels increment starting from 1, ex in:
`/subscriptions/mySub/resourceGroups/myRg/providers/Microsoft.Provider1/type1/name/providers/Microsoft.Provider2/type2/first_child/type3/second_child`

```
        name:          name,
        child_name_1 : first_child,
        child_name_2 : second_child
```

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [na ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

### Command Guidelines

- [y ] Each command and parameter has a meaningful description.
- [y ] Each new command has a test.

(see [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules))
